### PR TITLE
Add powsybl-afs-ws-client to distribution core pom.

### DIFF
--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -90,6 +90,11 @@
             <artifactId>powsybl-afs-storage-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-afs-ws-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Add powsybl-afs-ws-client to distribution core pom.
This enables using rest-app-file-system with itools.