### PR TITLE
Bus and ConnectableBus can also be exclusive

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalBuilder.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalBuilder.java
@@ -45,19 +45,25 @@ class TerminalBuilder {
     }
 
     TerminalExt build() {
-        if (node != null && connectableBus != null) {
+        String connectionBus = getConnectionBus();
+        if (node != null && connectionBus != null) {
             throw new ValidationException(validable,
                     "connection node and connection bus are exclusives");
         }
-        if (node == null) {
-            if (connectableBus == null) {
-                throw new ValidationException(validable, "connectable bus is not set");
-            }
-            if (bus != null && !bus.equals(connectableBus)) {
+
+        return node != null ? new NodeTerminal(network, node)
+                            : new BusTerminal(network, connectionBus, bus != null);
+    }
+
+    private String getConnectionBus() {
+        if (bus != null) {
+            if ((connectableBus != null) && (!bus.equals(connectableBus))) {
                 throw new ValidationException(validable, "connection bus is different to connectable bus");
             }
+
+            return bus;
+        } else {
+            return connectableBus;
         }
-        return node != null ? new NodeTerminal(network, node)
-                            : new BusTerminal(network, connectableBus, bus != null);
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalBuilder.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalBuilder.java
@@ -51,8 +51,15 @@ class TerminalBuilder {
                     "connection node and connection bus are exclusives");
         }
 
-        return node != null ? new NodeTerminal(network, node)
-                            : new BusTerminal(network, connectionBus, bus != null);
+        if (node == null) {
+            if (connectionBus == null) {
+                throw new ValidationException(validable, "connectable bus is not set");
+            }
+
+            return new BusTerminal(network, connectionBus, bus != null);
+        } else {
+            return new NodeTerminal(network, node);
+        }
     }
 
     private String getConnectionBus() {


### PR DESCRIPTION
It's not necessary to specify bus and connectableBus in BusBreakerTopology. If the two values are specified we have to check if both are equals.