### PR TITLE
IIDM-XML converter: read/write internal connections for node breaker topologies

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewInternalConnectionXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewInternalConnectionXml.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, RTE (http://www.rte-france.com)
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewInternalConnectionXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewInternalConnectionXml.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.xml;
+
+import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
+
+import javax.xml.stream.XMLStreamException;
+
+import com.powsybl.commons.xml.XmlUtil;
+import com.powsybl.iidm.network.VoltageLevel;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+public class NodeBreakerViewInternalConnectionXml {
+
+    static final NodeBreakerViewInternalConnectionXml INSTANCE = new NodeBreakerViewInternalConnectionXml();
+    static final String ROOT_ELEMENT_NAME = "internalConnection";
+
+    protected String getRootElementName() {
+        return ROOT_ELEMENT_NAME;
+    }
+
+    protected void write(int node1, int node2, NetworkXmlWriterContext context) throws XMLStreamException {
+        context.getWriter().writeEmptyElement(IIDM_URI, getRootElementName());
+        context.getWriter().writeAttribute("node1", Integer.toString(node1));
+        context.getWriter().writeAttribute("node2", Integer.toString(node2));
+        //context.getWriter().writeEndElement();
+    }
+
+    protected void read(VoltageLevel vl, NetworkXmlReaderContext context) {
+        int node1 = XmlUtil.readIntAttribute(context.getReader(), "node1");
+        int node2 = XmlUtil.readIntAttribute(context.getReader(), "node2");
+        vl.getNodeBreakerView().newInternalConnection().setNode1(node1).setNode2(node2).add();
+    }
+}

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewInternalConnectionXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewInternalConnectionXml.java
@@ -29,7 +29,6 @@ public class NodeBreakerViewInternalConnectionXml {
         context.getWriter().writeEmptyElement(IIDM_URI, getRootElementName());
         context.getWriter().writeAttribute("node1", Integer.toString(node1));
         context.getWriter().writeAttribute("node2", Integer.toString(node2));
-        //context.getWriter().writeEndElement();
     }
 
     protected void read(VoltageLevel vl, NetworkXmlReaderContext context) {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -6,9 +6,9 @@
  */
 package com.powsybl.iidm.xml;
 
+import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.network.*;
-
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
 
@@ -118,8 +118,8 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     private void writeNodeBreakerTopologyInternalConnection(int n1, int n2, NetworkXmlWriterContext context) {
         try {
             NodeBreakerViewInternalConnectionXml.INSTANCE.write(n1, n2, context);
-        } catch (XMLStreamException x) {
-            // Log the error
+        } catch (XMLStreamException e) {
+            throw new UncheckedXmlStreamException(e);
         }
     }
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -9,6 +9,9 @@ package com.powsybl.iidm.xml;
 import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.network.*;
 
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+
 import javax.xml.stream.XMLStreamException;
 
 import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
@@ -85,7 +88,39 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
         for (Switch sw : vl.getNodeBreakerView().getSwitches()) {
             NodeBreakerViewSwitchXml.INSTANCE.write(sw, vl, context);
         }
+        writeNodeBreakerTopologyInternalConnections(vl, context);
         context.getWriter().writeEndElement();
+    }
+
+    private void writeNodeBreakerTopologyInternalConnections(VoltageLevel vl, NetworkXmlWriterContext context) {
+        VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
+        int[] nodes = topo.getNodes();
+        // There is no way in IIDM to obtain the list of internal connections,
+        // we have to traverse all connectivity and consider an internal connection
+        // when there are two nodes linked with an edge that does not have an
+        // associated object
+        final TIntSet explored = new TIntHashSet();
+        for (int n : nodes) {
+            if (explored.contains(n) || topo.getTerminal(n) == null) {
+                continue;
+            }
+            explored.add(n);
+            topo.traverse(n, (n1, sw, n2) -> {
+                explored.add(n2);
+                if (sw == null) {
+                    writeNodeBreakerTopologyInternalConnection(n1, n2, context);
+                }
+                return topo.getTerminal(n2) == null;
+            });
+        }
+    }
+
+    private void writeNodeBreakerTopologyInternalConnection(int n1, int n2, NetworkXmlWriterContext context) {
+        try {
+            NodeBreakerViewInternalConnectionXml.INSTANCE.write(n1, n2, context);
+        } catch (XMLStreamException x) {
+            // Log the error
+        }
     }
 
     private void writeBusBreakerTopology(VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
@@ -215,6 +250,10 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
 
                             case NodeBreakerViewSwitchXml.ROOT_ELEMENT_NAME:
                                 NodeBreakerViewSwitchXml.INSTANCE.read(vl, context);
+                                break;
+
+                            case NodeBreakerViewInternalConnectionXml.ROOT_ELEMENT_NAME:
+                                NodeBreakerViewInternalConnectionXml.INSTANCE.read(vl, context);
                                 break;
 
                             default:

--- a/iidm/iidm-xml-converter/src/main/resources/xsd/iidm.xsd
+++ b/iidm/iidm-xml-converter/src/main/resources/xsd/iidm.xsd
@@ -103,6 +103,7 @@
         <xs:sequence>
             <xs:element name="busbarSection" minOccurs="0" maxOccurs="unbounded" type="iidm:BusbarSection"/>
             <xs:element name="switch" minOccurs="0" maxOccurs="unbounded" type="iidm:SwitchNode"/>
+            <xs:element name="internalConnection" minOccurs="0" maxOccurs="unbounded" type="iidm:InternalConnection"/>
         </xs:sequence>
         <xs:attribute name="nodeCount" use="required" type="xs:int"/>
     </xs:complexType>
@@ -161,6 +162,10 @@
                 <xs:attribute name="bus2" use="required" type="iidm:nonEmptyString"/>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="InternalConnection">
+        <xs:attribute name="node1" use="required" type="xs:int"/>
+        <xs:attribute name="node2" use="required" type="xs:int"/>
     </xs:complexType>
     <xs:complexType name="Point">
         <xs:attribute name="p" use="required" type="xs:double"/>

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NodeBreakerInternalConnectionsTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NodeBreakerInternalConnectionsTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.xml;
+
+import java.io.IOException;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.NetworkFactory;
+import com.powsybl.iidm.network.Substation;
+import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.VoltageLevel.NodeBreakerView;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+public class NodeBreakerInternalConnectionsTest extends AbstractConverterTest {
+
+    @Test
+    public void roundTripTest() throws IOException {
+        roundTripXmlTest(
+                networkWithInternalConnections(),
+                NetworkXml::writeAndValidate,
+                NetworkXml::read,
+                "/internalConnections.xiidm");
+    }
+
+    private Network networkWithInternalConnections() {
+        Network network = NetworkFactory
+                .create("internal-connections", "test")
+                .setCaseDate(DateTime.parse("2018-11-08T12:33:26.208+01:00"));
+
+        Substation s1 = network.newSubstation()
+                .setId("s1")
+                .setCountry(Country.ES)
+                .add();
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        NodeBreakerView n1 = vl1.getNodeBreakerView();
+        n1.setNodeCount(5);
+        vl1.newGenerator()
+                .setId("g1")
+                .setNode(0)
+                .setMinP(0)
+                .setMaxP(100)
+                .setTargetP(10)
+                .setVoltageRegulatorOn(true)
+                .setTargetV(400)
+                .add();
+        n1.newInternalConnection().setNode1(0).setNode2(1).add();
+        n1.newSwitch().setId("br1").setNode1(1).setNode2(2).setKind(SwitchKind.BREAKER).add();
+        n1.newBusbarSection().setId("b1").setNode(2).add();
+        n1.newInternalConnection().setNode1(3).setNode2(4).add();
+
+        Substation s2 = network.newSubstation()
+                .setId("s2")
+                .setCountry(Country.ES)
+                .add();
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        NodeBreakerView n2 = vl2.getNodeBreakerView();
+        n2.setNodeCount(5);
+        vl2.newLoad()
+                .setId("l2")
+                .setNode(0)
+                .setP0(10)
+                .setQ0(1)
+                .add();
+        n2.newInternalConnection().setNode1(0).setNode2(1).add();
+        n2.newSwitch().setId("br2").setNode1(1).setNode2(2).setKind(SwitchKind.BREAKER).add();
+        n2.newBusbarSection().setId("b2").setNode(2).add();
+        n2.newInternalConnection().setNode1(3).setNode2(4).add();
+
+        network.newLine()
+                .setId("line1-2")
+                .setVoltageLevel1("vl1")
+                .setNode1(4)
+                .setVoltageLevel2("vl2")
+                .setNode2(4)
+                .setR(0.1)
+                .setX(10)
+                .setG1(0)
+                .setB1(0)
+                .setG2(0)
+                .setB2(0)
+                .add();
+        return network;
+    }
+}

--- a/iidm/iidm-xml-converter/src/test/resources/internalConnections.xiidm
+++ b/iidm/iidm-xml-converter/src/test/resources/internalConnections.xiidm
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="internal-connections" caseDate="2018-11-08T12:33:26.208+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="s1" country="ES">
+        <iidm:voltageLevel id="vl1" nominalV="400.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology nodeCount="5">
+                <iidm:busbarSection id="b1" node="2"/>
+                <iidm:switch id="br1" kind="BREAKER" retained="false" open="false" node1="1" node2="2"/>
+                <iidm:internalConnection node1="0" node2="1"/>
+                <iidm:internalConnection node1="4" node2="3"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="g1" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="10.0" targetV="400.0" node="0">
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="s2" country="ES">
+        <iidm:voltageLevel id="vl2" nominalV="400.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology nodeCount="5">
+                <iidm:busbarSection id="b2" node="2"/>
+                <iidm:switch id="br2" kind="BREAKER" retained="false" open="false" node1="1" node2="2"/>
+                <iidm:internalConnection node1="0" node2="1"/>
+                <iidm:internalConnection node1="4" node2="3"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:load id="l2" loadType="UNDEFINED" p0="10.0" q0="1.0" node="0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="line1-2" r="0.1" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="4" voltageLevelId1="vl1" node2="4" voltageLevelId2="vl2"/>
+</iidm:network>


### PR DESCRIPTION
CGMES node-breaker models will be mapped to IIDM node-breaker topologies using internal connections.

Internal connections will be used to support CGMES ability to support multiple conducting equipment directly connected to a single Connectivity Node (in IIDM a node in the node-breaker topology can have only one element attached). Internal connections are preferred against fictitious switches, to avoid creation of unneeded objects.