### PR TITLE
Fix AMPL export for SVCs (per-unit instead of S).

### DIFF
--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplConstants.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplConstants.java
@@ -21,6 +21,9 @@ public final class AmplConstants {
 
     public static final Locale LOCALE = Locale.US;
 
+    /**
+     * Base power for computations = 100 MVA.
+     */
     public static final float SB = 100f;
 
     public static final String LEG1_SUFFIX = "_leg1";

--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
@@ -1343,8 +1343,8 @@ public class AmplNetworkWriter {
                                                                   new Column("bus"),
                                                                   new Column(CON_BUS),
                                                                   new Column(SUBSTATION),
-                                                                  new Column("minB (S)"),
-                                                                  new Column("maxB (S)"),
+                                                                  new Column("minB (pu)"),
+                                                                  new Column("maxB (pu)"),
                                                                   new Column(V_REGUL),
                                                                   new Column(TARGET_V),
                                                                   new Column(FAULT),
@@ -1367,14 +1367,15 @@ public class AmplNetworkWriter {
 
                 float vlSet = svc.getVoltageSetPoint();
                 float vb = t.getVoltageLevel().getNominalV();
+                float zb = vb * vb / AmplConstants.SB; //Base impedance
 
                 int vlNum = mapper.getInt(AmplSubset.VOLTAGE_LEVEL, t.getVoltageLevel().getId());
                 formatter.writeCell(num)
                         .writeCell(busNum)
                         .writeCell(conBusNum)
                         .writeCell(vlNum)
-                        .writeCell(svc.getBmin())
-                        .writeCell(svc.getBmax())
+                        .writeCell(svc.getBmin() * zb)
+                        .writeCell(svc.getBmax() * zb)
                         .writeCell(svc.getRegulationMode().equals(RegulationMode.VOLTAGE))
                         .writeCell(vlSet / vb)
                         .writeCell(faultNum)

--- a/ampl-converter/src/test/resources/inputs/svc-test-case.txt
+++ b/ampl-converter/src/test/resources/inputs/svc-test-case.txt
@@ -1,3 +1,3 @@
 #Static VAR compensators (svcTestCase/InitialState)
-#"num" "bus" "con. bus" "substation" "minB (S)" "maxB (S)" "v regul." "targetV (pu)" "fault" "curative" "id" "description" "P (MW)" "Q (MVar)"
-1 2 2 2 0.000200000 0.000800000 true 1.02632 0 0 "SVC2" "SVC2" -99999.0 -99999.0
+#"num" "bus" "con. bus" "substation" "minB (pu)" "maxB (pu)" "v regul." "targetV (pu)" "fault" "curative" "id" "description" "P (MW)" "Q (MVar)"
+1 2 2 2 0.288800 1.15520 true 1.02632 0 0 "SVC2" "SVC2" -99999.0 -99999.0


### PR DESCRIPTION
Export of B min and max for SVCs was not consistent with other equipments.