### PR TITLE
Test actions: only clone network if it is actually needed

### DIFF
--- a/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/LoadFlowActionSimulator.java
+++ b/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/LoadFlowActionSimulator.java
@@ -336,6 +336,11 @@ public class LoadFlowActionSimulator implements ActionSimulator {
                                 .distinct()
                                 .filter(id -> !context.isTested(id))
                                 .collect(Collectors.toList());
+
+        if (testActionIds.isEmpty()) {
+            return;
+        }
+
         byte[] contextNetwork = NetworkXml.gzip(context.getNetwork());
 
         for (String actionId : testActionIds) {


### PR DESCRIPTION
otherwise, there is an important performance penalty for all action simulator executions which do not use the test actions.