### PR TITLE
Add javadoc to AFS API and underlying storage API.

### DIFF
--- a/afs/GettingStarted.md
+++ b/afs/GettingStarted.md
@@ -31,9 +31,9 @@ Below, you will learn:
  - how to **use** the AFS API in your application
  - how you can **extend** and customize AFS for your needs
 
-## 1- Using AFS
+# 1- Using AFS
 
-#### Using AFS in your java application
+### Using AFS in your java application
 
 In order to use AFS in your application, you will first need to add some dependencies to your project:
  - `powsybl-afs-core` to use the core API in your code
@@ -87,7 +87,7 @@ my-first-fs
     +--my-first-project
 ```
 
-#### Using AFS from groovy scripts
+### Using AFS from groovy scripts
 
 Your configured AFS is also accessible from groovy. This comes in 2 flavours, either with an interactive console using the powsybl shell `powsyblsh`:
 ```bash
@@ -111,7 +111,8 @@ myFirstProject = afs.getRootFolder("my-first-fs")
                     .createProject("my-first-project");
 ```
 
-#### Using actual business objects
+
+### Using actual business objects
 
 All this is fine, but the primary goal of AFS is to manage your **business objects**, which we have not seen so far.
 
@@ -171,7 +172,7 @@ Network network = myImportedCase.getNetwork();
 ```
 
 
-#### Using a remote file system
+### Using a remote file system
 
 Powsybl provides a special implementation of application file system storage which forwards calls, through a REST API, to a remote AFS server. The server may use any storage implementation itself, for example the mapdb implementation.
 
@@ -195,21 +196,21 @@ This allows for great flexibility in the deployment of your application, for ins
 **Note:**
 The underlying REST API is documented at http://my-afs-server:8080/my-server-app/rest/swagger
 
-#### Listeners
+### Listeners
 
 TO BE COMPLETED
 
-#### Services
+### Services
 
 TO BE COMPLETED
 
-#### Dependencies
+### Dependencies
 
 TO BE COMPLETED
 
-## 2- Extending AFS for your needs
+# 2- Extending AFS for your needs
 
-#### 2.1 Adding your own file types
+### 2.1 Adding your own file types
 
 Powsybl-core already comes with a number of project file types:
  - Imported cases and virtual cases
@@ -323,6 +324,6 @@ myFooFile.runSomeCoolComputation()
 ```
 
 
-#### 2.2 Adding your own storage implementation
+### 2.2 Adding your own storage implementation
 
 TODO

--- a/afs/GettingStarted.md
+++ b/afs/GettingStarted.md
@@ -1,0 +1,328 @@
+# Getting started with AFS
+
+**AFS** stands for **A**pplication **F**ile**S**ystem.
+
+An AFS is meant to be used to organize your **business** data and store them,
+like a file system does for plain files.
+
+The structure of an AFS looks like:
+
+```
+   AppData
+     +-- FileSystem1
+     |   +-- File1
+     |   +-- File2
+     |   +-- Project1
+     |   |   +-- RootFolder
+     |   |       +-- ProjectFile1
+     |   |       +-- ProjectFolder1
+     |   |       |   +-- ProjectFile2
+     |   |       +-- ProjectFolder2
+     |   |           +-- ProjectFile3
+     |   +-- Project2
+     |      ...
+     |
+     +-- FileSystem2
+         ...
+```
+where each "project file" may represent a business object, for instance a network or a list of contingencies, or even a computation.
+
+Below, you will learn:
+ - how to **use** the AFS API in your application
+ - how you can **extend** and customize AFS for your needs
+
+## 1- Using AFS
+
+#### Using AFS in your java application
+
+In order to use AFS in your application, you will first need to add some dependencies to your project:
+ - `powsybl-afs-core` to use the core API in your code
+ - an actual implementation available at runtime: powsybl comes with `powsyl-afs-mapdb` for prototyping
+ - basic file types defined as extensions of the core: `powsybl-afs-ext-base`.
+
+For instance, if you use maven, in the dependencies section:
+```xml
+<dependency>
+  <groupId>com.powsybl</groupId>
+  <artifactId>powsybl-afs-core</artifactId>
+</dependency>
+<dependency>
+  <groupId>com.powsybl</groupId>
+  <artifactId>powsybl-afs-ext-base</artifactId>
+</dependency>
+<dependency>
+  <groupId>com.powsybl</groupId>
+  <artifactId>powsybl-afs-mapdb</artifactId>
+  <scope>runtime</scope>
+</dependency>
+```
+
+By default, powsybl will load application file system depending on your platform configuration (file *${HOME}/.itools/config.xml*). To tell AFS where it should store its data, you will need to configure your mapdb file system:
+```xml
+<mapdb-app-file-system>
+  <drive-name>my-first-fs</drive-name>
+  <db-file>/path/to/my/mapdb/file</db-file>
+</mapdb-app-file-system>
+```
+Here, we have defined a mapdb based file system, which will be named *my-first-fs* in your application, and stored in the file */path/to/my/mapdb/file*.
+
+Now, from your application, you will be able to interact with that file system. For example, you can create directories and projects:
+```java
+//Build an instance of AppData
+ComputationManager c = LocalComputationManager.getDefault(); //Do not pay attention to this part
+AppData appData = new AppData(c, c);
+
+//Get your file system
+AppFileSystem myFirstFs = appData.getFileSystem("my-first-fs");
+//Create a new folder at the root of you file system, and a new project in that folder.
+Project myFirstProject = myFirstFs.getRootFolder()
+         .createFolder("my-first-folder")
+         .createProject("my-first-project");
+```
+
+Everything that we have just created will be persisted to your mapdb file. Your file system tree now looks like:
+```
+my-first-fs
+  +-- my-first-folder
+    +--my-first-project
+```
+
+#### Using AFS from groovy scripts
+
+Your configured AFS is also accessible from groovy. This comes in 2 flavours, either with an interactive console using the powsybl shell `powsyblsh`:
+```bash
+powsyblsh
+groovy:000> :register com.powsybl.scripting.groovy.InitPowsybl
+groovy:000> :init_powsybl
+groovy:000> import com.powsybl.contingency.*
+groovy:000>
+```
+
+or using the `itools` command to execute a groovy script:
+```bash
+itools run-script --file my_script.groovy
+```
+
+From groovy code, powsybl provides a variable called `afs` which exposes base methods to access configured file systems. You can then simply perform the same thing as in the java section this way:
+```groovy
+//Create a new folder at the root of you file system, and a new project in that folder.
+myFirstProject = afs.getRootFolder("my-first-fs")
+                    .createFolder("my-first-folder")
+                    .createProject("my-first-project");
+```
+
+#### Using actual business objects
+
+All this is fine, but the primary goal of AFS is to manage your **business objects**, which we have not seen so far.
+
+AFS is fully extendable with your own type of files, but it already comes with a few basic types for grid studies. The most basic one may be the `ImportedCase` type, which expose a `Network` object to the API.
+
+Such files may only be created inside a project. Projects may be seen as a kind of workspace for a particular study or computation. Inside of a project, we can import a case from a file representing a network, for example an XIIDM file or a UCTE file.
+
+In java:
+```java
+ImportedCase myImportedCase = myFirstProject.getRootFolder()
+              .fileBuilder(ImportedCaseBuilder.class)
+              .withName("my-imported-case")
+              .withFile(Paths.get("path/to/network.xiidm"))
+              .build();
+```
+
+or in groovy with a nice, simplified syntax:
+```groovy
+myImportedCase = myFirstProject.getRootFolder().buildImportedCase {
+              name "my-imported-case"
+              file Paths.get("path/to/network.xiidm")
+            }
+```
+
+Now our tree looks like:
+```
+my-first-fs
+  +-- my-first-folder
+    +-- my-first-project
+      +-- "my-imported-case"
+```
+
+You can then use the methods exposed by your imported case to carry out some business related logic:
+
+```java
+//use stored network
+Network network = myImportedCase.getNetwork();
+//Carry out some computations ...
+...
+//Query stored network to get all substations names
+System.out.println(myImportedCase.queryNetwork(ScriptType.GROOVY,
+                            "network.substationStream.map {it.name} collect()"))
+```
+
+Of course, you can later retrieve your imported case from another execution or from another application, once it has been persisted to the underlying storage:
+```java
+//From another application:
+ImportedCase importedCase = appData.getFileSystem("my-first-fs")
+                                   .getRootFolder()
+                                   .getChild(Project.class, "my-first-folder/my-first-project/").get()
+                                   .getRootFolder().getChild("my-imported-case")
+                                   .orElseThrow(() -> new RuntimeException("Not found"));
+
+Network network = myImportedCase.getNetwork();
+//Do some stuff with network
+...
+```
+
+
+#### Using a remote file system
+
+Powsybl provides a special implementation of application file system storage which forwards calls, through a REST API, to a remote AFS server. The server may use any storage implementation itself, for example the mapdb implementation.
+
+That feature makes it easy to store data on a remote server.
+
+In order to use it you will need to :
+ - package in a war and deploy `powsybl-afs-ws-server` in a JEE server, like Wildfly
+ - configure app file systems in the server powsybl configuration file, for instance defining a mapdb file system as above
+ - add `powsybl-afs-ws-client` to the runtime dependencies of your client application
+ - configure in the powsybl configuration of your application the following rest file system:
+```xml
+<rest-app-file-system>
+  <url-address>http://my-afs-server:8080/my-server-app</url-address>
+</rest-app-file-system>
+```
+
+Now all file systems defined in the server configurations will be transparently accessible from your client application, without changing any of your code!
+
+This allows for great flexibility in the deployment of your application, for instance to run the same application as standalone or client/server.
+
+**Note:**
+The underlying REST API is documented at http://my-afs-server:8080/my-server-app/rest/swagger
+
+#### Listeners
+
+TO BE COMPLETED
+
+#### Services
+
+TO BE COMPLETED
+
+#### Dependencies
+
+TO BE COMPLETED
+
+## 2- Extending AFS for your needs
+
+#### 2.1 Adding your own file types
+
+Powsybl-core already comes with a number of project file types:
+ - Imported cases and virtual cases
+ - Contingency stores
+ - Action scripts
+ - Security analysis runner: an object from which you can launch a security analysis
+
+However, you will probably want to extend that list with your own type of data or computation. AFS provides an easy way to do so.
+
+Each project file type in AFS relies on the definition of 3 classes:
+ - The actual new type, which must extends ProjectFile
+ - A builder class for the new type, which must extends ProjectFile
+ - An extension class, in charge of registering the new type and its builder to AFS. It must implement the ProjectFileExtension interface, and be registered through the use of `@AutoService` annotation.
+
+First define you new type :
+```java
+class FooFile extends ProjectFile {
+
+    FooFile(ProjectFileCreationContext context) {
+        super(context, 0);
+    }
+
+    public void doSomeCoolStuff() { ... }
+    public Foo getSomeCoolData() { ... }
+    public FooResult runSomeCoolComputation() { ... }
+}
+```
+
+Then define how to build it. This involves at least creating a new node in the underlying storage, and may involve writing some data blob or defining depencencies to other nodes:
+```java
+class FooFileBuilder implements ProjectFileBuilder<FooFile> {
+
+    private final ProjectFileBuildContext context;
+    private String name;
+
+    FooFileBuilder(ProjectFileBuildContext context) {
+        this.context = Objects.requireNonNull(context);
+    }
+
+    public FooFileBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    //Storeds new node information in underlying storage, and builds actual object
+    @Override
+    public FooFile build() {
+        if (name == null) {
+            throw new IllegalStateException("name is not set");
+        }
+        String pseudoClass = "foo";
+
+        //Create new node in storage
+        NodeInfo info = context.getStorage().createNode(context.getFolderInfo().getId(), name, pseudoClass, "", 0, new NodeGenericMetadata());
+
+        //Possibly, write data to storage
+        try (OutputStream os = storage.writeBinaryData(info.getId(), "my_data")) {
+            os.write(...);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        //Possibly, add dependencies to other nodes
+        context.getStorage().addDependency(info.getId(), "my_dependency", dependencyNodeId);
+
+        //Return new object
+        return new FooFile(new ProjectFileCreationContext(info,
+                                                          context.getStorage(),
+                                                          context.getProject()));
+    }
+}
+```
+
+Finally, register your new type and its builder type through and extension class:
+```java
+@AutoService(ProjectFileExtension.class)
+public class FooFileExtension implements ProjectFileExtension<FooFile, FooFileBuilder> {
+    @Override
+    public Class<FooFile> getProjectFileClass() {
+        return FooFile.class;
+    }
+
+    @Override
+    public String getProjectFilePseudoClass() {
+        return "foo";
+    }
+
+    @Override
+    public Class<FooFileBuilder> getProjectFileBuilderClass() {
+        return FooFileBuilder.class;
+    }
+
+    @Override
+    public FooFile createProjectFile(ProjectFileCreationContext context) {
+        return new FooFile(context);
+    }
+
+    @Override
+    public FooFileBuilder createProjectFileBuilder(ProjectFileBuildContext context) {
+        return new FooFileBuilder(context);
+    }
+}
+```
+
+And that's it! You will now be able to use this new type of project file as any other.
+For instance, to create one in groovy:
+```groovy
+myFooFile = myFirstProject.getRootFolder().buildFoo { name "my-foo-file" }
+//use it!
+myFooFile.runSomeCoolComputation()
+```
+
+
+#### 2.2 Adding your own storage implementation
+
+TODO

--- a/afs/README.md
+++ b/afs/README.md
@@ -271,7 +271,7 @@ class FooFileBuilder implements ProjectFileBuilder<FooFile> {
     @Override
     public FooFile build() {
         if (name == null) {
-            throw new IllegalStateException("name is not set");
+            throw new IllegalArgumentException("name is not set");
         }
         String pseudoClass = "foo";
 
@@ -279,7 +279,7 @@ class FooFileBuilder implements ProjectFileBuilder<FooFile> {
         NodeInfo info = context.getStorage().createNode(context.getFolderInfo().getId(), name, pseudoClass, "", 0, new NodeGenericMetadata());
 
         //Possibly, write data to storage
-        try (OutputStream os = storage.writeBinaryData(info.getId(), "my_data")) {
+        try (OutputStream os = context.getStorage().writeBinaryData(info.getId(), "my_data")) {
             os.write(...);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -287,6 +287,9 @@ class FooFileBuilder implements ProjectFileBuilder<FooFile> {
 
         //Possibly, add dependencies to other nodes
         context.getStorage().addDependency(info.getId(), "my_dependency", dependencyNodeId);
+
+        //Flush modifications
+        context.getStorage().flush();
 
         //Return new object
         return new FooFile(new ProjectFileCreationContext(info,

--- a/afs/afs-core/src/main/java/com/powsybl/afs/AbstractNodeBase.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/AbstractNodeBase.java
@@ -16,6 +16,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
+ * Base class for all node objects stored in an AFS tree.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public abstract class AbstractNodeBase<F> {
@@ -34,6 +36,9 @@ public abstract class AbstractNodeBase<F> {
 
     public abstract Optional<F> getParent();
 
+    /**
+     * An ID uniquely identifying this node in the file system tree.
+     */
     public String getId() {
         return info.getId();
     }

--- a/afs/afs-core/src/main/java/com/powsybl/afs/AppData.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/AppData.java
@@ -14,6 +14,31 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
+ * An instance of AppData is the root of an application file system.
+ *
+ * Usually, an application will only have one instance of AppData.
+ * It is the first entrypoint of AFS, through which you can access to individual {@link AppFileSystem} objects.
+ *
+ * <pre>
+ *   //Get AppData instance.
+ *   AppData appData = ...
+ *
+ *   //Print file system names to console
+ *   appData.getFileSystems().stream().map(AppFileSystem::getName).forEach(System.out::println);
+ *
+ *   //Get file system with name "fs1"
+ *   AppFileSystem fs1 = appData.getFileSystem("fs1");
+ *
+ *   //Get root folder of "fs1"
+ *   Folder root = fs1.getRootFolder();
+ *
+ *   //Get the node of type Project at /folder1/folder2/my_project, if it exists.
+ *   Optional&lt;Project&gt; project = root.getChild(Project.class, "folder1", "folder2", "my_project");
+ *
+ *   ...
+ *
+ * </pre>
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class AppData implements AutoCloseable {

--- a/afs/afs-core/src/main/java/com/powsybl/afs/AppData.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/AppData.java
@@ -125,10 +125,16 @@ public class AppData implements AutoCloseable {
         fileSystems.put(fileSystem.getName(), fileSystem);
     }
 
+    /**
+     * The list of available file systems.
+     */
     public Collection<AppFileSystem> getFileSystems() {
         return fileSystems.values();
     }
 
+    /**
+     * Gets a file system by its {@code name}.
+     */
     public AppFileSystem getFileSystem(String name) {
         Objects.requireNonNull(name);
         return fileSystems.get(name);
@@ -202,6 +208,9 @@ public class AppData implements AutoCloseable {
         return longTimeExecutionComputationManager != null ? longTimeExecutionComputationManager : shortTimeExecutionComputationManager;
     }
 
+    /**
+     * Gets the list of remotely accessible file systems. Should not be used by the AFS API users.
+     */
     public List<String> getRemotelyAccessibleFileSystemNames() {
         return fileSystems.entrySet().stream()
                 .map(Map.Entry::getValue)
@@ -210,11 +219,21 @@ public class AppData implements AutoCloseable {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Gets low level storage interface for remotely accessible file systems. Should not be used by the AFS API users.
+     */
     public ListenableAppStorage getRemotelyAccessibleStorage(String fileSystemName) {
         AppFileSystem afs = fileSystems.get(fileSystemName);
         return afs != null ? afs.getStorage() : null;
     }
 
+    /**
+     * Gets a registered service of type U. To register a service, see {@link ServiceExtension}.
+     *
+     * @param serviceClass  the requested service type
+     * @param remoteStorage if {@code true}, tries to get a remote implementation first.
+     * @throws AfsException if no service implementation is found.
+     */
     <U> U findService(Class<U> serviceClass, boolean remoteStorage) {
         U service = null;
         if (remoteStorage) {
@@ -229,6 +248,9 @@ public class AppData implements AutoCloseable {
         return service;
     }
 
+    /**
+     * Closes any resources used by underlying file systems.
+     */
     @Override
     public void close() {
         getFileSystems().forEach(AppFileSystem::close);

--- a/afs/afs-core/src/main/java/com/powsybl/afs/AppFileSystem.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/AppFileSystem.java
@@ -15,6 +15,21 @@ import java.util.Objects;
 
 /**
  *
+ * An AppFileSystem instance is a tree of {@link Node} objects, starting with its root folder.
+ * <p>
+ * {@link Node} objects may be {@link Folder}s or {@link File}, or any new file type added
+ * by the user through the extension mechanism (see {@link FileExtension}).
+ * An application may have several instances of {@link AppFileSystem}, each one with a unique name.
+ * They are accessed through the parent {@link AppData} instance.
+ *
+ * <p>
+ * The AppFileSystem is backed by an {@link AppStorage} implementation, which is in charge of maintaining
+ * the state of data of the AppFileSystem. The implementation may bring additional functionalities:
+ * in-memory storage, database storage, remote storage, ...
+ *
+ * <p>
+ * Users of an AppFileSystem should not need to interact directly with the underlying {@link AppStorage}.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class AppFileSystem implements AutoCloseable {
@@ -62,6 +77,9 @@ public class AppFileSystem implements AutoCloseable {
         return new Folder(new FileCreationContext(rootNodeInfo, storage, this));
     }
 
+    /**
+     * Creates a new Node in this file system. This is a low level method, and should seldom be used by the AFS API users.
+     */
     public Node createNode(NodeInfo nodeInfo) {
         Objects.requireNonNull(nodeInfo);
         Objects.requireNonNull(data);
@@ -80,6 +98,9 @@ public class AppFileSystem implements AutoCloseable {
         }
     }
 
+    /**
+     * Get a project file by its ID.
+     */
     public <T extends ProjectFile> T findProjectFile(String projectFileId, Class<T> clazz) {
         Objects.requireNonNull(projectFileId);
         Objects.requireNonNull(clazz);

--- a/afs/afs-core/src/main/java/com/powsybl/afs/AppFileSystemProvider.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/AppFileSystemProvider.java
@@ -11,6 +11,8 @@ import com.powsybl.computation.ComputationManager;
 import java.util.List;
 
 /**
+ *
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface AppFileSystemProvider {

--- a/afs/afs-core/src/main/java/com/powsybl/afs/DependencyCache.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/DependencyCache.java
@@ -13,6 +13,10 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
+ * Allows to request and cache dependencies of a project file to one or several other project nodes.
+ * The request is defined by a dependency name, and by the type of the "target" nodes.
+ * <p>
+ * The objects are cached when retrieved, and will not be fetched again until invalidation of the cache.
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -46,6 +50,9 @@ public class DependencyCache<T> {
         projectFile.addListener(l);
     }
 
+    /**
+     * Invalidates the cache: dependencies will be fetched again on next request.
+     */
     public void invalidate() {
         lock.lock();
         try {
@@ -58,11 +65,19 @@ public class DependencyCache<T> {
         }
     }
 
+    /**
+     * Gets the first dependency of the project file which matches the specified dependency name and class.
+     * Result is cached, and will not be fetched again until the cache is invalidated.
+     */
     public Optional<T> getFirst() {
         List<T> all = getAll();
         return all.isEmpty() ? Optional.empty() : Optional.of(all.get(0));
     }
 
+    /**
+     * Gets all the dependencies of the project file which match the specified dependency name and class.
+     * Result is cached, and will not be fetched again until the cache is invalidated.
+     */
     public List<T> getAll() {
         lock.lock();
         try {

--- a/afs/afs-core/src/main/java/com/powsybl/afs/File.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/File.java
@@ -7,6 +7,10 @@
 package com.powsybl.afs;
 
 /**
+ *
+ * A file in an {@link AppFileSystem} object. New types of files may be added through
+ * the extension mechanism (see {@link FileExtension}).
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class File extends Node {

--- a/afs/afs-core/src/main/java/com/powsybl/afs/FileExtension.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/FileExtension.java
@@ -16,7 +16,7 @@ package com.powsybl.afs;
  * {@link com.google.auto.service.AutoService} annotation.
  *
  * <p>
- * The instance needs to define the new class, a name identying that class ("pseudo class"),
+ * The instance needs to define the new class, a name identifying that class ("pseudo class"),
  * and to provide a creation method for those new file objects. For instance:
  *
  * <pre>

--- a/afs/afs-core/src/main/java/com/powsybl/afs/FileExtension.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/FileExtension.java
@@ -7,13 +7,49 @@
 package com.powsybl.afs;
 
 /**
+ *
+ * Interface to add a new type of file to the application file system.
+ *
+ * <p>
+ * In order to add a new type of file to your {@link AppData} instance,
+ * you need to implement that interface and declare it to the runtime using the
+ * {@link com.google.auto.service.AutoService} annotation.
+ *
+ * <p>
+ * The instance needs to define the new class, a name identying that class ("pseudo class"),
+ * and to provide a creation method for those new file objects. For instance:
+ *
+ * <pre>
+ * {@literal @}AutoService
+ * public class MyFileExtension implements FileExtension&lt;MyFile&gt; {
+ *
+ *    {@literal @}Override
+ *    public Class<T> getFileClass() { return MyFile.class; }
+ *
+ *    {@literal @}Override
+ *    public String getFilePseudoClass() { return "myFile"; }
+ *
+ *    {@literal @}Override
+ *    public T createFile(FileCreationContext context) { return new MyFileExtension(context); }
+ * }
+ * </pre>
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface FileExtension<T extends File> {
 
+    /**
+     * The new type of object you want to add to your application file system.
+     */
     Class<T> getFileClass();
 
+    /**
+     * A "pseudo class" name for the new type.
+     */
     String getFilePseudoClass();
 
+    /**
+     * Creates an actual instance of the new type of file.
+     */
     T createFile(FileCreationContext context);
 }

--- a/afs/afs-core/src/main/java/com/powsybl/afs/Folder.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/Folder.java
@@ -16,6 +16,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
+ * A folder in an {@link AppFileSystem} tree.
+ *
+ * <p>
+ * Folders may have children folders or files, and provides methods to create new children.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class Folder extends Node implements FolderBase<Node, Folder> {
@@ -31,6 +36,9 @@ public class Folder extends Node implements FolderBase<Node, Folder> {
         return storage.isWritable(info.getId());
     }
 
+    /**
+     * Get the children nodes of this folder.
+     */
     @Override
     public List<Node> getChildren() {
         return storage.getChildNodes(info.getId())
@@ -40,12 +48,18 @@ public class Folder extends Node implements FolderBase<Node, Folder> {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Gets the child node at path "name/name2/..." relative to this folder, or empty if it does not exist.
+     */
     @Override
     public Optional<Node> getChild(String name, String... more) {
         NodeInfo childInfo = getChildInfo(name, more);
         return Optional.ofNullable(childInfo).map(fileSystem::createNode);
     }
 
+    /**
+     * Gets the child node of class T at path "name/name2/..." relative to this folder, in a typesafe way, or empty if it does not exist.
+     */
     @Override
     public <T extends Node> Optional<T> getChild(Class<T> clazz, String name, String... more) {
         Objects.requireNonNull(clazz);
@@ -54,11 +68,17 @@ public class Folder extends Node implements FolderBase<Node, Folder> {
                 .map(clazz::cast);
     }
 
+    /**
+     * Gets the folder at path "name/name2/..." relative to this folder, or empty if it does not exist.
+     */
     @Override
     public Optional<Folder> getFolder(String name, String... more) {
         return getChild(Folder.class, name, more);
     }
 
+    /**
+     * Creates a subfolder of this folder. If a folder with same name already exists, returns the existing folder.
+     */
     @Override
     public Folder createFolder(String name) {
         NodeInfo folderInfo = storage.getChildNode(info.getId(), name)
@@ -70,6 +90,9 @@ public class Folder extends Node implements FolderBase<Node, Folder> {
         return new Folder(new FileCreationContext(folderInfo, storage, fileSystem));
     }
 
+    /**
+     * Creates a new {@link Project} in this folder. If a project with same name already exists, returns the existing project.
+     */
     public Project createProject(String name) {
         NodeInfo projectInfo = storage.getChildNode(info.getId(), name)
                 .orElseGet(() -> {

--- a/afs/afs-core/src/main/java/com/powsybl/afs/Project.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/Project.java
@@ -11,6 +11,11 @@ import com.powsybl.afs.storage.NodeInfo;
 import java.util.Objects;
 
 /**
+ * A project is a special type of file in the file system, which represents workspace to carry out a study or computations.
+ *
+ * <p>
+ * A project will have its own tree of project folders and project files, with possible dependencies between files.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class Project extends File {
@@ -24,6 +29,9 @@ public class Project extends File {
         super(context, VERSION);
     }
 
+    /**
+     * Get the root folder of this project.
+     */
     public ProjectFolder getRootFolder() {
         NodeInfo rootFolderInfo = storage.getChildNode(info.getId(), ROOT_FOLDER_NAME).orElseThrow(AssertionError::new);
         return new ProjectFolder(new ProjectFileCreationContext(rootFolderInfo, storage, this));

--- a/afs/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
@@ -6,18 +6,76 @@
  */
 package com.powsybl.afs;
 
+
 /**
+ * Interface to add a new type of project file to the application file system.
+ *
+ * <p>
+ * In order to add a new type of project file to your {@link AppData} instance,
+ * you need to implement that interface and declare it to the runtime using the
+ * {@link com.google.auto.service.AutoService} annotation.
+ *
+ * <p>
+ * The instance needs to define the new class, a name identying that class ("pseudo class"),
+ * and to provide a builder object to create an actual instance of the new class. For instance:
+ *
+ * <pre>
+ *      {@literal @}AutoService(ProjectFileExtension.class)
+ *      public class FooFileExtension implements ProjectFileExtension<FooFile, FooFileBuilder> {
+ *
+ *      {@literal @}Override
+ *      public Class<FooFile> getProjectFileClass() {
+ *          return FooFile.class;
+ *      }
+ *
+ *      {@literal @}Override
+ *      public String getProjectFilePseudoClass() {
+ *          return "foo";
+ *      }
+ *
+ *      {@literal @}Override
+ *      public Class<FooFileBuilder> getProjectFileBuilderClass() {
+ *          return FooFileBuilder.class;
+ *      }
+ *
+ *      {@literal @}Override
+ *      public FooFile createProjectFile(ProjectFileCreationContext context) {
+ *          return new FooFile(context);
+ *      }
+ *
+ *      {@literal @}Override
+ *      public FooFileBuilder createProjectFileBuilder(ProjectFileBuildContext context) {
+ *          return new FooFileBuilder(context);
+ *      }
+ *  }
+ * </pre>
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface ProjectFileExtension<T extends ProjectFile, U extends ProjectFileBuilder<T>> {
 
+    /**
+     * The new project file type to be injected.
+     */
     Class<T> getProjectFileClass();
 
+    /**
+     * A "pseudo class" name for the new type.
+     */
     String getProjectFilePseudoClass();
 
+    /**
+     * The builder class for the new type. Builders will be in charge of creating actual instances of the new type.
+     */
     Class<U> getProjectFileBuilderClass();
 
+    /**
+     * Creates an object with default constructor.
+     */
     T createProjectFile(ProjectFileCreationContext context);
 
+    /**
+     * Creates a builder object, to build an instance of the new type with additional parameters passed to the builder.
+     */
     ProjectFileBuilder<T> createProjectFileBuilder(ProjectFileBuildContext context);
 }

--- a/afs/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
@@ -16,7 +16,7 @@ package com.powsybl.afs;
  * {@link com.google.auto.service.AutoService} annotation.
  *
  * <p>
- * The instance needs to define the new class, a name identying that class ("pseudo class"),
+ * The instance needs to define the new class, a name identifying that class ("pseudo class"),
  * and to provide a builder object to create an actual instance of the new class. For instance:
  *
  * <pre>

--- a/afs/afs-core/src/main/java/com/powsybl/afs/ProjectFolder.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/ProjectFolder.java
@@ -21,6 +21,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
+ * A folder in a {@link Project} tree.
+ *
+ * <p>
+ * Project folders may have children project folders or files, and provides methods to create new children.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class ProjectFolder extends ProjectNode implements FolderBase<ProjectNode, ProjectFolder> {
@@ -56,6 +61,9 @@ public class ProjectFolder extends ProjectNode implements FolderBase<ProjectNode
         storage.addListener(l);
     }
 
+    /**
+     * Gets the list of children nodes of this project folder.
+     */
     @Override
     public List<ProjectNode> getChildren() {
         return storage.getChildNodes(info.getId())
@@ -65,12 +73,18 @@ public class ProjectFolder extends ProjectNode implements FolderBase<ProjectNode
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Gets the child node at path "name/name2/..." relative to this folder, or empty if it does not exist.
+     */
     @Override
     public Optional<ProjectNode> getChild(String name, String... more) {
         NodeInfo childInfo = getChildInfo(name, more);
         return Optional.ofNullable(childInfo).map(project::createProjectNode);
     }
 
+    /**
+     * Gets the child node of class T at path "name/name2/..." relative to this folder, in a typesafe way, or empty if it does not exist.
+     */
     @Override
     public <T extends ProjectNode> Optional<T> getChild(Class<T> clazz, String name, String... more) {
         Objects.requireNonNull(clazz);
@@ -79,11 +93,17 @@ public class ProjectFolder extends ProjectNode implements FolderBase<ProjectNode
                 .map(clazz::cast);
     }
 
+    /**
+     * Gets the folder at path "name/name2/..." relative to this folder, or empty if it does not exist.
+     */
     @Override
     public Optional<ProjectFolder> getFolder(String name, String... more) {
         return getChild(ProjectFolder.class, name, more);
     }
 
+    /**
+     * Creates a subfolder of this folder. If a folder with same name already exists, returns the existing folder.
+     */
     @Override
     public ProjectFolder createFolder(String name) {
         NodeInfo folderInfo = storage.getChildNode(info.getId(), name)
@@ -95,6 +115,9 @@ public class ProjectFolder extends ProjectNode implements FolderBase<ProjectNode
         return new ProjectFolder(new ProjectFileCreationContext(folderInfo, storage, project));
     }
 
+    /**
+     * Gets a project file builder for type B, to build a new project file in this folder.
+     */
     public <F extends ProjectFile, B extends ProjectFileBuilder<F>> B fileBuilder(Class<B> clazz) {
         Objects.requireNonNull(clazz);
         ProjectFileExtension extension = project.getFileSystem().getData().getProjectFileExtension(clazz);

--- a/afs/afs-core/src/main/java/com/powsybl/afs/ServiceExtension.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/ServiceExtension.java
@@ -9,6 +9,14 @@ package com.powsybl.afs;
 import java.util.Objects;
 
 /**
+ *
+ * Registers a new implementation for service of type &lt;U&gt;, to be retrieved with {@link AppData#findService}.
+ *
+ * <p>
+ * A service is identified by its interface type and by a "remote" boolean.
+ * Therefore you may only have one local and one remote implementation of the same service registered with your AFS.
+ *
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface ServiceExtension<U> {
@@ -52,7 +60,13 @@ public interface ServiceExtension<U> {
         }
     }
 
+    /**
+     * Key identifying the service in AFS.
+     */
     ServiceKey<U> getServiceKey();
 
+    /**
+     * Creates the service instance.
+     */
     U createService();
 }

--- a/afs/afs-core/src/main/java/com/powsybl/afs/UnknownFile.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/UnknownFile.java
@@ -7,6 +7,8 @@
 package com.powsybl.afs;
 
 /**
+ * Represents a file object of an unknown type (for instance when trying to read a file of type unknown to your instance of AFS).
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class UnknownFile extends File {

--- a/afs/afs-core/src/main/java/com/powsybl/afs/UnknownProjectFile.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/UnknownProjectFile.java
@@ -7,6 +7,9 @@
 package com.powsybl.afs;
 
 /**
+ *
+ * Represents a project file object of an unknown type (for instance when trying to read a file of type unknown to your instance of AFS).
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class UnknownProjectFile extends ProjectFile {

--- a/afs/afs-core/src/main/java/com/powsybl/afs/package-info.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/package-info.java
@@ -1,0 +1,50 @@
+/**
+ *
+ *     AFS stands for Application FileSystem.
+ *     <p>
+ *     This package contains bases classes which define the concept of AFS.
+ *     An AFS is meant to be used to organize your business data and store them,
+ *     like a file system does for file.
+ *
+ *     <p>
+ *     The way data is actually stored is implementation-dependent,
+ *     and is defined through the implementation of the {@link com.powsybl.afs.storage.AppStorage} interface.
+ *
+ *     <p>
+ *     The entry point of AFS is the {@linkplain com.powsybl.afs.AppData} object.
+ *     It contains a list of {@link com.powsybl.afs.AppFileSystem}.
+ *
+ *     <p>
+ *     The structure of an AFS looks like:
+ *
+ *     <pre>
+ *         AppData
+ *          |
+ *          +-- FileSystem1
+ *          |   +-- File1
+ *          |   +-- File2
+ *          |   +-- Project1
+ *          |   |   +-- RootFolder
+ *          |   |       +-- ProjectFile1
+ *          |   |       +-- ProjectFolder1
+ *          |   |       |   +-- ProjectFile2
+ *          |   |       +-- ProjectFolder2
+ *          |   |           +-- ProjectFile3
+ *          |   +-- Project2
+ *          |      ...
+ *          |
+ *          +-- FileSystem2
+ *              ...
+ *
+ *
+ *     </pre>
+ *
+ *     <p>
+ *     You may add your own types of files and project files through and extension mechanism, see {@link com.powsybl.afs.FileExtension}
+ *     and {@link com.powsybl.afs.ProjectFileExtension}.
+ *
+ *
+ *     @auhor Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ *
+ */
+package com.powsybl.afs;

--- a/afs/afs-core/src/main/java/com/powsybl/afs/package-info.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/package-info.java
@@ -8,11 +8,11 @@
  *
  *     <p>
  *     The way data is actually stored is implementation-dependent,
- *     and is defined through the implementation of the {@link com.powsybl.afs.storage.AppStorage} interface.
+ *     and is defined through the implementation of the {@linkplain com.powsybl.afs.storage.AppStorage AppStorage} interface.
  *
  *     <p>
- *     The entry point of AFS is the {@linkplain com.powsybl.afs.AppData} object.
- *     It contains a list of {@link com.powsybl.afs.AppFileSystem}.
+ *     The entry point of AFS is the {@linkplain com.powsybl.afs.AppData AppData} object.
+ *     It contains a list of {@linkplain com.powsybl.afs.AppFileSystem AppFileSystem}s.
  *
  *     <p>
  *     The structure of an AFS looks like:
@@ -40,8 +40,8 @@
  *     </pre>
  *
  *     <p>
- *     You may add your own types of files and project files through and extension mechanism, see {@link com.powsybl.afs.FileExtension}
- *     and {@link com.powsybl.afs.ProjectFileExtension}.
+ *     You may add your own types of files and project files through and extension mechanism, see {@linkplain com.powsybl.afs.FileExtension FileExtension}
+ *     and {@linkplain com.powsybl.afs.ProjectFileExtension ProjectFileExtension}.
  *
  *
  *     @auhor Sylvain Leclerc <sylvain.leclerc@rte-france.com>

--- a/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/Case.java
+++ b/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/Case.java
@@ -17,6 +17,8 @@ import com.powsybl.iidm.import_.ImportersLoader;
 import java.util.Objects;
 
 /**
+ * A type of {@code File} which represents a {@link com.powsybl.iidm.network.Network}.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class Case extends File {

--- a/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/CaseExtension.java
+++ b/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/CaseExtension.java
@@ -15,6 +15,8 @@ import com.powsybl.iidm.import_.ImportersServiceLoader;
 import java.util.Objects;
 
 /**
+ * Defines the new type of file {@link Case}.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 @AutoService(FileExtension.class)

--- a/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCase.java
+++ b/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCase.java
@@ -24,7 +24,10 @@ import java.util.Objects;
 import java.util.Properties;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ *  A type of {@code ProjectFile} which represents a {@link Network} imported to the project,
+ *  and provides methods to get the {@code Network} object or query it with a script.
+ *
+ *  @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class ImportedCase extends ProjectFile implements ProjectCase {
 

--- a/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCaseBuilder.java
+++ b/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCaseBuilder.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 import java.util.Properties;
 
 /**
+ * Builder for the project file {@link ImportedCase}.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class ImportedCaseBuilder implements ProjectFileBuilder<ImportedCase> {

--- a/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCaseExtension.java
+++ b/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCaseExtension.java
@@ -17,6 +17,8 @@ import com.powsybl.iidm.import_.ImportersServiceLoader;
 import java.util.Objects;
 
 /**
+ * Defines the new type of project file {@link ImportedCase}.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 @AutoService(ProjectFileExtension.class)

--- a/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/NetworkCacheService.java
+++ b/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/NetworkCacheService.java
@@ -10,6 +10,8 @@ import com.powsybl.afs.ProjectFile;
 import com.powsybl.iidm.network.Network;
 
 /**
+ * Provides caching capabilities for loaded {@code Network} objects.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface NetworkCacheService {

--- a/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ProjectCase.java
+++ b/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ProjectCase.java
@@ -9,6 +9,8 @@ package com.powsybl.afs.ext.base;
 import com.powsybl.iidm.network.Network;
 
 /**
+ * Common interface for project files able to provide a Network.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface ProjectCase {

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorage.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorage.java
@@ -16,6 +16,15 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
+ *
+ * A storage which maintains data for an application file system. This is a low level object,
+ * and should not be used by users of the AFS API, but only when extending the AFS API
+ * with a new storage implementation or new file types for example.
+ *
+ * <p>
+ * An AppStorage implements low level methods to walk through a filesystem and to write and read data from this filesystem.
+ * It relies on nodes uniquely identified by and ID.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface AppStorage extends AutoCloseable {
@@ -24,72 +33,168 @@ public interface AppStorage extends AutoCloseable {
 
     boolean isRemote();
 
+    /**
+     * Returns the root node of the tree, creating it if it does not exist.
+     */
     NodeInfo createRootNodeIfNotExists(String name, String nodePseudoClass);
 
+    /**
+     * Creates a new node in the tree under a parent node. Returns {@code NodeInfo} corresponding to the newly created node.
+     */
     NodeInfo createNode(String parentNodeId, String name, String nodePseudoClass, String description, int version, NodeGenericMetadata genericMetadata);
 
     boolean isWritable(String nodeId);
 
+    /**
+     * Gets NodeInfo object for the node with ID {@code nodeId}.
+     */
     NodeInfo getNodeInfo(String nodeId);
 
     void setDescription(String nodeId, String description);
 
     void updateModificationTime(String nodeId);
 
+    /**
+     * Gets {@code NodeInfo} for child nodes of the node with ID {@code nodeId}.
+     */
     List<NodeInfo> getChildNodes(String nodeId);
 
+    /**
+     * Gets {@code NodeInfo} for child node with name {@code name} of the node with ID {@code nodeId}, empty if such a node does not exist.
+     */
     Optional<NodeInfo> getChildNode(String nodeId, String name);
 
+    /**
+     * Gets {@code NodeInfo} for parent node of the node with ID {@code nodeId}, empty if such a node does not exist.
+     */
     Optional<NodeInfo> getParentNode(String nodeId);
 
+    /**
+     * Sets new parent node for the node with ID {@code nodeId}.
+     */
     void setParentNode(String nodeId, String newParentNodeId);
 
+    /**
+     * Deletes the node with ID {@code nodeId}.
+     */
     String deleteNode(String nodeId);
 
+    /**
+     * Reads data associated to the node with ID {@code nodeId}. A node may have several data blobs associated to it,
+     * with different names. The parameters {@code name} specifies which of those data is requested.
+     */
     Optional<InputStream> readBinaryData(String nodeId, String name);
 
+    /**
+     * Returns an {@code OutputStream} to write data associated to the node with ID {@code nodeId}.
+     * A node may have several data blobs associated to it, with different names.
+     */
     OutputStream writeBinaryData(String nodeId, String name);
 
+    /**
+     * Returns {@code true} if data named {@code name} associated with the node with ID {@code nodeId} exists.
+     */
     boolean dataExists(String nodeId, String name);
 
+    /**
+     * Returns the lists of names of data associated to the node with ID {@code nodeId}.
+     */
     Set<String> getDataNames(String nodeId);
 
+    /**
+     * Removes the data blob named {@code name} associated with the node with ID {@code nodeId}.
+     */
     boolean removeData(String nodeId, String name);
 
+    /**
+     * Creates a time series associated with node with ID {@code nodeId}.
+     */
     void createTimeSeries(String nodeId, TimeSeriesMetadata metadata);
 
+    /**
+     * Returns names of all time series associated with node with ID {@code nodeId}.
+     */
     Set<String> getTimeSeriesNames(String nodeId);
 
+    /**
+     * Returns {@code true} if a time series named {@code timeSeriesName} associated with the node with ID {@code nodeId} exists.
+     */
     boolean timeSeriesExists(String nodeId, String timeSeriesName);
 
+    /**
+     * Returns metadata of time series associated with node with ID {@code nodeId} and with name in {@code timeSeriesNames}.
+     */
     List<TimeSeriesMetadata> getTimeSeriesMetadata(String nodeId, Set<String> timeSeriesNames);
 
+    /**
+     * Gets versions of time series data associated with node with ID {@code nodeId}.
+     */
     Set<Integer> getTimeSeriesDataVersions(String nodeId);
 
+    /**
+     * Gets versions of data for the time series with name {@code timeSeriesName} associated with node with ID {@code nodeId}.
+     */
     Set<Integer> getTimeSeriesDataVersions(String nodeId, String timeSeriesName);
 
+    /**
+     * Gets data (double) for the time series with names {@code timeSeriesNames} associated with node with ID {@code nodeId}.
+     */
     Map<String, List<DoubleArrayChunk>> getDoubleTimeSeriesData(String nodeId, Set<String> timeSeriesNames, int version);
 
+    /**
+     * Adds data (double) to the time series with names {@code timeSeriesNames} associated with node with ID {@code nodeId}.
+     */
     void addDoubleTimeSeriesData(String nodeId, int version, String timeSeriesName, List<DoubleArrayChunk> chunks);
 
+    /**
+     * Gets data (string) for the time series with names {@code timeSeriesNames} associated with node with ID {@code nodeId}.
+     */
     Map<String, List<StringArrayChunk>> getStringTimeSeriesData(String nodeId, Set<String> timeSeriesNames, int version);
 
+    /**
+     * Adds data (string) to the time series with names {@code timeSeriesNames} associated with node with ID {@code nodeId}.
+     */
     void addStringTimeSeriesData(String nodeId, int version, String timeSeriesName, List<StringArrayChunk> chunks);
 
+    /**
+     * Deletes time series associated with node with ID {@code nodeId}
+     */
     void clearTimeSeries(String nodeId);
 
+    /**
+     * Adds a dependency from node with ID {@code nodeId} to node with ID {@code toNodeId}.
+     * The dependency will be associated with the specified {@code name}.
+     */
     void addDependency(String nodeId, String name, String toNodeId);
 
+    /**
+     * Gets {@code NodeInfo} objects for dependencies of node with ID {@code nodeId}, and associated to the dependency name {@code name}.
+     */
     Set<NodeInfo> getDependencies(String nodeId, String name);
 
+    /**
+     * Gets all dependencies ({@code NodeDependency} objects) of node with ID {@code nodeId}.
+     */
     Set<NodeDependency> getDependencies(String nodeId);
 
+    /**
+     * Gets {@code NodeInfo} objects of nodes which depend on the node with ID {@code nodeId}.
+     */
     Set<NodeInfo> getBackwardDependencies(String nodeId);
 
+    /**
+     * Removes a dependency named {@code name} from node with ID {@code nodeId} to node with ID {@code toNodeId}.
+     */
     void removeDependency(String nodeId, String name, String toNodeId);
 
+    /**
+     * Flush any changes to underlying storage.
+     */
     void flush();
 
+    /**
+     * Closes any resource associated with this storage.
+     */
     @Override
     void close();
 }

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageDataSource.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageDataSource.java
@@ -18,6 +18,9 @@ import java.util.stream.Collectors;
 import com.powsybl.commons.datasource.DataSource;
 
 /**
+ * A datasource corresponding to a data blob stored in the file system.
+ * A data blob is associated to a node and a name identifying it among data blobs of this node.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class AppStorageDataSource implements DataSource {

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/DefaultListenableAppStorage.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/DefaultListenableAppStorage.java
@@ -18,6 +18,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
+ * A storage implementation which adds notification features to another underlying, wrapped, storage.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class DefaultListenableAppStorage extends ForwardingAppStorage implements ListenableAppStorage {

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/ForwardingAppStorage.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/ForwardingAppStorage.java
@@ -15,6 +15,8 @@ import java.io.OutputStream;
 import java.util.*;
 
 /**
+ * A storage implementation which simply delegates calls to another underlying AppStorage implementation.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class ForwardingAppStorage implements AppStorage {

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/ListenableAppStorage.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/ListenableAppStorage.java
@@ -9,6 +9,10 @@ package com.powsybl.afs.storage;
 import com.powsybl.afs.storage.events.AppStorageListener;
 
 /**
+ *
+ * A listenable {@link AppStorage}. Listeners will be notified of {@linkplain com.powsybl.afs.storage.events.NodeEvent NodeEvents} happening on the storage:
+ * node creation, removal, etc.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface ListenableAppStorage extends AppStorage {

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeDependency.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeDependency.java
@@ -9,6 +9,8 @@ package com.powsybl.afs.storage;
 import java.util.Objects;
 
 /**
+ * Represents a named dependency to a node in the tree.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class NodeDependency {

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeGenericMetadata.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeGenericMetadata.java
@@ -11,6 +11,9 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
+ *
+ * Metadata about a particular node. This is a low level object, should seldom be used by AFS API users.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class NodeGenericMetadata {

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeInfo.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeInfo.java
@@ -9,6 +9,8 @@ package com.powsybl.afs.storage;
 import java.util.Objects;
 
 /**
+ * Low level information about a node in an AFS tree. Should seldom be used by AFS API users.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class NodeInfo {
@@ -41,6 +43,9 @@ public class NodeInfo {
         this.genericMetadata = Objects.requireNonNull(genericMetadata);
     }
 
+    /**
+     * Returns the ID of this node, uniquely identifying it in the file system.
+     */
     public String getId() {
         return id;
     }


### PR DESCRIPTION
First steps to improve understanding of AFS by developer users: 
 - adds javadoc comments to the API, trying in the process to clarify separation between low level and high level API.
 - add a "Getting started" guide to use and extends AFS