### PR TITLE
Ability to import UCTE files with line and transformer with same ID

### DIFF
--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -25,7 +25,10 @@ import com.powsybl.ucte.network.io.UcteReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
@@ -94,7 +97,7 @@ public class UcteImporter implements Importer {
             }
 
             if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace("Create bus '{}'", ucteNodeCode.toString());
+                LOGGER.trace("Create bus '{}'", ucteNodeCode);
             }
 
             Bus bus = voltageLevel.getBusBreakerView().newBus()
@@ -656,6 +659,18 @@ public class UcteImporter implements Importer {
         return connected;
     }
 
+    private static void addTapChangers(UcteNetworkExt ucteNetwork, UcteTransformer ucteTransfo, TwoWindingsTransformer transformer) {
+        UcteRegulation ucteRegulation = ucteNetwork.getRegulation(ucteTransfo.getId());
+        if (ucteRegulation != null) {
+            if (ucteRegulation.getPhaseRegulation() != null) {
+                createRatioTapChanger(ucteRegulation.getPhaseRegulation(), transformer);
+            }
+            if (ucteRegulation.getAngleRegulation() != null) {
+                createPhaseTapChanger(ucteRegulation.getAngleRegulation(), transformer);
+            }
+        }
+    }
+
     private static void createTransformers(UcteNetworkExt ucteNetwork, Network network, EntsoeFileName ucteFileName) {
         for (UcteTransformer ucteTransfo : ucteNetwork.getTransformers()) {
             UcteNodeCode nodeCode1 = ucteTransfo.getId().getNodeCode1();
@@ -708,15 +723,7 @@ public class UcteImporter implements Importer {
                     .add();
             }
 
-            UcteRegulation ucteRegulation = ucteNetwork.getRegulation(ucteTransfo.getId());
-            if (ucteRegulation != null) {
-                if (ucteRegulation.getPhaseRegulation() != null) {
-                    createRatioTapChanger(ucteRegulation.getPhaseRegulation(), transformer);
-                }
-                if (ucteRegulation.getAngleRegulation() != null) {
-                    createPhaseTapChanger(ucteRegulation.getAngleRegulation(), transformer);
-                }
-            }
+            addTapChangers(ucteNetwork, ucteTransfo, transformer);
         }
     }
 

--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -280,6 +280,7 @@ public class UcteImporter implements Importer {
 
         // create coupler between YNODE and other node
         xNodeVoltageLevel.getBusBreakerView().newSwitch()
+                .setEnsureIdUnicity(true)
                 .setId(ucteLine.getId().toString())
                 .setBus1(yNodeName)
                 .setBus2(ucteOtherNodeCode.toString())
@@ -354,6 +355,7 @@ public class UcteImporter implements Importer {
             // standard coupler
             VoltageLevel voltageLevel = network.getVoltageLevel(ucteVoltageLevel1.getName());
             voltageLevel.getBusBreakerView().newSwitch()
+                    .setEnsureIdUnicity(true)
                     .setId(ucteLine.getId().toString())
                     .setBus1(nodeCode1.toString())
                     .setBus2(nodeCode2.toString())
@@ -373,6 +375,7 @@ public class UcteImporter implements Importer {
         }
         VoltageLevel voltageLevel = network.getVoltageLevel(ucteVoltageLevel1.getName());
         voltageLevel.getBusBreakerView().newSwitch()
+                .setEnsureIdUnicity(true)
                 .setId(ucteLine.getId().toString())
                 .setBus1(nodeCode1.toString())
                 .setBus2(nodeCode2.toString())
@@ -386,6 +389,7 @@ public class UcteImporter implements Importer {
         LOGGER.trace("Create line '{}'", ucteLine.getId());
 
         Line l = network.newLine()
+                .setEnsureIdUnicity(true)
                 .setId(ucteLine.getId().toString())
                 .setVoltageLevel1(ucteVoltageLevel1.getName())
                 .setVoltageLevel2(ucteVoltageLevel2.getName())
@@ -616,6 +620,7 @@ public class UcteImporter implements Importer {
 
         // create a transformer connected to the YNODE and other node
         return substation.newTwoWindingsTransformer()
+                .setEnsureIdUnicity(true)
                 .setId(ucteTransfo.getId().toString())
                 .setVoltageLevel1(voltageLevelId1)
                 .setVoltageLevel2(voltageLevelId2)
@@ -679,6 +684,7 @@ public class UcteImporter implements Importer {
             } else {
                 // standard transformer
                 transformer = substation.newTwoWindingsTransformer()
+                        .setEnsureIdUnicity(true)
                         .setId(ucteTransfo.getId().toString())
                         .setVoltageLevel1(ucteVoltageLevel2.getName())
                         .setVoltageLevel2(ucteVoltageLevel1.getName())

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
@@ -76,4 +76,14 @@ public class UcteImporterTest {
         MergedXnode mergedXnode = l.getExtension(MergedXnode.class);
         assertNotNull(mergedXnode);
     }
+
+    @Test
+    public void lineAndTransformerSameId() {
+        ReadOnlyMemDataSource dataSource = DataSourceUtil.createReadOnlyMemDataSource("sameId.uct", getClass().getResourceAsStream("/sameId.uct"));
+        Network network = new UcteImporter().importData(dataSource, null);
+
+        assertEquals(0, network.getLineCount());
+        assertEquals(1, network.getTwoWindingsTransformerCount());
+        assertEquals(1, network.getSwitchStream().count());
+    }
 }

--- a/ucte/ucte-converter/src/test/resources/sameId.uct
+++ b/ucte/ucte-converter/src/test/resources/sameId.uct
@@ -1,0 +1,13 @@
+##C 2007.05.01
+Test case to check the import of a file with a line and a transformer with identical
+node-node-order "identifier".
+##N
+##ZFR
+ISSUE 21              0 0 217.41       0       0       0       0       0       0       0       0
+ISSUE 22              0 0 217.42       0       0       0       0       0       0       0       0                                 
+##L
+ISSUE 21 ISSUE 22 1 7      0 0.0000        0   5051
+##T
+ISSUE 21 ISSUE 22 1 0 126.0 220.0 160.0 0.2700 9.7300 -20.1200      0    733
+##R
+ISSUE 21 ISSUE 22 1 1.090 11   0


### PR DESCRIPTION
- In UCTE importer, leave possibility to have transformers and lines with same IDs.

  This is allowed by the format. A more accurate solution should still forbid 2 lines
  to have the same ID, or 2 transformers to have the same ID, and maybe have a
  custom ID in that case.
- Add corresponding unit test.