### PR TITLE
Parallel action-simulator: copy once

### DIFF
--- a/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/LoadFlowActionSimulator.java
+++ b/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/LoadFlowActionSimulator.java
@@ -82,6 +82,14 @@ public class LoadFlowActionSimulator implements ActionSimulator {
         return config;
     }
 
+    protected Network getNetwork() {
+        return network;
+    }
+
+    protected boolean isApplyIfSolvedViolations() {
+        return applyIfSolvedViolations;
+    }
+
     @Override
     public void start(ActionDb actionDb, String... contingencyIds) {
         start(actionDb, Arrays.asList(contingencyIds));

--- a/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/ParallelLoadFlowActionSimulator.java
+++ b/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/ParallelLoadFlowActionSimulator.java
@@ -107,7 +107,6 @@ public class ParallelLoadFlowActionSimulator extends LoadFlowActionSimulator {
                     .program(ITOOLS_PRG)
                     .id(SUB_TASK_ID)
                     .build();
-            LOGGER.debug("Submitting command: {}", subItoolsCmd.toString(1));
             return Collections.singletonList(new CommandExecution(subItoolsCmd, actualTaskCount, 1));
         }
 
@@ -123,6 +122,10 @@ public class ParallelLoadFlowActionSimulator extends LoadFlowActionSimulator {
                 results.add(SecurityAnalysisResultDeserializer.read(taskResultFile));
             }
             return SecurityAnalysisResultMerger.merge(results);
+        }
+
+        private String getOutputFileName(int taskNumber) {
+            return "task_" + taskNumber + "_result.json";
         }
 
         private SimpleCommandBuilder buildCommand(Path workingDir) throws IOException {
@@ -143,7 +146,7 @@ public class ParallelLoadFlowActionSimulator extends LoadFlowActionSimulator {
                 .addOption(CASE_FILE, networkDest.toString())
                 .addOption(DSL_FILE, dslFileDest.toString())
                 .addOption(TASK, i -> new Partition(i + 1, actualTaskCount).toString())
-                .addOption(OUTPUT_FILE, i -> getOutputFileName(i))
+                .addOption(OUTPUT_FILE, this::getOutputFileName)
                 .addOption(OUTPUT_FORMAT, "JSON")
                 .addFlag(APPLY_IF_SOLVED_VIOLATIONS, isApplyIfSolvedViolations());
 
@@ -193,9 +196,5 @@ public class ParallelLoadFlowActionSimulator extends LoadFlowActionSimulator {
             super.arg(arg);
             return this;
         }
-    }
-
-    private static String getOutputFileName(int taskNumber) {
-        return "task_" + taskNumber + "_result.json";
     }
 }

--- a/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/ParallelLoadFlowActionSimulator.java
+++ b/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/ParallelLoadFlowActionSimulator.java
@@ -10,19 +10,20 @@ import com.powsybl.action.dsl.ActionDb;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.computation.*;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.xml.NetworkXml;
 import com.powsybl.security.SecurityAnalysisResult;
 import com.powsybl.security.SecurityAnalysisResultMerger;
-import com.powsybl.security.converter.SecurityAnalysisResultExporters;
 import com.powsybl.security.json.SecurityAnalysisResultDeserializer;
-import com.powsybl.tools.ToolRunningContext;
-import org.apache.commons.cli.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static com.powsybl.action.simulator.tools.ActionSimulatorToolConstants.*;
 
@@ -31,28 +32,31 @@ import static com.powsybl.action.simulator.tools.ActionSimulatorToolConstants.*;
  */
 public class ParallelLoadFlowActionSimulator extends LoadFlowActionSimulator {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParallelLoadFlowActionSimulator.class);
+
     private static final String ITOOLS_PRG = "itools";
 
     private final int taskCount;
-
-    private final CommandLine commandLine;
+    private final Path dslFile;
+    private final List<Consumer<SecurityAnalysisResult>> resultHandlers;
 
     private static final String SUB_TASK_ID = "sas"; // sub_action_simulator
 
-    public ParallelLoadFlowActionSimulator(Network network, ToolRunningContext context, CommandLine commandLine) {
-        this(network, context, commandLine, LoadFlowActionSimulatorConfig.load(), false, Collections.emptyList());
+    public ParallelLoadFlowActionSimulator(Network network, Path dslFile, ComputationManager cm, int taskCount) {
+        this(network, dslFile, cm, taskCount, LoadFlowActionSimulatorConfig.load(), false, Collections.emptyList());
     }
 
-    public ParallelLoadFlowActionSimulator(Network network, ToolRunningContext context, CommandLine commandLine,
-                                           LoadFlowActionSimulatorConfig config, boolean applyIfSolved, LoadFlowActionSimulatorObserver... observers) {
-        this(network, context, commandLine, config, applyIfSolved, Arrays.asList(observers));
+    public ParallelLoadFlowActionSimulator(Network network, Path dslFile, ComputationManager cm, int taskCount, LoadFlowActionSimulatorConfig config,
+                                           boolean applyIfSolved, Consumer<SecurityAnalysisResult>... resultHandlers) {
+        this(network, dslFile, cm, taskCount, config, applyIfSolved, Arrays.asList(resultHandlers));
     }
 
-    public ParallelLoadFlowActionSimulator(Network network, ToolRunningContext context, CommandLine commandLine,
-                                           LoadFlowActionSimulatorConfig config, boolean applyIfSolved, List<LoadFlowActionSimulatorObserver> observers) {
-        super(network, context.getLongTimeExecutionComputationManager(), config, applyIfSolved, observers);
-        this.commandLine = Objects.requireNonNull(commandLine);
-        this.taskCount = Integer.parseInt(commandLine.getOptionValue(TASK_COUNT));
+    public ParallelLoadFlowActionSimulator(Network network, Path dslFile, ComputationManager cm, int taskCount, LoadFlowActionSimulatorConfig config,
+                                           boolean applyIfSolved, List<Consumer<SecurityAnalysisResult>> resultHandlers) {
+        super(network, cm, config, applyIfSolved);
+        this.dslFile = Objects.requireNonNull(dslFile);
+        this.taskCount = taskCount;
+        this.resultHandlers = resultHandlers;
     }
 
     @Override
@@ -62,30 +66,20 @@ public class ParallelLoadFlowActionSimulator extends LoadFlowActionSimulator {
 
     @Override
     public void start(ActionDb actionDb, List<String> contingencyIds) {
+
+        LOGGER.debug("Starting parallel action simulator.");
+
         ComputationManager manager = getComputationManager();
         ExecutionEnvironment itoolsEnvironment = new ExecutionEnvironment(Collections.emptyMap(), "subTask_", getConfig().isDebug());
 
-        int atMostTasks = Integer.min(taskCount, contingencyIds.size());
-        List<CompletableFuture<SecurityAnalysisResult>> results = new ArrayList<>();
-        for (int i = 1; i <= atMostTasks; i++) {
-            CompletableFuture<SecurityAnalysisResult> future = manager.execute(itoolsEnvironment,
-                    new SubTaskHandler(new Partition(i, atMostTasks)));
-            results.add(future);
-        }
-        CompletableFuture.allOf(results.toArray(new CompletableFuture[0])).join();
-
-        // merge results and re-print to output-file
-        SecurityAnalysisResult[] securityAnalysisResults = new SecurityAnalysisResult[results.size()];
+        int actualTaskCount = Math.min(taskCount, contingencyIds.size());
+        CompletableFuture<SecurityAnalysisResult> future = manager.execute(itoolsEnvironment, new SubTaskHandler(actualTaskCount));
         try {
-            for (int i = 0; i < results.size(); i++) {
-                securityAnalysisResults[i] = results.get(i).get();
-            }
+            SecurityAnalysisResult result = future.get();
+            resultHandlers.forEach(h -> h.accept(result));
         } catch (Exception e) {
             throw new PowsyblException(e);
         }
-
-        SecurityAnalysisResult securityAnalysisResult = SecurityAnalysisResultMerger.merge(securityAnalysisResults);
-        SecurityAnalysisResultExporters.export(securityAnalysisResult, Paths.get(commandLine.getOptionValue(OUTPUT_FILE)), commandLine.getOptionValue(OUTPUT_FORMAT));
     }
 
     @Override
@@ -93,84 +87,115 @@ public class ParallelLoadFlowActionSimulator extends LoadFlowActionSimulator {
         start(actionDb, Arrays.asList(contingencyIds));
     }
 
+    /**
+     * Execution handler for sub-tasks.
+     * copies network and groovy file to working directory,
+     * then launches one itools command for each subtask.
+     * Finally, reads and merge results.
+     */
     private class SubTaskHandler extends AbstractExecutionHandler<SecurityAnalysisResult> {
 
-        private final Partition partition;
+        private final int actualTaskCount;
 
-        SubTaskHandler(Partition partition) {
-            this.partition = Objects.requireNonNull(partition);
+        SubTaskHandler(int actualTaskCount) {
+            this.actualTaskCount = actualTaskCount;
         }
 
         @Override
         public List<CommandExecution> before(Path workingDir) throws IOException {
-            List<String> args = rebuildSubProgramArgs(workingDir);
-            SimpleCommand subItoolsCmd = new SimpleCommandBuilder()
+            SimpleCommand subItoolsCmd = buildCommand(workingDir)
                     .program(ITOOLS_PRG)
                     .id(SUB_TASK_ID)
-                    .args(args)
                     .build();
-            return Collections.singletonList(new CommandExecution(subItoolsCmd, 1, 1));
+            LOGGER.debug("Submitting command: {}", subItoolsCmd.toString(1));
+            return Collections.singletonList(new CommandExecution(subItoolsCmd, actualTaskCount, 1));
+        }
+
+        /**
+         * Reads result files and merge them.
+         */
+        @Override
+        public SecurityAnalysisResult after(Path workingDir, ExecutionReport report) {
+            LOGGER.debug("End of command execution in {}. ", workingDir);
+            List<SecurityAnalysisResult> results = new ArrayList<>();
+            for (int taskNum = 0; taskNum < actualTaskCount; taskNum++) {
+                Path taskResultFile = workingDir.resolve(getOutputFileName(taskNum));
+                results.add(SecurityAnalysisResultDeserializer.read(taskResultFile));
+            }
+            return SecurityAnalysisResultMerger.merge(results);
+        }
+
+        private SimpleCommandBuilder buildCommand(Path workingDir) throws IOException {
+
+            OptionCommandBuilder builder = new OptionCommandBuilder();
+
+            // copy input files to slave workingDir
+            Path networkDest = workingDir.resolve("network.xiidm");
+            LOGGER.debug("Copying network to file {}", networkDest);
+            NetworkXml.write(getNetwork(), networkDest);
+
+            Path dslFileDest = workingDir.resolve("action-script.groovy");
+            LOGGER.debug("Copying action file from {} to {}", dslFile, dslFileDest);
+            Files.copy(dslFile, dslFileDest);
+
+            builder
+                .arg("action-simulator")
+                .addOption(CASE_FILE, networkDest.toString())
+                .addOption(DSL_FILE, dslFileDest.toString())
+                .addOption(TASK, i -> new Partition(i + 1, actualTaskCount).toString())
+                .addOption(OUTPUT_FILE, i -> getOutputFileName(i))
+                .addOption(OUTPUT_FORMAT, "JSON")
+                .addFlag(APPLY_IF_SOLVED_VIOLATIONS, isApplyIfSolvedViolations());
+
+            return builder;
+        }
+    }
+
+    /**
+     * Simple command builder with additional methods to easily add options as "--opt=value"
+     */
+    protected static class OptionCommandBuilder extends SimpleCommandBuilder {
+
+        /**
+         * Adds a literal option.
+         */
+        public OptionCommandBuilder addFlag(String flagName, boolean flagValue) {
+            if (flagValue) {
+                arg("--" + flagName);
+            }
+            return this;
+        }
+
+        /**
+         * Adds a literal option.
+         */
+        public OptionCommandBuilder addOption(String opt, String value) {
+            arg("--" + opt + "=" + value);
+            return this;
+        }
+
+        /**
+         * Adds an option dependent on the execution count
+         */
+        public OptionCommandBuilder addOption(String opt, Function<Integer, String> fn) {
+            arg(i -> "--" + opt + "=" + fn.apply(i));
+            return this;
         }
 
         @Override
-        public SecurityAnalysisResult after(Path workingDir, ExecutionReport report) {
-            Path fileName = Paths.get(commandLine.getOptionValue(OUTPUT_FILE)).getFileName();
-            Path outputFile = workingDir.resolve(fileName);
-            return SecurityAnalysisResultDeserializer.read(outputFile);
+        public OptionCommandBuilder arg(String arg) {
+            super.arg(arg);
+            return this;
         }
 
-        private void addRequiredArgs(List<String> list, String optName) {
-            if (commandLine.hasOption(optName)) {
-                String optValue = toOption(optName, commandLine.getOptionValue(optName));
-                list.add(optValue);
-            } else {
-                throw new IllegalArgumentException("Missing option[" + optName + "]");
-            }
+        @Override
+        public SimpleCommandBuilder arg(Function<Integer, String> arg) {
+            super.arg(arg);
+            return this;
         }
+    }
 
-        private void addArgs(List<String> list, String optName) {
-            if (commandLine.hasOption(optName)) {
-                String optValue = toOption(optName, commandLine.getOptionValue(optName));
-                list.add(optValue);
-            }
-        }
-
-        private List<String> rebuildSubProgramArgs(Path workingDir) throws IOException {
-            List<String> args = new ArrayList<>(); // subtask command args
-            args.add("action-simulator");
-            // copy input files to slave workingDir
-            Path caseFile = copyFromOptionValueToWorkingDir(CASE_FILE, workingDir);
-            String caseFileOpt = toOption(CASE_FILE, caseFile.toAbsolutePath().toString());
-            args.add(caseFileOpt);
-            Path dslFile = copyFromOptionValueToWorkingDir(DSL_FILE, workingDir);
-            String dslFileOpt = toOption(DSL_FILE, dslFile.toAbsolutePath().toString());
-            args.add(dslFileOpt);
-
-            String partitionOpt = toOption(TASK, partition.toString());
-            args.add(partitionOpt);
-
-            if (commandLine.hasOption(OUTPUT_FILE)) {
-                Path fileName = Paths.get(commandLine.getOptionValue(OUTPUT_FILE)).getFileName();
-                String tmpFolderOpt = toOption(OUTPUT_FILE, workingDir.resolve(fileName).toAbsolutePath().toString());
-                args.add(tmpFolderOpt);
-            }
-
-            addRequiredArgs(args, OUTPUT_FORMAT);
-
-            addArgs(args, APPLY_IF_SOLVED_VIOLATIONS);
-
-            return args;
-        }
-
-        private Path copyFromOptionValueToWorkingDir(String opt, Path workingDir) throws IOException {
-            Path source = Paths.get(commandLine.getOptionValue(opt));
-            String name = source.getFileName().toString();
-            Path dest = workingDir.resolve(name);
-            return Files.copy(source, dest);
-        }
-
-        private String toOption(String opt, String value) {
-            return "--" + opt + "=" + value;
-        }
+    private static String getOutputFileName(int taskNumber) {
+        return "task_" + taskNumber + "_result.json";
     }
 }

--- a/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/SecurityAnalysisResultHandler.java
+++ b/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/SecurityAnalysisResultHandler.java
@@ -10,7 +10,9 @@ import com.powsybl.action.simulator.tools.AbstractSecurityAnalysisResultBuilder;
 import com.powsybl.security.SecurityAnalysisResult;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -21,6 +23,14 @@ import java.util.function.Consumer;
 public class SecurityAnalysisResultHandler extends AbstractSecurityAnalysisResultBuilder {
 
     private final List<Consumer<SecurityAnalysisResult>> handlers = new ArrayList<>();
+
+    public SecurityAnalysisResultHandler() {
+    }
+
+    public SecurityAnalysisResultHandler(Collection<Consumer<SecurityAnalysisResult>> handlers) {
+        Objects.requireNonNull(handlers);
+        this.handlers.addAll(handlers);
+    }
 
     public SecurityAnalysisResultHandler add(Consumer<SecurityAnalysisResult> handler) {
         handlers.add(handler);

--- a/action/action-simulator/src/test/java/com/powsybl/action/simulator/loadflow/ParallelLoadFlowActionSimulatorTest.java
+++ b/action/action-simulator/src/test/java/com/powsybl/action/simulator/loadflow/ParallelLoadFlowActionSimulatorTest.java
@@ -7,14 +7,12 @@
 package com.powsybl.action.simulator.loadflow;
 
 import com.powsybl.action.dsl.ActionDb;
-import com.powsybl.action.simulator.tools.ActionSimulatorToolConstants;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.tools.ToolRunningContext;
-import org.apache.commons.cli.CommandLine;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
@@ -36,15 +34,10 @@ public class ParallelLoadFlowActionSimulatorTest {
     public void setup() {
         Network network = mock(Network.class);
         computationManager = mock(ComputationManager.class);
-        ToolRunningContext context = mock(ToolRunningContext.class);
-        when(context.getLongTimeExecutionComputationManager()).thenReturn(computationManager);
-
-        CommandLine commandLine = mock(CommandLine.class);
-        when(commandLine.getOptionValue(ActionSimulatorToolConstants.TASK_COUNT)).thenReturn("7");
 
         LoadFlowActionSimulatorConfig config = mock(LoadFlowActionSimulatorConfig.class);
 
-        parallelLoadFlowActionSimulator = new ParallelLoadFlowActionSimulator(network, context, commandLine, config, false, Collections.emptyList());
+        parallelLoadFlowActionSimulator = new ParallelLoadFlowActionSimulator(network, Paths.get("actions.groovy"), computationManager, 7, config, false, Collections.emptyList());
 
         actionDb = mock(ActionDb.class);
         contingencies = mock(List.class);
@@ -59,7 +52,7 @@ public class ParallelLoadFlowActionSimulatorTest {
         } catch (Exception e) {
             // do nothing
         }
-        verify(computationManager, times(7)).execute(any(), any());
+        verify(computationManager, times(1)).execute(any(), any());
     }
 
     @Test
@@ -70,6 +63,6 @@ public class ParallelLoadFlowActionSimulatorTest {
         } catch (Exception e) {
             // do nothing
         }
-        verify(computationManager, times(3)).execute(any(), any());
+        verify(computationManager, times(1)).execute(any(), any());
     }
 }

--- a/computation/src/main/java/com/powsybl/computation/SimpleCommandBuilder.java
+++ b/computation/src/main/java/com/powsybl/computation/SimpleCommandBuilder.java
@@ -8,10 +8,7 @@ package com.powsybl.computation;
 
 import com.powsybl.commons.PowsyblException;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -48,6 +45,23 @@ public class SimpleCommandBuilder extends AbstractCommandBuilder<SimpleCommandBu
     public SimpleCommandBuilder args(String... args) {
         Objects.requireNonNull(args);
         args(Arrays.asList(args));
+        return this;
+    }
+
+    public SimpleCommandBuilder arg(String arg) {
+        Objects.requireNonNull(args);
+        arg(i -> arg);
+        return this;
+    }
+
+    public SimpleCommandBuilder arg(Function<Integer, String> arg) {
+        Objects.requireNonNull(arg);
+        Function<Integer, List<String> > previous = args;
+        args = i -> {
+            List<String> r = new ArrayList<>(previous.apply(i));
+            r.add(arg.apply(i));
+            return r;
+        };
         return this;
     }
 

--- a/computation/src/test/java/com/powsybl/computation/SimpleCommandTest.java
+++ b/computation/src/test/java/com/powsybl/computation/SimpleCommandTest.java
@@ -50,6 +50,19 @@ public class SimpleCommandTest {
         assertEquals(ImmutableList.of("arg1", "file1"), cmd1.getArgs(1));
     }
 
+    @Test
+    public void testInhomogeneousArgs() {
+        SimpleCommand cmd1 = new SimpleCommandBuilder()
+                .id("cmd1")
+                .program("prg1")
+                .args("literal_arg_1", "literal_arg_2")
+                .arg("literal_arg_3")
+                .arg(i -> "instantiated_arg_" + i)
+                .build();
+
+        assertEquals(ImmutableList.of("literal_arg_1", "literal_arg_2", "literal_arg_3", "instantiated_arg_4"), cmd1.getArgs(4));
+    }
+
     @Test(expected = RuntimeException.class)
     public void testErrorTimeout() {
         new SimpleCommandBuilder()

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisResultMerger.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisResultMerger.java
@@ -6,10 +6,7 @@
  */
 package com.powsybl.security;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * @author Yichen Tang <yichen.tang at rte-france.com>
@@ -36,6 +33,11 @@ public final class SecurityAnalysisResultMerger {
             Arrays.stream(results, 1, results.length).forEach(r -> res.getPostContingencyResults().addAll(r.getPostContingencyResults()));
         }
         return res;
+    }
+
+    public static SecurityAnalysisResult merge(Collection<SecurityAnalysisResult> results) {
+        Objects.requireNonNull(results);
+        return merge(results.toArray(new SecurityAnalysisResult[results.size()]));
     }
 
     private SecurityAnalysisResultMerger() {


### PR DESCRIPTION
 * Only use one working directory for all subtasks, copying only once input files
 * Try to use business objects instead of command line arguments for the parallel implementation