### PR TITLE
Fix bug in getSubstations(Country country, String tso, String... geographicalTags)

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
@@ -27,7 +27,7 @@ final class Substations {
             return substations;
         }
         return Iterables.filter(substations, substation -> {
-            if (country != null && country == substation.getCountry()) {
+            if (country != null && country != substation.getCountry()) {
                 return false;
             }
             if (tso != null && !tso.equals(substation.getTso())) {

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworkTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworkTest.java
@@ -49,6 +49,7 @@ public class NetworkTest {
         Country country1 = network.getCountries().iterator().next();
 
         assertEquals(1, Iterables.size(network.getSubstations()));
+        assertEquals(1, Iterables.size(network.getSubstations(Country.FR, "TSO1", "region1")));
         assertEquals(1, network.getSubstationCount());
 
         Substation substation1 = network.getSubstation("substation1");


### PR DESCRIPTION
**Bug Fix** : 
* Substations.*filter* used to exclude substation with same country : **CORRECTED**
* the method getSubstations(Country country, String tso, String... geographicalTags) is tested in NetworkTest