### PR TITLE
Unify duplicated code for power flow computation

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.loadflow;
+package com.powsybl.iidm.network.util;
 
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Line;
@@ -55,7 +55,47 @@ public class BranchData {
     private double computedP2;
     private double computedQ2;
 
-    public BranchData(Line line, float epsilonX, boolean applyReactanceCorrection) {
+    public BranchData(String id,
+            double r, double x,
+            double rho1, double rho2,
+            double u1, double u2, double theta1, double theta2,
+            double alpha1, double alpha2,
+            double g1, double g2, double b1, double b2,
+            double p1, double q1, double p2, double q2,
+            boolean connected1, boolean connected2,
+            boolean mainComponent1, boolean mainComponent2,
+            double epsilonX, boolean applyReactanceCorrection) {
+        this.id = id;
+        this.r = r;
+        this.x = x;
+        double fixedX = getFixedX(x, epsilonX, applyReactanceCorrection);
+        z = Math.hypot(r, fixedX);
+        y = 1 / z;
+        ksi = Math.atan2(r, fixedX);
+        this.rho1 = rho1;
+        this.rho2 = rho2;
+        this.u1 = u1;
+        this.u2 = u2;
+        this.theta1 = theta1;
+        this.theta2 = theta2;
+        this.alpha1 = alpha1;
+        this.alpha2 = alpha2;
+        this.g1 = g1;
+        this.g2 = g2;
+        this.b1 = b1;
+        this.b2 = b2;
+        this.p1 = p1;
+        this.q1 = q1;
+        this.p2 = p2;
+        this.q2 = q2;
+        this.connected1 = connected1;
+        this.connected2 = connected2;
+        this.mainComponent1 = mainComponent1;
+        this.mainComponent2 = mainComponent2;
+        computeValues();
+    }
+
+    public BranchData(Line line, double epsilonX, boolean applyReactanceCorrection) {
         Objects.requireNonNull(line);
 
         id = line.getId();
@@ -98,7 +138,7 @@ public class BranchData {
         computeValues();
     }
 
-    public BranchData(TwoWindingsTransformer twt, float epsilonX, boolean applyReactanceCorrection, boolean specificCompatibility) {
+    public BranchData(TwoWindingsTransformer twt, double epsilonX, boolean applyReactanceCorrection, boolean specificCompatibility) {
         Objects.requireNonNull(twt);
 
         id = twt.getId();
@@ -141,7 +181,7 @@ public class BranchData {
         computeValues();
     }
 
-    private double getFixedX(double x, float epsilonX, boolean applyReactanceCorrection) {
+    private double getFixedX(double x, double epsilonX, boolean applyReactanceCorrection) {
         return Math.abs(x) < epsilonX && applyReactanceCorrection ? epsilonX : x;
     }
 

--- a/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/LoadFlowResultsCompletion.java
+++ b/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/LoadFlowResultsCompletion.java
@@ -11,6 +11,7 @@ import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Terminal;
 import com.powsybl.iidm.network.TwoTerminalsConnectable.Side;
+import com.powsybl.iidm.network.util.BranchData;
 import com.powsybl.loadflow.validation.CandidateComputation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/loadflow/loadflow-results-completion/src/test/java/com/powsybl/loadflow/BranchDataTest.java
+++ b/loadflow/loadflow-results-completion/src/test/java/com/powsybl/loadflow/BranchDataTest.java
@@ -6,9 +6,11 @@
  */
 package com.powsybl.loadflow;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import com.powsybl.iidm.network.util.BranchData;
 
 /**
  *

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/BusesValidation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/BusesValidation.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ShuntCompensator;
@@ -87,6 +88,19 @@ public final class BusesValidation {
         }
     }
 
+    private static void p(String eqt, Identifiable id, Terminal t) {
+        if (LOGGER.isWarnEnabled()) {
+            LOGGER.warn(
+                    String.format("    %-5s  %10.4f  %10.4f  %s", eqt, t.getP(), t.getQ(), id.getId()));
+        }
+    }
+
+    private static void p(String cat, double p, double q) {
+        if (LOGGER.isWarnEnabled()) {
+            LOGGER.warn(String.format("    %-5s  %10.4f  %10.4f", cat, p, q));
+        }
+    }
+
     public static boolean checkBuses(Bus bus, ValidationConfig config, ValidationWriter busesWriter) {
         Objects.requireNonNull(bus);
         Objects.requireNonNull(config);
@@ -110,8 +124,32 @@ public final class BusesValidation {
         double tltP = bus.getThreeWindingTransformerStream().map(tlt -> getThreeWindingTransformerTerminal(tlt, bus)).mapToDouble(Terminal::getP).sum();
         double tltQ = bus.getThreeWindingTransformerStream().map(tlt -> getThreeWindingTransformerTerminal(tlt, bus)).mapToDouble(Terminal::getQ).sum();
         boolean mainComponent = bus.isInMainConnectedComponent();
-        return checkBuses(bus.getId(), loadP, loadQ, genP, genQ, shuntP, shuntQ, svcP, svcQ, vscCSP, vscCSQ, lineP, lineQ,
+        boolean r = checkBuses(bus.getId(), loadP, loadQ, genP, genQ, shuntP, shuntQ, svcP, svcQ, vscCSP, vscCSQ, lineP, lineQ,
                           danglingLineP, danglingLineQ, twtP, twtQ, tltP, tltQ, mainComponent, config, busesWriter);
+        String ref = "";
+        if (bus.getVoltageLevel() != null) {
+            ref = bus.getVoltageLevel().getName() + ref;
+            if (bus.getVoltageLevel().getSubstation() != null) {
+                ref = bus.getVoltageLevel().getSubstation().getName() + " " + ref;
+            }
+        }
+        if (!r || ref.contains("PP_Brussels")) {
+            LOGGER.warn("Details of {} bus {}", ref, bus.getId());
+            bus.getLoadStream().forEach(l -> p("load", l, l.getTerminal()));
+            bus.getGeneratorStream().forEach(g -> p("gen", g, g.getTerminal()));
+            bus.getLineStream().forEach(l -> p("line", l, getBranchTerminal(l, bus)));
+            bus.getTwoWindingTransformerStream().forEach(t -> p("2wtx", t, getBranchTerminal(t, bus)));
+            bus.getDanglingLineStream().forEach(d -> p("dngl", d, d.getTerminal()));
+            bus.getShuntStream().forEach(s -> p("shunt", s, s.getTerminal()));
+            bus.getThreeWindingTransformerStream().forEach(t -> p("3wtx", t, getThreeWindingTransformerTerminal(t, bus)));
+
+            double incomingP = genP + shuntP + svcP + vscCSP + lineP + danglingLineP + twtP + tltP;
+            double incomingQ = genQ + shuntQ + svcQ + vscCSQ + lineQ + danglingLineQ + twtQ + tltQ;
+            double sump = Math.abs(incomingP + loadP);
+            double sumq = Math.abs(incomingQ + loadQ);
+            p("SUM", sump, sumq);
+        }
+        return r;
     }
 
     private static Terminal getBranchTerminal(Branch branch, Bus bus) {
@@ -157,11 +195,19 @@ public final class BusesValidation {
         double incomingQ = genQ + shuntQ + svcQ + vscCSQ + lineQ + danglingLineQ + twtQ + tltQ;
         if (ValidationUtils.isMainComponent(config, mainComponent)) {
             if (ValidationUtils.areNaN(config, incomingP, loadP) || Math.abs(incomingP + loadP) > config.getThreshold()) {
-                LOGGER.warn("{} {}: {} P {} {}", ValidationType.BUSES, ValidationUtils.VALIDATION_ERROR, id, incomingP, loadP);
+                LOGGER.warn("{} {}: {} P   {}   {} {}", ValidationType.BUSES,
+                        ValidationUtils.VALIDATION_ERROR, id,
+                        String.format("%6.2f", Math.abs(incomingP + loadP)),
+                        String.format("%6.2f", incomingP),
+                        String.format("%6.2f", loadP));
                 validated = false;
             }
             if (ValidationUtils.areNaN(config, incomingQ, loadQ) || Math.abs(incomingQ + loadQ) > config.getThreshold()) {
-                LOGGER.warn("{} {}: {} Q {} {}", ValidationType.BUSES, ValidationUtils.VALIDATION_ERROR, id, incomingQ, loadQ);
+                LOGGER.warn("{} {}: {} Q   {}   {} {}", ValidationType.BUSES,
+                        ValidationUtils.VALIDATION_ERROR, id,
+                        String.format("%6.2f", Math.abs(incomingQ + loadQ)),
+                        String.format("%6.2f", incomingQ),
+                        String.format("%6.2f", loadQ));
                 validated = false;
             }
         }

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/BusesValidation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/BusesValidation.java
@@ -157,10 +157,10 @@ public final class BusesValidation {
         double incomingQ = genQ + shuntQ + svcQ + vscCSQ + lineQ + danglingLineQ + twtQ + tltQ;
         if (ValidationUtils.isMainComponent(config, mainComponent)) {
             if (ValidationUtils.areNaN(config, incomingP, loadP) || Math.abs(incomingP + loadP) > config.getThreshold()) {
-                LOGGER.warn("{} {}: {} P {} {}", ValidationType.BUSES, ValidationUtils.VALIDATION_ERROR, id, incomingP, loadP);                
+                LOGGER.warn("{} {}: {} P {} {}", ValidationType.BUSES, ValidationUtils.VALIDATION_ERROR, id, incomingP, loadP);
                 validated = false;
             }
-            if (ValidationUtils.areNaN(config, incomingQ, loadQ) || Math.abs(incomingQ + loadQ) > config.getThreshold()) {               
+            if (ValidationUtils.areNaN(config, incomingQ, loadQ) || Math.abs(incomingQ + loadQ) > config.getThreshold()) {
                 LOGGER.warn("{} {}: {} Q {} {}", ValidationType.BUSES, ValidationUtils.VALIDATION_ERROR, id, incomingQ, loadQ);
                 validated = false;
             }

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/FlowsValidation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/FlowsValidation.java
@@ -18,10 +18,10 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
+import com.powsybl.iidm.network.util.BranchData;
 import com.powsybl.loadflow.validation.io.ValidationWriter;
 
 /**
@@ -35,92 +35,54 @@ public final class FlowsValidation {
     private FlowsValidation() {
     }
 
-    public static boolean checkFlows(String id, double r, double x, double rho1, double rho2, double u1, double u2, double theta1, double theta2, double alpha1,
-                                     double alpha2, double g1, double g2, double b1, double b2, double p1, double q1, double p2, double q2, boolean connected1,
-                                     boolean connected2, boolean mainComponent1, boolean mainComponent2, ValidationConfig config, Writer writer) {
-        Objects.requireNonNull(id);
+    public static boolean checkFlows(BranchData branch, ValidationConfig config, Writer writer) {
+        Objects.requireNonNull(branch);
+        Objects.requireNonNull(branch.getId());
         Objects.requireNonNull(config);
         Objects.requireNonNull(writer);
 
-        try (ValidationWriter flowsWriter = ValidationUtils.createValidationWriter(id, config, writer, ValidationType.FLOWS)) {
-            return checkFlows(id, r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
-                              mainComponent1, mainComponent2, config, flowsWriter);
+        try (ValidationWriter flowsWriter = ValidationUtils.createValidationWriter(branch.getId(), config, writer, ValidationType.FLOWS)) {
+            return checkFlows(branch, config, flowsWriter);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    public static boolean checkFlows(String id, double r, double x, double rho1, double rho2, double u1, double u2, double theta1, double theta2, double alpha1,
-                                      double alpha2, double g1, double g2, double b1, double b2, double p1, double q1, double p2, double q2, boolean connected1,
-                                      boolean connected2, boolean mainComponent1, boolean mainComponent2, ValidationConfig config, ValidationWriter flowsWriter) {
-        Objects.requireNonNull(id);
+    public static boolean checkFlows(BranchData branch, ValidationConfig config, ValidationWriter flowsWriter) {
+        Objects.requireNonNull(branch);
+        Objects.requireNonNull(branch.getId());
         Objects.requireNonNull(config);
         Objects.requireNonNull(flowsWriter);
         boolean validated = true;
 
-        double fixedX = x;
-        if (Math.abs(fixedX) < config.getEpsilonX() && config.applyReactanceCorrection()) {
-            LOGGER.info("x {} -> {}", fixedX, config.getEpsilonX());
-            fixedX = config.getEpsilonX();
+        if (!branch.isConnected1()) {
+            validated &= checkDisconnectedTerminal(branch.getId(), "1", branch.getP1(), branch.getComputedP1(), branch.getQ1(), branch.getComputedQ1(), config);
         }
-        double z = Math.hypot(r, fixedX);
-        double y = 1 / z;
-        double ksi = Math.atan2(r, fixedX);
-        double computedU1 = computeU(connected1, connected2, u1, u2, rho1, rho2, g1, b1, y, ksi);
-        double computedU2 = computeU(connected2, connected1, u2, u1, rho2, rho1, g2, b2, y, ksi);
-        double computedTheta1 = computeTheta(connected1, connected2, theta1, theta2, alpha1, alpha2, computedU1, computedU2, rho1, rho2, g1, b1, y, ksi);
-        double computedTheta2 = computeTheta(connected2, connected1, theta2, theta1, alpha2, alpha1, computedU2, computedU1, rho2, rho1, g2, b2, y, ksi);
-        double p1Calc = connected1 ? rho1 * rho2 * computedU1 * computedU2 * y * Math.sin(computedTheta1 - computedTheta2 - ksi + alpha1 - alpha2) + rho1 * rho1 * computedU1 * computedU1 * (y * Math.sin(ksi) + g1) : Double.NaN;
-        double q1Calc = connected1 ? -rho1 * rho2 * computedU1 * computedU2 * y * Math.cos(computedTheta1 - computedTheta2 - ksi + alpha1 - alpha2) + rho1 * rho1 * computedU1 * computedU1 * (y * Math.cos(ksi) - b1) : Double.NaN;
-        double p2Calc = connected2 ? rho2 * rho1 * computedU2 * computedU1 * y * Math.sin(computedTheta2 - computedTheta1 - ksi + alpha2 - alpha1) + rho2 * rho2 * computedU2 * computedU2 * (y * Math.sin(ksi) + g2) : Double.NaN;
-        double q2Calc = connected2 ? -rho2 * rho1 * computedU2 * computedU1 * y * Math.cos(computedTheta2 - computedTheta1 - ksi + alpha2 - alpha1) + rho2 * rho2 * computedU2 * computedU2 * (y * Math.cos(ksi) - b2) : Double.NaN;
-
-        if (!connected1) {
-            validated &= checkDisconnectedTerminal(id, "1", p1, p1Calc, q1, q1Calc, config);
+        if (!branch.isConnected2()) {
+            validated &= checkDisconnectedTerminal(branch.getId(), "2", branch.getP2(), branch.getComputedP2(), branch.getQ2(), branch.getComputedQ2(), config);
         }
-        if (!connected2) {
-            validated &= checkDisconnectedTerminal(id, "2", p2, p2Calc, q2, q2Calc, config);
+        if (branch.isConnected1() && ValidationUtils.isMainComponent(config, branch.isMainComponent1())) {
+            validated &= checkConnectedTerminal(branch.getId(), "1", branch.getP1(), branch.getComputedP1(), branch.getQ1(), branch.getComputedQ1(), config);
         }
-        if (connected1 && ValidationUtils.isMainComponent(config, mainComponent1)) {
-            validated &= checkConnectedTerminal(id, "1", p1, p1Calc, q1, q1Calc, config);
-        }
-        if (connected2 && ValidationUtils.isMainComponent(config, mainComponent2)) {
-            validated &= checkConnectedTerminal(id, "2", p2, p2Calc, q2, q2Calc, config);
+        if (branch.isConnected2() && ValidationUtils.isMainComponent(config, branch.isMainComponent2())) {
+            validated &= checkConnectedTerminal(branch.getId(), "2", branch.getP2(), branch.getComputedP2(), branch.getQ2(), branch.getComputedQ2(), config);
         }
         try {
-            flowsWriter.write(id, p1, p1Calc, q1, q1Calc, p2, p2Calc, q2, q2Calc, r, x, g1, g2, b1, b2, rho1, rho2, alpha1, alpha2, u1, u2, theta1, theta2, z, y, ksi,
-                              connected1, connected2, mainComponent1, mainComponent2, validated);
+            flowsWriter.write(branch.getId(),
+                    branch.getP1(), branch.getComputedP1(), branch.getQ1(), branch.getComputedQ1(),
+                    branch.getP2(), branch.getComputedP2(), branch.getQ2(), branch.getComputedQ2(),
+                    branch.getR(), branch.getX(),
+                    branch.getG1(), branch.getG2(), branch.getB1(), branch.getB2(),
+                    branch.getRho1(), branch.getRho2(), branch.getAlpha1(), branch.getAlpha2(),
+                    branch.getU1(), branch.getU2(), branch.getTheta1(), branch.getTheta2(),
+                    branch.getZ(), branch.getY(), branch.getKsi(),
+                    branch.isConnected1(), branch.isConnected2(),
+                    branch.isMainComponent1(), branch.isMainComponent2(),
+                    validated);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
         return validated;
-    }
-
-    private static double computeU(boolean connected, boolean otherConnected, double u, double otherU, double rho, double otherRho, double g, double b, double y, double ksi) {
-        if (connected) {
-            return u;
-        }
-        if (!otherConnected) {
-            return u;
-        }
-        double z1 = y * Math.sin(ksi) + g;
-        double z2 = y * Math.cos(ksi) - b;
-        return 1 / Math.sqrt(z1 * z1 + z2 * z2) * (otherRho / rho) * y * otherU;
-    }
-
-    private static double computeTheta(boolean connected, boolean otherConnected, double theta, double otherTheta, double alpha, double otherAlpha, double u, double otherU,
-                                       double rho, double otherRho, double g, double b, double y, double ksi) {
-        if (connected) {
-            return theta;
-        }
-        if (!otherConnected) {
-            return theta;
-        }
-        double z1 = y * Math.sin(ksi) + g;
-        double z2 = y * Math.cos(ksi) - b;
-        double phi = -(-otherTheta - ksi + alpha - otherAlpha);
-        double cosTheatMinusPhi = rho / otherRho * u / otherU * (Math.cos(ksi) - b / y);
-        return Math.atan(-z1 / z2) + phi + (cosTheatMinusPhi < 0 ? Math.PI : 0);
     }
 
     private static boolean checkDisconnectedTerminal(String id, String terminalNumber, double p, double pCalc, double q, double qCalc, ValidationConfig config) {
@@ -166,36 +128,8 @@ public final class FlowsValidation {
         Objects.requireNonNull(config);
         Objects.requireNonNull(flowsWriter);
 
-        double p1 = l.getTerminal1().getP();
-        double q1 = l.getTerminal1().getQ();
-        double p2 = l.getTerminal2().getP();
-        double q2 = l.getTerminal2().getQ();
-        Bus bus1 = l.getTerminal1().getBusView().getBus();
-        Bus bus2 = l.getTerminal2().getBusView().getBus();
-        double r = l.getR();
-        double x = l.getX();
-        double rho1 = 1.0;
-        double rho2 = 1.0;
-        double u1 = bus1 != null ? bus1.getV() : Double.NaN;
-        double u2 = bus2 != null ? bus2.getV() : Double.NaN;
-        double theta1 = bus1 != null ? Math.toRadians(bus1.getAngle()) : Double.NaN;
-        double theta2 = bus2 != null ? Math.toRadians(bus2.getAngle()) : Double.NaN;
-        double alpha1 = 0.0;
-        double alpha2 = 0.0;
-        double g1 = l.getG1();
-        double g2 = l.getG2();
-        double b1 = l.getB1();
-        double b2 = l.getB2();
-        boolean connected1 = bus1 != null ? true : false;
-        boolean connected2 = bus2 != null ? true : false;
-        Bus connectableBus1 = l.getTerminal1().getBusView().getConnectableBus();
-        Bus connectableBus2 = l.getTerminal2().getBusView().getConnectableBus();
-        boolean connectableMainComponent1 = connectableBus1 != null ? connectableBus1.isInMainConnectedComponent() : false;
-        boolean connectableMainComponent2 = connectableBus2 != null ? connectableBus2.isInMainConnectedComponent() : false;
-        boolean mainComponent1 = bus1 != null ? bus1.isInMainConnectedComponent() : connectableMainComponent1;
-        boolean mainComponent2 = bus2 != null ? bus2.isInMainConnectedComponent() : connectableMainComponent2;
-        return checkFlows(l.getId(), r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
-                          mainComponent1, mainComponent2, config, flowsWriter);
+        BranchData branch = new BranchData(l, config.getEpsilonX(), config.applyReactanceCorrection());
+        return checkFlows(branch, config, flowsWriter);
     }
 
     public static boolean checkFlows(TwoWindingsTransformer twt, ValidationConfig config, Writer writer) {
@@ -215,75 +149,8 @@ public final class FlowsValidation {
         Objects.requireNonNull(config);
         Objects.requireNonNull(flowsWriter);
 
-        double p1 = twt.getTerminal1().getP();
-        double q1 = twt.getTerminal1().getQ();
-        double p2 = twt.getTerminal2().getP();
-        double q2 = twt.getTerminal2().getQ();
-        Bus bus1 = twt.getTerminal1().getBusView().getBus();
-        Bus bus2 = twt.getTerminal2().getBusView().getBus();
-        double r = getR(twt);
-        double x = getX(twt);
-        double g1 = getG1(twt, config);
-        double g2 = config.getLoadFlowParameters().isSpecificCompatibility() ? twt.getG() / 2 : 0.0;
-        double b1 = getB1(twt, config);
-        double b2 = config.getLoadFlowParameters().isSpecificCompatibility() ? twt.getB() / 2 : 0.0;
-        double rho1 = getRho1(twt);
-        double rho2 = 1.0;
-        double u1 = bus1 != null ? bus1.getV() : Double.NaN;
-        double u2 = bus2 != null ? bus2.getV() : Double.NaN;
-        double theta1 = bus1 != null ? Math.toRadians(bus1.getAngle()) : Double.NaN;
-        double theta2 = bus2 != null ? Math.toRadians(bus2.getAngle()) : Double.NaN;
-        double alpha1 = twt.getPhaseTapChanger() != null ? Math.toRadians(twt.getPhaseTapChanger().getCurrentStep().getAlpha()) : 0.0;
-        double alpha2 = 0.0;
-        boolean connected1 = bus1 != null ? true : false;
-        boolean connected2 = bus2 != null ? true : false;
-        Bus connectableBus1 = twt.getTerminal1().getBusView().getConnectableBus();
-        Bus connectableBus2 = twt.getTerminal2().getBusView().getConnectableBus();
-        boolean connectableMainComponent1 = connectableBus1 != null ? connectableBus1.isInMainConnectedComponent() : false;
-        boolean connectableMainComponent2 = connectableBus2 != null ? connectableBus2.isInMainConnectedComponent() : false;
-        boolean mainComponent1 = bus1 != null ? bus1.isInMainConnectedComponent() : connectableMainComponent1;
-        boolean mainComponent2 = bus2 != null ? bus2.isInMainConnectedComponent() : connectableMainComponent2;
-        return checkFlows(twt.getId(), r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
-                          mainComponent1, mainComponent2, config, flowsWriter);
-    }
-
-    private static double getValue(double initialValue, double rtcStepValue, double ptcStepValue) {
-        return initialValue * (1 + rtcStepValue / 100) * (1 + ptcStepValue / 100);
-    }
-
-    private static double getR(TwoWindingsTransformer twt) {
-        return getValue(twt.getR(),
-                twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getR() : 0,
-                twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getR() : 0);
-    }
-
-    private static double getX(TwoWindingsTransformer twt) {
-        return getValue(twt.getX(),
-                twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getX() : 0,
-                twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getX() : 0);
-    }
-
-    private static double getG1(TwoWindingsTransformer twt, ValidationConfig config) {
-        return getValue(config.getLoadFlowParameters().isSpecificCompatibility() ? twt.getG() / 2 : twt.getG(),
-                twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getG() : 0,
-                twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getG() : 0);
-    }
-
-    private static double getB1(TwoWindingsTransformer twt, ValidationConfig config) {
-        return getValue(config.getLoadFlowParameters().isSpecificCompatibility() ? twt.getB() / 2 : twt.getB(),
-                twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getB() : 0,
-                twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getB() : 0);
-    }
-
-    private static double getRho1(TwoWindingsTransformer twt) {
-        double rho1 = twt.getRatedU2() / twt.getRatedU1();
-        if (twt.getRatioTapChanger() != null) {
-            rho1 *= twt.getRatioTapChanger().getCurrentStep().getRho();
-        }
-        if (twt.getPhaseTapChanger() != null) {
-            rho1 *= twt.getPhaseTapChanger().getCurrentStep().getRho();
-        }
-        return rho1;
+        BranchData branch = new BranchData(twt, config.getEpsilonX(), config.applyReactanceCorrection(), config.getLoadFlowParameters().isSpecificCompatibility());
+        return checkFlows(branch, config, flowsWriter);
     }
 
     public static boolean checkFlows(Network network, ValidationConfig config, Writer writer) {

--- a/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/FlowsValidationTest.java
+++ b/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/FlowsValidationTest.java
@@ -9,6 +9,7 @@ package com.powsybl.loadflow.validation;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.PrintWriter;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.output.NullWriter;
@@ -24,6 +25,7 @@ import com.powsybl.iidm.network.RatioTapChangerStep;
 import com.powsybl.iidm.network.Terminal;
 import com.powsybl.iidm.network.Terminal.BusView;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
+import com.powsybl.iidm.network.util.BranchData;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.mock.LoadFlowFactoryMock;
 import com.powsybl.loadflow.validation.io.ValidationWriter;
@@ -150,41 +152,41 @@ public class FlowsValidationTest extends AbstractValidationTest {
         double p2 = -40.073254;
         double q2 = -2.3003194;
 
-        assertTrue(FlowsValidation.checkFlows("test", r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
-                                              mainComponent1, mainComponent2, looseConfig, NullWriter.NULL_WRITER));
-        assertFalse(FlowsValidation.checkFlows("test", r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
-                                               mainComponent1, mainComponent2, strictConfig, NullWriter.NULL_WRITER));
+        assertTrue(FlowsValidation.checkFlows(new BranchData("test", r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
+                                              mainComponent1, mainComponent2, looseConfig.getEpsilonX(), looseConfig.applyReactanceCorrection()), looseConfig, NullWriter.NULL_WRITER));
+        assertFalse(FlowsValidation.checkFlows(new BranchData("test", r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
+                                               mainComponent1, mainComponent2, strictConfig.getEpsilonX(), strictConfig.applyReactanceCorrection()), strictConfig, NullWriter.NULL_WRITER));
 
         double r = 0.04 / (rho2 * rho2);
         double x = 0.423 / (rho2 * rho2);
         double rho1 = 1 / rho2;
         double rho2 = 1;
 
-        assertTrue(FlowsValidation.checkFlows("test", r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
-                                              mainComponent1, mainComponent2, looseConfig, NullWriter.NULL_WRITER));
-        assertFalse(FlowsValidation.checkFlows("test", r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
-                                               mainComponent1, mainComponent2, strictConfig, NullWriter.NULL_WRITER));
+        assertTrue(FlowsValidation.checkFlows(new BranchData("test", r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
+                                              mainComponent1, mainComponent2, looseConfig.getEpsilonX(), looseConfig.applyReactanceCorrection()), looseConfig, NullWriter.NULL_WRITER));
+        assertFalse(FlowsValidation.checkFlows(new BranchData("test", r, x, rho1, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
+                                               mainComponent1, mainComponent2, strictConfig.getEpsilonX(), strictConfig.applyReactanceCorrection()), strictConfig, NullWriter.NULL_WRITER));
 
         // check disconnected on one end
-        assertTrue(FlowsValidation.checkFlows("test", r, x, rho1, rho2, Float.NaN, u2, Float.NaN, theta2, alpha1, alpha2, g1, g2, b1, b2, Float.NaN, Float.NaN, 0.0, 0.0, false, connected2,
-                                            mainComponent1, mainComponent2, looseConfig, NullWriter.NULL_WRITER));
-        assertFalse(FlowsValidation.checkFlows("test", r, x, rho1, rho2, Float.NaN, u2, Float.NaN, theta2, alpha1, alpha2, g1, g2, b1, b2, Float.NaN, Float.NaN, 0.2, 0.0, false, connected2,
-                                               mainComponent1, mainComponent2, looseConfig, NullWriter.NULL_WRITER));
+        assertTrue(FlowsValidation.checkFlows(new BranchData("test", r, x, rho1, rho2, Double.NaN, u2, Double.NaN, theta2, alpha1, alpha2, g1, g2, b1, b2, Double.NaN, Double.NaN, 0f, 0f, false, connected2,
+                                            mainComponent1, mainComponent2, looseConfig.getEpsilonX(), looseConfig.applyReactanceCorrection()), looseConfig, new PrintWriter(System.err)));
+        assertFalse(FlowsValidation.checkFlows(new BranchData("test", r, x, rho1, rho2, Double.NaN, u2, Double.NaN, theta2, alpha1, alpha2, g1, g2, b1, b2, Double.NaN, Double.NaN, 0.2f, 0f, false, connected2,
+                                               mainComponent1, mainComponent2, looseConfig.getEpsilonX(), looseConfig.applyReactanceCorrection()), looseConfig, NullWriter.NULL_WRITER));
 
         // check disconnected on both end
-        assertTrue(FlowsValidation.checkFlows("test", r, x, rho1, rho2, Float.NaN, Float.NaN, Float.NaN, Float.NaN, alpha1, alpha2, g1, g2, b1, b2, Float.NaN, Float.NaN, Float.NaN, Float.NaN,
-                                              false, false, mainComponent1, mainComponent2, looseConfig, NullWriter.NULL_WRITER));
-        assertFalse(FlowsValidation.checkFlows("test", r, x, rho1, rho2, Float.NaN, Float.NaN, Float.NaN, Float.NaN, alpha1, alpha2, g1, g2, b1, b2, p1, q2, Float.NaN, Float.NaN,
-                                              false, false, mainComponent1, mainComponent2, looseConfig, NullWriter.NULL_WRITER));
-        assertFalse(FlowsValidation.checkFlows("test", r, x, rho1, rho2, Float.NaN, Float.NaN, Float.NaN, Float.NaN, alpha1, alpha2, g1, g2, b1, b2, Float.NaN, Float.NaN, p2, q2,
-                                              false, false, mainComponent1, mainComponent2, looseConfig, NullWriter.NULL_WRITER));
+        assertTrue(FlowsValidation.checkFlows(new BranchData("test", r, x, rho1, rho2, Double.NaN, Double.NaN, Double.NaN, Double.NaN, alpha1, alpha2, g1, g2, b1, b2, Float.NaN, Float.NaN, Float.NaN, Float.NaN,
+                                              false, false, mainComponent1, mainComponent2, looseConfig.getEpsilonX(), looseConfig.applyReactanceCorrection()), looseConfig, NullWriter.NULL_WRITER));
+        assertFalse(FlowsValidation.checkFlows(new BranchData("test", r, x, rho1, rho2, Double.NaN, Double.NaN, Double.NaN, Double.NaN, alpha1, alpha2, g1, g2, b1, b2, p1, q2, Double.NaN, Double.NaN,
+                                              false, false, mainComponent1, mainComponent2, looseConfig.getEpsilonX(), looseConfig.applyReactanceCorrection()), looseConfig, NullWriter.NULL_WRITER));
+        assertFalse(FlowsValidation.checkFlows(new BranchData("test", r, x, rho1, rho2, Double.NaN, Double.NaN, Double.NaN, Double.NaN, alpha1, alpha2, g1, g2, b1, b2, Double.NaN, Double.NaN, p2, q2,
+                                              false, false, mainComponent1, mainComponent2, looseConfig.getEpsilonX(), looseConfig.applyReactanceCorrection()), looseConfig, NullWriter.NULL_WRITER));
 
         // check with NaN values
-        assertFalse(FlowsValidation.checkFlows("test", r, x, Double.NaN, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
-                                               mainComponent1, mainComponent2, looseConfig, NullWriter.NULL_WRITER));
+        assertFalse(FlowsValidation.checkFlows(new BranchData("test", r, x, Double.NaN, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
+                                               mainComponent1, mainComponent2, looseConfig.getEpsilonX(), looseConfig.applyReactanceCorrection()), looseConfig, NullWriter.NULL_WRITER));
         looseConfig.setOkMissingValues(true);
-        assertTrue(FlowsValidation.checkFlows("test", r, x, Double.NaN, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
-                                              mainComponent1, mainComponent2, looseConfig, NullWriter.NULL_WRITER));
+        assertTrue(FlowsValidation.checkFlows(new BranchData("test", r, x, Double.NaN, rho2, u1, u2, theta1, theta2, alpha1, alpha2, g1, g2, b1, b2, p1, q1, p2, q2, connected1, connected2,
+                                              mainComponent1, mainComponent2, looseConfig.getEpsilonX(), looseConfig.applyReactanceCorrection()), looseConfig, NullWriter.NULL_WRITER));
         looseConfig.setOkMissingValues(false);
     }
 
@@ -251,5 +253,4 @@ public class FlowsValidationTest extends AbstractValidationTest {
         ValidationWriter validationWriter = ValidationUtils.createValidationWriter(network.getId(), looseConfig, NullWriter.NULL_WRITER, ValidationType.FLOWS);
         assertTrue(ValidationType.FLOWS.check(network, looseConfig, validationWriter));
     }
-
 }


### PR DESCRIPTION
Unified duplicated code for power flow computation: it was present in `BranchData.java` (in `loadflow-results-completion` module) and in `FlowsValidation.java` (in `loadflow-validation` module). 

Moved the `BranchData.java` module to iidm-api module (inside `util` package) and used it from `loadflow-validation`.

Thought it was convenient to move the code to `iidm-api`, conceptually it is at a similar level of already existing `SV.java` code. Also, it helps to get rid of potential cyclic dependencies between loadflow results completion and loadflow validation.

