### PR TITLE
Fix closing of lazily created computation managers:

### DIFF
--- a/computation/src/main/java/com/powsybl/computation/LazyCreatedComputationManager.java
+++ b/computation/src/main/java/com/powsybl/computation/LazyCreatedComputationManager.java
@@ -66,7 +66,10 @@ public class LazyCreatedComputationManager implements ComputationManager {
     }
 
     @Override
-    public void close() {
-        getComputationManager().close();
+    public synchronized void close() {
+        //Close the underlying delegate only if it has been initialized.
+        if (delegate != null) {
+            delegate.close();
+        }
     }
 }


### PR DESCRIPTION
the delegate was systematically created and closed
when closing the lazy implementation.