### PR TITLE
Add a default implementation to all deprecated methods

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/config/ModuleConfig.java
+++ b/commons/src/main/java/com/powsybl/commons/config/ModuleConfig.java
@@ -46,7 +46,9 @@ public interface ModuleConfig {
      * @deprecated Use getOptionalIntegerProperty(String) instead.
      */
     @Deprecated
-    Integer getOptionalIntProperty(String name);
+    default Integer getOptionalIntProperty(String name) {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
     Optional<Integer> getOptionalIntegerProperty(String name);
 
@@ -70,7 +72,9 @@ public interface ModuleConfig {
      * @deprecated Use getOptionalBooleanProperty(String) instead.
      */
     @Deprecated
-    Boolean getOptinalBooleanProperty(String name);
+    default Boolean getOptinalBooleanProperty(String name) {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
     Optional<Boolean> getOptionalBooleanProperty(String name);
 

--- a/computation/src/main/java/com/powsybl/computation/CommandExecutor.java
+++ b/computation/src/main/java/com/powsybl/computation/CommandExecutor.java
@@ -17,12 +17,18 @@ import java.nio.file.Path;
 public interface CommandExecutor extends AutoCloseable {
 
     @Deprecated
-    Path getWorkingDir();
+    default Path getWorkingDir() {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
     @Deprecated
-    void start(CommandExecution execution, ExecutionListener listener) throws Exception;
+    default void start(CommandExecution execution, ExecutionListener listener) throws Exception {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
     @Deprecated
-    ExecutionReport start(CommandExecution execution) throws Exception;
+    default ExecutionReport start(CommandExecution execution) throws Exception {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
 }

--- a/computation/src/main/java/com/powsybl/computation/ComputationManager.java
+++ b/computation/src/main/java/com/powsybl/computation/ComputationManager.java
@@ -27,7 +27,9 @@ public interface ComputationManager extends AutoCloseable {
      * @deprecated Use execute(ExecutionEnvironment, ExecutionHandler<R>) instead.
      */
     @Deprecated
-    CommandExecutor newCommandExecutor(Map<String, String> env, String workingDirPrefix, boolean debug) throws Exception;
+    default CommandExecutor newCommandExecutor(Map<String, String> env, String workingDirPrefix, boolean debug) throws Exception {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
     <R> CompletableFuture<R> execute(ExecutionEnvironment environment, ExecutionHandler<R> handler);
 

--- a/computation/src/main/java/com/powsybl/computation/ExecutionHandler.java
+++ b/computation/src/main/java/com/powsybl/computation/ExecutionHandler.java
@@ -28,7 +28,9 @@ public interface ExecutionHandler<R> {
      * @deprecated Use onExecutionCompletion(CommandExecution, int) instead.
      */
     @Deprecated
-    void onProgress(CommandExecution execution, int executionIndex);
+    default void onProgress(CommandExecution execution, int executionIndex) {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
     R after(Path workingDir, ExecutionReport report) throws IOException;
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
@@ -62,7 +62,9 @@ public interface Network extends Container<Network> {
          * @deprecated use getSwitches() instead.
          */
         @Deprecated
-        Iterable<Switch> getSwitchs();
+        default Iterable<Switch> getSwitchs() {
+            throw new UnsupportedOperationException("deprecated");
+        }
 
         /**
          * Get all switches

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
@@ -22,7 +22,9 @@ public interface LoadFlow extends Versionable {
      * @deprecated Use LoadFlowResult run(LoadFlowParameters parameters) instead
      */
     @Deprecated
-    LoadFlowResult run() throws Exception;
+    default LoadFlowResult run() throws Exception {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
     default CompletableFuture<LoadFlowResult> runAsync(String workingStateId, LoadFlowParameters parameters) {
         throw new UnsupportedOperationException();

--- a/security-analysis/src/main/java/com/powsybl/security/SecurityAnalysis.java
+++ b/security-analysis/src/main/java/com/powsybl/security/SecurityAnalysis.java
@@ -35,17 +35,23 @@ public interface SecurityAnalysis {
      * @deprecated Use CompletableFuture<SecurityAnalysisResult> runAsync(ContingenciesProvider, String, SecurityAnalysisParameters) instead
      */
     @Deprecated
-    CompletableFuture<SecurityAnalysisResult> runAsync(ContingenciesProvider contingenciesProvider, String workingStateId, LoadFlowParameters parameters);
+    default CompletableFuture<SecurityAnalysisResult> runAsync(ContingenciesProvider contingenciesProvider, String workingStateId, LoadFlowParameters parameters) {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
     /**
      * @deprecated Use CompletableFuture<SecurityAnalysisResult> runAsync(ContingenciesProvider, String, SecurityAnalysisParameters) instead
      */
     @Deprecated
-    CompletableFuture<SecurityAnalysisResult> runAsync(ContingenciesProvider contingenciesProvider, String workingStateId);
+    default CompletableFuture<SecurityAnalysisResult> runAsync(ContingenciesProvider contingenciesProvider, String workingStateId) {
+        throw new UnsupportedOperationException("deprecated");
+    }
 
     /**
      * @deprecated Use CompletableFuture<SecurityAnalysisResult> runAsync(ContingenciesProvider, String, SecurityAnalysisParameters) instead
      */
     @Deprecated
-    CompletableFuture<SecurityAnalysisResult> runAsync(ContingenciesProvider contingenciesProvider);
+    default CompletableFuture<SecurityAnalysisResult> runAsync(ContingenciesProvider contingenciesProvider) {
+        throw new UnsupportedOperationException("deprecated");
+    }
 }


### PR DESCRIPTION
Add a default implementation to all deprecated methods to be able to safely remove these methods (without compilation issue or synchronization)