### PR TITLE
Add arbitrary "CandidateComputation" for loadflow validation

### DIFF
--- a/loadflow/loadflow-validation/pom.xml
+++ b/loadflow/loadflow-validation/pom.xml
@@ -47,6 +47,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-impl</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputation.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2018, All partners of the iTesla project (http://www.itesla-project.eu/consortium)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.loadflow.validation;
+
+import com.powsybl.computation.ComputationManager;
+import com.powsybl.iidm.network.Network;
+
+/**
+ * A computation carried out on a network, which result
+ * may be validated through the validation tool.
+ *
+ * All computation tools which want to pass the validation tests
+ * must implement that interface and register itself as a known
+ * candidate through the use of @AutoService.
+ *
+ * Must be thread-safe.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ */
+public interface CandidateComputation {
+
+    /**
+     * A name which uniquely identifies that computation.
+     */
+    String getName();
+
+    /**
+     * A computation carried out on the {@param network}.
+     */
+    void run(Network network, ComputationManager computationManager) throws Exception;
+
+}

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, All partners of the iTesla project (http://www.itesla-project.eu/consortium)
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputation.java
@@ -31,6 +31,6 @@ public interface CandidateComputation {
     /**
      * A computation carried out on the {@param network}.
      */
-    void run(Network network, ComputationManager computationManager) throws Exception;
+    void run(Network network, ComputationManager computationManager);
 
 }

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputations.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputations.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2018, All partners of the iTesla project (http://www.itesla-project.eu/consortium)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.loadflow.validation;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+/**
+ * Provides access to the list of known candidate computations.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ */
+public final class CandidateComputations {
+
+    //Lazy initialization of the list of computations
+    private static final Supplier<List<CandidateComputation>> COMPUTATIONS =
+            Suppliers.memoize(() -> ImmutableList.copyOf(ServiceLoader.load(CandidateComputation.class)));
+
+    private CandidateComputations() {
+    }
+
+    /**
+     * Get the list of all known candidate computations implementations.
+     */
+    public static List<CandidateComputation> getComputations() {
+        return COMPUTATIONS.get();
+    }
+
+    /**
+     * Get the list of all known candidate computations names.
+     */
+    public static List<String> getComputationsNames() {
+        return getComputations().stream().map(CandidateComputation::getName).collect(Collectors.toList());
+    }
+
+    /**
+     * Get a candidate computation by its name.
+     */
+    public static Optional<CandidateComputation> getComputation(String name) {
+        return getComputations().stream().filter(c -> c.getName().equals(name)).findFirst();
+    }
+
+}

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputations.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputations.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, All partners of the iTesla project (http://www.itesla-project.eu/consortium)
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/LoadFlowComputation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/LoadFlowComputation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, All partners of the iTesla project (http://www.itesla-project.eu/consortium)
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/LoadFlowComputation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/LoadFlowComputation.java
@@ -37,14 +37,18 @@ public class LoadFlowComputation implements CandidateComputation {
      * Returns the loadflow factory configured in "loadflow-validation" module,
      * or else the default platform loadflow factory.
      */
-    private static LoadFlowFactory getLoadFlowFactory() throws IllegalAccessException, InstantiationException {
+    private static LoadFlowFactory getLoadFlowFactory() {
 
         PlatformConfig platformConfig = PlatformConfig.defaultConfig();
 
         if (platformConfig.moduleExists("loadflow-validation")) {
             ModuleConfig config = platformConfig.getModuleConfig("loadflow-validation");
             if (config.hasProperty("load-flow-factory")) {
-                return config.getClassProperty("load-flow-factory", LoadFlowFactory.class).newInstance();
+                try {
+                    return config.getClassProperty("load-flow-factory", LoadFlowFactory.class).newInstance();
+                } catch (InstantiationException | IllegalAccessException e) {
+                    throw new PowsyblException("Could not instantiate load flow factory.", e);
+                }
             }
         }
 
@@ -52,7 +56,7 @@ public class LoadFlowComputation implements CandidateComputation {
     }
 
     @Override
-    public void run(Network network, ComputationManager computationManager) throws Exception {
+    public void run(Network network, ComputationManager computationManager) {
         Objects.requireNonNull(network);
         Objects.requireNonNull(computationManager);
 

--- a/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/CandidateComputationsTest.java
+++ b/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/CandidateComputationsTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.loadflow.validation;
 
 import com.google.auto.service.AutoService;
@@ -28,8 +34,8 @@ import static org.junit.Assert.*;
  */
 public class CandidateComputationsTest {
 
-    InMemoryPlatformConfig platformConfig;
-    FileSystem fileSystem;
+    private InMemoryPlatformConfig platformConfig;
+    private FileSystem fileSystem;
 
     private static <T> Supplier<T> failure() {
         return () -> {
@@ -61,7 +67,7 @@ public class CandidateComputationsTest {
     }
 
     @Test
-    public void runDummyComputation() throws Exception {
+    public void runDummyComputation() {
         Network network = EurostagTutorialExample1Factory.create();
 
         CandidateComputation computation = CandidateComputations.getComputation("dummy").orElseGet(failure());

--- a/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/CandidateComputationsTest.java
+++ b/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/CandidateComputationsTest.java
@@ -1,0 +1,59 @@
+package com.powsybl.loadflow.validation;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.computation.ComputationManager;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ */
+public class CandidateComputationsTest {
+
+    private static <T> Supplier<T> failure() {
+        return () -> {
+            fail();
+            return null;
+        };
+    }
+
+    @Test
+    public void loadFlowExists() {
+        CandidateComputation computation = CandidateComputations.getComputation("loadflow")
+                .orElseGet(failure());
+        assertNotNull(computation);
+        assertEquals("loadflow", computation.getName());
+    }
+
+    @AutoService(CandidateComputation.class)
+    public static class DummyComputation implements CandidateComputation {
+
+        @Override
+        public String getName() {
+            return "dummy";
+        }
+
+        @Override
+        public void run(Network network, ComputationManager computationManager) throws Exception {
+            network.getGenerator("GEN").getTerminal().setP(126f);
+        }
+    }
+
+    @Test
+    public void runDummyComputation() throws Exception {
+        Network network = EurostagTutorialExample1Factory.create();
+
+        CandidateComputation computation = CandidateComputations.getComputation("dummy").orElseGet(failure());
+        assertNotNull(computation);
+        assertEquals("dummy", computation.getName());
+
+        computation.run(network, null);
+        assertEquals(126f, network.getGenerator("GEN").getTerminal().getP(), 0f);
+    }
+
+}

--- a/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/CandidateComputationsTest.java
+++ b/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/CandidateComputationsTest.java
@@ -1,11 +1,24 @@
 package com.powsybl.loadflow.validation;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.config.InMemoryPlatformConfig;
+import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.loadflow.*;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.*;
@@ -14,6 +27,9 @@ import static org.junit.Assert.*;
  * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
  */
 public class CandidateComputationsTest {
+
+    InMemoryPlatformConfig platformConfig;
+    FileSystem fileSystem;
 
     private static <T> Supplier<T> failure() {
         return () -> {
@@ -39,7 +55,7 @@ public class CandidateComputationsTest {
         }
 
         @Override
-        public void run(Network network, ComputationManager computationManager) throws Exception {
+        public void run(Network network, ComputationManager computationManager) {
             network.getGenerator("GEN").getTerminal().setP(126f);
         }
     }
@@ -56,4 +72,73 @@ public class CandidateComputationsTest {
         assertEquals(126f, network.getGenerator("GEN").getTerminal().getP(), 0f);
     }
 
+    @Test
+    public void listComputationsNames() {
+        assertTrue(ImmutableSet.copyOf(CandidateComputations.getComputationsNames()).containsAll(ImmutableSet.of("dummy", "loadflow")));
+    }
+
+
+    @Test
+    public void listComputations() {
+        assertTrue(ImmutableSet.copyOf(CandidateComputations.getComputationsNames()).containsAll(ImmutableSet.of("dummy", "loadflow")));
+        assertEquals(ImmutableSet.of("dummy", "loadflow"), ImmutableSet.copyOf(CandidateComputations.getComputationsNames()));
+    }
+
+    @Before
+    public void setUp() {
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
+        platformConfig = new InMemoryPlatformConfig(fileSystem);
+        PlatformConfig.setDefaultConfig(platformConfig);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        fileSystem.close();
+    }
+
+    public static class LoadFlowFactoryMock implements LoadFlowFactory {
+
+        @Override
+        public LoadFlow create(Network network, ComputationManager computationManager, int priority) {
+            return new LoadFlow() {
+
+                @Override
+                public LoadFlowResult run(LoadFlowParameters parameters) throws Exception {
+                    return null;
+                }
+
+                @Override
+                public CompletableFuture<LoadFlowResult> runAsync(String workingStateId, LoadFlowParameters parameters) {
+                    network.getGenerator("GEN").getTerminal().setP(92f);
+                    return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), ""));
+                }
+
+                @Override
+                public String getName() {
+                    return "loadflow-mock";
+                }
+
+                @Override
+                public String getVersion() {
+                    return null;
+                }
+            };
+        }
+    }
+
+
+    @Test
+    public void runLoadFlowMock() throws Exception {
+
+        platformConfig.createModuleConfig("loadflow-validation").setClassProperty("load-flow-factory", LoadFlowFactoryMock.class);
+
+        Network network = EurostagTutorialExample1Factory.create();
+
+        CandidateComputation computation = CandidateComputations.getComputation("loadflow").orElseGet(failure());
+        assertNotNull(computation);
+        assertEquals("loadflow", computation.getName());
+
+        computation.run(network, Mockito.mock(ComputationManager.class));
+        assertEquals(92f, network.getGenerator("GEN").getTerminal().getP(), 0f);
+    }
 }


### PR DESCRIPTION
 - Add "CandidateComputation" interface for validation.
 - Add a command line option "--run-computation <COMPUTATION>" to select which
"CandidateComputation" to run.
 - Add loadflow based implementation