### PR TITLE
Fix extensions export with bus breaker topology level

### DIFF
--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/BusbarSectionExt.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/BusbarSectionExt.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/BusbarSectionExt.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/BusbarSectionExt.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.test;
+
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.BusbarSection;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ */
+public class BusbarSectionExt extends AbstractExtension<BusbarSection> {
+
+    public BusbarSectionExt(BusbarSection busbarSection) {
+        super(busbarSection);
+    }
+
+    @Override
+    public String getName() {
+        return "busbarSectionExt";
+    }
+}

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
@@ -55,6 +55,8 @@ abstract class AbstractIdentifiableXml<T extends Identifiable, A extends Identif
         if (hasSubElements || identifiable.hasProperty()) {
             context.getWriter().writeEndElement();
         }
+
+        context.addExportedEquipment(identifiable);
     }
 
     protected void readUntilEndRootElement(XMLStreamReader reader, XmlUtil.XmlEventHandler eventHandler) throws XMLStreamException {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -151,7 +151,13 @@ public final class NetworkXml implements XmlConstants {
     }
 
     private static void writeExtensions(Network n, NetworkXmlWriterContext context) throws XMLStreamException {
+
         for (Identifiable<?> identifiable : n.getIdentifiables()) {
+
+            if (!context.isExportedEquipment(identifiable)) {
+                continue;
+            }
+
             Collection<? extends Extension<? extends Identifiable<?>>> extensions = identifiable.getExtensions();
             if (!extensions.isEmpty()) {
                 context.getWriter().writeStartElement(IIDM_URI, EXTENSION_ELEMENT_NAME);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlWriterContext.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlWriterContext.java
@@ -7,8 +7,12 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.Identifiable;
 
 import javax.xml.stream.XMLStreamWriter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -18,12 +22,15 @@ public class NetworkXmlWriterContext extends XmlContext implements XmlWriterCont
     private final XMLStreamWriter writer;
     private final XMLExportOptions options;
     private final BusFilter filter;
+    private final Set<Identifiable> exportedEquipments;
 
     NetworkXmlWriterContext(Anonymizer anonymizer, XMLStreamWriter writer, XMLExportOptions options, BusFilter filter) {
         super(anonymizer);
         this.writer = writer;
         this.options = options;
         this.filter = filter;
+
+        this.exportedEquipments = new HashSet<>();
     }
 
     @Override
@@ -37,5 +44,17 @@ public class NetworkXmlWriterContext extends XmlContext implements XmlWriterCont
 
     public BusFilter getFilter() {
         return filter;
+    }
+
+    public Set<Identifiable> getExportedEquipments() {
+        return Collections.unmodifiableSet(exportedEquipments);
+    }
+
+    public void addExportedEquipment(Identifiable<?> equipment) {
+        exportedEquipments.add(equipment);
+    }
+
+    public boolean isExportedEquipment(Identifiable<?> equipment) {
+        return exportedEquipments.contains(equipment);
     }
 }

--- a/iidm/iidm-xml-converter/src/test/resources/xsd/busbarSectionExt.xsd
+++ b/iidm/iidm-xml-converter/src/test/resources/xsd/busbarSectionExt.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.itesla_project.eu/schema/iidm/ext/busbarSectionExt/1_0"
+           elementFormDefault="qualified">
+    <xs:element name="busbarSectionExt">
+        <xs:complexType/>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
Node breaker files with extensions for busbar sections or switches, when exported in bus breaker topology, would not be reimported because those extensions do not have any more their corresponding "identifiable".

Now, we maintain a set of actually exported identifiables, and only export extensions for those identifiables.