### PR TITLE
add an interface in AbstractConverterTest to refactor serializer tests

### DIFF
--- a/commons/src/test/java/com/powsybl/commons/AbstractConverterTest.java
+++ b/commons/src/test/java/com/powsybl/commons/AbstractConverterTest.java
@@ -36,6 +36,11 @@ public abstract class AbstractConverterTest {
     protected FileSystem fileSystem;
     protected Path tmpDir;
 
+    protected interface RoundTripUtil<T> {
+        T roundTrip(T data, String ref) throws IOException;
+    }
+
+
     @Before
     public void setUp() throws IOException {
         fileSystem = Jimfs.newFileSystem(Configuration.unix());


### PR DESCRIPTION
RoundTripUtil is added to refactor  code in serializer tests for extensions