### PR TITLE
Keep DSL elements in the same order as they are defined.

### DIFF
--- a/action/action-dsl/src/main/java/com/powsybl/action/dsl/ActionDb.java
+++ b/action/action-dsl/src/main/java/com/powsybl/action/dsl/ActionDb.java
@@ -9,21 +9,18 @@ package com.powsybl.action.dsl;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.contingency.Contingency;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class ActionDb {
 
-    private final Map<String, Contingency> contingencies = new HashMap<>();
+    private final Map<String, Contingency> contingencies = new LinkedHashMap<>();
 
-    private final Map<String, Rule> rules = new HashMap<>();
+    private final Map<String, Rule> rules = new LinkedHashMap<>();
 
-    private final Map<String, Action> actions = new HashMap<>();
+    private final Map<String, Action> actions = new LinkedHashMap<>();
 
     public void addContingency(Contingency contingency) {
         Objects.requireNonNull(contingency);

--- a/action/action-dsl/src/test/java/com/powsybl/action/dsl/ActionDbTest.java
+++ b/action/action-dsl/src/test/java/com/powsybl/action/dsl/ActionDbTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.fail;
 public class ActionDbTest {
 
     @Test
-    public void testContigencies() {
+    public void testContingencies() {
         Contingency contingency = Mockito.mock(Contingency.class);
         Mockito.when(contingency.getId()).thenReturn("id");
 

--- a/action/action-dsl/src/test/java/com/powsybl/action/dsl/GroovyDslContingenciesProviderTest.java
+++ b/action/action-dsl/src/test/java/com/powsybl/action/dsl/GroovyDslContingenciesProviderTest.java
@@ -73,6 +73,24 @@ public class GroovyDslContingenciesProviderTest {
         assertEquals("NHV1_NHV2_1", element.getId());
     }
 
+    @Test
+    public void testOrder() throws IOException {
+        try (Writer writer = Files.newBufferedWriter(dslFile, StandardCharsets.UTF_8)) {
+            writer.write(String.join(System.lineSeparator(),
+                    "contingency('c1') {",
+                    "    equipments 'NHV1_NHV2_1'",
+                    "}",
+                    "contingency('c2') {",
+                    "    equipments 'NHV1_NHV2_2'",
+                    "}"));
+        }
+        List<Contingency> contingencies = new GroovyDslContingenciesProvider(dslFile)
+                .getContingencies(network);
+        assertEquals(2, contingencies.size());
+        assertEquals("c1", contingencies.get(0).getId());
+        assertEquals("c2", contingencies.get(1).getId());
+    }
+
 
     private static Set<String> getContingenciesNames(List<Contingency> contingencies) {
         return contingencies.stream().map(Contingency::getId).collect(Collectors.toSet());


### PR DESCRIPTION
In particular, keep contingency in the same order as they are defined.
Otherwise, execution flow will be different from an execution to another for functionalities such as security-analysis.