### PR TITLE
Constant countries ordering

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -171,7 +171,7 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Mult
 
     @Override
     public Set<Country> getCountries() {
-        return getSubstationStream().map(Substation::getCountry).collect(Collectors.toSet());
+        return getSubstationStream().map(Substation::getCountry).collect(Collectors.toCollection(() -> EnumSet.noneOf(Country.class)));
     }
 
     @Override


### PR DESCRIPTION
Use EnumSet for the countries of a network, in particular to respect a constant order
from call to call to "getCountries".
