### PR TITLE
Small fixes in IIDM implementation

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Line.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Line.java
@@ -18,7 +18,7 @@ package com.powsybl.iidm.network;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  * @see LineAdder
  */
-public interface Line extends Branch<Line>, LineCharasteristics<Line> {
+public interface Line extends Branch<Line>, LineCharacteristics<Line> {
 
     boolean isTieLine();
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/LineCharacteristics.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/LineCharacteristics.java
@@ -9,7 +9,7 @@ package com.powsybl.iidm.network;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public interface LineCharasteristics<T> {
+public interface LineCharacteristics<T> {
 
     /**
      * Get the series resistance in &#937;.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TieLine.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TieLine.java
@@ -11,7 +11,7 @@ package com.powsybl.iidm.network;
  */
 public interface TieLine extends Line {
 
-    interface HalfLine extends LineCharasteristics<HalfLine> {
+    interface HalfLine extends LineCharacteristics<HalfLine> {
 
         String getId();
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorImpl.java
@@ -76,7 +76,7 @@ class ShuntCompensatorImpl extends AbstractConnectable<ShuntCompensator> impleme
     @Override
     public ShuntCompensatorImpl setMaximumSectionCount(int maximumSectionCount) {
         ValidationUtil.checkSections(this, getCurrentSectionCount(), maximumSectionCount);
-        float oldValue = this.maximumSectionCount;
+        int oldValue = this.maximumSectionCount;
         this.maximumSectionCount = maximumSectionCount;
         notifyUpdate("maximumSectionCount", oldValue, maximumSectionCount);
         return this;


### PR DESCRIPTION
Rename the LineCharasteristics interface to LineCharacteristics
Fix the type of oldValue in ShuntCompensatorImpl::setMaximumSectionCount