### PR TITLE
Fix sonarcloud.io code coverage score

### DIFF
--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -255,14 +255,53 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>${maven.antrun.version}</version>
                         <executions>
                             <execution>
                                 <phase>verify</phase>
                                 <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target name="copy jacoco reports">
+                                        <copy todir="${project.build.directory}/jacoco" flatten="true">
+                                            <fileset dir=".." includes="**/jacoco*.exec"/>
+                                        </copy>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>report-aggregate</id>
+                                <phase>verify</phase>
+                                <goals>
                                     <goal>report-aggregate</goal>
                                 </goals>
+                                <configuration>
+                                    <title>${project.parent.name}</title>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>merge</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>merge</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${project.parent.build.directory}/jacoco-merge.exec</destFile>
+                                    <fileSets>
+                                        <fileSet>
+                                            <directory>${project.build.directory}/jacoco</directory>
+                                        </fileSet>
+                                    </fileSets>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
         <java.version>1.8</java.version>
 
+        <maven.antrun.version>1.8</maven.antrun.version>
         <maven.build-helper.version>3.0.0</maven.build-helper.version>
         <maven.compiler.version>3.6.0</maven.compiler.version>
         <maven.findbugs.version>3.0.4</maven.findbugs.version>
@@ -62,6 +63,10 @@
         <groovyeclipsecompiler.version>2.9.2-01</groovyeclipsecompiler.version>
         <groovyeclipsebatch.version>2.4.3-01</groovyeclipsebatch.version>
 
+        <sonar.jacoco.reportPaths>
+            ../target/jacoco-merge.exec,
+            ../../target/jacoco-merge.exec
+        </sonar.jacoco.reportPaths>
         <sonar.exclusions>
             **/cim1/**/*, **/generated/**/*
         </sonar.exclusions>
@@ -312,6 +317,9 @@
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
+                                <configuration>
+                                    <destFile>${project.build.directory}/jacoco-${project.artifactId}.exec</destFile>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
- generate individual jacoco reports suffixed by the artifactId of each module
- copy all the jacoco files to target/jacoco of the aggregator module
- merge the reports to target/jacoco-merge.exec of the parent module
- use the merge report in sonar analysis

Hack: due to the two levels of hierarchy, we have to specify to different path to the merged report in sonar.jacoco.reportPaths property