### PR TITLE
extensions delimiter for ExternalSecurityAnalysis bug fixing

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/ExternalSecurityAnalysis.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/ExternalSecurityAnalysis.java
@@ -150,7 +150,7 @@ public class ExternalSecurityAnalysis implements SecurityAnalysis {
                     .option("contingencies-file", CONTINGENCIES_FILE)
                     .option("parameters-file", PARAMETERS_FILE);
             if (!extensions.isEmpty()) {
-                cmdBuilder.option("with-extensions", String.join(", ", extensions));
+                cmdBuilder.option("with-extensions", String.join(",", extensions));
             }
             return cmdBuilder;
         }


### PR DESCRIPTION
extensions delimiter should be only "comma" not "comma space"