### PR TITLE
Security analysis  action simulator  output table format

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/io/table/AbstractTableFormatter.java
+++ b/commons/src/main/java/com/powsybl/commons/io/table/AbstractTableFormatter.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.nocrala.tools.texttablefmt.CellStyle;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -26,9 +28,16 @@ public abstract class AbstractTableFormatter implements TableFormatter {
 
     protected abstract TableFormatter write(String value) throws IOException;
 
+    protected abstract TableFormatter write(String value, CellStyle cellStyle) throws IOException;
+
     @Override
     public TableFormatter writeCell(String s) throws IOException {
         return write(s);
+    }
+
+    @Override
+    public TableFormatter writeCell(String s, CellStyle cellStyle) throws IOException {
+        return write(s, cellStyle);
     }
 
     @Override
@@ -54,6 +63,21 @@ public abstract class AbstractTableFormatter implements TableFormatter {
     @Override
     public TableFormatter writeCell(double d) throws IOException {
         return write(Double.isNaN(d) ? invalidString : String.format(locale, "%g", d));
+    }
+
+    @Override
+    public TableFormatter writeCell(int i, CellStyle cellStyle) throws IOException {
+        return write(Integer.toString(i), cellStyle);
+    }
+
+    @Override
+    public TableFormatter writeCell(float f, CellStyle cellStyle, String stringFormat) throws IOException {
+        return write(Float.isNaN(f) ? invalidString : String.format(locale, stringFormat, f), cellStyle);
+    }
+
+    @Override
+    public TableFormatter writeCell(double d, CellStyle cellStyle, String stringFormat) throws IOException {
+        return write(Double.isNaN(d) ? invalidString : String.format(locale, stringFormat, d), cellStyle);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/io/table/AsciiTableFormatter.java
+++ b/commons/src/main/java/com/powsybl/commons/io/table/AsciiTableFormatter.java
@@ -16,7 +16,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
 /**
- * @author Geoffroy Jamgotchian <geoffr    oy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class AsciiTableFormatter extends AbstractTableFormatter {
 

--- a/commons/src/main/java/com/powsybl/commons/io/table/AsciiTableFormatter.java
+++ b/commons/src/main/java/com/powsybl/commons/io/table/AsciiTableFormatter.java
@@ -7,6 +7,7 @@
 package com.powsybl.commons.io.table;
 
 import org.nocrala.tools.texttablefmt.BorderStyle;
+import org.nocrala.tools.texttablefmt.CellStyle;
 import org.nocrala.tools.texttablefmt.Table;
 
 import java.io.IOException;
@@ -15,7 +16,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian <geoffr    oy.jamgotchian at rte-france.com>
  */
 public class AsciiTableFormatter extends AbstractTableFormatter {
 
@@ -52,8 +53,18 @@ public class AsciiTableFormatter extends AbstractTableFormatter {
     }
 
     @Override
+    protected TableFormatter write(String value, CellStyle cellStyle) throws IOException {
+        table.addCell(value, cellStyle);
+        return this;
+    }
+
+    @Override
     public void close() throws IOException {
-        writer.write(title + ":" + System.lineSeparator());
+        if (null == title || title.isEmpty()) {
+            writer.write(System.lineSeparator());
+        } else {
+            writer.write(title + ":" + System.lineSeparator());
+        }
         writer.write(table.render() + System.lineSeparator());
         writer.close();
     }

--- a/commons/src/main/java/com/powsybl/commons/io/table/CsvTableFormatter.java
+++ b/commons/src/main/java/com/powsybl/commons/io/table/CsvTableFormatter.java
@@ -11,6 +11,8 @@ import java.io.Writer;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.nocrala.tools.texttablefmt.CellStyle;
+
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -88,6 +90,11 @@ public class CsvTableFormatter extends AbstractTableFormatter {
             column = 0;
         }
         return this;
+    }
+
+    @Override
+    protected TableFormatter write(String value, CellStyle cellStyle) throws IOException {
+        return write(value);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/io/table/TableFormatter.java
+++ b/commons/src/main/java/com/powsybl/commons/io/table/TableFormatter.java
@@ -8,6 +8,8 @@ package com.powsybl.commons.io.table;
 
 import java.io.IOException;
 
+import org.nocrala.tools.texttablefmt.CellStyle;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -16,6 +18,8 @@ public interface TableFormatter extends AutoCloseable {
     TableFormatter writeComment(String comment) throws IOException;
 
     TableFormatter writeCell(String s) throws IOException;
+
+    TableFormatter writeCell(String s, CellStyle cellStyle) throws IOException;
 
     TableFormatter writeEmptyCell() throws IOException;
 
@@ -30,4 +34,10 @@ public interface TableFormatter extends AutoCloseable {
     TableFormatter writeCell(boolean b) throws IOException;
 
     @Override void close() throws IOException;
+
+    TableFormatter writeCell(int i, CellStyle cellStyle) throws IOException;
+
+    TableFormatter writeCell(float f, CellStyle cellStyle, String stringFormat) throws IOException;
+
+    TableFormatter writeCell(double d, CellStyle cellStyle, String stringFormat) throws IOException;
 }

--- a/security-analysis/src/main/java/com/powsybl/security/Security.java
+++ b/security-analysis/src/main/java/com/powsybl/security/Security.java
@@ -7,15 +7,17 @@
  */
 package com.powsybl.security;
 
+import com.powsybl.commons.io.table.AsciiTableFormatterFactory;
 import com.powsybl.commons.io.table.Column;
 import com.powsybl.commons.io.table.TableFormatter;
 import com.powsybl.commons.io.table.TableFormatterConfig;
 import com.powsybl.commons.io.table.TableFormatterFactory;
 import com.powsybl.iidm.network.*;
-import org.nocrala.tools.texttablefmt.BorderStyle;
-import org.nocrala.tools.texttablefmt.Table;
+import org.nocrala.tools.texttablefmt.CellStyle;
+import org.nocrala.tools.texttablefmt.CellStyle.HorizontalAlign;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.*;
@@ -160,33 +162,49 @@ public final class Security {
     public static String printLimitsViolations(List<LimitViolation> violations, LimitViolationFilter filter) {
         Objects.requireNonNull(violations);
         Objects.requireNonNull(filter);
+
+        TableFormatterFactory formatterFactory = new AsciiTableFormatterFactory();
+        Writer writer = new StringWriter();
+        TableFormatterConfig formatterConfig = new TableFormatterConfig(Locale.getDefault(), ',', "inv", true, true);
         List<LimitViolation> filteredViolations = filter.apply(violations);
-        if (filteredViolations.size() > 0) {
-            filteredViolations.sort(Comparator.comparing(LimitViolation::getSubjectId));
-            Table table = new Table(9, BorderStyle.CLASSIC_WIDE);
-            table.addCell("Country");
-            table.addCell("Base voltage");
-            table.addCell("Equipment (" + filteredViolations.size() + ")");
-            table.addCell("Violation type");
-            table.addCell("Violation name");
-            table.addCell("Value");
-            table.addCell("Limit");
-            table.addCell("abs(value-limit)");
-            table.addCell("Loading rate %");
-            for (LimitViolation violation : filteredViolations) {
-                table.addCell(violation.getCountry() != null ? violation.getCountry().name() : "");
-                table.addCell(Float.isNaN(violation.getBaseVoltage()) ? "" : Float.toString(violation.getBaseVoltage()));
-                table.addCell(violation.getSubjectId());
-                table.addCell(violation.getLimitType().name());
-                table.addCell(getViolationName(violation));
-                table.addCell(Float.toString(violation.getValue()));
-                table.addCell(getViolationLimit(violation));
-                table.addCell(Float.toString(Math.abs(violation.getValue() - violation.getLimit() * violation.getLimitReduction())));
-                table.addCell(Integer.toString(getViolationValue(violation)));
-            }
-            return table.render();
+
+        try (TableFormatter formatter = formatterFactory.create(writer,
+                "",
+                formatterConfig,
+                new Column("Country"),
+                new Column("Base voltage"),
+                new Column("Equipment (" + filteredViolations.size() + ")"),
+                new Column("Violation type"),
+                new Column("Violation name"),
+                new Column("Value"),
+                new Column("Limit"),
+                new Column("abs(value-limit)"),
+                new Column("Loading rate %"))) {
+            filteredViolations.stream()
+                    .sorted(Comparator.comparing(LimitViolation::getSubjectId))
+                    .forEach(violation -> {
+                        try {
+                            formatter.writeCell(violation.getCountry() != null ? violation.getCountry().name() : "")
+                                     .writeCell(Float.isNaN(violation.getBaseVoltage()) ? "" : Float.toString(violation.getBaseVoltage()))
+                                     .writeCell(violation.getSubjectId())
+                                     .writeCell(violation.getLimitType().name())
+                                     .writeCell(getViolationName(violation))
+                                     .writeCell(violation.getValue(), createNumberCellStyle(), getNumberStringFormat())
+                                     .writeCell(getViolationLimit(violation), createNumberCellStyle(), getNumberStringFormat())
+                                     .writeCell(getAbsValueLimit(violation), createNumberCellStyle(), getNumberStringFormat())
+                                     .writeCell(getViolationValue(violation), createNumberCellStyle(), getNumberStringFormat());
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
-        return null;
+        return writer.toString().trim();
+    }
+
+    private static float getAbsValueLimit(LimitViolation violation) {
+        return Float.valueOf(Float.toString(violation.getLimit()) + (violation.getLimitReduction() != 1f ? " * " + violation.getLimitReduction() : ""));
     }
 
     public static void printPreContingencyViolations(SecurityAnalysisResult result, Writer writer, TableFormatterFactory formatterFactory,
@@ -229,9 +247,9 @@ public final class Security {
                                     .writeCell(violation.getSubjectId())
                                     .writeCell(violation.getLimitType().name())
                                     .writeCell(getViolationName(violation))
-                                    .writeCell(violation.getValue())
-                                    .writeCell(getViolationLimit(violation))
-                                    .writeCell(getViolationValue(violation));
+                                    .writeCell(violation.getValue(), createNumberCellStyle(), getNumberStringFormat())
+                                    .writeCell(getViolationLimit(violation), createNumberCellStyle(), getNumberStringFormat())
+                                    .writeCell(getViolationValueFloat(violation), createNumberCellStyle(), getNumberStringFormat());
                         } catch (IOException e) {
                             throw new UncheckedIOException(e);
                         }
@@ -245,12 +263,24 @@ public final class Security {
         return Objects.toString(violation.getLimitName(), "");
     }
 
-    private static String getViolationLimit(LimitViolation violation) {
-        return Float.toString(violation.getLimit()) + (violation.getLimitReduction() != 1f ? " * " + violation.getLimitReduction() : "");
+    private static float getViolationLimit(LimitViolation violation) {
+        return Float.valueOf(Float.toString(violation.getLimit()) + (violation.getLimitReduction() != 1f ? " * " + violation.getLimitReduction() : ""));
     }
 
     private static int getViolationValue(LimitViolation violation) {
         return Math.round(Math.abs(violation.getValue()) / violation.getLimit() * 100f);
+    }
+
+    private static float getViolationValueFloat(LimitViolation violation) {
+        return Math.abs(violation.getValue()) / violation.getLimit() * 100f;
+    }
+
+    public static CellStyle createNumberCellStyle() {
+        return new CellStyle(HorizontalAlign.right);
+    }
+
+    public static String getNumberStringFormat() {
+        return new String("%.4f");
     }
 
     /**
@@ -370,9 +400,9 @@ public final class Security {
                                                             .writeCell(violation.getSubjectId())
                                                             .writeCell(violation.getLimitType().name())
                                                             .writeCell(getViolationName(violation))
-                                                            .writeCell(violation.getValue())
-                                                            .writeCell(getViolationLimit(violation))
-                                                            .writeCell(getViolationValue(violation));
+                                                            .writeCell(violation.getValue(), createNumberCellStyle(), getNumberStringFormat())
+                                                            .writeCell(getViolationLimit(violation), createNumberCellStyle(), getNumberStringFormat())
+                                                            .writeCell(getViolationValueFloat(violation), createNumberCellStyle(), getNumberStringFormat());
                                                 } catch (IOException e) {
                                                     throw new UncheckedIOException(e);
                                                 }

--- a/security-analysis/src/main/java/com/powsybl/security/Security.java
+++ b/security-analysis/src/main/java/com/powsybl/security/Security.java
@@ -280,7 +280,7 @@ public final class Security {
     }
 
     public static String getNumberStringFormat() {
-        return new String("%.4f");
+        return "%.4f";
     }
 
     /**

--- a/security-analysis/src/test/java/com/powsybl/security/SecurityTest.java
+++ b/security-analysis/src/test/java/com/powsybl/security/SecurityTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-fLimitViolationTyperance.com>
  */
 public class SecurityTest {
 
@@ -64,7 +64,7 @@ public class SecurityTest {
                                  "Pre-contingency violations",
                                  "Action,Equipment,Violation type,Violation name,Value,Limit,Loading rate %",
                                  "action1,,,,,,",
-                                 ",line1,CURRENT,20',1100.00,1000.0,110"),
+                                 ",line1,CURRENT,20',1100.0000,1000.0000,110.0000"),
                      writer.toString().trim());
     }
 
@@ -81,8 +81,8 @@ public class SecurityTest {
                                  "Contingency,Status,Action,Equipment,Violation type,Violation name,Value,Limit,Loading rate %",
                                  "contingency1,converge,,,,,,,",
                                  ",,action2,,,,,,",
-                                 ",,,line1,CURRENT,20',1100.00,1000.0,110",
-                                 ",,,line2,CURRENT,10',950.000,900.0,106"),
+                                 ",,,line1,CURRENT,20',1100.0000,1000.0000,110.0000",
+                                 ",,,line2,CURRENT,10',950.0000,900.0000,105.5556"),
                      writer.toString().trim());
     }
 
@@ -99,21 +99,21 @@ public class SecurityTest {
                                  "Contingency,Status,Action,Equipment,Violation type,Violation name,Value,Limit,Loading rate %",
                                  "contingency1,converge,,,,,,,",
                                  ",,action2,,,,,,",
-                                 ",,,line2,CURRENT,10',950.000,900.0,106"),
+                                 ",,,line2,CURRENT,10',950.0000,900.0000,105.5556"),
                      writer.toString().trim());
     }
 
     @Test
-    public void printLimitsViolations() {
-        assertEquals(String.join("\n",
-                                 "+---------+--------------+---------------+----------------+----------------+--------+--------+------------------+----------------+",
-                                 "| Country | Base voltage | Equipment (2) | Violation type | Violation name | Value  | Limit  | abs(value-limit) | Loading rate % |",
-                                 "+---------+--------------+---------------+----------------+----------------+--------+--------+------------------+----------------+",
-                                 "|         |              | line1         | CURRENT        | 20'            | 1100.0 | 1000.0 | 100.0            | 110            |",
-                                 "|         |              | line2         | CURRENT        | 10'            | 950.0  | 900.0  | 50.0             | 106            |",
-                                 "+---------+--------------+---------------+----------------+----------------+--------+--------+------------------+----------------+"),
+    public void printLimitsViolations() throws Exception {
+        assertEquals("+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+\n" +
+                     "| Country | Base voltage | Equipment (2) | Violation type | Violation name | Value     | Limit     | abs(value-limit) | Loading rate % |\n" +
+                     "+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+\n" +
+                     "|         |              | line1         | CURRENT        | 20'            | 1100,0000 | 1000,0000 |        1000,0000 |       110,0000 |\n" +
+                     "|         |              | line2         | CURRENT        | 10'            |  950,0000 |  900,0000 |         900,0000 |       106,0000 |\n" +
+                     "+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+",
                      Security.printLimitsViolations(Arrays.asList(line1Violation, line2Violation), new LimitViolationFilter()));
     }
+
 
     @Test
     public void checkLimits() {

--- a/security-analysis/src/test/java/com/powsybl/security/SecurityTest.java
+++ b/security-analysis/src/test/java/com/powsybl/security/SecurityTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-fLimitViolationTyperance.com>
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class SecurityTest {
 
@@ -105,13 +105,16 @@ public class SecurityTest {
 
     @Test
     public void printLimitsViolations() throws Exception {
-        assertEquals("+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+\n" +
+    	Locale tmpLocale = Locale.getDefault();
+    	Locale.setDefault(Locale.FRANCE);
+    	assertEquals("+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+\n" +
                      "| Country | Base voltage | Equipment (2) | Violation type | Violation name | Value     | Limit     | abs(value-limit) | Loading rate % |\n" +
                      "+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+\n" +
                      "|         |              | line1         | CURRENT        | 20'            | 1100,0000 | 1000,0000 |        1000,0000 |       110,0000 |\n" +
                      "|         |              | line2         | CURRENT        | 10'            |  950,0000 |  900,0000 |         900,0000 |       106,0000 |\n" +
                      "+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+",
                      Security.printLimitsViolations(Arrays.asList(line1Violation, line2Violation), new LimitViolationFilter()));
+    	Locale.setDefault(tmpLocale);
     }
 
 

--- a/security-analysis/src/test/java/com/powsybl/security/SecurityTest.java
+++ b/security-analysis/src/test/java/com/powsybl/security/SecurityTest.java
@@ -105,16 +105,16 @@ public class SecurityTest {
 
     @Test
     public void printLimitsViolations() throws Exception {
-    	Locale tmpLocale = Locale.getDefault();
-    	Locale.setDefault(Locale.FRANCE);
-    	assertEquals("+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+\n" +
+        Locale tmpLocale = Locale.getDefault();
+        Locale.setDefault(Locale.FRANCE);
+        assertEquals("+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+\n" +
                      "| Country | Base voltage | Equipment (2) | Violation type | Violation name | Value     | Limit     | abs(value-limit) | Loading rate % |\n" +
                      "+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+\n" +
                      "|         |              | line1         | CURRENT        | 20'            | 1100,0000 | 1000,0000 |        1000,0000 |       110,0000 |\n" +
                      "|         |              | line2         | CURRENT        | 10'            |  950,0000 |  900,0000 |         900,0000 |       106,0000 |\n" +
                      "+---------+--------------+---------------+----------------+----------------+-----------+-----------+------------------+----------------+",
                      Security.printLimitsViolations(Arrays.asList(line1Violation, line2Violation), new LimitViolationFilter()));
-    	Locale.setDefault(tmpLocale);
+        Locale.setDefault(tmpLocale);
     }
 
 


### PR DESCRIPTION
I've fixed the decimals for the columns : "Value", "Limit", "abs(value-limit)", "Loading rate %" in the table : "Starting pre-contingency analysis" for the command "./itools action-simulator".
I've fixed the "Value, "Limit", "Loading rate %"  in the tables  : "Pre-contingency violations" and "Post-contingency limit violations".
All the mentioned columns have now 4 digits for decimals and are aligned to the right. 
