### PR TITLE
Add extension mechanism for loadflow parameters.

### DIFF
--- a/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/LoadFlowActionSimulator.java
+++ b/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/LoadFlowActionSimulator.java
@@ -18,6 +18,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.xml.NetworkXml;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowFactory;
+import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.security.LimitViolation;
 import com.powsybl.security.LimitViolationFilter;
@@ -132,7 +133,7 @@ public class LoadFlowActionSimulator implements ActionSimulator {
         LOGGER.info("Running loadflow ({})", loadFlow.getName());
         LoadFlowResult result;
         try {
-            result = loadFlow.run();
+            result = loadFlow.run(LoadFlowParameters.load());
         } catch (Exception e) {
             throw new PowsyblException(e);
         }

--- a/action/action-simulator/src/test/java/com/powsybl/action/simulator/AbstractLoadFlowRulesEngineTest.java
+++ b/action/action-simulator/src/test/java/com/powsybl/action/simulator/AbstractLoadFlowRulesEngineTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractLoadFlowRulesEngineTest {
         Mockito.when(loadFlowResult.isOk())
                 .thenReturn(true);
         Mockito.when(loadFlow.getName()).thenReturn("load flow mock");
-        Mockito.when(loadFlow.run())
+        Mockito.when(loadFlow.run(Mockito.any()))
                 .thenReturn(loadFlowResult);
         LoadFlowActionSimulatorObserver observer = createObserver();
         GroovyCodeSource src = new GroovyCodeSource(new InputStreamReader(getClass().getResourceAsStream(getDslFile())), "test", GroovyShell.DEFAULT_CODE_BASE);

--- a/action/action-util/src/main/java/com/powsybl/action/util/LoadFlowBasedPhaseShifterOptimizer.java
+++ b/action/action-util/src/main/java/com/powsybl/action/util/LoadFlowBasedPhaseShifterOptimizer.java
@@ -14,6 +14,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowFactory;
+import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +44,7 @@ public class LoadFlowBasedPhaseShifterOptimizer implements PhaseShifterOptimizer
 
     private void runLoadFlow(LoadFlow loadFlow) {
         try {
-            LoadFlowResult result = loadFlow.run();
+            LoadFlowResult result = loadFlow.run(LoadFlowParameters.load());
             if (!result.isOk()) {
                 throw new PowsyblException("Load flow diverged during phase shifter optimization");
             }

--- a/loadflow/loadflow-api/src/main/groovy/com/powsybl/loadflow/LoadFlowGroovyScriptExtension.groovy
+++ b/loadflow/loadflow-api/src/main/groovy/com/powsybl/loadflow/LoadFlowGroovyScriptExtension.groovy
@@ -48,7 +48,7 @@ class LoadFlowGroovyScriptExtension implements GroovyScriptExtension {
         binding.loadFlow = { Network network, LoadFlowParameters parameters = this.parameters ->
             LoadFlowFactory loadFlowFactory = loadFlowFactorySupplier.get()
             LoadFlow loadFlow = loadFlowFactory.create(network, computationManager, 0);
-            loadFlow.run()
+            loadFlow.run(parameters)
         }
     }
 }

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
@@ -18,6 +18,10 @@ public interface LoadFlow extends Versionable {
 
     LoadFlowResult run(LoadFlowParameters parameters) throws Exception;
 
+    /**
+     * @deprecated Use LoadFlowResult run(LoadFlowParameters parameters) instead
+     */
+    @Deprecated
     LoadFlowResult run() throws Exception;
 
     default CompletableFuture<LoadFlowResult> runAsync(String workingStateId, LoadFlowParameters parameters) {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/tools/RunLoadFlowTool.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/tools/RunLoadFlowTool.java
@@ -10,6 +10,7 @@ import com.google.auto.service.AutoService;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.config.ComponentDefaultConfig;
 import com.powsybl.commons.io.table.*;
+import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.tools.Command;
 import com.powsybl.tools.Tool;
 import com.powsybl.tools.ToolRunningContext;
@@ -146,7 +147,7 @@ public class RunLoadFlowTool implements Tool {
             throw new PowsyblException("Case '" + caseFile + "' not found");
         }
         LoadFlow loadFlow = defaultConfig.newFactoryImpl(LoadFlowFactory.class).create(network, context.getComputationManager(), 0);
-        LoadFlowResult result = loadFlow.run();
+        LoadFlowResult result = loadFlow.run(LoadFlowParameters.load());
 
         if (outputFile != null) {
             exportResult(result, context, outputFile, format);

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowExtensionGroovyScriptTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowExtensionGroovyScriptTest.java
@@ -36,7 +36,7 @@ public class LoadFlowExtensionGroovyScriptTest extends AbstractGroovyScriptTest 
         Mockito.when(result.isOk())
                 .thenReturn(true);
         LoadFlow loadFlow = Mockito.mock(LoadFlow.class);
-        Mockito.when(loadFlow.run())
+        Mockito.when(loadFlow.run(Mockito.any()))
                 .thenReturn(result);
         loadFlowFactory = Mockito.mock(LoadFlowFactory.class);
         Mockito.when(loadFlowFactory.create(Mockito.any(Network.class), Mockito.any(ComputationManager.class), Mockito.anyInt()))


### PR DESCRIPTION
- Extensions may be defined in platform config and loaded
  through an instance of LoadFlowParameters.ConfigLoader.
- Deprecate the run() method of the LoadFlow interface