### PR TITLE
Fix sonar issues

### DIFF
--- a/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/RunningContext.java
+++ b/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/RunningContext.java
@@ -59,12 +59,7 @@ public class RunningContext {
     }
 
     private AtomicInteger getRuleMatchCountInternal(String ruleId) {
-        AtomicInteger count = rulesMatchCount.get(ruleId);
-        if (count == null) {
-            count = new AtomicInteger();
-            rulesMatchCount.put(ruleId, count);
-        }
-        return count;
+        return rulesMatchCount.computeIfAbsent(ruleId, k -> new AtomicInteger());
     }
 
     public int getRuleMatchCount(String ruleId) {

--- a/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/LocalNetworkService.java
+++ b/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/LocalNetworkService.java
@@ -101,7 +101,7 @@ public class LocalNetworkService implements NetworkService {
         ModificationScript script = virtualCase.getScript()
                                                .orElseThrow(VirtualCase::createScriptLinkIsDeadException);
 
-        LOGGER.info("Applying script to network of project case " + virtualCase.getId());
+        LOGGER.info("Applying script to network of project case {}", virtualCase.getId());
 
         return applyScript(modifiedNetwork.getNetwork(), modifiedNetwork.getScriptOutput(), script);
     }

--- a/commons/src/main/java/com/powsybl/commons/config/ModuleConfig.java
+++ b/commons/src/main/java/com/powsybl/commons/config/ModuleConfig.java
@@ -42,6 +42,9 @@ public interface ModuleConfig {
 
     int getIntProperty(String name);
 
+    /**
+     * @deprecated Use getOptionalIntegerProperty(String) instead.
+     */
     @Deprecated
     Integer getOptionalIntProperty(String name);
 
@@ -63,6 +66,9 @@ public interface ModuleConfig {
 
     boolean getBooleanProperty(String name, boolean defaultValue);
 
+    /**
+     * @deprecated Use getOptionalBooleanProperty(String) instead.
+     */
     @Deprecated
     Boolean getOptinalBooleanProperty(String name);
 

--- a/commons/src/main/java/com/powsybl/commons/config/PlatformConfig.java
+++ b/commons/src/main/java/com/powsybl/commons/config/PlatformConfig.java
@@ -26,14 +26,17 @@ import java.util.Objects;
  */
 public class PlatformConfig {
 
+    /**
+     * @deprecated Use getDefaultConfigDir() instead.
+     */
     @Deprecated
     public static final Path CONFIG_DIR;
 
+    /**
+     * @deprecated Use getDefaultCacheDir() instead.
+     */
     @Deprecated
     public static final Path CACHE_DIR;
-
-    @Deprecated
-    private static final String CONFIG_NAME;
 
     private static PlatformConfig defaultConfig;
 
@@ -49,8 +52,6 @@ public class PlatformConfig {
 
     static {
         CONFIG_DIR = FileUtil.createDirectory(getDefaultConfigDir(FileSystems.getDefault()));
-
-        CONFIG_NAME = System.getProperty("itools.config.name");
 
         CACHE_DIR = FileUtil.createDirectory(getDefaultCacheDir(FileSystems.getDefault()));
     }

--- a/commons/src/main/java/com/powsybl/commons/config/PropertiesPlatformConfig.java
+++ b/commons/src/main/java/com/powsybl/commons/config/PropertiesPlatformConfig.java
@@ -29,6 +29,9 @@ public class PropertiesPlatformConfig extends PlatformConfig {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesPlatformConfig.class);
 
+    /**
+     * @deprecated Use PropertiesPlatformConfig(FileSystem, Path, Path) instead.
+     */
     @Deprecated
     public PropertiesPlatformConfig(Path configDir, FileSystem fileSystem) {
         this(fileSystem, configDir, getDefaultCacheDir(fileSystem));

--- a/commons/src/main/java/com/powsybl/commons/config/XmlPlatformConfig.java
+++ b/commons/src/main/java/com/powsybl/commons/config/XmlPlatformConfig.java
@@ -33,6 +33,9 @@ public class XmlPlatformConfig extends InMemoryPlatformConfig {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(XmlPlatformConfig.class);
 
+    /**
+     * @deprecated Use XmlPlatformConfig(FileSystem, Path, Path, String) instead.
+     */
     @Deprecated
     public XmlPlatformConfig(Path configDir, String configName, FileSystem fs)
             throws IOException, SAXException, ParserConfigurationException {

--- a/commons/src/main/java/com/powsybl/commons/datasource/GzMemDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/GzMemDataSource.java
@@ -19,7 +19,7 @@ public class GzMemDataSource extends ReadOnlyMemDataSource {
     GzMemDataSource(String fileName, InputStream content) {
         super(DataSourceUtil.getBaseName(fileName));
 
-        String zipped = fileName.substring(0, fileName.lastIndexOf("."));
+        String zipped = fileName.substring(0, fileName.lastIndexOf('.'));
         putData(zipped, content);
     }
 

--- a/commons/src/main/java/com/powsybl/commons/util/StringAnonymizer.java
+++ b/commons/src/main/java/com/powsybl/commons/util/StringAnonymizer.java
@@ -50,12 +50,8 @@ public class StringAnonymizer {
         if (str == null) {
             return null;
         }
-        String str2 = mapping.get(str);
-        if (str2 == null) {
-            str2 = getAlpha(mapping.size() + 1);
-            mapping.put(str, str2);
-        }
-        return str2;
+
+        return mapping.computeIfAbsent(str, k -> getAlpha(mapping.size() + 1));
     }
 
     public String deanonymize(String str) {

--- a/computation-mpi/src/main/java/com/powsybl/computation/mpi/CsvMpiStatistics.java
+++ b/computation-mpi/src/main/java/com/powsybl/computation/mpi/CsvMpiStatistics.java
@@ -573,11 +573,7 @@ public class CsvMpiStatistics implements MpiStatistics {
                 public void onTaskEnd(StatisticsReader.TaskExecution task, StatisticsReader.JobExecution job) {
                     if (task.workingDataSize != null) {
                         String slaveId = task.slaveRank + "_" + task.slaveThread;
-                        AtomicLong workingDataSize = workingDataSizePerSlave.get(slaveId);
-                        if (workingDataSize == null) {
-                            workingDataSize = new AtomicLong();
-                            workingDataSizePerSlave.put(slaveId, workingDataSize);
-                        }
+                        AtomicLong workingDataSize = workingDataSizePerSlave.computeIfAbsent(slaveId, k -> new AtomicLong());
                         workingDataSize.addAndGet(task.workingDataSize);
                         totalWorkingDataSize[0] += task.workingDataSize;
                     }

--- a/computation/src/main/java/com/powsybl/computation/AbstractExecutionHandler.java
+++ b/computation/src/main/java/com/powsybl/computation/AbstractExecutionHandler.java
@@ -30,6 +30,9 @@ public abstract class AbstractExecutionHandler<R> implements ExecutionHandler<R>
     public void onExecutionCompletion(CommandExecution execution, int executionIndex) {
     }
 
+    /**
+     * @deprecated Use onExecutionCompletion(CommandExecution, int) instead.
+     */
     @Override
     @Deprecated
     public void onProgress(CommandExecution execution, int executionIndex) {

--- a/computation/src/main/java/com/powsybl/computation/CommandExecutor.java
+++ b/computation/src/main/java/com/powsybl/computation/CommandExecutor.java
@@ -9,6 +9,7 @@ package com.powsybl.computation;
 import java.nio.file.Path;
 
 /**
+ * @deprecated Use ExecutionHandler instead.
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */

--- a/computation/src/main/java/com/powsybl/computation/ComputationManager.java
+++ b/computation/src/main/java/com/powsybl/computation/ComputationManager.java
@@ -23,6 +23,9 @@ public interface ComputationManager extends AutoCloseable {
 
     OutputStream newCommonFile(String fileName) throws IOException;
 
+    /**
+     * @deprecated Use execute(ExecutionEnvironment, ExecutionHandler<R>) instead.
+     */
     @Deprecated
     CommandExecutor newCommandExecutor(Map<String, String> env, String workingDirPrefix, boolean debug) throws Exception;
 

--- a/computation/src/main/java/com/powsybl/computation/DefaultExecutionHandler.java
+++ b/computation/src/main/java/com/powsybl/computation/DefaultExecutionHandler.java
@@ -11,7 +11,8 @@ import java.nio.file.Path;
 import java.util.List;
 
 /**
- * Use {@link AbstractExecutionHandler} instead
+ * @deprecated Use {@link AbstractExecutionHandler} instead.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  * @param <R>
  */

--- a/computation/src/main/java/com/powsybl/computation/ExecutionHandler.java
+++ b/computation/src/main/java/com/powsybl/computation/ExecutionHandler.java
@@ -24,6 +24,9 @@ public interface ExecutionHandler<R> {
         onProgress(execution, executionIndex);
     }
 
+    /**
+     * @deprecated Use onExecutionCompletion(CommandExecution, int) instead.
+     */
     @Deprecated
     void onProgress(CommandExecution execution, int executionIndex);
 

--- a/computation/src/main/java/com/powsybl/computation/InputFile.java
+++ b/computation/src/main/java/com/powsybl/computation/InputFile.java
@@ -31,7 +31,7 @@ public class InputFile {
     }
 
     public InputFile(Function<Integer, String> nameFunc, FilePreProcessor preProcessor) {
-        this.name = new FunctionFileName(nameFunc, name -> checkName(name, preProcessor));
+        this.name = new FunctionFileName(nameFunc, fileName -> checkName(fileName, preProcessor));
         this.preProcessor = preProcessor;
     }
 

--- a/contingency-api/src/main/java/com/powsybl/contingency/tasks/ModificationTask.java
+++ b/contingency-api/src/main/java/com/powsybl/contingency/tasks/ModificationTask.java
@@ -14,6 +14,9 @@ import com.powsybl.iidm.network.Network;
  */
 public interface ModificationTask {
 
+    /**
+     * @deprecated Use modify(Network, ComputationManager) instead.
+     */
     @Deprecated
     default void modify(Network network) {
         modify(network, null);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AbstractTopologyVisitor.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AbstractTopologyVisitor.java
@@ -7,7 +7,8 @@
 package com.powsybl.iidm.network;
 
 /**
- * Use {@link DefaultTopologyVisitor} instead
+ * @deprecated Use {@link DefaultTopologyVisitor} instead.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 @Deprecated

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ConnectedComponent.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ConnectedComponent.java
@@ -7,7 +7,7 @@
 package com.powsybl.iidm.network;
 
 /**
- * To replace by @link{Component}
+ * @deprecated To replace by @link{Component}
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/SingleTerminalConnectable.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/SingleTerminalConnectable.java
@@ -7,7 +7,7 @@
 package com.powsybl.iidm.network;
 
 /**
- * Use {@link Injection} instead.
+ * @deprecated Use {@link Injection} instead.
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */

--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importers.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importers.java
@@ -369,11 +369,17 @@ public final class Importers {
         return createDataSource(absFile.getParent(), absFile.getFileName().toString());
     }
 
+    /**
+     * @deprecated Use createDataSource(Path, String) instead.
+     */
     @Deprecated
     public static DataSource createReadOnly(Path directory, String fileNameOrBaseName) {
         return createDataSource(directory, fileNameOrBaseName);
     }
 
+    /**
+     * @deprecated Use createDataSource(Path) instead.
+     */
     @Deprecated
     public static DataSource createReadOnly(Path file) {
         return createDataSource(file);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
@@ -190,6 +190,6 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, S
 
     @Override
     protected String getTypeDescription() {
-        return "hvdcLine";
+        return TYPE_DESCRIPTION;
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -643,7 +643,7 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Mult
                 setComponentNumber(bus, result.getComponentNumber()[i]);
             }
 
-            LOGGER.debug(getComponentLabel() + " components computed in {} ms", System.currentTimeMillis() - startTime);
+            LOGGER.debug("{} components computed in {} ms", getComponentLabel(), System.currentTimeMillis() - startTime);
         }
 
         List<C> getConnectedComponents() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -382,6 +382,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             updateCache(sw -> sw.isOpen() || sw.isRetained());
         }
 
+        @Override
         protected BusChecker getBusChecker() {
             return CALCULATED_BUS_BREAKER_CHECKER;
         }
@@ -506,11 +507,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             AtomicInteger i;
             lock.lock();
             try {
-                i = counter.get(voltageLevel);
-                if (i == null) {
-                    i = new AtomicInteger();
-                    counter.put(voltageLevel, i);
-                }
+                i = counter.computeIfAbsent(voltageLevel, k -> new AtomicInteger());
             } finally {
                 lock.unlock();
             }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ValidationUtil.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ValidationUtil.java
@@ -17,6 +17,9 @@ public final class ValidationUtil {
     private ValidationUtil() {
     }
 
+    /**
+     * @deprecated Use checkActivePowerSetpoint(Validable, float) instead.
+     */
     @Deprecated
     static void checkTargetP(Validable validable, float targetP) {
         checkActivePowerSetpoint(validable, targetP);

--- a/security-analysis/src/main/java/com/powsybl/security/PostContingencyResult.java
+++ b/security-analysis/src/main/java/com/powsybl/security/PostContingencyResult.java
@@ -43,16 +43,25 @@ public class PostContingencyResult {
         return limitViolationsResult;
     }
 
+    /**
+     * @deprecated Use getLimitViolationsResult().isComputationOk() instead.
+     */
     @Deprecated
     public boolean isComputationOk() {
         return limitViolationsResult.isComputationOk();
     }
 
+    /**
+     * @deprecated Use getLimitViolationsResult().getLimitViolations() instead.
+     */
     @Deprecated
     public List<LimitViolation> getLimitViolations() {
         return limitViolationsResult.getLimitViolations();
     }
 
+    /**
+     * @deprecated Use getLimitViolationsResult().getActionsTaken() instead.
+     */
     @Deprecated
     public List<String> getActionsTaken() {
         return limitViolationsResult.getActionsTaken();

--- a/security-analysis/src/main/java/com/powsybl/security/PreContingencyResult.java
+++ b/security-analysis/src/main/java/com/powsybl/security/PreContingencyResult.java
@@ -9,6 +9,8 @@ package com.powsybl.security;
 import java.util.List;
 
 /**
+ * @deprecated Use LimitViolationsResult instead.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */

--- a/tools/src/main/java/com/powsybl/tools/CommandLineTools.java
+++ b/tools/src/main/java/com/powsybl/tools/CommandLineTools.java
@@ -63,12 +63,12 @@ public class CommandLineTools {
         Map<String, Collection<Tool>> toolsByTheme = new TreeMap<>(Multimaps.index(allTools, tool -> tool.getCommand().getTheme()).asMap());
         for (Map.Entry<String, Collection<Tool>> entry : toolsByTheme.entrySet()) {
             String theme = entry.getKey();
-            List<Tool> tools = new ArrayList<>(entry.getValue());
-            Collections.sort(tools, Comparator.comparing(t -> t.getCommand().getName()));
             usage.append(theme != null ? theme : "Others").append(":").append(System.lineSeparator());
-            for (Tool tool : tools) {
-                usage.append(String.format("    %-40s %s", tool.getCommand().getName(), tool.getCommand().getDescription())).append(System.lineSeparator());
-            }
+            entry.getValue().stream()
+                .sorted(Comparator.comparing(t -> t.getCommand().getName()))
+                .forEach(tool ->
+                    usage.append(String.format("    %-40s %s", tool.getCommand().getName(), tool.getCommand().getDescription())).append(System.lineSeparator())
+            );
             usage.append(System.lineSeparator());
         }
 

--- a/tools/src/main/java/com/powsybl/tools/Tool.java
+++ b/tools/src/main/java/com/powsybl/tools/Tool.java
@@ -30,6 +30,9 @@ public interface Tool {
         run(line);
     }
 
+    /**
+     * @deprecated Use run(CommandLine, ToolRunningContext) instead.
+     */
     @Deprecated
     default void run(CommandLine line) throws Exception {
     }

--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -217,8 +217,8 @@ public class UcteImporter implements Importer {
 
         UcteNode ucteXnode = ucteNetwork.getNode(ucteXnodeCode);
 
-        LOGGER.warn("Create small impedance dangling line '{}' (coupler connected to XNODE '{}')",
-                xNodeName + yNodeName, ucteXnode.getCode());
+        LOGGER.warn("Create small impedance dangling line '{}{}' (coupler connected to XNODE '{}')",
+                xNodeName, yNodeName, ucteXnode.getCode());
 
         float p0 = 0;
         if (isValueValid(ucteXnode.getActiveLoad())) {
@@ -515,8 +515,8 @@ public class UcteImporter implements Importer {
 
         UcteNode ucteXnode = ucteNetwork.getNode(xNodeCode);
 
-        LOGGER.warn("Create small impedance dangling line '{}' (transformer connected to XNODE '{}')",
-                xNodeName + yNodeName, ucteXnode.getCode());
+        LOGGER.warn("Create small impedance dangling line '{}{}' (transformer connected to XNODE '{}')",
+                xNodeName, yNodeName, ucteXnode.getCode());
 
         float p0 = 0;
         if (isValueValid(ucteXnode.getActiveLoad())) {

--- a/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/io/UcteRecordWriter.java
+++ b/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/io/UcteRecordWriter.java
@@ -9,6 +9,7 @@ package com.powsybl.ucte.network.io;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.util.Locale;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -53,7 +54,8 @@ class UcteRecordWriter {
     }
 
     private String alignAndTruncate(String str, int strLen, Alignment alignment) {
-        String formattedStr = String.format(java.util.Locale.US, "%" + (alignment.equals(Alignment.LEFT) ? "-" : "") + strLen + "s", str);
+        String format = String.format(Locale.US, alignment.equals(Alignment.LEFT) ? "%%-%ds" : "%%%ds", strLen);
+        String formattedStr = String.format(Locale.US, format, str);
         return formattedStr.substring(0, strLen);
     }
 


### PR DESCRIPTION
- Format specifiers should be used instead of string concatenation.
- Use already-defined constant 'TYPE_DESCRIPTION' instead of duplicating its value here.
- Rename "xxx" which hides the field declared at line XX.
- Replace this "Map.get()" and condition with a call to "Map.computeIfAbsent()".
- Add the "@Override" annotation above this method signature
- Put single-quotes around '.' to use the faster "lastIndexOf(char)" method.
- Use the built-in formatting to construct this argument.
- Add the missing @deprecated Javadoc tag.