### PR TITLE
Do not use ACDCTerminal.sequenceNumber to identify the switch terminals

### DIFF
--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -311,12 +311,11 @@ WHERE {
     VALUES ?type { cim:Switch cim:Breaker cim:Disconnector } .
     ?Terminal1
         a cim:Terminal ;
-        cim:Terminal.ConductingEquipment ?Switch ;
-        cim:ACDCTerminal.sequenceNumber "1" .
+        cim:Terminal.ConductingEquipment ?Switch .
     ?Terminal2
         a cim:Terminal ;
-        cim:Terminal.ConductingEquipment ?Switch ;
-        cim:ACDCTerminal.sequenceNumber "2" .
+        cim:Terminal.ConductingEquipment ?Switch .
+    FILTER ( STR(?Terminal1) < STR(?Terminal2) )
     OPTIONAL {
         ?EquipmentContainer a cim:VoltageLevel .
         BIND ( ?EquipmentContainer AS ?VoltageLevel )


### PR DESCRIPTION
`ACDCTerminal.sequenceNumber` is not a required property. ENTSO-E node-breaker test configurations use it, but sample test cases from FINGRID do not.