### PR TITLE
Generate javadoc also for cim1-model module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,6 @@
                         <additionalOptions>-views -all</additionalOptions>
                         <additionalOptions>-Xdoclint:none</additionalOptions>
                         <useStandardDocletOptions>false</useStandardDocletOptions>
-                        <excludePackageNames>cim1*</excludePackageNames>
                         <docfilessubdirs>true</docfilessubdirs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Fix release generation by generating a javadoc jar also for cim1-model module