### PR TITLE
AFS command line tool improvements

### DIFF
--- a/afs/afs-core/src/main/java/com/powsybl/afs/AppFileSystemTool.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/AppFileSystemTool.java
@@ -8,6 +8,7 @@ package com.powsybl.afs;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.tools.Command;
+import com.powsybl.tools.CommandLineTools;
 import com.powsybl.tools.Tool;
 import com.powsybl.tools.ToolRunningContext;
 import org.apache.commons.cli.CommandLine;
@@ -96,7 +97,8 @@ public class AppFileSystemTool implements Tool {
                 String path = line.getOptionValue(LS);
                 runLs(context, appData, path);
             } else {
-                throw new AfsException("Undefined sub command");
+                Command command = getCommand();
+                CommandLineTools.printCommandUsage(command.getName(), command.getOptions(), command.getUsageFooter(), context.getErrorStream());
             }
         }
     }

--- a/scripting/src/main/groovy/com/powsybl/scripting/groovy/AfsGroovyFacade.groovy
+++ b/scripting/src/main/groovy/com/powsybl/scripting/groovy/AfsGroovyFacade.groovy
@@ -23,7 +23,7 @@ class AfsGroovyFacade {
         this.data = data
     }
 
-    List<String> listFs() {
+    List<String> getFileSystemNames() {
         data.getFileSystems().stream().map({fs -> fs.getName()}).collect(Collectors.toList())
     }
 

--- a/scripting/src/test/java/com/powsybl/scripting/groovy/AfsGroovyScriptTest.java
+++ b/scripting/src/test/java/com/powsybl/scripting/groovy/AfsGroovyScriptTest.java
@@ -25,7 +25,7 @@ public class AfsGroovyScriptTest extends AbstractGroovyScriptTest {
     @Override
     protected Reader getCodeReader() {
         return new StringReader(String.join(System.lineSeparator(),
-                "println afs.listFs()",
+                "println afs.fileSystemNames",
                 "project = afs.getRootFolder('mem').createProject('test')",
                 "print project.getName()"
         ));

--- a/tools/src/main/java/com/powsybl/tools/CommandLineTools.java
+++ b/tools/src/main/java/com/powsybl/tools/CommandLineTools.java
@@ -104,7 +104,7 @@ public class CommandLineTools {
         return optionsWithHelp;
     }
 
-    private void printCommandUsage(String name, Options options, String usageFooter, PrintStream err) {
+    public static void printCommandUsage(String name, Options options, String usageFooter, PrintStream err) {
         HelpFormatter formatter = new HelpFormatter();
         PrintWriter writer = new PrintWriter(err);
 


### PR DESCRIPTION
- print the usage instead of throwing an exception if the sub command is not pass
- rename listFs function to getFileSystemNames