### PR TITLE
CGMES Nonlinear Shunt Compensators

### DIFF
--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Catalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Catalog.java
@@ -7,8 +7,13 @@
 
 package com.powsybl.cgmes.conformity.test;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.cgmes.model.test.FakeCgmesModel;
+import com.powsybl.cgmes.model.test.TestGridModel;
 import com.powsybl.cgmes.model.test.TestGridModelResources;
 
 /**
@@ -30,6 +35,25 @@ public class CgmesConformity1Catalog {
                 base + "MicroGridTestConfiguration_BC_BE_SSH_V2.xml",
                 base + "MicroGridTestConfiguration_BC_BE_SV_V2.xml",
                 base + "MicroGridTestConfiguration_BC_BE_TP_V2.xml",
+                baseBoundary + "MicroGridTestConfiguration_EQ_BD.xml",
+                baseBoundary + "MicroGridTestConfiguration_TP_BD.xml");
+    }
+
+    public TestGridModel microGridType4BE() {
+        String base = ENTSOE_CONFORMITY_1
+                + "/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/";
+        String baseBoundary = ENTSOE_CONFORMITY_1
+                + "/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_BD_v2/";
+        return new TestGridModelResources(
+                "MicroGrid-Type4-BE",
+                expectedMicroGridType4BE(),
+                base + "MicroGridTestConfiguration_T4_BE_DL_V2.xml",
+                base + "MicroGridTestConfiguration_T4_BE_DY_V2.xml",
+                base + "MicroGridTestConfiguration_T4_BE_EQ_V2.xml",
+                base + "MicroGridTestConfiguration_T4_BE_GL_V2.xml",
+                base + "MicroGridTestConfiguration_T4_BE_SSH_V2.xml",
+                base + "MicroGridTestConfiguration_T4_BE_SV_V2.xml",
+                base + "MicroGridTestConfiguration_T4_BE_TP_V2.xml",
                 baseBoundary + "MicroGridTestConfiguration_EQ_BD.xml",
                 baseBoundary + "MicroGridTestConfiguration_TP_BD.xml");
     }
@@ -141,7 +165,7 @@ public class CgmesConformity1Catalog {
                 baseBoundary + "SmallGridTestConfiguration_TP_BD_v3.0.0.xml");
     }
 
-    public CgmesModel expectedMicroGridBaseCaseBE() {
+    public FakeCgmesModel expectedMicroGridBaseCaseBE() {
         return new FakeCgmesModel()
                 .modelId("MicroBaseCaseBE")
                 .version("unknown")
@@ -347,7 +371,7 @@ public class CgmesConformity1Catalog {
                         "_550ebe0d-f2b2-48c1-991f-cebea43a21aa");
     }
 
-    private CgmesModel expectedMiniNodeBreaker() {
+    private FakeCgmesModel expectedMiniNodeBreaker() {
         return new FakeCgmesModel()
                 .modelId("MiniNodeBreakerBaseCaseComplete")
                 .version("unknown")
@@ -834,6 +858,184 @@ public class CgmesConformity1Catalog {
                 .asynchronousMachines("_062ece1f-ade5-4d20-9c3a-fd8f12d12ec1",
                         "_ba62884d-8800-41a8-9c26-698297d7ebaa",
                         "_f184d87b-5565-45ee-89b4-29e8a42d3ad1");
+    }
+
+    public CgmesModel expectedMicroGridType4BE() {
+        FakeCgmesModel m = expectedMicroGridBaseCaseBE();
+        m.voltageLevels("_69ef0dbd-da79-4eef-a02f-690cb8a28361");
+        m.terminals("_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7",
+                "_67bb74f1-8620-4a32-9d7d-a44092d11d22",
+                "_8171fc34-6891-40e0-92d1-da9f4ba69e26");
+        m.terminalLimits(
+                "_0068a5c1-9212-4366-8e0e-cf621a92a8b7",
+                "_0068a5c1-9212-4366-8e0e-cf621a92a8b71",
+                "_08322f60-4e75-4a00-a4e0-0c55bf588919",
+                "_08322f60-4e75-4a00-a4e0-0c55bf5889191",
+                "_1b0850d6-317b-40a3-aa98-040b64f9350c",
+                "_1e793cd6-1608-46af-a3f7-b4d1cabc9d58",
+                "_2bb91774-4c1f-4dd6-aeb3-87a3009306c0",
+                "_2bb91774-4c1f-4dd6-aeb3-87a3009306c01",
+                "_2eb0f5f3-1377-4ea8-b794-a86c28039603",
+                "_2eb0f5f3-1377-4ea8-b794-a86c280396031",
+                "_328d2341-1ab1-417a-9246-8aa0e8124e9c",
+                "_328d2341-1ab1-417a-9246-8aa0e8124e9c1",
+                "_33d5e916-21fd-4d24-802d-69c0eb173eaf",
+                "_33d5e916-21fd-4d24-802d-69c0eb173eaf1",
+                "_3707e6e7-69e5-4f10-bc43-2812519c2842",
+                "_3707e6e7-69e5-4f10-bc43-2812519c28421",
+                "_382e1966-5b98-4257-a0e5-e0cce107f85d",
+                "_382e1966-5b98-4257-a0e5-e0cce107f85d1",
+                "_3ee6fbe2-5862-473e-b09d-a44522c6bf9e",
+                "_3ee6fbe2-5862-473e-b09d-a44522c6bf9e1",
+                "_4dca5f0b-dadf-46c9-aa93-5ff360c120fd",
+                "_4dca5f0b-dadf-46c9-aa93-5ff360c120fd1",
+                "_4f36a64e-0494-47b0-a552-93db9d01eb8a",
+                "_4f36a64e-0494-47b0-a552-93db9d01eb8a1",
+                "_50c2510a-8f27-44f3-a3a5-64ae99b6c077",
+                "_50c2510a-8f27-44f3-a3a5-64ae99b6c0771",
+                "_51a7a0f8-8b3c-4a59-9890-55de5f7de19b",
+                "_51a7a0f8-8b3c-4a59-9890-55de5f7de19b1",
+                "_55d9cdaf-9b02-448b-9206-f12f3c8d2f64",
+                "_55d9cdaf-9b02-448b-9206-f12f3c8d2f641",
+                "_56a462e6-5117-456b-9d0c-8d62b9a1f14a",
+                "_56a462e6-5117-456b-9d0c-8d62b9a1f14a1",
+                "_58c959fd-3675-4ad4-a221-9647b57073dd1",
+                "_58ccdb26-c046-4189-a1c2-e542a168f853",
+                "_58ccdb26-c046-4189-a1c2-e542a168f8531",
+                "_5ba29c54-df69-4e8f-8835-58f7deb762d9",
+                "_5ba29c54-df69-4e8f-8835-58f7deb762d91",
+                "_5f3bd045-4b3a-47f5-acce-6b45d332633b",
+                "_5f3bd045-4b3a-47f5-acce-6b45d332633b1",
+                "_6236459d-8471-44be-9b66-b271ac407165",
+                "_648d7a22-9468-4c53-9528-99c9f82d3e45",
+                "_648d7a22-9468-4c53-9528-99c9f82d3e451",
+                "_69ef4dd8-9f2a-48f7-a230-c4cd695f48761",
+                "_6a000ecb-b731-4cc0-9791-980a4d8c2891",
+                "_6a000ecb-b731-4cc0-9791-980a4d8c28911",
+                "_6c95290e-c4a6-4fa9-8d48-d4c847a1d2c4",
+                "_6c95290e-c4a6-4fa9-8d48-d4c847a1d2c41",
+                "_701a0052-ddb1-484a-885c-600c74063a6a",
+                "_701a0052-ddb1-484a-885c-600c74063a6a1",
+                "_7166b977-0713-4afd-9674-d5073c972321",
+                "_7166b977-0713-4afd-9674-d5073c9723211",
+                "_78a00357-6831-4773-a317-f0092621fb0c",
+                "_78a00357-6831-4773-a317-f0092621fb0c1",
+                "_8447ed5e-3d27-42c0-9e67-9affdda0be451",
+                "_858ebaaa-eec6-48e1-b579-b10986e0ddb6",
+                "_858ebaaa-eec6-48e1-b579-b10986e0ddb61",
+                "_86143da2-d202-41e3-a1b4-7eb13ba09334",
+                "_86143da2-d202-41e3-a1b4-7eb13ba093341",
+                "_89893083-697f-45cd-bdce-14f57fed5914",
+                "_89893083-697f-45cd-bdce-14f57fed59141",
+                "_8a9d3c6a-e33f-4a3b-828a-4a696602e4d2",
+                "_8a9d3c6a-e33f-4a3b-828a-4a696602e4d21",
+                "_94489b05-9fba-4d28-a720-f2f731fcbeb4",
+                "_94489b05-9fba-4d28-a720-f2f731fcbeb41",
+                "_9732c968-c1c4-446a-b47b-9038f5a59724",
+                "_9b2c1328-381e-4277-9042-94b0085f2b77",
+                "_a47ed63a-6b8a-4ccd-aae8-d6781f644ce5",
+                "_a47ed63a-6b8a-4ccd-aae8-d6781f644ce52",
+                "_a4fce087-92c7-454e-a901-b3efceafca61",
+                "_a4fce087-92c7-454e-a901-b3efceafca611",
+                "_a94ca937-819e-4975-a1fd-34598e05d56e",
+                "_a94ca937-819e-4975-a1fd-34598e05d56e1",
+                "_b0c127b9-ba6a-4c95-9c9f-a331e9237bb0",
+                "_b0c127b9-ba6a-4c95-9c9f-a331e9237bb01",
+                "_b1714414-0394-42b6-b441-a664069554a21",
+                "_b2f157c0-ced9-4692-b430-4864d5a665e4",
+                "_b2f157c0-ced9-4692-b430-4864d5a665e41",
+                "_b659ed1b-c1a0-459e-a858-6c3f7431f4f2",
+                "_b659ed1b-c1a0-459e-a858-6c3f7431f4f21",
+                "_bcf693fe-ccc9-443d-90d6-21d3702b4186",
+                "_bcf693fe-ccc9-443d-90d6-21d3702b41861",
+                "_bfdc67ea-b21a-4f48-a425-0c715c7e16e01",
+                "_c1e9a43c-a753-4f7c-b847-b7807c3779b5",
+                "_c1e9a43c-a753-4f7c-b847-b7807c3779b51",
+                "_c23d7e6c-1e09-452e-a82d-70599ec197b2",
+                "_c23d7e6c-1e09-452e-a82d-70599ec197b21",
+                "_c8852f92-33cc-44eb-b977-d282bb648d2f",
+                "_c8852f92-33cc-44eb-b977-d282bb648d2f1",
+                "_c90ed10b-9e23-48b5-a0f0-3ee7729dc83e",
+                "_c90ed10b-9e23-48b5-a0f0-3ee7729dc83e1",
+                "_cd228cb6-24ad-45f3-b9a1-24361a743d22",
+                "_cd228cb6-24ad-45f3-b9a1-24361a743d221",
+                "_cdb0571a-cacd-4f39-9537-0bfdf3f0fd1b",
+                "_cdb0571a-cacd-4f39-9537-0bfdf3f0fd1b2",
+                "_cde82226-7cea-4d13-b0b0-f545a0e08a18",
+                "_cde82226-7cea-4d13-b0b0-f545a0e08a181",
+                "_d29ef207-67d3-47bb-82ea-9d82074dde55",
+                "_d39031b2-8181-4b02-a4fe-2a4a5296dd51",
+                "_d39031b2-8181-4b02-a4fe-2a4a5296dd511",
+                "_d91f4be3-9191-4cf9-a271-5fd1f54465ce",
+                "_d91f4be3-9191-4cf9-a271-5fd1f54465ce1",
+                "_dea05113-ef3e-4161-957d-4602c874839e",
+                "_df47a1fa-8065-4c82-bc45-f62e92caaf3e",
+                "_df47a1fa-8065-4c82-bc45-f62e92caaf3e1",
+                "_e16c3321-9a86-4975-ba5e-4788ac070e54",
+                "_e16c3321-9a86-4975-ba5e-4788ac070e541",
+                "_e1ae19e7-8bb7-42ce-8ae6-24893f16e366",
+                "_ebe4f8e3-7bc8-4162-8bdf-e100742b23631",
+                "_f2b59bb4-79ce-4f17-8fc6-c006407b6358",
+                "_f2b59bb4-79ce-4f17-8fc6-c006407b63581",
+                "_f49c1cf8-6dad-442b-8b6e-88d17969887f",
+                "_f49c1cf8-6dad-442b-8b6e-88d17969887f1",
+                "_f552f5f8-348a-4299-81e6-c8f5a39a6db3",
+                "_f552f5f8-348a-4299-81e6-c8f5a39a6db31",
+                "_f6fbfd23-8043-4d2a-a547-73d14bd161cf",
+                "_f6fbfd23-8043-4d2a-a547-73d14bd161cf1",
+                "_f8bd3d90-ecc2-4f16-9de9-22ba0e62c1f3",
+                "_f8bd3d90-ecc2-4f16-9de9-22ba0e62c1f31",
+                "_fad252e8-cd6e-4226-9c0f-3a9f1e43904d",
+                "_fad252e8-cd6e-4226-9c0f-3a9f1e43904d1",
+                "_fd227658-0e1b-4ecd-952a-c6b0307b1ea1",
+                "_fd227658-0e1b-4ecd-952a-c6b0307b1ea11",
+                "_ff466d18-e4f5-439b-a50a-daec2fa41e2c",
+                "_ff466d18-e4f5-439b-a50a-daec2fa41e2c1");
+        Set<String> tlremove = new HashSet<>(Arrays.asList(
+                "_acbd4688-6393-4b43-a9f4-27d8c3f8c309",
+                "_1c8440dc-e65d-4337-9d3e-7558062228da1",
+                "_bfdc67ea-b21a-4f48-a425-0c715c7e16e02",
+                "_1c8440dc-e65d-4337-9d3e-7558062228da",
+                "_6f70e245-e075-4ed9-9f86-f137b7e33313",
+                "_6f70e245-e075-4ed9-9f86-f137b7e333131",
+                "_da1cb116-0730-4a00-b795-8ab0b52ad89f",
+                "_5b77485f-20a3-4a19-8d15-e4038c81663f",
+                "_69ef4dd8-9f2a-48f7-a230-c4cd695f48762",
+                "_aaa63bb1-fa34-41a3-bd92-0637bfce549c",
+                "_661b3900-dc24-4af5-8720-3e675b48b747",
+                "_2e27135c-53b6-4bd0-a4c1-5312fdbf0704",
+                "_661b3900-dc24-4af5-8720-3e675b48b7471",
+                "_4af98ccd-29f1-4039-86cd-c23fc2deb3bc",
+                "_2e27135c-53b6-4bd0-a4c1-5312fdbf07041",
+                "_84d4dbeb-ef3b-43a1-9a7e-ce5713013498",
+                "_7939fc42-08ef-4ce7-9912-97552a4db39a",
+                "_0d6f26df-9f86-4df0-b00c-bfb23870257f"));
+        m.terminalLimits().removeIf(tl -> tlremove.contains(tl.getId("OperationalLimit")));
+        m.topologicalNodes("_23b65c6b-2351-4673-89e9-1895c7291543");
+        m.transformerEnds(
+                "_3c59d1b0-1ee9-4ca3-9086-4fe102b51b21",
+                "_ba56158e-0c51-448d-999b-44cb0b3cebf5",
+                "_bf76ac9d-0144-48f5-a24a-34ae15a455fb",
+                "_e22f3c30-63f5-47bf-a8c4-fee2483d426c");
+        Set<String> teremove = new HashSet<>(Arrays.asList(
+                "_1912224a-9e98-41aa-84cf-00875bce7264",
+                "_49ca3fd4-1b54-4c5b-83fd-4dbd0f9fec9d",
+                "_664a19e1-1dc2-48d5-b265-c0630981e61c",
+                "_81a18364-0397-48d3-b850-22a0e34b410f"));
+        m.transformerEnds().removeIf(te -> teremove.contains(te.getId("TransformerEnd")));
+        m.ratioTapChangers()
+                .removeIf(rtc -> rtc.getId("RatioTapChanger").equals("_955d9cd0-4a10-4031-b008-60c0dc340a07"));
+        m.phaseTapChangers()
+                .removeIf(ptc -> ptc.getId("PhaseTapChanger").equals("_6ebbef67-3061-4236-a6fd-6ccc4595f6c3"));
+        m.phaseTapChangers(
+                "_36b83adb-3d45-4693-8967-96627b5f9ec9",
+                "_63454a73-f439-45bb-951a-e7b193986571");
+        // Remove the NonLinearShuntCompensator
+        // We will keep it when we convert non-linear shunt compensators
+        m.shuntCompensators()
+                .removeIf(sc -> sc.getId("ShuntCompensator").equals("_002b0a40-3957-46db-b84a-30420083558f"));
+        m.staticVarCompensators("_3c69652c-ff14-4550-9a87-b6fdaccbb5f4");
+        return m;
     }
 
     private static final String ENTSOE_CONFORMITY_1 = "conformity/cas-1.1.3-data-4.0.3";

--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Catalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Catalog.java
@@ -371,7 +371,7 @@ public class CgmesConformity1Catalog {
                         "_550ebe0d-f2b2-48c1-991f-cebea43a21aa");
     }
 
-    private FakeCgmesModel expectedMiniNodeBreaker() {
+    private CgmesModel expectedMiniNodeBreaker() {
         return new FakeCgmesModel()
                 .modelId("MiniNodeBreakerBaseCaseComplete")
                 .version("unknown")

--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Catalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Catalog.java
@@ -1030,10 +1030,6 @@ public class CgmesConformity1Catalog {
         m.phaseTapChangers(
                 "_36b83adb-3d45-4693-8967-96627b5f9ec9",
                 "_63454a73-f439-45bb-951a-e7b193986571");
-        // Remove the NonLinearShuntCompensator
-        // We will keep it when we convert non-linear shunt compensators
-        m.shuntCompensators()
-                .removeIf(sc -> sc.getId("ShuntCompensator").equals("_002b0a40-3957-46db-b84a-30420083558f"));
         m.staticVarCompensators("_3c69652c-ff14-4550-9a87-b6fdaccbb5f4");
         return m;
     }

--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
@@ -590,11 +590,6 @@ public class CgmesConformity1NetworkCatalog {
                 .setV(223.435281)
                 .setAngle(-17.412200);
 
-        // LinearShuntCompensator in BaseCase changed to
-        // NonlinearShuntCompensator in the Type4_T4 variant
-        // Remove it in the expected network until we implement conversion
-        network.getShuntCompensator("_002b0a40-3957-46db-b84a-30420083558f").remove();
-
         VoltageLevel vlAnvers220 = network.getVoltageLevel("_d0486169-2205-40b2-895e-b672ecb9e5fc");
         vlAnvers220.newStaticVarCompensator()
                 .setId("_3c69652c-ff14-4550-9a87-b6fdaccbb5f4")

--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
@@ -24,6 +24,7 @@ import com.powsybl.iidm.network.NetworkFactory;
 import com.powsybl.iidm.network.PhaseTapChangerAdder;
 import com.powsybl.iidm.network.RatioTapChangerAdder;
 import com.powsybl.iidm.network.ShuntCompensator;
+import com.powsybl.iidm.network.StaticVarCompensator;
 import com.powsybl.iidm.network.Substation;
 import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
@@ -34,16 +35,16 @@ import com.powsybl.iidm.network.VoltageLevel;
  */
 public class CgmesConformity1NetworkCatalog {
 
-    public Network microBE() {
-        String modelId = "urn:uuid:d400c631-75a0-4c30-8aed-832b0d282e73";
-        Network expected = NetworkFactory.create(modelId, "no-format");
-        Substation sBrussels = expected.newSubstation()
+    public Network microBE(String modelId) {
+        Network network = NetworkFactory.create(modelId, "no-format");
+
+        Substation sBrussels = network.newSubstation()
                 .setId("_37e14a0f-5e34-4647-a062-8bfd9305fa9d")
                 .setName("PP_Brussels")
                 .setCountry(Country.BE)
                 .setGeographicalTags("_c1d5bfc88f8011e08e4d00247eb1f55e") // ELIA-Brussels
                 .add();
-        Substation sAnvers = expected.newSubstation()
+        Substation sAnvers = network.newSubstation()
                 .setId("_87f7002b-056f-4a6a-a872-1744eea757e3")
                 .setName("Anvers")
                 .setCountry(Country.BE)
@@ -173,7 +174,7 @@ public class CgmesConformity1NetworkCatalog {
                 .add();
         busBrussels380.setV(412.989001);
         busBrussels380.setAngle(-6.780710);
-        ShuntCompensator shBrussels380 = vlBrussels380.newShunt()
+        ShuntCompensator shBrussels380 = vlBrussels380.newShuntCompensator()
                 .setId("_002b0a40-3957-46db-b84a-30420083558f")
                 .setName("BE_S2")
                 .setConnectableBus(busBrussels380.getId())
@@ -222,7 +223,7 @@ public class CgmesConformity1NetworkCatalog {
                 .setB(2.51956e-5)
                 .setUcteXnodeCode("TN_Border_MA11")
                 .add();
-        ShuntCompensator shBrussels110 = vlBrussels110.newShunt()
+        ShuntCompensator shBrussels110 = vlBrussels110.newShuntCompensator()
                 .setId("_d771118f-36e9-4115-a128-cc3d9ce3e3da")
                 .setName("BE_S1")
                 .setConnectableBus(busBrussels110.getId())
@@ -269,7 +270,7 @@ public class CgmesConformity1NetworkCatalog {
         // expected.newLine()
         // .setId("17086487-56ba-4979-b8de-064025a6b4da")
         // .add();
-        Line lineBE2 = expected.newLine()
+        Line lineBE2 = network.newLine()
                 .setId("_b58bf21a-096a-4dae-9a01-3f03b60c24c7")
                 .setName("BE-Line_2")
                 .setR(1.935)
@@ -296,7 +297,7 @@ public class CgmesConformity1NetworkCatalog {
         // expected.newLine()
         // .setId("b18cd1aa-7808-49b9-a7cf-605eaf07b006")
         // .add();
-        Line lineBE6 = expected.newLine()
+        Line lineBE6 = network.newLine()
                 .setId("_ffbabc27-1ccd-4fdc-b037-e341706c8d29")
                 .setName("BE-Line_6")
                 .setR(5.203)
@@ -488,58 +489,12 @@ public class CgmesConformity1NetworkCatalog {
             double xmin = 14.518904;
             double xmax = 14.518904;
             double voltageInc = 1.25;
-            PhaseTapChangerAdder ptca = txBE21.newPhaseTapChanger()
-                    .setLowTapPosition(low)
-                    .setTapPosition(position);
-            // Intermediate calculations made using double precision
-            double du0 = 0;
-            double du = voltageInc / 100;
-            double theta = Math.PI / 2;
-            LOG.debug("EXPECTED du0,du,theta {} {} {}", du0, du, theta);
-
-            List<Double> alphas = new ArrayList<>();
-            List<Double> rhos = new ArrayList<>();
-            for (int k = low; k <= high; k++) {
-                int n = k - neutral;
-                double dx = (n * du - du0) * Math.cos(theta);
-                double dy = (n * du - du0) * Math.sin(theta);
-                double alpha = Math.atan2(dy, 1 + dx);
-                double rho = 1 / Math.hypot(dy, 1 + dx);
-                alphas.add(alpha);
-                rhos.add(rho);
-                LOG.debug("EXPECTED    n,dx,dy,alpha,rho  {} {} {} {} {}", n, dx, dy, alpha, rho);
-            }
-            double alphaMax = alphas.stream()
-                    .mapToDouble(Double::doubleValue)
-                    .max()
-                    .orElse(Double.NaN);
-            LOG.debug("EXPECTED    alphaMax {}", alphaMax);
-            LOG.debug("EXPECTED    xStepMin, xStepMax {}, {}", xmin, xmax);
-            for (int k = 0; k < alphas.size(); k++) {
-                double alpha = alphas.get(k);
-                double rho = rhos.get(k);
-                // x for current k
-                double numer = Math.sin(theta) - Math.tan(alphaMax) * Math.cos(theta);
-                double denom = Math.sin(theta) - Math.tan(alpha) * Math.cos(theta);
-                double xn = xmin + (xmax - xmin)
-                        * Math.pow(Math.tan(alpha) / Math.tan(alphaMax) * numer / denom, 2);
-                xn = xn * rho02;
-                double dx = (xn - txBE21.getX()) / txBE21.getX() * 100;
-                ptca.beginStep()
-                        .setRho(rho)
-                        .setAlpha(Math.toDegrees(alpha))
-                        .setR(0)
-                        .setX(dx)
-                        .setG(0)
-                        .setB(0)
-                        .endStep();
-                if (LOG.isDebugEnabled()) {
-                    int n = (low + k) - neutral;
-                    LOG.debug("EXPECTED    n,rho,alpha,x,dx   {} {} {} {} {}",
-                            n, rho, Math.toDegrees(alpha), xn, dx);
-                }
-            }
-            ptca.add();
+            double windingConnectionAngle = 90;
+            addPhaseTapChanger(txBE21,
+                    PhaseTapChangerType.ASYMMETRICAL,
+                    low, high, neutral, position,
+                    xmin, xmax,
+                    voltageInc, windingConnectionAngle);
         }
         {
             double p = -90;
@@ -568,7 +523,279 @@ public class CgmesConformity1NetworkCatalog {
             genBrussels10.getTerminal().setQ(q);
         }
 
-        return expected;
+        return network;
+    }
+
+    public Network microBaseCaseBE() {
+        String modelId = "urn:uuid:d400c631-75a0-4c30-8aed-832b0d282e73";
+        return microBE(modelId);
+    }
+
+    public Network microType4BE() {
+        String modelId = "urn:uuid:96adadbe-902b-4cd6-9fc8-01a56ecbee79";
+        Network network = microBE(modelId);
+        // Add voltage level in Anvers
+        VoltageLevel vlAnvers225 = network.getSubstation("_87f7002b-056f-4a6a-a872-1744eea757e3")
+                .newVoltageLevel()
+                .setId("_69ef0dbd-da79-4eef-a02f-690cb8a28361")
+                .setName("225 kV")
+                .setNominalV(225.0)
+                .setLowVoltageLimit(202.5)
+                .setHighVoltageLimit(247.5)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        Bus busAnvers225 = vlAnvers225.getBusBreakerView().newBus()
+                .setId("_23b65c6b-2351-4673-89e9-1895c7291543")
+                .add()
+                .setV(223.435281)
+                .setAngle(-17.412200);
+
+        Bus busBrussels21 = network
+                .getVoltageLevel("_929ba893-c9dc-44d7-b1fd-30834bd3ab85")
+                .getBusBreakerView()
+                .getBus("_f96d552a-618d-4d0c-a39a-2dea3c411dee")
+                .setV(21.987000)
+                .setAngle(-20.588300);
+        Bus busBrussels110 = network
+                .getVoltageLevel("_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0")
+                .getBusBreakerView()
+                .getBus("_5c74cb26-ce2f-40c6-951d-89091eb781b6")
+                .setV(115.5)
+                .setAngle(-22.029800);
+        Bus busBrussels10 = network
+                .getVoltageLevel("_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386")
+                .getBusBreakerView()
+                .getBus("_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e")
+                .setV(10.816961)
+                .setAngle(-19.642100);
+
+        Bus busBrussels380 = network
+                .getVoltageLevel("_469df5f7-058f-4451-a998-57a48e8a56fe")
+                .getBusBreakerView()
+                .getBus("_e44141af-f1dc-44d3-bfa4-b674e5c953d7")
+                .setV(414.114413)
+                .setAngle(-21.526500);
+
+        Bus busBrussels225 = network
+                .getVoltageLevel("_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c")
+                .getBusBreakerView()
+                .getBus("_99b219f3-4593-428b-a4da-124a54630178")
+                .setV(224.156562)
+                .setAngle(-21.796200);
+
+        Bus busAnvers220 = network
+                .getVoltageLevel("_d0486169-2205-40b2-895e-b672ecb9e5fc")
+                .getBusBreakerView()
+                .getBus("_f70f6bad-eb8d-4b8f-8431-4ab93581514e")
+                .setV(223.435281)
+                .setAngle(-17.412200);
+
+        // LinearShuntCompensator in BaseCase changed to
+        // NonlinearShuntCompensator in the Type4_T4 variant
+        // Remove it in the expected network until we implement conversion
+        network.getShuntCompensator("_002b0a40-3957-46db-b84a-30420083558f").remove();
+
+        VoltageLevel vlAnvers220 = network.getVoltageLevel("_d0486169-2205-40b2-895e-b672ecb9e5fc");
+        vlAnvers220.newStaticVarCompensator()
+                .setId("_3c69652c-ff14-4550-9a87-b6fdaccbb5f4")
+                .setName("SVC-1230797516")
+                .setBus("_f70f6bad-eb8d-4b8f-8431-4ab93581514e")
+                .setConnectableBus("_f70f6bad-eb8d-4b8f-8431-4ab93581514e")
+                .setBmax(5062.5)
+                .setBmin(-5062.5)
+                .setRegulationMode(StaticVarCompensator.RegulationMode.VOLTAGE)
+                .setVoltageSetPoint(229.5)
+                .add();
+
+        double p = -118.0;
+        double q = -85.603401;
+        Generator genBrussels21 = network
+                .getGenerator("_550ebe0d-f2b2-48c1-991f-cebea43a21aa")
+                .setTargetP(-p)
+                .setTargetQ(-q);
+        genBrussels21.getTerminal().setP(p).setQ(q);
+
+        p = -90.0;
+        q = 84.484905;
+        Generator genBrussels10 = network
+                .getGenerator("_3a3b27be-b18b-4385-b557-6735d733baf0")
+                .setTargetP(-p)
+                .setTargetQ(-q);
+        genBrussels10.getTerminal().setP(p).setQ(q);
+
+        // Line _df16b3dd comes from a SeriesCompensator in CGMES model
+        Line scAnvers = network.newLine()
+                .setId("_df16b3dd-c905-4a6f-84ee-f067be86f5da")
+                .setName("SER-RLC-1230822986")
+                .setR(0)
+                .setX(-31.830989)
+                .setB1(0)
+                .setG1(0)
+                .setB2(0)
+                .setG2(0)
+                .setConnectableBus1(busAnvers225.getId())
+                .setBus1(busAnvers225.getId())
+                .setVoltageLevel1(vlAnvers225.getId())
+                .setConnectableBus2(busAnvers220.getId())
+                .setBus2(busAnvers220.getId())
+                .setVoltageLevel2(vlAnvers220.getId())
+                .add();
+
+        Line lineBE2 = network.getLine("_b58bf21a-096a-4dae-9a01-3f03b60c24c7");
+        lineBE2.getCurrentLimits1().setPermanentLimit(2000.0);
+        lineBE2.getCurrentLimits2().setPermanentLimit(2000.0);
+
+        network.getTwoWindingsTransformer("_e482b89a-fa84-4ea9-8e70-a83d44790957")
+                .getRatioTapChanger().setTapPosition(20);
+
+        TwoWindingsTransformer txBE22 = network.getTwoWindingsTransformer("_b94318f6-6d24-4f56-96b9-df2531ad6543");
+        txBE22.getRatioTapChanger().remove();
+        {
+            int low = 1;
+            int high = 25;
+            int neutral = 13;
+            int position = 10;
+            double xmin = 10.396291;
+            double xmax = 11.881475;
+            double voltageInc = 1.25;
+            double windingConnectionAngle = 5;
+            addPhaseTapChanger(txBE22,
+                    PhaseTapChangerType.ASYMMETRICAL,
+                    low, high, neutral, position,
+                    xmin, xmax,
+                    voltageInc, windingConnectionAngle);
+        }
+
+        {
+            TwoWindingsTransformer txBE21 = network.getTwoWindingsTransformer("_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0");
+            txBE21.getPhaseTapChanger().remove();
+            int low = 1;
+            int high = 25;
+            int neutral = 13;
+            int position = 13;
+            double xmin = 12.099087;
+            double xmax = 16.938722;
+            double voltageInc = 1.25;
+            // winding connection angle property is only defined for Asymmetrical
+            double windingConnectionAngle = Double.NaN;
+            addPhaseTapChanger(txBE21,
+                    PhaseTapChangerType.SYMMETRICAL,
+                    low, high, neutral, position,
+                    xmin, xmax,
+                    voltageInc, windingConnectionAngle);
+        }
+
+        network.getDanglingLine("_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4")
+                .setP0(-86.814383)
+                .setQ0(4.958972);
+        network.getDanglingLine("_17086487-56ba-4979-b8de-064025a6b4da")
+                .setP0(-89.462903)
+                .setQ0(1.519011);
+        network.getDanglingLine("_78736387-5f60-4832-b3fe-d50daf81b0a6")
+                .setP0(-16.452661)
+                .setQ0(64.018020);
+        network.getDanglingLine("_b18cd1aa-7808-49b9-a7cf-605eaf07b006")
+                .setP0(-31.579291)
+                .setQ0(120.813763);
+        network.getDanglingLine("_ed0c5d75-4a54-43c8-b782-b20d7431630b")
+                .setP0(-11.518775)
+                .setQ0(67.377544);
+        return network;
+    }
+
+    enum PhaseTapChangerType {
+        ASYMMETRICAL, SYMMETRICAL
+    };
+
+    private void addPhaseTapChanger(
+            TwoWindingsTransformer tx,
+            PhaseTapChangerType type,
+            int low, int high, int neutral, int position,
+            double xmin, double xmax,
+            double voltageInc,
+            double windingConnectionAngle) {
+        LOG.debug("EXPECTED tx {}", tx.getId());
+        double rho0 = tx.getRatedU2() / tx.getRatedU1();
+        double rho02 = rho0 * rho0;
+
+        PhaseTapChangerAdder ptca = tx.newPhaseTapChanger()
+                .setLowTapPosition(low)
+                .setTapPosition(position);
+        // Intermediate calculations made using double precision
+        double du0 = 0;
+        double du = voltageInc / 100;
+        double theta = Math.toRadians(
+                type.equals(PhaseTapChangerType.ASYMMETRICAL)
+                        ? windingConnectionAngle
+                        : 90);
+        LOG.debug("EXPECTED du0,du,theta {} {} {}", du0, du, theta);
+
+        List<Double> alphas = new ArrayList<>();
+        List<Double> rhos = new ArrayList<>();
+        for (int k = low; k <= high; k++) {
+            int n = k - neutral;
+            double alpha;
+            double rho;
+            if (type.equals(PhaseTapChangerType.ASYMMETRICAL)) {
+                double dx = (n * du - du0) * Math.cos(theta);
+                double dy = (n * du - du0) * Math.sin(theta);
+                alpha = Math.atan2(dy, 1 + dx);
+                rho = 1 / Math.hypot(dy, 1 + dx);
+                LOG.debug("EXPECTED    n,dx,dy,alpha,rho  {} {} {} {} {}", n, dx, dy, alpha, rho);
+            } else if (type.equals(PhaseTapChangerType.SYMMETRICAL)) {
+                double dy = (n * du / 2 - du0) * Math.sin(theta);
+                alpha = 2 * Math.asin(dy);
+                rho = 1.0;
+                LOG.debug("EXPECTED    n,dy,alpha,rho  {} {} {} {}", n, dy, alpha, rho);
+            } else {
+                alpha = Double.NaN;
+                rho = Double.NaN;
+            }
+            alphas.add(alpha);
+            rhos.add(rho);
+        }
+        double alphaMax = alphas.stream()
+                .mapToDouble(Double::doubleValue)
+                .max()
+                .orElse(Double.NaN);
+        LOG.debug("EXPECTED    alphaMax {}", alphaMax);
+        LOG.debug("EXPECTED    xStepMin, xStepMax {}, {}", xmin, xmax);
+        LOG.debug("EXPECTED    u2,u1,rho0square {}, {}, {}", tx.getRatedU2(), tx.getRatedU1(), rho02);
+        for (int k = 0; k < alphas.size(); k++) {
+            double alpha = alphas.get(k);
+            double rho = rhos.get(k);
+
+            // x for current k
+            double xn;
+            if (type.equals(PhaseTapChangerType.ASYMMETRICAL)) {
+                double numer = Math.sin(theta) - Math.tan(alphaMax) * Math.cos(theta);
+                double denom = Math.sin(theta) - Math.tan(alpha) * Math.cos(theta);
+                xn = xmin + (xmax - xmin)
+                        * Math.pow(Math.tan(alpha) / Math.tan(alphaMax) * numer / denom, 2);
+            } else if (type.equals(PhaseTapChangerType.SYMMETRICAL)) {
+                xn = xmin + (xmax - xmin)
+                        * Math.pow(Math.sin(alpha / 2) / Math.sin(alphaMax / 2), 2);
+            } else {
+                xn = Double.NaN;
+            }
+            xn = xn * rho02;
+            double dx = (xn - tx.getX()) / tx.getX() * 100;
+
+            ptca.beginStep()
+                    .setRho(rho)
+                    .setAlpha(Math.toDegrees(alpha))
+                    .setR(0)
+                    .setX(dx)
+                    .setG(0)
+                    .setB(0)
+                    .endStep();
+            if (LOG.isDebugEnabled()) {
+                int n = (low + k) - neutral;
+                LOG.debug("EXPECTED    n,rho,alpha,x,dx   {} {} {} {} {}",
+                        n, rho, Math.toDegrees(alpha), xn, dx);
+            }
+        }
+        ptca.add();
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(CgmesConformity1NetworkCatalog.class);

--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
@@ -661,9 +661,9 @@ public class CgmesConformity1NetworkCatalog {
                     voltageInc, windingConnectionAngle);
         }
 
+        TwoWindingsTransformer txBE21 = network.getTwoWindingsTransformer("_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0");
+        txBE21.getPhaseTapChanger().remove();
         {
-            TwoWindingsTransformer txBE21 = network.getTwoWindingsTransformer("_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0");
-            txBE21.getPhaseTapChanger().remove();
             int low = 1;
             int high = 25;
             int neutral = 13;
@@ -720,7 +720,7 @@ public class CgmesConformity1NetworkCatalog {
         double du0 = 0;
         double du = voltageInc / 100;
         double theta = Math.toRadians(
-                type.equals(PhaseTapChangerType.ASYMMETRICAL)
+                type == PhaseTapChangerType.ASYMMETRICAL
                         ? windingConnectionAngle
                         : 90);
         LOG.debug("EXPECTED du0,du,theta {} {} {}", du0, du, theta);
@@ -731,13 +731,13 @@ public class CgmesConformity1NetworkCatalog {
             int n = k - neutral;
             double alpha;
             double rho;
-            if (type.equals(PhaseTapChangerType.ASYMMETRICAL)) {
+            if (type == PhaseTapChangerType.ASYMMETRICAL) {
                 double dx = (n * du - du0) * Math.cos(theta);
                 double dy = (n * du - du0) * Math.sin(theta);
                 alpha = Math.atan2(dy, 1 + dx);
                 rho = 1 / Math.hypot(dy, 1 + dx);
                 LOG.debug("EXPECTED    n,dx,dy,alpha,rho  {} {} {} {} {}", n, dx, dy, alpha, rho);
-            } else if (type.equals(PhaseTapChangerType.SYMMETRICAL)) {
+            } else if (type == PhaseTapChangerType.SYMMETRICAL) {
                 double dy = (n * du / 2 - du0) * Math.sin(theta);
                 alpha = 2 * Math.asin(dy);
                 rho = 1.0;
@@ -762,12 +762,12 @@ public class CgmesConformity1NetworkCatalog {
 
             // x for current k
             double xn;
-            if (type.equals(PhaseTapChangerType.ASYMMETRICAL)) {
+            if (type == PhaseTapChangerType.ASYMMETRICAL) {
                 double numer = Math.sin(theta) - Math.tan(alphaMax) * Math.cos(theta);
                 double denom = Math.sin(theta) - Math.tan(alpha) * Math.cos(theta);
                 xn = xmin + (xmax - xmin)
                         * Math.pow(Math.tan(alpha) / Math.tan(alphaMax) * numer / denom, 2);
-            } else if (type.equals(PhaseTapChangerType.SYMMETRICAL)) {
+            } else if (type == PhaseTapChangerType.SYMMETRICAL) {
                 xn = xmin + (xmax - xmin)
                         * Math.pow(Math.sin(alpha / 2) / Math.sin(alphaMax / 2), 2);
             } else {

--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Test.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Test.java
@@ -40,6 +40,11 @@ public class CgmesConformity1Test {
     }
 
     @Test
+    public void microGridType4BE() throws IOException {
+        new CgmesModelTester(catalog.microGridType4BE()).test();
+    }
+
+    @Test
     public void miniBusBranch() throws IOException {
         new CgmesModelTester(catalog.miniBusBranch()).test();
     }

--- a/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_BD_v2/MicroGridTestConfiguration_EQ_BD.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_BD_v2/MicroGridTestConfiguration_EQ_BD.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF  xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<!-- Exported from CIMSpy EE/CIMdesk on Sat May 30 07:14:51.783. -->
+	<md:FullModel rdf:about="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66">
+		<md:Model.created>2014-06-01T11:20:39</md:Model.created>
+		<md:Model.scenarioTime>2014-06-01T10:30:00</md:Model.scenarioTime>
+		<md:Model.version>1</md:Model.version>
+		<md:Model.description>CGMES Conformity Assessment: &apos;MicroGridTestConfiguration (Boundary MAS)...&apos; Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+		<md:Model.modelingAuthoritySet>http://entsoe.eu/Boundary/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+		<md:Model.profile>http://entsoe.eu/CIM/EquipmentBoundary/3/1</md:Model.profile>
+		<md:Model.profile>http://entsoe.eu/CIM/EquipmentBoundaryOperation/3/1</md:Model.profile>
+	</md:FullModel>
+	<cim:BaseVoltage rdf:ID="_7891a026ba2c42098556665efd13ba94">
+		<cim:IdentifiedObject.description>Base Voltage 220 kV</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>220 kV</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>220</entsoe:IdentifiedObject.shortName>
+		<cim:BaseVoltage.nominalVoltage>220</cim:BaseVoltage.nominalVoltage>
+	</cim:BaseVoltage>
+	<cim:BaseVoltage rdf:ID="_63893f24-5b4e-407c-9a1e-4ff71121f33c">
+		<cim:IdentifiedObject.description>Base Voltage 225 kV</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>225 kV</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>225</entsoe:IdentifiedObject.shortName>
+		<cim:BaseVoltage.nominalVoltage>225</cim:BaseVoltage.nominalVoltage>
+	</cim:BaseVoltage>
+	<cim:BaseVoltage rdf:ID="_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6">
+		<cim:IdentifiedObject.description>Base Voltage 380 kV</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>380 kV</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>380</entsoe:IdentifiedObject.shortName>
+		<cim:BaseVoltage.nominalVoltage>380</cim:BaseVoltage.nominalVoltage>
+	</cim:BaseVoltage>
+	<cim:BaseVoltage rdf:ID="_65dd04e792584b3b912374e35dec032e">
+		<cim:IdentifiedObject.description>Base Voltage 400 kV</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>400 kV</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>400</entsoe:IdentifiedObject.shortName>
+		<cim:BaseVoltage.nominalVoltage>400</cim:BaseVoltage.nominalVoltage>
+	</cim:BaseVoltage>
+	<cim:ConnectivityNode rdf:ID="_b675a570-cb6e-11e1-bcee-406c8f32ef58">
+		<cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>Border_AL11</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>XCA_AL11</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-ES-PT-10004U</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<entsoe:ConnectivityNode.fromEndIsoCode>ES</entsoe:ConnectivityNode.fromEndIsoCode>
+		<entsoe:ConnectivityNode.fromEndName>Cartelle</entsoe:ConnectivityNode.fromEndName>
+		<entsoe:ConnectivityNode.fromEndNameTso>REE</entsoe:ConnectivityNode.fromEndNameTso>
+		<entsoe:ConnectivityNode.toEndIsoCode>PT</entsoe:ConnectivityNode.toEndIsoCode>
+		<entsoe:ConnectivityNode.toEndName>Alto Lindoso</entsoe:ConnectivityNode.toEndName>
+		<entsoe:ConnectivityNode.toEndNameTso>REN</entsoe:ConnectivityNode.toEndNameTso>
+		<entsoe:ConnectivityNode.boundaryPoint>true</entsoe:ConnectivityNode.boundaryPoint>
+		<cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_d4affe50316740bdbbf4ae9c7cbf3cfd_X"/>
+	</cim:ConnectivityNode>
+	<cim:ConnectivityNode rdf:ID="_b67c8340-cb6e-11e1-bcee-406c8f32ef58">
+		<cim:IdentifiedObject.description>RG CE; 400 kV; OHL</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>Border_GY11</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>XWI_GY11</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-HU-00002U</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<entsoe:ConnectivityNode.fromEndIsoCode>AT</entsoe:ConnectivityNode.fromEndIsoCode>
+		<entsoe:ConnectivityNode.fromEndName>Wien</entsoe:ConnectivityNode.fromEndName>
+		<entsoe:ConnectivityNode.fromEndNameTso>APG</entsoe:ConnectivityNode.fromEndNameTso>
+		<entsoe:ConnectivityNode.toEndIsoCode>HU</entsoe:ConnectivityNode.toEndIsoCode>
+		<entsoe:ConnectivityNode.toEndName>Győr</entsoe:ConnectivityNode.toEndName>
+		<entsoe:ConnectivityNode.toEndNameTso>MAVIR</entsoe:ConnectivityNode.toEndNameTso>
+		<entsoe:ConnectivityNode.boundaryPoint>true</entsoe:ConnectivityNode.boundaryPoint>
+		<cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_f03d65b2a51049ffa533e433721145c1_X"/>
+	</cim:ConnectivityNode>
+	<cim:ConnectivityNode rdf:ID="_1c4a9e9c-ef00-42c9-9845-f64f9ca1e57a">
+		<cim:IdentifiedObject.description>HVDC-AC; 220 kV; OHL</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>Border_HVDC-AC</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>HVDC-AC-1</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-DC-NL-00082X</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<entsoe:ConnectivityNode.fromEndIsoCode>NL</entsoe:ConnectivityNode.fromEndIsoCode>
+		<entsoe:ConnectivityNode.fromEndName>HVDC/NL</entsoe:ConnectivityNode.fromEndName>
+		<entsoe:ConnectivityNode.fromEndNameTso>NL</entsoe:ConnectivityNode.fromEndNameTso>
+		<entsoe:ConnectivityNode.toEndIsoCode>BE</entsoe:ConnectivityNode.toEndIsoCode>
+		<entsoe:ConnectivityNode.toEndName>NL_AC-1</entsoe:ConnectivityNode.toEndName>
+		<entsoe:ConnectivityNode.toEndNameTso>NL-HVDC-1</entsoe:ConnectivityNode.toEndNameTso>
+		<entsoe:ConnectivityNode.boundaryPoint>true</entsoe:ConnectivityNode.boundaryPoint>
+		<cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8FE2EC11-3357-4506-BF11-80302102B3F2"/>
+	</cim:ConnectivityNode>
+	<cim:ConnectivityNode rdf:ID="_b67cf870-cb6e-11e1-bcee-406c8f32ef58">
+		<cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>Border_MA11</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>XKA_MA11</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-SI-00001T</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<entsoe:ConnectivityNode.fromEndIsoCode>AT</entsoe:ConnectivityNode.fromEndIsoCode>
+		<entsoe:ConnectivityNode.fromEndName>Kainachtal</entsoe:ConnectivityNode.fromEndName>
+		<entsoe:ConnectivityNode.fromEndNameTso>APG</entsoe:ConnectivityNode.fromEndNameTso>
+		<entsoe:ConnectivityNode.toEndIsoCode>SI</entsoe:ConnectivityNode.toEndIsoCode>
+		<entsoe:ConnectivityNode.toEndName>Maribor</entsoe:ConnectivityNode.toEndName>
+		<entsoe:ConnectivityNode.toEndNameTso>ELES</entsoe:ConnectivityNode.toEndNameTso>
+		<entsoe:ConnectivityNode.boundaryPoint>true</entsoe:ConnectivityNode.boundaryPoint>
+		<cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_9d25a1f9e5d14d47b6dcde99c4380b40_X"/>
+	</cim:ConnectivityNode>
+	<cim:ConnectivityNode rdf:ID="_b66f15c0-cb6e-11e1-bcee-406c8f32ef58">
+		<cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>Border_ST23</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>XZE_ST23</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00016Z</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<entsoe:ConnectivityNode.fromEndIsoCode>AT</entsoe:ConnectivityNode.fromEndIsoCode>
+		<entsoe:ConnectivityNode.fromEndName>Zell/Ziller</entsoe:ConnectivityNode.fromEndName>
+		<entsoe:ConnectivityNode.fromEndNameTso>APG</entsoe:ConnectivityNode.fromEndNameTso>
+		<entsoe:ConnectivityNode.toEndIsoCode>DE</entsoe:ConnectivityNode.toEndIsoCode>
+		<entsoe:ConnectivityNode.toEndName>Strass</entsoe:ConnectivityNode.toEndName>
+		<entsoe:ConnectivityNode.toEndNameTso>TIWAG-Netz</entsoe:ConnectivityNode.toEndNameTso>
+		<entsoe:ConnectivityNode.boundaryPoint>true</entsoe:ConnectivityNode.boundaryPoint>
+		<cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8d7bad8bcc634e0796e362390d9040b6_X"/>
+	</cim:ConnectivityNode>
+	<cim:ConnectivityNode rdf:ID="_b6978550-cb6e-11e1-bcee-406c8f32ef58">
+		<cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>Border_ST24</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>XZE_ST24</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00017X</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<entsoe:ConnectivityNode.fromEndIsoCode>AT</entsoe:ConnectivityNode.fromEndIsoCode>
+		<entsoe:ConnectivityNode.fromEndName>Zell/Ziller</entsoe:ConnectivityNode.fromEndName>
+		<entsoe:ConnectivityNode.fromEndNameTso>APG</entsoe:ConnectivityNode.fromEndNameTso>
+		<entsoe:ConnectivityNode.toEndIsoCode>DE</entsoe:ConnectivityNode.toEndIsoCode>
+		<entsoe:ConnectivityNode.toEndName>Strass</entsoe:ConnectivityNode.toEndName>
+		<entsoe:ConnectivityNode.toEndNameTso>TIWAG-Netz</entsoe:ConnectivityNode.toEndNameTso>
+		<entsoe:ConnectivityNode.boundaryPoint>true</entsoe:ConnectivityNode.boundaryPoint>
+		<cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_1fa19c281c8f4e1eaad9e1cab70f923e_X"/>
+	</cim:ConnectivityNode>
+	<cim:GeographicalRegion rdf:ID="_7e6dab445e92469892d1dcc3421cce1a">
+		<cim:IdentifiedObject.description>Economic and political union of member states located primarily in Europe</cim:IdentifiedObject.description>
+		<cim:IdentifiedObject.name>EU</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-EU-EU-000001</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<entsoe:IdentifiedObject.shortName>EU</entsoe:IdentifiedObject.shortName>
+	</cim:GeographicalRegion>
+	<cim:Junction rdf:ID="_5249A78F-6642-4fc5-968F-06E2ED18FAB7">
+		<cim:IdentifiedObject.name>Junction_XJ1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Junction at XJ1</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>XJ1</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-70314J</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_f03d65b2a51049ffa533e433721145c1_X"/>
+	</cim:Junction>
+	<cim:Line rdf:ID="_8FE2EC11-3357-4506-BF11-80302102B3F2">
+		<cim:IdentifiedObject.name>TieLine_HVDC-NL</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>HVDC TieLine at NL</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>HVDC_NL</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10344U</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:Line.Region rdf:resource="#_d81ceddefca04ab8960433e4a8839325"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_d4affe50316740bdbbf4ae9c7cbf3cfd_X">
+		<cim:IdentifiedObject.name>TieLine_XCA_AL11</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>TieLine at XCA_AL11</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>XCA_AL11</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10314U</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:Line.Region rdf:resource="#_d81ceddefca04ab8960433e4a8839325"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_9d25a1f9e5d14d47b6dcde99c4380b40_X">
+		<cim:IdentifiedObject.name>TieLine_XKA_MA11</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>TieLine at XKA_MA11</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>XKA_MA11</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10114U</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:Line.Region rdf:resource="#_d81ceddefca04ab8960433e4a8839325"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_f03d65b2a51049ffa533e433721145c1_X">
+		<cim:IdentifiedObject.name>TieLine_XWI_GY11</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>TieLine at XWI_GY11</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>XWI_GY11</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10014U</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:Line.Region rdf:resource="#_d81ceddefca04ab8960433e4a8839325"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_8d7bad8bcc634e0796e362390d9040b6_X">
+		<cim:IdentifiedObject.name>TieLine_XZE_ST23</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>TieLine at XZE_ST23</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>XZE_ST23</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10234U</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:Line.Region rdf:resource="#_d81ceddefca04ab8960433e4a8839325"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_1fa19c281c8f4e1eaad9e1cab70f923e_X">
+		<cim:IdentifiedObject.name>TieLine_XZE_ST24</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>TieLine at XZE_ST24</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>XZE_ST24</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10274U</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:Line.Region rdf:resource="#_d81ceddefca04ab8960433e4a8839325"/>
+	</cim:Line>
+	<cim:SubGeographicalRegion rdf:ID="_d81ceddefca04ab8960433e4a8839325">
+		<cim:IdentifiedObject.name>ENTSO-E</cim:IdentifiedObject.name>
+		<cim:SubGeographicalRegion.Region rdf:resource="#_7e6dab445e92469892d1dcc3421cce1a"/>
+		<cim:IdentifiedObject.description>ENTSO-E region</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>ENTSO-E</entsoe:IdentifiedObject.shortName>
+	</cim:SubGeographicalRegion>
+	<cim:Terminal rdf:ID="_b9376bea-c55d-40f3-93ca-6a81fa1186a0">
+		<cim:Terminal.ConductingEquipment rdf:resource="#_5249A78F-6642-4fc5-968F-06E2ED18FAB7"/>
+	</cim:Terminal>
+	<entsoe:EnergySchedulingType rdf:ID="_24C12434-E42B-497f-928F-119C6AE92079">
+		<cim:IdentifiedObject.name>Biomass</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Generation type Biomass</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>EST-Biomass</entsoe:IdentifiedObject.shortName>
+	</entsoe:EnergySchedulingType>
+	<entsoe:EnergySchedulingType rdf:ID="_FB6F43D6-E71E-423a-8CEB-084BC504FD1A">
+		<cim:IdentifiedObject.name>Co-generation</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Generation type Co-generation</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>CoGen</entsoe:IdentifiedObject.shortName>
+	</entsoe:EnergySchedulingType>
+	<entsoe:EnergySchedulingType rdf:ID="_1CDFB476-4E01-4488-B5A2-FDDEA0488C59">
+		<cim:IdentifiedObject.name>Geothermal</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Generation type Geothermal</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>Geotherm</entsoe:IdentifiedObject.shortName>
+	</entsoe:EnergySchedulingType>
+	<entsoe:EnergySchedulingType rdf:ID="_2C897906-9B7F-4508-B132-74EA3EE1D3B0">
+		<cim:IdentifiedObject.name>Marine</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Generation type Marine</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>ES-Marine</entsoe:IdentifiedObject.shortName>
+	</entsoe:EnergySchedulingType>
+	<entsoe:EnergySchedulingType rdf:ID="_A43C7A90-B4C7-460c-A607-942EFA3EFB79">
+		<cim:IdentifiedObject.name>Other renewable</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Generation type Other renewable</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>OtherRenew</entsoe:IdentifiedObject.shortName>
+	</entsoe:EnergySchedulingType>
+	<entsoe:EnergySchedulingType rdf:ID="_1C405140-0F45-4534-9C90-F38F4905362C">
+		<cim:IdentifiedObject.name>Waste</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Generation type Waste</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>EST-Waste</entsoe:IdentifiedObject.shortName>
+	</entsoe:EnergySchedulingType>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_BD_v2/MicroGridTestConfiguration_TP_BD.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_BD_v2/MicroGridTestConfiguration_TP_BD.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" 
+xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" 
+xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
+  <md:FullModel rdf:about="urn:uuid:2399cbd1-9a39-11e0-aa80-0800200c9a66">
+    <md:Model.created>2014-06-01T11:21:24</md:Model.created>
+    <md:Model.scenarioTime>2014-06-01T10:30:00</md:Model.scenarioTime>
+	<md:Model.version>1</md:Model.version>
+	<md:Model.description>CGMES Conformity Assessment: 'MicroGridTestConfiguration (Boundary MAS)...' Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://entsoe.eu/Boundary/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://entsoe.eu/CIM/TopologyBoundary/3/1</md:Model.profile>
+    <md:Model.DependentOn rdf:resource="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66" />
+  </md:FullModel>
+  <cim:ConnectivityNode rdf:about="#_b675a570-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_d4affe50316740bdbbf4ae9c7cbf3cfd" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:about="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_f03d65b2a51049ffa533e433721145c1" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:about="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_9d25a1f9e5d14d47b6dcde99c4380b40" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:about="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_8d7bad8bcc634e0796e362390d9040b6" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:about="#_b6978550-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_1fa19c281c8f4e1eaad9e1cab70f923e" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:about="#_1c4a9e9c-ef00-42c9-9845-f64f9ca1e57a">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_1098b1c9-dc85-40ce-b65c-39ae02a3afaa" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_f03d65b2a51049ffa533e433721145c1">
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>TN_Border_GY11</cim:IdentifiedObject.name>
+	<entsoe:IdentifiedObject.shortName>XWI_GY11</entsoe:IdentifiedObject.shortName>
+    <entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-HU-00002U</entsoe:IdentifiedObject.energyIdentCodeEic>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_f03d65b2a51049ffa533e433721145c1_X" />
+    <entsoe:TopologicalNode.fromEndIsoCode>AT</entsoe:TopologicalNode.fromEndIsoCode>
+    <entsoe:TopologicalNode.fromEndName>Wien</entsoe:TopologicalNode.fromEndName>
+    <entsoe:TopologicalNode.fromEndNameTso>APG</entsoe:TopologicalNode.fromEndNameTso>
+    <entsoe:TopologicalNode.toEndIsoCode>HU</entsoe:TopologicalNode.toEndIsoCode>
+    <entsoe:TopologicalNode.toEndName>Győr</entsoe:TopologicalNode.toEndName>
+    <entsoe:TopologicalNode.toEndNameTso>MAVIR</entsoe:TopologicalNode.toEndNameTso>
+    <entsoe:TopologicalNode.boundaryPoint>true</entsoe:TopologicalNode.boundaryPoint>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_d4affe50316740bdbbf4ae9c7cbf3cfd">
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>TN_Border_AL11</cim:IdentifiedObject.name>
+	<entsoe:IdentifiedObject.shortName>XCA_AL11</entsoe:IdentifiedObject.shortName>
+    <entsoe:IdentifiedObject.energyIdentCodeEic>10T-ES-PT-10004U</entsoe:IdentifiedObject.energyIdentCodeEic>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_d4affe50316740bdbbf4ae9c7cbf3cfd_X" />
+    <entsoe:TopologicalNode.fromEndIsoCode>ES</entsoe:TopologicalNode.fromEndIsoCode>
+    <entsoe:TopologicalNode.fromEndName>Cartelle</entsoe:TopologicalNode.fromEndName>
+    <entsoe:TopologicalNode.fromEndNameTso>REE</entsoe:TopologicalNode.fromEndNameTso>
+    <entsoe:TopologicalNode.toEndIsoCode>PT</entsoe:TopologicalNode.toEndIsoCode>
+    <entsoe:TopologicalNode.toEndName>Alto Lindoso</entsoe:TopologicalNode.toEndName>
+    <entsoe:TopologicalNode.toEndNameTso>REN</entsoe:TopologicalNode.toEndNameTso>
+    <entsoe:TopologicalNode.boundaryPoint>true</entsoe:TopologicalNode.boundaryPoint>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_9d25a1f9e5d14d47b6dcde99c4380b40">
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>TN_Border_MA11</cim:IdentifiedObject.name>
+	<entsoe:IdentifiedObject.shortName>XKA_MA11</entsoe:IdentifiedObject.shortName>
+    <entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-SI-00001T</entsoe:IdentifiedObject.energyIdentCodeEic>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_9d25a1f9e5d14d47b6dcde99c4380b40_X" />
+    <entsoe:TopologicalNode.fromEndIsoCode>AT</entsoe:TopologicalNode.fromEndIsoCode>
+    <entsoe:TopologicalNode.fromEndName>Kainachtal</entsoe:TopologicalNode.fromEndName>
+    <entsoe:TopologicalNode.fromEndNameTso>APG</entsoe:TopologicalNode.fromEndNameTso>
+    <entsoe:TopologicalNode.toEndIsoCode>SI</entsoe:TopologicalNode.toEndIsoCode>
+    <entsoe:TopologicalNode.toEndName>Maribor</entsoe:TopologicalNode.toEndName>
+    <entsoe:TopologicalNode.toEndNameTso>ELES</entsoe:TopologicalNode.toEndNameTso>
+    <entsoe:TopologicalNode.boundaryPoint>true</entsoe:TopologicalNode.boundaryPoint>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_8d7bad8bcc634e0796e362390d9040b6">
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>TN_Border_ST23</cim:IdentifiedObject.name>
+	<entsoe:IdentifiedObject.shortName>XZE_ST23</entsoe:IdentifiedObject.shortName>
+    <entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00016Z</entsoe:IdentifiedObject.energyIdentCodeEic>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_8d7bad8bcc634e0796e362390d9040b6_X" />
+    <entsoe:TopologicalNode.fromEndIsoCode>AT</entsoe:TopologicalNode.fromEndIsoCode>
+    <entsoe:TopologicalNode.fromEndName>Zell/Ziller</entsoe:TopologicalNode.fromEndName>
+    <entsoe:TopologicalNode.fromEndNameTso>APG</entsoe:TopologicalNode.fromEndNameTso>
+    <entsoe:TopologicalNode.toEndIsoCode>DE</entsoe:TopologicalNode.toEndIsoCode>
+    <entsoe:TopologicalNode.toEndName>Strass</entsoe:TopologicalNode.toEndName>
+    <entsoe:TopologicalNode.toEndNameTso>TIWAG-Netz</entsoe:TopologicalNode.toEndNameTso>
+    <entsoe:TopologicalNode.boundaryPoint>true</entsoe:TopologicalNode.boundaryPoint>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_1fa19c281c8f4e1eaad9e1cab70f923e">
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>TN_Border_ST24</cim:IdentifiedObject.name>
+	<entsoe:IdentifiedObject.shortName>XZE_ST24</entsoe:IdentifiedObject.shortName>
+    <entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00017X</entsoe:IdentifiedObject.energyIdentCodeEic>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_1fa19c281c8f4e1eaad9e1cab70f923e_X" />
+    <entsoe:TopologicalNode.fromEndIsoCode>AT</entsoe:TopologicalNode.fromEndIsoCode>
+    <entsoe:TopologicalNode.fromEndName>Zell/Ziller</entsoe:TopologicalNode.fromEndName>
+    <entsoe:TopologicalNode.fromEndNameTso>APG</entsoe:TopologicalNode.fromEndNameTso>
+    <entsoe:TopologicalNode.toEndIsoCode>DE</entsoe:TopologicalNode.toEndIsoCode>
+    <entsoe:TopologicalNode.toEndName>Strass</entsoe:TopologicalNode.toEndName>
+    <entsoe:TopologicalNode.toEndNameTso>TIWAG-Netz</entsoe:TopologicalNode.toEndNameTso>
+    <entsoe:TopologicalNode.boundaryPoint>true</entsoe:TopologicalNode.boundaryPoint>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_1098b1c9-dc85-40ce-b65c-39ae02a3afaa">
+    <cim:IdentifiedObject.description>HVDC-AC; 220 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_HVDC-AC</cim:IdentifiedObject.name>
+	<entsoe:IdentifiedObject.shortName>HVDC-AC-1</entsoe:IdentifiedObject.shortName>
+    <entsoe:IdentifiedObject.energyIdentCodeEic>10T-DC-NL-00082X</entsoe:IdentifiedObject.energyIdentCodeEic>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_8FE2EC11-3357-4506-BF11-80302102B3F2" />
+    <entsoe:TopologicalNode.fromEndIsoCode>NL</entsoe:TopologicalNode.fromEndIsoCode>
+    <entsoe:TopologicalNode.fromEndName>HVDC/NL</entsoe:TopologicalNode.fromEndName>
+    <entsoe:TopologicalNode.fromEndNameTso>NL</entsoe:TopologicalNode.fromEndNameTso>
+    <entsoe:TopologicalNode.toEndIsoCode>BE</entsoe:TopologicalNode.toEndIsoCode>
+    <entsoe:TopologicalNode.toEndName>NL_AC-1</entsoe:TopologicalNode.toEndName>
+    <entsoe:TopologicalNode.toEndNameTso>NL-HVDC-1</entsoe:TopologicalNode.toEndNameTso>
+    <entsoe:TopologicalNode.boundaryPoint>true</entsoe:TopologicalNode.boundaryPoint>
+  </cim:TopologicalNode>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_DL_V2.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_DL_V2.xml
@@ -1,0 +1,1867 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF  xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<!-- Exported from CIMSpy EE/CIMdesk on Fri May 29 09:35:41.410. -->
+	<md:FullModel rdf:about="urn:uuid:80f1fec9-412f-4ca5-8706-d0d3382e9a71">
+		<md:Model.created>2014-10-24T16:53:10</md:Model.created>
+		<md:Model.scenarioTime>2014-03-28T10:13:02</md:Model.scenarioTime>
+		<md:Model.version>2</md:Model.version>
+		<md:Model.DependentOn rdf:resource="urn:uuid:96adadbe-902b-4cd6-9fc8-01a56ecbee79"/>
+		<md:Model.DependentOn rdf:resource="urn:uuid:2399cbd1-9a39-11e0-aa80-0800200c9a66"/>
+		<md:Model.DependentOn rdf:resource="urn:uuid:806f9f1b-ff69-4fb5-80f9-a8f393d31ebb"/>
+		<md:Model.DependentOn rdf:resource="urn:uuid:af6ed855-b817-447c-b436-51d87f630214"/>
+		<md:Model.description>CGMES Conformity Assessment: &apos;MicroGridTestConfiguration....T4 (MAS BE) Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+		<md:Model.modelingAuthoritySet>http://ELIA/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+		<md:Model.profile>http://entsoe.eu/CIM/DiagramLayout/3/1</md:Model.profile>
+		<md:Model.Supersedes rdf:resource="urn:uuid:0eb1540d-5ca3-40ab-9bf7-c91ec4c5d7c3"/>
+	</md:FullModel>
+	<cim:Diagram rdf:ID="_6fad1a33-3289-481e-9857-0b2c7c8ab7cf">
+		<cim:IdentifiedObject.name>Diagram 0</cim:IdentifiedObject.name>
+		<cim:Diagram.orientation rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OrientationKind.negative"/>
+	</cim:Diagram>
+	<cim:Diagram rdf:ID="_2f94b674-8d48-4221-b14f-b3930f73cfaf">
+		<cim:IdentifiedObject.name>MAS BE</cim:IdentifiedObject.name>
+		<cim:Diagram.orientation rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OrientationKind.negative"/>
+	</cim:Diagram>
+	<cim:DiagramObject rdf:ID="_0041238b-e225-4bb4-a087-e30c3264fad5">
+		<cim:IdentifiedObject.name>name 1</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_10ffd5f6-2182-440f-9081-798444a82097">
+		<cim:IdentifiedObject.name>name 10</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_d1fa1f79-9e17-40bc-ba65-b9223f0e12ec">
+		<cim:IdentifiedObject.name>name 100</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_d631ccc7-9269-4d29-a040-a7d1f62283b7">
+		<cim:IdentifiedObject.name>name 101</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_c3774d3f-f48c-4954-a0cf-b4572eb714fd"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_db88e81e-15eb-4eb1-8e80-0e667e19bc9d">
+		<cim:IdentifiedObject.name>name 102</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_e560ce95-5c71-4f05-a363-afa000854174">
+		<cim:IdentifiedObject.name>name 103</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_4152a759-f5da-4bd3-9ac4-e656795cadf0"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_e956df2b-2d2f-4019-9947-c7ee12083bba">
+		<cim:IdentifiedObject.name>name 104</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_ec973a2c-0d07-4010-ace5-2e1eba913560">
+		<cim:IdentifiedObject.name>name 105</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_ed7d1be5-bab7-4a66-80d5-ddd0508a9a62">
+		<cim:IdentifiedObject.name>name 106</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_9d25a1f9e5d14d47b6dcde99c4380b40"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_f056b0f6-44c0-420a-b894-a82568016200">
+		<cim:IdentifiedObject.name>name 107</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_8d7bad8bcc634e0796e362390d9040b6"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_f15d77ae-01ed-4317-a957-c2c6e57dd354">
+		<cim:IdentifiedObject.name>name 108</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_f2457d1e-2b1c-459b-adde-1eb039d4a884">
+		<cim:IdentifiedObject.name>name 109</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_53072f42-f77b-47e2-bd9a-e097c910b173"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_17aa0491-ca4f-4f4e-a1aa-625d83c4a9f0">
+		<cim:IdentifiedObject.name>name 11</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_c3774d3f-f48c-4954-a0cf-b4572eb714fd"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_f27e9e1b-75be-43c6-951a-c920261d6279">
+		<cim:IdentifiedObject.name>name 110</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_f4b985d7-8ada-4ef1-8729-2898113c5518">
+		<cim:IdentifiedObject.name>name 111</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_f523b1f9-7d1f-407c-b653-56050d9afef4">
+		<cim:IdentifiedObject.name>name 112</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_f685e307-a592-4e7f-ac6e-de18a8c7fd37">
+		<cim:IdentifiedObject.name>name 113</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_f9c478fa-8bce-4776-9db5-ab016226a865">
+		<cim:IdentifiedObject.name>name 114</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_17be1dea-46fc-4f39-885c-ea5449db5f6e">
+		<cim:IdentifiedObject.name>name 12</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_17ea148a-6258-46b1-aabc-4801924e90f4">
+		<cim:IdentifiedObject.name>name 13</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_1aa1047c-c086-42c8-8940-57aeb58e46c1">
+		<cim:IdentifiedObject.name>name 14</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_f03d65b2a51049ffa533e433721145c1"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_1b3f3a10-ee2a-42cb-af9a-b5bbb12ea73d">
+		<cim:IdentifiedObject.name>name 15</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_67bb74f1-8620-4a32-9d7d-a44092d11d22"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_1bf8bf2a-95dc-49b1-b3eb-24edb8fd6d01">
+		<cim:IdentifiedObject.name>name 16</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_8d7bad8bcc634e0796e362390d9040b6"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_1d94fc8c-735b-4d9d-859a-2cd5750499f5">
+		<cim:IdentifiedObject.name>name 17</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_1f07a698-2f75-46fe-91fd-9296bb2ca1f5">
+		<cim:IdentifiedObject.name>name 18</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_22ab1002-de10-4b59-88d3-94de2f5cb673">
+		<cim:IdentifiedObject.name>name 19</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_0d7fa0bd-7b54-4d13-9e4f-060bd9c5dcee"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_0092f03d-730f-4308-8f31-db491b6f0e0e">
+		<cim:IdentifiedObject.name>name 2</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_22f2b0f9-9c90-4951-a790-a296e56cc9a2">
+		<cim:IdentifiedObject.name>name 20</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ab7ece75-d726-48c8-a924-b0a9325e6d51"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_2a7ea854-cf66-4d4b-979c-0b272ecb4a84">
+		<cim:IdentifiedObject.name>name 21</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_329eba15-da28-4084-8b22-774ae3a556df"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_2c516a38-71d2-4de5-85a9-0afffe05ffae">
+		<cim:IdentifiedObject.name>name 22</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_f03d65b2a51049ffa533e433721145c1"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_2da8d6de-0e60-406a-9290-c77eb4562044">
+		<cim:IdentifiedObject.name>name 23</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_2f4cd61e-4c81-463d-a6b3-2103c6028926">
+		<cim:IdentifiedObject.name>name 24</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_313779f2-9e6f-45bd-968f-15b48921980d">
+		<cim:IdentifiedObject.name>name 25</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_42a025a2-6c0b-4d70-b950-7466a1c0e20f">
+		<cim:IdentifiedObject.name>name 26</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_44b1b66d-ddfa-490a-bff9-dbcb8320f5a9">
+		<cim:IdentifiedObject.name>name 27</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_44ffbfc7-4bb7-4ac3-bc3c-73705e4c3b9d">
+		<cim:IdentifiedObject.name>name 28</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_4c19ace6-c825-4c5b-87d9-031e6e6a3379"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_486cc37c-1cb6-41e3-98a9-5c4328dba04b">
+		<cim:IdentifiedObject.name>name 29</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_02ff2be9-590b-4379-8837-f7d634057f10">
+		<cim:IdentifiedObject.name>name 3</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_4a3e71f2-dd66-4115-bfcc-55a03c073d1e">
+		<cim:IdentifiedObject.name>name 30</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_4d9787fa-b36e-4d91-a618-45278ede1aa9">
+		<cim:IdentifiedObject.name>name 31</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_4e0dc5c7-827c-45be-b753-993c46797db1">
+		<cim:IdentifiedObject.name>name 32</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_500f3d14-b121-4a34-a006-5081b1c3ba68">
+		<cim:IdentifiedObject.name>name 33</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_5598f55b-2e85-4d7c-990d-21ad4113c77c">
+		<cim:IdentifiedObject.name>name 34</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_570c6871-8dc3-40af-992f-4cdb1569bb7a">
+		<cim:IdentifiedObject.name>name 35</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_a036b765-1669-4f64-acd3-1e8fbd513312"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_5714ac9d-ffeb-4463-baf1-15badcedbe61">
+		<cim:IdentifiedObject.name>name 36</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_5937d9a6-6a72-4fa9-b8b0-d061cf264a02">
+		<cim:IdentifiedObject.name>name 37</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_f9437903-14ef-44d1-aac7-2e906abf44f5"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_5ab788df-2567-4f42-8276-aab8e9ad84b6">
+		<cim:IdentifiedObject.name>name 38</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_76e9ca77-f805-40ea-8120-5a6d58416d34"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_5ac29d08-ccb1-466b-bbce-c38f0ea88cc7">
+		<cim:IdentifiedObject.name>name 39</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_0315a656-5d50-456e-a9cf-02ca90293c60">
+		<cim:IdentifiedObject.name>name 4</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_5d803d89-a0f5-4e30-a5e3-cd72fcedd406">
+		<cim:IdentifiedObject.name>name 40</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_24413233-26c3-4f7e-9f72-4461796938be"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_60e73084-c6e6-4c97-99e9-341a90b10556">
+		<cim:IdentifiedObject.name>name 41</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_62b95ce1-f99e-47d3-8ce1-40dc5df886ef">
+		<cim:IdentifiedObject.name>name 42</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_63d7f88f-c76c-401a-8e53-5b3d4e0adb56">
+		<cim:IdentifiedObject.name>name 43</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_64f3347a-19d5-4f36-b063-1ae0ca672dcc">
+		<cim:IdentifiedObject.name>name 44</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ca7974cf-b25e-4898-9221-7154233e5eb2"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_6502a255-7eac-4e64-9f31-1b43c2adce99">
+		<cim:IdentifiedObject.name>name 45</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_6812c2d9-b66d-446b-951b-bb7a33290f2a">
+		<cim:IdentifiedObject.name>name 46</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_69219ae6-3aab-4681-aada-978633dc29f5">
+		<cim:IdentifiedObject.name>name 47</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_76e9ca77-f805-40ea-8120-5a6d58416d34"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_69ca607d-c98d-4954-8e1b-442b6b65f651">
+		<cim:IdentifiedObject.name>name 48</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_6a31e1aa-0a4d-4c11-870b-a0c4fc9ba8df">
+		<cim:IdentifiedObject.name>name 49</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_cb459405-cc14-4215-a45c-416789205904"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_03578ffe-0f2f-45bf-8a0b-60f3ccc56c4b">
+		<cim:IdentifiedObject.name>name 5</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_d4affe50316740bdbbf4ae9c7cbf3cfd"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_6b41046f-bc49-4b2c-a36a-5d9a6748d42f">
+		<cim:IdentifiedObject.name>name 50</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_6ed80ccf-b4df-421a-8f8e-1d28334eeac1">
+		<cim:IdentifiedObject.name>name 51</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_6f362107-aa26-4bd2-a574-174d566a56ce">
+		<cim:IdentifiedObject.name>name 52</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_700f84b4-f4a5-4699-aeeb-e27ff1d6de40">
+		<cim:IdentifiedObject.name>name 53</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_d4affe50316740bdbbf4ae9c7cbf3cfd"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_7185661e-b18d-4360-9fd3-2313e4547591">
+		<cim:IdentifiedObject.name>name 54</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_87ea56f3-962a-427a-85d6-13b1f9295174"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_74be8007-e5aa-4946-afc0-517ef5ef894a">
+		<cim:IdentifiedObject.name>name 55</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_1fa19c281c8f4e1eaad9e1cab70f923e"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_773aaf03-1d51-4d22-adf4-cf8193ff3800">
+		<cim:IdentifiedObject.name>name 56</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_fe1ce9ce-d742-42d7-8e29-edf4e89482cb"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_7acfb469-69ce-4857-ba3e-877887a1bacb">
+		<cim:IdentifiedObject.name>name 57</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_4c19ace6-c825-4c5b-87d9-031e6e6a3379"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_7d80a8aa-a3af-42e8-84dc-b51be971ebd2">
+		<cim:IdentifiedObject.name>name 58</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_7de5e86a-395f-450c-916f-35f45bdaf804">
+		<cim:IdentifiedObject.name>name 59</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_c41978db-794b-4bae-953e-60fc519e87dd"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_053cb234-ee27-4661-bd81-b7a1928070d2">
+		<cim:IdentifiedObject.name>name 6</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ca7974cf-b25e-4898-9221-7154233e5eb2"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_81da1e63-5c47-4e68-8155-037c54a51bce">
+		<cim:IdentifiedObject.name>name 60</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_83d5d95c-839c-4a2a-8b69-95d371f3ef4c">
+		<cim:IdentifiedObject.name>name 61</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_1fa19c281c8f4e1eaad9e1cab70f923e"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_85482758-627c-4ccf-b992-c75b53ea2425">
+		<cim:IdentifiedObject.name>name 62</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_85631193-5b47-449e-b7bf-ccbfd4600160">
+		<cim:IdentifiedObject.name>name 63</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_d238885e-d9b6-4edc-8567-6a68c605ed67"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_8841f3a6-5dbf-47b3-97e5-6959a1852799">
+		<cim:IdentifiedObject.name>name 64</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b9539c41-d114-4280-8a54-8ecec398091e"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_8c5eb776-670a-48b6-8a75-5b7e70720504">
+		<cim:IdentifiedObject.name>name 65</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_9d25a1f9e5d14d47b6dcde99c4380b40"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_8fbc9ed5-5d11-4f1d-a1ba-d7458cea9ec5">
+		<cim:IdentifiedObject.name>name 66</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_92763ef0-2f0a-41b6-b7eb-7915d0456bca">
+		<cim:IdentifiedObject.name>name 67</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_93dababc-98d0-4fa8-82d6-e113b0baa22a">
+		<cim:IdentifiedObject.name>name 68</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_95ff3cb3-ebb5-47e3-a264-b5144ffe8d4b">
+		<cim:IdentifiedObject.name>name 69</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_0b177fc2-b019-4849-928b-bd586e28e3d5">
+		<cim:IdentifiedObject.name>name 7</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_cb459405-cc14-4215-a45c-416789205904"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_97dbc2cc-531e-4b01-8f6d-93f74bc092b4">
+		<cim:IdentifiedObject.name>name 70</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_8ced59c7-2085-4de1-8079-6493838af8be"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_9a5ec60d-49dc-4c1d-84eb-9a81f5642484">
+		<cim:IdentifiedObject.name>name 71</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_9a78619d-05c3-4c1e-9889-4dfad32eeea9">
+		<cim:IdentifiedObject.name>name 72</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_9b180b60-4037-4adb-904f-be0a31806e30">
+		<cim:IdentifiedObject.name>name 73</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_9cce9230-6e60-459e-b5c0-cd0dd6187421">
+		<cim:IdentifiedObject.name>name 74</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_9d52445b-66c5-4dca-8060-5b251febc263">
+		<cim:IdentifiedObject.name>name 75</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_a28b14a1-5c84-432b-baa6-52511f310ec7">
+		<cim:IdentifiedObject.name>name 76</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_86a6f0ca-4cf3-4d06-a65b-bd6b2e8e32a8"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_a2e136aa-2049-4089-ae71-c85a93b4f5af">
+		<cim:IdentifiedObject.name>name 77</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_a47dfa2f-b509-4b08-ae9a-3f9cd046abd4">
+		<cim:IdentifiedObject.name>name 78</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_ab7ece75-d726-48c8-a924-b0a9325e6d51"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_a7961cc9-80bf-420d-a40c-a8a0c1fcd68e">
+		<cim:IdentifiedObject.name>name 79</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_0f94b29e-1f4a-4f91-9d46-e1b46c245ada">
+		<cim:IdentifiedObject.name>name 8</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_a7cdcca3-3068-47c7-a9ab-8b1dbd9bd01a">
+		<cim:IdentifiedObject.name>name 80</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_ab42b273-336e-4245-8c13-c3e5e175e4b7">
+		<cim:IdentifiedObject.name>name 81</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_b1031e6a-f154-4f1a-a257-85f531563f75">
+		<cim:IdentifiedObject.name>name 82</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_983593b6-fefd-4cd5-b270-68be8c047e84"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_b2d070be-8aef-4794-afc6-1dd7fcce9e3b">
+		<cim:IdentifiedObject.name>name 83</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_14b352cb-5574-40c5-bf83-0ed3574554a3"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_b31dc8e9-f397-4946-a99e-41f8b51886a1">
+		<cim:IdentifiedObject.name>name 84</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_22af3121-1a66-4546-bd80-4371f417c644"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_b3bce9e1-5098-4960-8234-4e49153d068a">
+		<cim:IdentifiedObject.name>name 85</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_b78b4023-30e7-4e0f-9804-ed55c5500a4f">
+		<cim:IdentifiedObject.name>name 86</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_beffa353-7d10-421d-9c08-036b744b1cee"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_b7ed953c-db61-40d5-a373-b751c236baf9">
+		<cim:IdentifiedObject.name>name 87</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_ba74ef42-750c-4ef0-929f-ca67331f3619">
+		<cim:IdentifiedObject.name>name 88</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_beffa353-7d10-421d-9c08-036b744b1cee"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_bc8fc197-09ad-4eba-aca6-e3101631ae12">
+		<cim:IdentifiedObject.name>name 89</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_109ce03e-ad93-4349-b990-09a8e06a7883">
+		<cim:IdentifiedObject.name>name 9</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_22af3121-1a66-4546-bd80-4371f417c644"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_bef06e00-258d-4fe0-ac1c-352054470c53">
+		<cim:IdentifiedObject.name>name 90</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_c07481df-eb89-4181-a179-7b9d05fbefd9">
+		<cim:IdentifiedObject.name>name 91</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_c40ae0d6-3deb-40c0-be19-cb8affefa9de">
+		<cim:IdentifiedObject.name>name 92</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_c6d170b8-9839-4d85-9e36-780955efe6af">
+		<cim:IdentifiedObject.name>name 93</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_a036b765-1669-4f64-acd3-1e8fbd513312"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_c9fbd712-356b-411b-9a2f-a8de53d25594">
+		<cim:IdentifiedObject.name>name 94</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_cddbdb38-ae9b-42f4-9339-d2ef8316fad8">
+		<cim:IdentifiedObject.name>name 95</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_ce024232-9da1-410b-98c3-c2397d34d1f1">
+		<cim:IdentifiedObject.name>name 96</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_ced2343d-1d6b-4072-b4e3-11b4853f5998">
+		<cim:IdentifiedObject.name>name 97</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_8171fc34-6891-40e0-92d1-da9f4ba69e26"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_cf260d94-5db2-44b2-9196-a7171df2eb39">
+		<cim:IdentifiedObject.name>name 98</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_6fad1a33-3289-481e-9857-0b2c7c8ab7cf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObject rdf:ID="_d0671443-d7b6-45c7-8601-aeaadb345cee">
+		<cim:IdentifiedObject.name>name 99</cim:IdentifiedObject.name>
+		<cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+		<cim:DiagramObject.IdentifiedObject rdf:resource="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5"/>
+		<cim:DiagramObject.Diagram rdf:resource="#_2f94b674-8d48-4221-b14f-b3930f73cfaf"/>
+	</cim:DiagramObject>
+	<cim:DiagramObjectPoint rdf:ID="_016ff1f3-a0a8-44e3-9310-a242404dcb56">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>330.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>259.800000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9a5ec60d-49dc-4c1d-84eb-9a81f5642484"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_020c790b-9095-415f-a910-9f2f0a138932">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>424.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>166.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b2d070be-8aef-4794-afc6-1dd7fcce9e3b"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_020ce849-4010-425d-a8f1-9b5438690b11">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>220.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>216.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a47dfa2f-b509-4b08-ae9a-3f9cd046abd4"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_02b858d8-b146-44fa-b10b-31888a7c0679">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8fbc9ed5-5d11-4f1d-a1ba-d7458cea9ec5"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_037b2d78-61c4-4a5c-8514-edcc3e329285">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>194.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>116.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6812c2d9-b66d-446b-951b-bb7a33290f2a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_04eb9ec5-58a2-4d89-9220-7ba810ddbc08">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>336.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>244.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ced2343d-1d6b-4072-b4e3-11b4853f5998"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_0640c5be-4566-44f6-948f-2fc884a610c0">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>160.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>90.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0041238b-e225-4bb4-a087-e30c3264fad5"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_07e30844-c98b-4a7e-9424-fca32fbc561c">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>256.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>196.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_570c6871-8dc3-40af-992f-4cdb1569bb7a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_0946ec76-2f97-4359-bd20-a82aa312371e">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>336.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>258.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a7961cc9-80bf-420d-a40c-a8a0c1fcd68e"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_0b54d2ee-f631-4e81-bff3-f1ae899511c4">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>216.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f056b0f6-44c0-420a-b894-a82568016200"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_0cb41f76-9448-4733-91f6-3c89d4d44ca0">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>265.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>230.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_22f2b0f9-9c90-4951-a790-a296e56cc9a2"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_0cd7a18d-52be-407c-9d30-249bb6284892">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>402.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>185.600000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_cddbdb38-ae9b-42f4-9339-d2ef8316fad8"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_0d54c78e-88e1-47f8-bd55-4e624643f19d">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>329.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>266.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9cce9230-6e60-459e-b5c0-cd0dd6187421"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_0d819a66-e2f0-4aa7-a786-968535a372b9">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>402.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>87.600000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_cddbdb38-ae9b-42f4-9339-d2ef8316fad8"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_103d3708-a181-4da2-94ec-6c2a7196a924">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>330.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>256.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b3bce9e1-5098-4960-8234-4e49153d068a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_126cac65-d358-4a46-8d1c-2b92a85d4616">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>160.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_053cb234-ee27-4661-bd81-b7a1928070d2"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_1359f295-53dd-4f00-9441-32bec3a66eb9">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>422.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>100.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_17ea148a-6258-46b1-aabc-4801924e90f4"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_140ffa5d-1f4f-4ba6-aec7-1f61e974111a">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>368.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>234.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_93dababc-98d0-4fa8-82d6-e113b0baa22a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_147524aa-f835-4aeb-a869-c9e42c94df13">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>402.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>124.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_17aa0491-ca4f-4f4e-a1aa-625d83c4a9f0"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_149ff05d-3e9c-4430-8ac5-c8494ff7e484">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>78.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1d94fc8c-735b-4d9d-859a-2cd5750499f5"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_14db1046-7ee9-49bb-ac1a-04bed59cf301">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>160.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>82.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f9c478fa-8bce-4776-9db5-ab016226a865"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_15f7fd52-7256-4657-902d-2569aeb5b6fa">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>146.700000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>90.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_81da1e63-5c47-4e68-8155-037c54a51bce"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_191234e9-2a66-4132-a3e1-fa7e5a0ad8cc">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>295.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>124.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9d52445b-66c5-4dca-8060-5b251febc263"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_1b0f6477-924c-4f7b-9c0d-3af9cc776bb1">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>88.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2c516a38-71d2-4de5-85a9-0afffe05ffae"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_20205665-0bd1-4a19-827a-092398ce5b7d">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>203.100000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>156.100000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_773aaf03-1d51-4d22-adf4-cf8193ff3800"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_2101383e-f44b-4c26-bf26-192a840b4696">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>381.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>218.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ce024232-9da1-410b-98c3-c2397d34d1f1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_22f7298a-4142-4a72-97ea-a51e0632fd6b">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>301.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>210.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c6d170b8-9839-4d85-9e36-780955efe6af"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_2414bce8-5cce-47a5-8753-00024f5113ee">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>205.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>124.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5714ac9d-ffeb-4463-baf1-15badcedbe61"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_2546e516-9547-45ef-b98c-daceccdfa42b">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>336.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>252.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1b3f3a10-ee2a-42cb-af9a-b5bbb12ea73d"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_25e2c18b-b7ea-417c-a6c7-751f6cbe1770">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>212.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1bf8bf2a-95dc-49b1-b3eb-24edb8fd6d01"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_271ff856-29be-42a9-8788-2d0c946ddb35">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>240.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>142.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9a78619d-05c3-4c1e-9889-4dfad32eeea9"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_282bcdc6-5435-4be0-8a27-d1df04760a56">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>428.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>166.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7de5e86a-395f-450c-916f-35f45bdaf804"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_284e9217-4dff-4b3e-95da-d98bc67de761">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>47.100000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>176.700000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e560ce95-5c71-4f05-a363-afa000854174"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_2a459057-4a19-401b-9c4a-f6fd5c2bad0e">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>362.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>244.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d1fa1f79-9e17-40bc-ba65-b9223f0e12ec"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_2b540c07-bdcc-4d4f-a09b-398a55789a4c">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>320.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>246.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1b3f3a10-ee2a-42cb-af9a-b5bbb12ea73d"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_2ce135e2-3d6b-4604-ada4-c4016be0fb31">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>352.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>162.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5ac29d08-ccb1-466b-bbce-c38f0ea88cc7"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_2ecb6d81-3ddd-44b9-80d0-758d4b1402c4">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>264.600000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_74be8007-e5aa-4946-afc0-517ef5ef894a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_2f51c8c6-e6c9-4396-a3c3-a798808d0d79">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>356.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>158.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_69ca607d-c98d-4954-8e1b-442b6b65f651"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_30cf6e51-3a92-4fb6-b01f-5cb5a3829271">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>166.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ed7d1be5-bab7-4a66-80d5-ddd0508a9a62"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_30f28cde-d8cf-4b7b-a5ef-ecf58259621f">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>302.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>164.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_17be1dea-46fc-4f39-885c-ea5449db5f6e"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3176a50f-0235-4131-9927-b20dc61eea43">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>190.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>116.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0b177fc2-b019-4849-928b-bd586e28e3d5"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_31cb1b56-672f-40cb-836d-cc506b7e138d">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>171.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f15d77ae-01ed-4317-a957-c2c6e57dd354"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3461d46d-4d92-4f0a-acf1-bf90a30ca66a">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>160.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>100.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c40ae0d6-3deb-40c0-be19-cb8affefa9de"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_346f58af-5641-4fd8-8ba9-af6f5b5f8681">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>198.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f056b0f6-44c0-420a-b894-a82568016200"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3487a0c0-b1ab-4bc8-b45c-fac745d12aa2">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>205.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>230.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_22f2b0f9-9c90-4951-a790-a296e56cc9a2"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_363a90e0-a6c2-4ea2-b1f8-fe846623f536">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>329.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>230.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7d80a8aa-a3af-42e8-84dc-b51be971ebd2"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3736345f-f294-4b5e-b8d2-002f3c4b33f3">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>381.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>272.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_42a025a2-6c0b-4d70-b950-7466a1c0e20f"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3841ddda-3eeb-4b85-a67b-2a4132740470">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>172.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_92763ef0-2f0a-41b6-b7eb-7915d0456bca"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3931f103-6273-46a4-aafe-e88991c8a905">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>160.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>110.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_44b1b66d-ddfa-490a-bff9-dbcb8320f5a9"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3977d731-5b2d-451b-a824-1ebbafaac099">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>108.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f4b985d7-8ada-4ef1-8729-2898113c5518"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_399c7c47-1f5d-4ef7-a110-73a22632f0a6">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>144.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4d9787fa-b36e-4d91-a618-45278ede1aa9"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3b3484bb-f6ad-4dfe-80a1-72fcb384bf17">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>329.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>200.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9cce9230-6e60-459e-b5c0-cd0dd6187421"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3c47719d-8e8a-4437-b409-2ea84c9d2474">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>284.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>196.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_570c6871-8dc3-40af-992f-4cdb1569bb7a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3d2204e4-e8bf-4147-97c7-9ff23f57cca8">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>240.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>216.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7acfb469-69ce-4857-ba3e-877887a1bacb"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3d833398-4cb8-4dd9-91a9-ffda28aa8b78">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>361.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>170.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_bc8fc197-09ad-4eba-aca6-e3101631ae12"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3eb8d799-f5f2-49ff-8ffd-2bfde5af7e40">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>356.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>130.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_500f3d14-b121-4a34-a006-5081b1c3ba68"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3efc9d21-67f8-461e-8dee-3b5437d7b48d">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>158.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_69ca607d-c98d-4954-8e1b-442b6b65f651"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_3f62c82f-505e-4c4a-a851-e1ef9dde4e89">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>302.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_17be1dea-46fc-4f39-885c-ea5449db5f6e"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_4098f42f-0a46-459d-b166-6990b7e07258">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>305.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>124.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_17aa0491-ca4f-4f4e-a1aa-625d83c4a9f0"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_41596ade-eff4-4619-943b-0164d1862625">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>336.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>216.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_63d7f88f-c76c-401a-8e53-5b3d4e0adb56"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_41868e6b-0715-48a5-8ee9-db27e6810d0f">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>402.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>100.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b31dc8e9-f397-4946-a99e-41f8b51886a1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_4379dcca-4c65-49ae-8cf6-9df1c41c4b50">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>329.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>210.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c6d170b8-9839-4d85-9e36-780955efe6af"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_43cfc4c8-defb-4eb5-83ad-90d652f46bb4">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>218.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ce024232-9da1-410b-98c3-c2397d34d1f1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_463366b0-dabc-444f-9549-9ea591bb4b65">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>275.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>230.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f685e307-a592-4e7f-ac6e-de18a8c7fd37"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_48420bfe-33cc-4101-b13f-bc78122dfc04">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>145.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>224.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_313779f2-9e6f-45bd-968f-15b48921980d"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_4b1a72e9-bee7-43b1-bb4e-aaa2923c64db">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>222.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>152.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2da8d6de-0e60-406a-9290-c77eb4562044"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_4ecf8bee-2930-4c76-83b1-efa5535be6c9">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>204.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>168.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_97dbc2cc-531e-4b01-8f6d-93f74bc092b4"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_4f68b66c-db04-481f-af84-0d9da5b57572">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>273.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>166.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f27e9e1b-75be-43c6-951a-c920261d6279"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_50b7ac87-ca6e-4065-aeb6-f3e0399a9092">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>356.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>168.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a7cdcca3-3068-47c7-a9ab-8b1dbd9bd01a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_511e1dd7-85b7-48a6-94b8-6585e6191b6c">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>370.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>170.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_69219ae6-3aab-4681-aada-978633dc29f5"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_53cb804c-2c06-4a76-beca-43eefd0980d0">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>204.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>144.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a28b14a1-5c84-432b-baa6-52511f310ec7"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_557b34f5-9756-48d3-877c-564a516cef07">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>285.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>166.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f27e9e1b-75be-43c6-951a-c920261d6279"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_58175244-5b78-4155-b7ff-53863283c6c2">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>200.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>104.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c07481df-eb89-4181-a179-7b9d05fbefd9"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_5823b0bc-12b4-4132-b8d9-c9cf4c20d7df">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>426.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>214.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7185661e-b18d-4360-9fd3-2313e4547591"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_58b9b8a6-cb71-4909-8f9c-6a683b9a6c79">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>369.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>268.200000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_85482758-627c-4ccf-b992-c75b53ea2425"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_5b180921-223b-4dae-bf91-a0d74a4824c2">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>356.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>80.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a7cdcca3-3068-47c7-a9ab-8b1dbd9bd01a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_5b6e4c22-5db3-45ce-8990-2d8d87083dbd">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>369.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>264.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d0671443-d7b6-45c7-8601-aeaadb345cee"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_5cb0e8de-da55-453e-a874-362c392b0e36">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>381.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>248.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_db88e81e-15eb-4eb1-8e80-0e667e19bc9d"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_5e03cd07-6e02-42c3-8706-6be53913fc2a">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>205.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_64f3347a-19d5-4f36-b063-1ae0ca672dcc"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_5f369843-e2cd-44f8-8c9c-3659124ebe98">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>247.900000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a2e136aa-2049-4089-ae71-c85a93b4f5af"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_6173d096-d20d-4f5b-ba73-ecf0a0a4bab9">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>94.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6502a255-7eac-4e64-9f31-1b43c2adce99"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_628c5033-d9a9-4d4a-87d2-c816d7252044">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>145.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f15d77ae-01ed-4317-a957-c2c6e57dd354"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_640bd33f-0179-44c8-85fe-2eb864333d93">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>426.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>138.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f2457d1e-2b1c-459b-adde-1eb039d4a884"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_64b4ae66-1d0a-4381-aadb-3779fa4095c1">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>99.900000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8841f3a6-5dbf-47b3-97e5-6959a1852799"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_64d9926a-d085-4d3e-8f1b-be0c2136f728">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>368.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>244.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d1fa1f79-9e17-40bc-ba65-b9223f0e12ec"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_6575e532-fff5-4204-a30f-d9d31cba7126">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>297.700000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>210.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0315a656-5d50-456e-a9cf-02ca90293c60"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_659bd4d0-dc12-4536-a12e-abfb6d665975">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>320.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>156.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5ab788df-2567-4f42-8276-aab8e9ad84b6"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_65e02669-3be5-4988-86bf-01148bf6b7e6">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>356.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>94.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6502a255-7eac-4e64-9f31-1b43c2adce99"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_66657301-38ca-4361-8886-e44dc04a0345">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>336.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>188.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a7961cc9-80bf-420d-a40c-a8a0c1fcd68e"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_6a462a41-2d72-46ba-b7dc-f770df22e09e">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>285.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>162.300000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5ac29d08-ccb1-466b-bbce-c38f0ea88cc7"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_6bbbb1a0-60b6-4c43-9d47-9931d9c81e6b">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>352.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>244.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0092f03d-730f-4308-8f31-db491b6f0e0e"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_6dc26c25-10ec-487e-ab0e-ae8547c51459">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>254.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_74be8007-e5aa-4946-afc0-517ef5ef894a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_6f175a24-e227-4b54-a3cb-5666eda8c892">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>47.100000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>188.700000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2a7ea854-cf66-4d4b-979c-0b272ecb4a84"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_6f9750e5-ba91-4b7c-9f37-1458f49beb29">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>284.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>216.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7acfb469-69ce-4857-ba3e-877887a1bacb"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_71634b3b-bafd-4d94-9fd6-da80543eeaa8">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>156.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>90.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0041238b-e225-4bb4-a087-e30c3264fad5"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_724ca7df-e04d-414c-a226-351357da1f48">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>347.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>100.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_02ff2be9-590b-4379-8837-f7d634057f10"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_72b169e9-a1cd-458b-98a1-492ef325224d">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>184.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ed7d1be5-bab7-4a66-80d5-ddd0508a9a62"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_7578aa86-2ea7-4679-bdc5-50691d24fdd0">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>160.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>216.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a47dfa2f-b509-4b08-ae9a-3f9cd046abd4"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_76df745b-e299-4966-8a9e-848460ffc11c">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>342.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>244.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ced2343d-1d6b-4072-b4e3-11b4853f5998"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_76e4095d-1e3d-4ec2-962e-eeb9aa732e1e">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>240.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>147.900000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_95ff3cb3-ebb5-47e3-a264-b5144ffe8d4b"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_76fd0c8c-307f-4bcc-9505-48b613df5109">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>140.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_03578ffe-0f2f-45bf-8a0b-60f3ccc56c4b"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_798fce3d-30d2-43e9-8c3e-d48682ca7679">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>190.700000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>104.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_bef06e00-258d-4fe0-ac1c-352054470c53"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_7b65013a-e166-4100-b5be-95585b8c33f7">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>166.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7de5e86a-395f-450c-916f-35f45bdaf804"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_7c44abc7-1fed-4453-9dff-a323c34aa201">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>336.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>256.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b3bce9e1-5098-4960-8234-4e49153d068a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_7c8bbf05-9193-4f4d-9a71-4e93e3d6382f">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>100.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>210.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_cf260d94-5db2-44b2-9196-a7171df2eb39"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_7d603800-e025-4c34-8c08-7619356498e1">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>381.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>264.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d0671443-d7b6-45c7-8601-aeaadb345cee"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_7d92fe76-9373-4aca-95dc-c32e69605202">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>336.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>234.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4e0dc5c7-827c-45be-b753-993c46797db1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_7e9ed5b8-eefa-48ff-8cca-bcfd2bb69bb3">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>104.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2c516a38-71d2-4de5-85a9-0afffe05ffae"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_801c3db9-a9e4-4dad-bce8-aeff9c45b890">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>190.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>150.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b1031e6a-f154-4f1a-a257-85f531563f75"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_806cb855-2c6a-441c-af38-1e18a88e1069">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>32.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>178.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5937d9a6-6a72-4fa9-b8b0-d061cf264a02"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_8088f649-41ca-4702-b6e9-71b8211353ce">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>250.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>110.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_62b95ce1-f99e-47d3-8ce1-40dc5df886ef"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_843beb6e-47a5-4883-9d64-0d92851c63e1">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>402.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>144.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4d9787fa-b36e-4d91-a618-45278ede1aa9"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_8698cfa8-2dfd-4e49-a5e7-6e708cf4fa5e">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>402.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>108.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f4b985d7-8ada-4ef1-8729-2898113c5518"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_87fd6edb-3974-454c-b016-2f8ae9d0b866">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>250.200000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_83d5d95c-839c-4a2a-8b69-95d371f3ef4c"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_8875cf4e-fe54-4c1c-8b43-088b6a80a7ac">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>320.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>256.300000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c9fbd712-356b-411b-9a2f-a8de53d25594"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_8968b01b-ffbb-4dfa-89eb-386cc9679432">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>284.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>234.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4e0dc5c7-827c-45be-b753-993c46797db1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_8b047137-e9e8-47ce-8d86-eddfee6506b7">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>240.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>155.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9a78619d-05c3-4c1e-9889-4dfad32eeea9"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_8b9a7389-a629-4b37-a56e-213e29effc85">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>285.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>156.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_486cc37c-1cb6-41e3-98a9-5c4328dba04b"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_8d51dd9e-7adb-4245-a1a7-ed24a874ba72">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>285.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>169.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_486cc37c-1cb6-41e3-98a9-5c4328dba04b"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_9236b724-f678-4126-84a7-653bb5f8a034">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>154.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_700f84b4-f4a5-4699-aeeb-e27ff1d6de40"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_966b6b50-9866-4d03-984d-543023c773dc">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>311.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>86.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_109ce03e-ad93-4349-b990-09a8e06a7883"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_96d2cc6e-c449-4cc4-8a32-f15d3c3bf91e">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>152.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8c5eb776-670a-48b6-8a75-5b7e70720504"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_9ba3f74c-1575-4a7f-84ea-04f374872fec">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>311.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>156.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5598f55b-2e85-4d7c-990d-21ad4113c77c"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_9d115b0c-d799-46c9-9985-e04d16cea9f3">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>381.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>230.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7d80a8aa-a3af-42e8-84dc-b51be971ebd2"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_9f3e0ef0-fe9c-4a22-b376-e270396754f5">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>84.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b78b4023-30e7-4e0f-9804-ed55c5500a4f"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_9fdc1619-f9ba-488f-8f51-b972af31f775">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>244.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0f94b29e-1f4a-4f91-9d46-e1b46c245ada"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_a0925bef-143f-4c06-b91e-cc0a2455c9e6">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>205.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>266.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6ed80ccf-b4df-421a-8f8e-1d28334eeac1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_a2ef95b6-7b2b-4597-a783-ce200b67c4ff">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>130.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_500f3d14-b121-4a34-a006-5081b1c3ba68"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_a50a36ed-79c5-4113-a306-c917309a7c67">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>402.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>170.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_69219ae6-3aab-4681-aada-978633dc29f5"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_a5680b08-d614-4cf8-aba9-76f138fbc99f">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>356.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>86.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_109ce03e-ad93-4349-b990-09a8e06a7883"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_a5683b0c-a215-4980-a240-cc0454b1771b">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>422.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>138.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5d803d89-a0f5-4e30-a5e3-cd72fcedd406"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_a8982e34-c2ac-45cc-a430-b68bda674fd6">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>152.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>100.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6a31e1aa-0a4d-4c11-870b-a0c4fc9ba8df"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_a901e1de-eb4f-45d8-a23e-6ba5ba44c8df">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>285.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>230.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_44ffbfc7-4bb7-4ac3-bc3c-73705e4c3b9d"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_ad525f5b-e07b-4754-8f82-b26cb9e71b5d">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>430.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>214.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_85631193-5b47-449e-b7bf-ccbfd4600160"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b0f29019-9108-49e1-ab35-d71a8d3ef867">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>258.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f523b1f9-7d1f-407c-b653-56050d9afef4"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b12d26de-21c5-44c1-a9d9-4fc51939f158">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>424.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>248.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2f4cd61e-4c81-463d-a6b3-2103c6028926"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b5277ffb-5ddf-4e81-a516-fbc1ab98e376">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>123.700000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4a3e71f2-dd66-4115-bfcc-55a03c073d1e"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b647b06b-dbf7-46ec-b1d0-9b8f2692ba51">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>138.100000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f2457d1e-2b1c-459b-adde-1eb039d4a884"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b667e047-d96e-46ba-b3b2-85fdc81e6c1f">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>102.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1aa1047c-c086-42c8-8940-57aeb58e46c1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b7aefdc9-0910-4341-b62a-a89097736d3d">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>352.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>206.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6f362107-aa26-4bd2-a574-174d566a56ce"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b7d5eeb9-b3e8-4014-ade1-613e5a8ab78a">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>356.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>110.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d631ccc7-9269-4d29-a040-a7d1f62283b7"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b84ccbfc-328c-4488-a401-6e64268cf923">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>136.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9b180b60-4037-4adb-904f-be0a31806e30"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b88ae21a-ab95-417b-87e8-dabebadca5fc">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>100.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ab42b273-336e-4245-8c13-c3e5e175e4b7"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_b9d06089-bd63-4dfc-863d-f182b96c004b">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>205.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>88.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6ed80ccf-b4df-421a-8f8e-1d28334eeac1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_bcd445b4-45de-46c6-b448-272883018b01">
+		<cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>284.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_17be1dea-46fc-4f39-885c-ea5449db5f6e"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_be312bc1-087c-4000-8ee4-65c7fef3115e">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>240.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>110.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_44b1b66d-ddfa-490a-bff9-dbcb8320f5a9"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_bee85c47-d49e-449f-8f87-973cd9f69aaa">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>145.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>180.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_313779f2-9e6f-45bd-968f-15b48921980d"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_c08d30ef-2957-44e5-a456-27466d79f2e4">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>285.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>124.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5714ac9d-ffeb-4463-baf1-15badcedbe61"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_c2f1fd97-fc34-49d3-afe0-594372c4b5ac">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>213.900000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_85631193-5b47-449e-b7bf-ccbfd4600160"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_c3ccbc9a-0300-4c29-a35b-c12fa56580d0">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>230.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1bf8bf2a-95dc-49b1-b3eb-24edb8fd6d01"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_c67ceaa7-7069-421f-a807-2fdbb2c841b1">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>336.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>244.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0f94b29e-1f4a-4f91-9d46-e1b46c245ada"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_c6f4ac18-9192-4efe-bc11-cdf500badc51">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>160.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>266.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f9c478fa-8bce-4776-9db5-ab016226a865"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_c9b9b60c-6dec-4236-96ee-3092d7d8b838">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>228.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>152.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_60e73084-c6e6-4c97-99e9-341a90b10556"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_cbd41d1a-7ab7-4cc7-8104-784089f1802a">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>145.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ba74ef42-750c-4ef0-929f-ca67331f3619"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_ced3dac6-6d44-44b7-8e08-10a0ecc06623">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>381.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>258.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f523b1f9-7d1f-407c-b653-56050d9afef4"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_cf5e1d49-9373-4ca2-b616-d82f7b6eba1f">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>118.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1aa1047c-c086-42c8-8940-57aeb58e46c1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_d24c204e-2f46-4c06-91c8-beea07efdbc2">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>170.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8c5eb776-670a-48b6-8a75-5b7e70720504"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_d341e52d-b4cc-47e3-b6bc-5798ee216ff0">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>284.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>216.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_63d7f88f-c76c-401a-8e53-5b3d4e0adb56"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_d4a43d98-43c6-4a69-ab6e-dbc4d7121c6c">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>336.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8fbc9ed5-5d11-4f1d-a1ba-d7458cea9ec5"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_d79d2843-abca-43a2-9f6a-c3b6a0ffd3c2">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>301.700000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>86.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ec973a2c-0d07-4010-ace5-2e1eba913560"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_d92d86c8-c2c3-4798-a670-689663e1befc">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>205.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>104.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c07481df-eb89-4181-a179-7b9d05fbefd9"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_dcb39f48-e10b-4e09-9eec-e6bc335e19ec">
+		<cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>329.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>206.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6f362107-aa26-4bd2-a574-174d566a56ce"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_de2ff311-40b2-4b3d-80db-ca86d14909ff">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>230.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>216.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1f07a698-2f75-46fe-91fd-9296bb2ca1f5"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_e1b788f9-11cc-49ad-8a59-23b0af8651d2">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>47.100000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>200.700000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_22ab1002-de10-4b59-88d3-94de2f5cb673"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_e41f038f-5298-4d00-a97d-43aaad8a90a9">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>428.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>248.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a2e136aa-2049-4089-ae71-c85a93b4f5af"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_e590f495-b60f-44e8-b41e-9d15f5744423">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>181.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b7ed953c-db61-40d5-a373-b751c236baf9"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_e5f64fdb-5f93-4b48-860a-5c34acb20177">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>156.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>100.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c40ae0d6-3deb-40c0-be19-cb8affefa9de"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_e71f2d71-6d9e-4346-8ca1-c0c04f6c3b81">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>329.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>248.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_db88e81e-15eb-4eb1-8e80-0e667e19bc9d"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_ea25868e-b3b3-4b28-afe4-3109b66f61ed">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>426.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>100.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8841f3a6-5dbf-47b3-97e5-6959a1852799"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_ea574615-7b7e-4b97-9bb5-99671fe301f0">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>302.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>148.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_95ff3cb3-ebb5-47e3-a264-b5144ffe8d4b"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_eb6235f7-1347-467e-9054-ae6407b7ea41">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>100.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>166.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_cf260d94-5db2-44b2-9196-a7171df2eb39"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_ed2c1375-ae99-4372-b059-4712069ab4ad">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>356.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>100.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b31dc8e9-f397-4946-a99e-41f8b51886a1"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_ed98bfa4-1e0a-4ce1-b342-985b16ed1528">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>284.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>236.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e956df2b-2d2f-4019-9947-c7ee12083bba"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_ee6e2738-ee82-46c4-871c-148cd88e8dcd">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>368.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>252.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_93dababc-98d0-4fa8-82d6-e113b0baa22a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_eed77ad6-2f9b-46dc-bfe5-95025217e2f3">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>381.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>202.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_42a025a2-6c0b-4d70-b950-7466a1c0e20f"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_ef152cf6-e6e5-49dd-85d7-1343310d8831">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>126.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ab42b273-336e-4245-8c13-c3e5e175e4b7"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f15cd5cd-f9d4-4114-a6d3-06bea50220a5">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>191.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_64f3347a-19d5-4f36-b063-1ae0ca672dcc"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f3bc7d1e-0cdd-406b-893c-08b5b64d7d38">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>240.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_83d5d95c-839c-4a2a-8b69-95d371f3ef4c"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f3cebc3d-4aed-4d50-820d-1eb952002d56">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>260.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>110.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d631ccc7-9269-4d29-a040-a7d1f62283b7"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f52ce7cd-280a-48f2-a1de-d6c965050f33">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>402.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>172.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_92763ef0-2f0a-41b6-b7eb-7915d0456bca"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f58d52fa-013f-41e2-806c-a55d282ea71d">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>240.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>152.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_60e73084-c6e6-4c97-99e9-341a90b10556"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f6048f35-8a03-4a37-bd30-9ab410ff5bf1">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>205.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>116.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6812c2d9-b66d-446b-951b-bb7a33290f2a"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f6921d13-d178-435d-ab46-4f91fe0a41af">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>146.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_053cb234-ee27-4661-bd81-b7a1928070d2"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f7c070f7-5831-4e2a-a9b5-c41d0134ca90">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>356.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>156.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5ab788df-2567-4f42-8276-aab8e9ad84b6"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f869b0be-27c0-4bce-a5b2-b21a8bbc6e1e">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>284.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>188.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e956df2b-2d2f-4019-9947-c7ee12083bba"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f875ccee-1470-42f0-9c26-8a5625ebf592">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>329.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>230.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_44ffbfc7-4bb7-4ac3-bc3c-73705e4c3b9d"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f8de8048-c804-4100-9ca4-6f371dd5e098">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>267.700000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>166.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6b41046f-bc49-4b2c-a36a-5d9a6748d42f"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f909e58c-edfa-4368-9765-0738fdecabe7">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>352.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>178.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6f362107-aa26-4bd2-a574-174d566a56ce"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_f9537a87-23c8-4c1b-abaa-d013874681e2">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>252.200000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>196.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_10ffd5f6-2182-440f-9081-798444a82097"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_fb4860bf-983f-492e-b236-86c2ffecca35">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>129.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>204.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ba74ef42-750c-4ef0-929f-ca67331f3619"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_fb94c121-35db-4379-817a-4ccce540a770">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>438.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>124.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_03578ffe-0f2f-45bf-8a0b-60f3ccc56c4b"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_fe223c21-6c9e-48e2-98e6-25ee7b287e22">
+		<cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>483.500000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>138.400000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_700f84b4-f4a5-4699-aeeb-e27ff1d6de40"/>
+	</cim:DiagramObjectPoint>
+	<cim:DiagramObjectPoint rdf:ID="_ff2fd0ce-73ee-4ce7-9577-76bf7cb46a77">
+		<cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+		<cim:DiagramObjectPoint.xPosition>100.000000</cim:DiagramObjectPoint.xPosition>
+		<cim:DiagramObjectPoint.yPosition>190.000000</cim:DiagramObjectPoint.yPosition>
+		<cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b78b4023-30e7-4e0f-9804-ed55c5500a4f"/>
+	</cim:DiagramObjectPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_DY_V2.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_DY_V2.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
+  <md:FullModel rdf:about="urn:uuid:af6ed855-b817-447c-b436-51d87f630214">
+    <md:Model.created>2014-10-24T16:53:10</md:Model.created>
+    <md:Model.scenarioTime>2014-03-28T10:13:02</md:Model.scenarioTime>
+    <md:Model.version>2</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:96adadbe-902b-4cd6-9fc8-01a56ecbee79"/>
+    <md:Model.DependentOn rdf:resource="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66"/>
+    <md:Model.description>CGMES Conformity Assessment: 'MicroGridTestConfiguration....T4 (MAS BE) Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://ELIA/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://entsoe.eu/CIM/Dynamics/3/1</md:Model.profile>
+    <md:Model.Supersedes rdf:resource="urn:uuid:239caf0a-38bf-468b-a4d8-15f619886c58"/>
+  </md:FullModel>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_b1510df7-10dc-49e6-9ee5-eae9cfecd432">
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa"/>
+    <cim:IdentifiedObject.name>BE-G2</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:RotatingMachineDynamics.damping>0e+000</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>4.250000</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.saturationFactor>0e+000</cim:RotatingMachineDynamics.saturationFactor>
+    <cim:RotatingMachineDynamics.saturationFactor120>0e+000</cim:RotatingMachineDynamics.saturationFactor120>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.160000</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0e+000</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>6.400000</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.120000</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.120000</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>6.400000</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.200000</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.970000</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.290000</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.200000</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>1.970000</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.290000</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RotorKind.roundRotor"/>
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineModelKind.subtransient"/>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_3a5b94b5-0790-41ee-9c6b-90237b9919eb">
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0"/>
+    <cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:RotatingMachineDynamics.damping>0e+000</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>4.250000</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.saturationFactor>0e+000</cim:RotatingMachineDynamics.saturationFactor>
+    <cim:RotatingMachineDynamics.saturationFactor120>0e+000</cim:RotatingMachineDynamics.saturationFactor120>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.160000</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0e+000</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>6.400000</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.120000</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.120000</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>6.400000</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.200000</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.970000</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.290000</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.200000</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>1.970000</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.290000</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RotorKind.roundRotor"/>
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineModelKind.subtransient"/>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:VCompIEEEType1 rdf:ID="_983593b6-fefd-4cd5-b270-68be8c047e84">
+    <cim:IdentifiedObject.name>BE-G2-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_86a6f0ca-4cf3-4d06-a65b-bd6b2e8e32a8"/>
+    <cim:VCompIEEEType1.rc>0.000000</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.tr>0.000000</cim:VCompIEEEType1.tr>
+    <cim:VCompIEEEType1.xc>0.01</cim:VCompIEEEType1.xc>
+  </cim:VCompIEEEType1>
+  <cim:ExcIEEEAC4A rdf:ID="_86a6f0ca-4cf3-4d06-a65b-bd6b2e8e32a8">
+    <cim:IdentifiedObject.name>BE-G2-ExcAC4A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_b1510df7-10dc-49e6-9ee5-eae9cfecd432"/>
+    <cim:ExcIEEEAC4A.vimax>0.100000</cim:ExcIEEEAC4A.vimax>
+    <cim:ExcIEEEAC4A.vimin>-0.100000</cim:ExcIEEEAC4A.vimin>
+    <cim:ExcIEEEAC4A.tc>1.800000</cim:ExcIEEEAC4A.tc>
+    <cim:ExcIEEEAC4A.tb>8.500000</cim:ExcIEEEAC4A.tb>
+    <cim:ExcIEEEAC4A.ka>250.000000</cim:ExcIEEEAC4A.ka>
+    <cim:ExcIEEEAC4A.ta>0.070000</cim:ExcIEEEAC4A.ta>
+    <cim:ExcIEEEAC4A.vrmax>5.000000</cim:ExcIEEEAC4A.vrmax>
+    <cim:ExcIEEEAC4A.vrmin>-4.650000</cim:ExcIEEEAC4A.vrmin>
+    <cim:ExcIEEEAC4A.kc>0.050000</cim:ExcIEEEAC4A.kc>
+  </cim:ExcIEEEAC4A>
+  <cim:Pss2B rdf:ID="_fe1ce9ce-d742-42d7-8e29-edf4e89482cb">
+    <cim:IdentifiedObject.name>BE-G2-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_86a6f0ca-4cf3-4d06-a65b-bd6b2e8e32a8"/>
+    <cim:Pss2B.tw1>2.000000</cim:Pss2B.tw1>
+    <cim:Pss2B.tw2>2.000000</cim:Pss2B.tw2>
+    <cim:Pss2B.tw3>2.000000</cim:Pss2B.tw3>
+    <cim:Pss2B.tw4>0.000000</cim:Pss2B.tw4>
+    <cim:Pss2B.t6>0.000000</cim:Pss2B.t6>
+    <cim:Pss2B.t7>2.000000</cim:Pss2B.t7>
+    <cim:Pss2B.t1>0.120000</cim:Pss2B.t1>
+    <cim:Pss2B.t2>0.020000</cim:Pss2B.t2>
+    <cim:Pss2B.t3>0.350000</cim:Pss2B.t3>
+    <cim:Pss2B.t4>0.020000</cim:Pss2B.t4>
+    <cim:Pss2B.t8>0.000000</cim:Pss2B.t8>
+    <cim:Pss2B.t9>0.100000</cim:Pss2B.t9>
+    <cim:Pss2B.t10>0.000000</cim:Pss2B.t10>
+    <cim:Pss2B.t11>0.000000</cim:Pss2B.t11>
+    <cim:Pss2B.ks1>8.000000</cim:Pss2B.ks1>
+    <cim:Pss2B.ks2>0.310000</cim:Pss2B.ks2>
+    <cim:Pss2B.ks3>1.000000</cim:Pss2B.ks3>
+    <cim:Pss2B.ks4>1.000000</cim:Pss2B.ks4>
+    <cim:Pss2B.n>1</cim:Pss2B.n>
+    <cim:Pss2B.m>5</cim:Pss2B.m>
+    <cim:Pss2B.vstmin>-0.100000</cim:Pss2B.vstmin>
+    <cim:Pss2B.vstmax>0.100000</cim:Pss2B.vstmax>
+    <cim:Pss2B.vsi1max>999.000000</cim:Pss2B.vsi1max>
+    <cim:Pss2B.vsi1min>-999.000000</cim:Pss2B.vsi1min>
+    <cim:Pss2B.vsi2max>999.000000</cim:Pss2B.vsi2max>
+    <cim:Pss2B.vsi2min>-999.000000</cim:Pss2B.vsi2min>
+    <cim:Pss2B.a>1.000000</cim:Pss2B.a>
+    <cim:Pss2B.ta>0.000000</cim:Pss2B.ta>
+    <cim:Pss2B.tb>0.000000</cim:Pss2B.tb>
+    <cim:Pss2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#InputSignalKind.rotorSpeed"/>
+    <cim:Pss2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#InputSignalKind.generatorElectricalPower"/>
+  </cim:Pss2B>
+  <cim:VCompIEEEType1 rdf:ID="_f9437903-14ef-44d1-aac7-2e906abf44f5">
+    <cim:IdentifiedObject.name>BE-G1-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_4152a759-f5da-4bd3-9ac4-e656795cadf0"/>
+    <cim:VCompIEEEType1.rc>0.000000</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.tr>0.000000</cim:VCompIEEEType1.tr>
+    <cim:VCompIEEEType1.xc>0.01</cim:VCompIEEEType1.xc>
+  </cim:VCompIEEEType1>
+  <cim:ExcIEEEAC4A rdf:ID="_4152a759-f5da-4bd3-9ac4-e656795cadf0">
+    <cim:IdentifiedObject.name>BE-G1-ExcAC4A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_3a5b94b5-0790-41ee-9c6b-90237b9919eb"/>
+    <cim:ExcIEEEAC4A.vimax>0.100000</cim:ExcIEEEAC4A.vimax>
+    <cim:ExcIEEEAC4A.vimin>-0.100000</cim:ExcIEEEAC4A.vimin>
+    <cim:ExcIEEEAC4A.tc>1.800000</cim:ExcIEEEAC4A.tc>
+    <cim:ExcIEEEAC4A.tb>8.500000</cim:ExcIEEEAC4A.tb>
+    <cim:ExcIEEEAC4A.ka>200.000000</cim:ExcIEEEAC4A.ka>
+    <cim:ExcIEEEAC4A.ta>0.070000</cim:ExcIEEEAC4A.ta>
+    <cim:ExcIEEEAC4A.vrmax>5.000000</cim:ExcIEEEAC4A.vrmax>
+    <cim:ExcIEEEAC4A.vrmin>-4.650000</cim:ExcIEEEAC4A.vrmin>
+    <cim:ExcIEEEAC4A.kc>0.050000</cim:ExcIEEEAC4A.kc>
+  </cim:ExcIEEEAC4A>
+  <cim:Pss2B rdf:ID="_329eba15-da28-4084-8b22-774ae3a556df">
+    <cim:IdentifiedObject.name>BE-G1-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_4152a759-f5da-4bd3-9ac4-e656795cadf0"/>
+    <cim:Pss2B.tw1>2.000000</cim:Pss2B.tw1>
+    <cim:Pss2B.tw2>2.000000</cim:Pss2B.tw2>
+    <cim:Pss2B.tw3>2.000000</cim:Pss2B.tw3>
+    <cim:Pss2B.tw4>0.000000</cim:Pss2B.tw4>
+    <cim:Pss2B.t6>0.000000</cim:Pss2B.t6>
+    <cim:Pss2B.t7>2.000000</cim:Pss2B.t7>
+    <cim:Pss2B.t1>0.200000</cim:Pss2B.t1>
+    <cim:Pss2B.t2>0.020000</cim:Pss2B.t2>
+    <cim:Pss2B.t3>0.450000</cim:Pss2B.t3>
+    <cim:Pss2B.t4>0.020000</cim:Pss2B.t4>
+    <cim:Pss2B.t8>0.200000</cim:Pss2B.t8>
+    <cim:Pss2B.t9>0.100000</cim:Pss2B.t9>
+    <cim:Pss2B.t10>0.000000</cim:Pss2B.t10>
+    <cim:Pss2B.t11>0.000000</cim:Pss2B.t11>
+    <cim:Pss2B.ks1>16.000000</cim:Pss2B.ks1>
+    <cim:Pss2B.ks2>0.310000</cim:Pss2B.ks2>
+    <cim:Pss2B.ks3>1.000000</cim:Pss2B.ks3>
+    <cim:Pss2B.ks4>1.000000</cim:Pss2B.ks4>
+    <cim:Pss2B.n>1</cim:Pss2B.n>
+    <cim:Pss2B.m>5</cim:Pss2B.m>
+    <cim:Pss2B.vstmin>-0.100000</cim:Pss2B.vstmin>
+    <cim:Pss2B.vstmax>0.100000</cim:Pss2B.vstmax>
+    <cim:Pss2B.vsi1max>999.000000</cim:Pss2B.vsi1max>
+    <cim:Pss2B.vsi1min>-999.000000</cim:Pss2B.vsi1min>
+    <cim:Pss2B.vsi2max>999.000000</cim:Pss2B.vsi2max>
+    <cim:Pss2B.vsi2min>-999.000000</cim:Pss2B.vsi2min>
+    <cim:Pss2B.a>1.000000</cim:Pss2B.a>
+    <cim:Pss2B.ta>0.000000</cim:Pss2B.ta>
+    <cim:Pss2B.tb>0.000000</cim:Pss2B.tb>
+    <cim:Pss2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#InputSignalKind.rotorSpeed"/>
+    <cim:Pss2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#InputSignalKind.generatorElectricalPower"/>
+  </cim:Pss2B>
+  <cim:GovSteam0 rdf:ID="_8ced59c7-2085-4de1-8079-6493838af8be">
+    <cim:IdentifiedObject.name>BE-G2-Turb-TGOV1</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_b1510df7-10dc-49e6-9ee5-eae9cfecd432"/>
+    <cim:GovSteam0.r>0.040000</cim:GovSteam0.r>
+    <cim:GovSteam0.t1>0.300000</cim:GovSteam0.t1>
+    <cim:GovSteam0.vmax>1.000000</cim:GovSteam0.vmax>
+    <cim:GovSteam0.vmin>0.000000</cim:GovSteam0.vmin>
+    <cim:GovSteam0.t2>1.500000</cim:GovSteam0.t2>
+    <cim:GovSteam0.t3>5.000000</cim:GovSteam0.t3>
+    <cim:GovSteam0.dt>0.300000</cim:GovSteam0.dt>
+    <cim:GovSteam0.mwbase>0.000000</cim:GovSteam0.mwbase>
+  </cim:GovSteam0>
+  <cim:GovSteam1 rdf:ID="_0d7fa0bd-7b54-4d13-9e4f-060bd9c5dcee">
+    <cim:IdentifiedObject.name>BE-G1-TurbIEEEEG1</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_3a5b94b5-0790-41ee-9c6b-90237b9919eb"/>
+    <cim:GovSteam1.t1>5.000000</cim:GovSteam1.t1>
+    <cim:GovSteam1.t2>1.500000</cim:GovSteam1.t2>
+    <cim:GovSteam1.k>25.000000</cim:GovSteam1.k>
+    <cim:GovSteam1.t3>0.300000</cim:GovSteam1.t3>
+    <cim:GovSteam1.uo>1.050000</cim:GovSteam1.uo>
+    <cim:GovSteam1.uc>-1.050000</cim:GovSteam1.uc>
+    <cim:GovSteam1.pmax>1.050000</cim:GovSteam1.pmax>
+    <cim:GovSteam1.pmin>0.000000</cim:GovSteam1.pmin>
+    <cim:GovSteam1.t4>0.150000</cim:GovSteam1.t4>
+    <cim:GovSteam1.t5>2.000000</cim:GovSteam1.t5>
+    <cim:GovSteam1.t6>0.100000</cim:GovSteam1.t6>
+    <cim:GovSteam1.t7>0.000000</cim:GovSteam1.t7>
+    <cim:GovSteam1.k1>0.250000</cim:GovSteam1.k1>
+    <cim:GovSteam1.k2>0.000000</cim:GovSteam1.k2>
+    <cim:GovSteam1.k3>0.600000</cim:GovSteam1.k3>
+    <cim:GovSteam1.k4>0.000000</cim:GovSteam1.k4>
+    <cim:GovSteam1.k5>0.150000</cim:GovSteam1.k5>
+    <cim:GovSteam1.k6>0.000000</cim:GovSteam1.k6>
+    <cim:GovSteam1.k7>0.000000</cim:GovSteam1.k7>
+    <cim:GovSteam1.k8>0.000000</cim:GovSteam1.k8>
+    <cim:GovSteam1.db1>0.000000</cim:GovSteam1.db1>
+    <cim:GovSteam1.eps>0.000000</cim:GovSteam1.eps>
+    <cim:GovSteam1.db2>0.000000</cim:GovSteam1.db2>
+    <cim:GovSteam1.gv1>0.000000</cim:GovSteam1.gv1>
+    <cim:GovSteam1.pgv1>0.000000</cim:GovSteam1.pgv1>
+    <cim:GovSteam1.gv2>0.250000</cim:GovSteam1.gv2>
+    <cim:GovSteam1.pgv2>0.250000</cim:GovSteam1.pgv2>
+    <cim:GovSteam1.gv3>0.500000</cim:GovSteam1.gv3>
+    <cim:GovSteam1.pgv3>0.500000</cim:GovSteam1.pgv3>
+    <cim:GovSteam1.gv4>0.750000</cim:GovSteam1.gv4>
+    <cim:GovSteam1.pgv4>0.750000</cim:GovSteam1.pgv4>
+    <cim:GovSteam1.gv5>1.000000</cim:GovSteam1.gv5>
+    <cim:GovSteam1.pgv5>1.000000</cim:GovSteam1.pgv5>
+    <cim:GovSteam1.gv6>1.250000</cim:GovSteam1.gv6>
+    <cim:GovSteam1.pgv6>1.250000</cim:GovSteam1.pgv6>
+    <cim:GovSteam1.sdb1>true</cim:GovSteam1.sdb1>
+    <cim:GovSteam1.sdb2>true</cim:GovSteam1.sdb2>
+    <cim:GovSteam1.valve>true</cim:GovSteam1.valve>
+    <cim:GovSteam1.mwbase>0</cim:GovSteam1.mwbase>
+  </cim:GovSteam1>
+  <cim:EnergyConsumer rdf:about="#_b1480a00-b427-4001-a26c-51954d2bb7e9">
+    <cim:EnergyConsumer.LoadDynamics rdf:resource="#_15c43948-1890-4ce4-8246-16d29f1ebdb6"/>
+  </cim:EnergyConsumer>
+  <cim:LoadAggregate rdf:ID="_15c43948-1890-4ce4-8246-16d29f1ebdb6">
+    <cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+  </cim:LoadAggregate>
+  <cim:LoadStatic rdf:ID="_b307ede0-52c3-4d7a-a51d-8020e2d75d63">
+    <cim:LoadStatic.LoadAggregate rdf:resource="#_15c43948-1890-4ce4-8246-16d29f1ebdb6"/>
+    <cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+    <cim:LoadStatic.staticLoadModelType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#StaticLoadModelKind.constantZ"/>
+  </cim:LoadStatic>
+  <cim:EnergyConsumer rdf:about="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8">
+    <cim:EnergyConsumer.LoadDynamics rdf:resource="#_96cd3885-586e-4fd9-8521-d63a65fceabb"/>
+  </cim:EnergyConsumer>
+  <cim:LoadAggregate rdf:ID="_96cd3885-586e-4fd9-8521-d63a65fceabb">
+    <cim:IdentifiedObject.name>BE-Load_2</cim:IdentifiedObject.name>
+  </cim:LoadAggregate>
+  <cim:LoadStatic rdf:ID="_0f370368-ba51-4df4-9a0b-0840ae9d2e2e">
+    <cim:LoadStatic.LoadAggregate rdf:resource="#_96cd3885-586e-4fd9-8521-d63a65fceabb"/>
+    <cim:IdentifiedObject.name>BE-Load_2</cim:IdentifiedObject.name>
+    <cim:LoadStatic.staticLoadModelType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#StaticLoadModelKind.constantZ"/>
+  </cim:LoadStatic>
+  <cim:EnergyConsumer rdf:about="#_cb459405-cc14-4215-a45c-416789205904">
+    <cim:EnergyConsumer.LoadDynamics rdf:resource="#_a31f10d9-4069-4f52-afa1-1a25e8c3b5d4"/>
+  </cim:EnergyConsumer>
+  <cim:LoadAggregate rdf:ID="_a31f10d9-4069-4f52-afa1-1a25e8c3b5d4">
+    <cim:IdentifiedObject.name>BE-Load_1</cim:IdentifiedObject.name>
+  </cim:LoadAggregate>
+  <cim:LoadStatic rdf:ID="_d9d8ab71-0768-4d5e-9999-424e52f5854a">
+    <cim:LoadStatic.LoadAggregate rdf:resource="#_a31f10d9-4069-4f52-afa1-1a25e8c3b5d4"/>
+    <cim:IdentifiedObject.name>BE-Load_1</cim:IdentifiedObject.name>
+    <cim:LoadStatic.staticLoadModelType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#StaticLoadModelKind.constantZ"/>
+  </cim:LoadStatic>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_EQ_V2.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_EQ_V2.xml
@@ -1,0 +1,3126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF  xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<!-- Exported from CIMSpy EE/CIMdesk on Fri May 29 16:43:16.554. -->
+	<md:FullModel rdf:about="urn:uuid:96adadbe-902b-4cd6-9fc8-01a56ecbee79">
+		<md:Model.created>2014-10-24T16:53:10</md:Model.created>
+		<md:Model.scenarioTime>2014-03-28T10:13:02</md:Model.scenarioTime>
+		<md:Model.version>2</md:Model.version>
+		<md:Model.DependentOn rdf:resource="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66"/>
+		<md:Model.description>CGMES Conformity Assessment: &apos;MicroGridTestConfiguration....T4 (MAS BE) Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+		<md:Model.modelingAuthoritySet>http://ELIA/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+		<md:Model.profile>http://entsoe.eu/CIM/EquipmentCore/3/1</md:Model.profile>
+		<md:Model.profile>http://entsoe.eu/CIM/EquipmentShortCircuit/3/1</md:Model.profile>
+		<md:Model.Supersedes rdf:resource="urn:uuid:d400c631-75a0-4c30-8aed-832b0d282e73"/>
+	</md:FullModel>
+	<cim:ACLineSegment rdf:ID="_17086487-56ba-4979-b8de-064025a6b4da">
+		<cim:IdentifiedObject.name>BE-Line_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_1</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:IdentifiedObject.description>10T-AT-DE-000061</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_2b659afe-2ac3-425c-9418-3383e09b4b39"/>
+		<cim:ACLineSegment.r>2.200000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>68.200000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000829380</cim:ACLineSegment.bch>
+		<cim:Conductor.length>22.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000308000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+		<cim:ACLineSegment.r0>6.600000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>204.600000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0000262637</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000308000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_b58bf21a-096a-4dae-9a01-3f03b60c24c7">
+		<cim:IdentifiedObject.name>BE-Line_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_2</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00010A</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:IdentifiedObject.description>10T-AT-DE-00010A</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_b5d6ed2b-c961-4521-8aef-b943d7dc6c15"/>
+		<cim:ACLineSegment.r>1.935000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>34.200000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000424115</cim:ACLineSegment.bch>
+		<cim:Conductor.length>45.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000675000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>true</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+		<cim:ACLineSegment.r0>3.195000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>102.600000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0000664447</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000675000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_78736387-5f60-4832-b3fe-d50daf81b0a6">
+		<cim:IdentifiedObject.name>BE-Line_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_3</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00008Y</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:IdentifiedObject.description>10T-AT-DE-00008Y</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_185273ba-a4e8-4754-8038-3b33eb76132e"/>
+		<cim:ACLineSegment.r>1.050000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>12.000000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0001498540</cim:ACLineSegment.bch>
+		<cim:Conductor.length>30.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000600000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6"/>
+		<cim:ACLineSegment.r0>3.150000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>36.000000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0000292168</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000600000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_ed0c5d75-4a54-43c8-b782-b20d7431630b">
+		<cim:IdentifiedObject.name>BE-Line_4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>to be connected to the boundary set</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_f04af3a9-24e3-46dd-91c0-97fea3ecc6a7"/>
+		<cim:ACLineSegment.r>0.240000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>2.000000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000251956</cim:ACLineSegment.bch>
+		<cim:Conductor.length>40.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000400000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6"/>
+		<cim:ACLineSegment.r0>0.720000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>6.000000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0000628319</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000400000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_b18cd1aa-7808-49b9-a7cf-605eaf07b006">
+		<cim:IdentifiedObject.name>BE-Line_5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_5</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_608059fa-f262-463d-a8a8-80844a2a7021"/>
+		<cim:ACLineSegment.r>0.420000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>6.300000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000659734</cim:ACLineSegment.bch>
+		<cim:Conductor.length>35.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000420000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6"/>
+		<cim:ACLineSegment.r0>1.260000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>18.900000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0000340863</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000420000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_ffbabc27-1ccd-4fdc-b037-e341706c8d29">
+		<cim:IdentifiedObject.name>BE-Line_6</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_6</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>TYNDP project BE-4; map reference 567</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_cc4b99a5-e20d-407c-9d8e-a682b9723613"/>
+		<cim:ACLineSegment.r>5.203000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>71.000000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000200119</cim:ACLineSegment.bch>
+		<cim:Conductor.length>100.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0001200000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>true</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+		<cim:ACLineSegment.r0>15.000000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>213.000000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0001476549</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0001200000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4">
+		<cim:IdentifiedObject.name>BE-Line_7</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_7</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:IdentifiedObject.description>10T-AT-DE-000061</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_a8aa134c-be99-4e28-8e51-2d01a3b3e078"/>
+		<cim:ACLineSegment.r>4.600000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>69.000000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000216770</cim:ACLineSegment.bch>
+		<cim:Conductor.length>23.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000575000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+		<cim:ACLineSegment.r0>13.800000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>207.000000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0000289027</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000575000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:BaseVoltage rdf:ID="_862a4658-6b03-4550-9de2-b5c413912b75">
+		<cim:BaseVoltage.nominalVoltage>10.50</cim:BaseVoltage.nominalVoltage>
+		<cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>10.50</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.name>10.50 kV</cim:IdentifiedObject.name>
+	</cim:BaseVoltage>
+	<cim:BaseVoltage rdf:ID="_00b17311-075f-48f6-a79b-597f42af4694">
+		<cim:BaseVoltage.nominalVoltage>110.00</cim:BaseVoltage.nominalVoltage>
+		<cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>110.00</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.name>110.00 kV</cim:IdentifiedObject.name>
+	</cim:BaseVoltage>
+	<cim:BaseVoltage rdf:ID="_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2">
+		<cim:BaseVoltage.nominalVoltage>21.00</cim:BaseVoltage.nominalVoltage>
+		<cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>21.00</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.name>21.00 kV</cim:IdentifiedObject.name>
+	</cim:BaseVoltage>
+	<cim:BusbarSection rdf:ID="_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c">
+		<cim:IdentifiedObject.name>BE-Busbar_1</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_ef45b632-3028-4afe-bc4c-a4fa323d83fe">
+		<cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_d0486169-2205-40b2-895e-b672ecb9e5fc"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_5caf27ed-d2f8-458a-834a-6b3193a982e6">
+		<cim:IdentifiedObject.name>BE-Busbar_3</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_fd649fe1-bdf5-4062-98ea-bbb66f50402d">
+		<cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_364c9ca2-0d1d-4363-8f46-e586f8f66a8c">
+		<cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0"/>
+		<cim:BusbarSection.ipMax>5000.000000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_63f25be7-7592-4cf1-8401-5772046ef2ae">
+		<cim:IdentifiedObject.name>N1230992288</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_c8ce5e08-5ee3-42d9-aa44-5792db252d9f">
+		<cim:IdentifiedObject.name>N1230992291</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_8da0ff82-2f23-4231-ac9b-28b9c9141432">
+		<cim:IdentifiedObject.name>N1230992411</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_d0486169-2205-40b2-895e-b672ecb9e5fc"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_d6986ea6-fadc-4113-806a-a8f95f62c216">
+		<cim:IdentifiedObject.name>N1230992414</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_d0486169-2205-40b2-895e-b672ecb9e5fc"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:CurrentLimit rdf:ID="_88240efd-b544-4131-bc99-e6b77d4bac881">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_08322f60-4e75-4a00-a4e0-0c55bf5889191">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_c90ed10b-9e23-48b5-a0f0-3ee7729dc83e1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d055ace9-3bd3-49d8-a0ae-99f4e21efe761">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_86143da2-d202-41e3-a1b4-7eb13ba093341">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_648d7a22-9468-4c53-9528-99c9f82d3e451">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_bc51e778-64a2-4176-8d7b-8bdbe0b089cb1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3707e6e7-69e5-4f10-bc43-2812519c28421">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_701a0052-ddb1-484a-885c-600c74063a6a1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_bfdc67ea-b21a-4f48-a425-0c715c7e16e01">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1800.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_31f7b62d-4707-4067-b1d5-44976db91f001">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_50c2510a-8f27-44f3-a3a5-64ae99b6c0771">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_328d2341-1ab1-417a-9246-8aa0e8124e9c1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_69ef4dd8-9f2a-48f7-a230-c4cd695f48761">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1800.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_1b18dc2e-d876-4213-b9c2-ddfde01caa5a1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_cde82226-7cea-4d13-b0b0-f545a0e08a181">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_2eb0f5f3-1377-4ea8-b794-a86c280396031">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_858ebaaa-eec6-48e1-b579-b10986e0ddb61">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3cff44a0-b9a5-4b35-a724-8740d73c07c91">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a94ca937-819e-4975-a1fd-34598e05d56e1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_94489b05-9fba-4d28-a720-f2f731fcbeb41">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a4fce087-92c7-454e-a901-b3efceafca611">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_4574ae6a-6ee5-4d9d-9cf3-0bdcc944b2081">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f49c1cf8-6dad-442b-8b6e-88d17969887f1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_382e1966-5b98-4257-a0e5-e0cce107f85d1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b0c127b9-ba6a-4c95-9c9f-a331e9237bb01">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3ebc30bc-3b24-4ee1-9534-da22e2cd66d11">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fd227658-0e1b-4ecd-952a-c6b0307b1ea11">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3ee6fbe2-5862-473e-b09d-a44522c6bf9e1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_c1e9a43c-a753-4f7c-b847-b7807c3779b51">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fc9a338c-df48-4c21-91ea-c9286542d3881">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_5f3bd045-4b3a-47f5-acce-6b45d332633b1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_df47a1fa-8065-4c82-bc45-f62e92caaf3e1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_2bb91774-4c1f-4dd6-aeb3-87a3009306c01">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_cdb0571a-cacd-4f39-9537-0bfdf3f0fd1b2">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-6</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1800.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_955b2d6c-7874-40c9-93f1-7a45d3084166"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e80822fa-fc7f-4a11-a084-10b4893b75461">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_51a7a0f8-8b3c-4a59-9890-55de5f7de19b1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_bcf693fe-ccc9-443d-90d6-21d3702b41861">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_0068a5c1-9212-4366-8e0e-cf621a92a8b71">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a47ed63a-6b8a-4ccd-aae8-d6781f644ce52">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-6</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1800.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_955b2d6c-7874-40c9-93f1-7a45d3084166"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f9f95a0f-f165-4717-b44a-384e7d6af5a11">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_58ccdb26-c046-4189-a1c2-e542a168f8531">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_cd228cb6-24ad-45f3-b9a1-24361a743d221">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_4dca5f0b-dadf-46c9-aa93-5ff360c120fd1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fdae97f0-ee12-4d0e-9bba-e994b2ca78fb1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d39031b2-8181-4b02-a4fe-2a4a5296dd511">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_5ba29c54-df69-4e8f-8835-58f7deb762d91">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_89893083-697f-45cd-bdce-14f57fed59141">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f454fa68-0bd5-4e4e-92d6-6108176ad3bf1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_ebe4f8e3-7bc8-4162-8bdf-e100742b23631">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1395.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_8447ed5e-3d27-42c0-9e67-9affdda0be451">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1350.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6a000ecb-b731-4cc0-9791-980a4d8c28911">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_8b68c876-8c3c-486f-a478-04c5f7c879af1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b1714414-0394-42b6-b441-a664069554a21">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1395.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_58c959fd-3675-4ad4-a221-9647b57073dd1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1350.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e16c3321-9a86-4975-ba5e-4788ac070e541">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3503e388-5b7c-4e29-ae10-1f45a2c0c96b1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1177.290000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_8a9d3c6a-e33f-4a3b-828a-4a696602e4d21">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1177.290000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_ff466d18-e4f5-439b-a50a-daec2fa41e2c1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1177.290000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b659ed1b-c1a0-459e-a858-6c3f7431f4f21">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1177.290000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_05b69cbf-0e24-4c98-bd81-9450c751be6f1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>12371.760000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_7166b977-0713-4afd-9674-d5073c9723211">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>12371.760000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_78a00357-6831-4773-a317-f0092621fb0c1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>12371.760000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_33d5e916-21fd-4d24-802d-69c0eb173eaf1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>12371.760000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_4f36a64e-0494-47b0-a552-93db9d01eb8a1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1535.220000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_88aa13e4-d3fe-4c47-9e47-39f8bb805e73"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6c95290e-c4a6-4fa9-8d48-d4c847a1d2c41">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3070.440000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f6fbfd23-8043-4d2a-a547-73d14bd161cf1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>844.380000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0b7c4239-3c1b-438e-994d-f2a402ba743c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fad252e8-cd6e-4226-9c0f-3a9f1e43904d1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3070.440000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e8889178-5295-439f-916c-e28eff9141be1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>844.380000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f552f5f8-348a-4299-81e6-c8f5a39a6db31">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>844.380000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_55d9cdaf-9b02-448b-9206-f12f3c8d2f641">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>844.380000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_c8852f92-33cc-44eb-b977-d282bb648d2f1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>844.380000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_7fe9c4b1-7ca5-40f1-9eb4-a51caaa33f7c1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1535.220000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d91f4be3-9191-4cf9-a271-5fd1f54465ce1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1535.220000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_56a462e6-5117-456b-9d0c-8d62b9a1f14a1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1535.220000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f2b59bb4-79ce-4f17-8fc6-c006407b63581">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1535.220000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_8117eb14-2b1e-4a66-8dfa-54d2fe69c1861">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>16083.360000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f8bd3d90-ecc2-4f16-9de9-22ba0e62c1f31">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>16083.360000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_c23d7e6c-1e09-452e-a82d-70599ec197b21">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>16083.360000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b2f157c0-ced9-4692-b430-4864d5a665e41">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>16083.360000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_5343c925-7df1-42b3-b9e0-6260a494c4cd"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_7156a0ea-cf7a-46b0-91c0-a973e1c6feb2">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1574.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_ad0fa884-ec20-4908-9986-48ab09ac55cd">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1574.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e9171d11-8877-48ab-a50a-7ede9d4ec4b6">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_19627231-9a8b-45e1-815c-b280a66a59ca">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f454fa68-0bd5-4e4e-92d6-6108176ad3bf">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_8b68c876-8c3c-486f-a478-04c5f7c879af">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_ebe4f8e3-7bc8-4162-8bdf-e100742b2363">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1550.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b1714414-0394-42b6-b441-a664069554a2">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1550.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_8447ed5e-3d27-42c0-9e67-9affdda0be45">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1500.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_58c959fd-3675-4ad4-a221-9647b57073dd">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1500.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6a000ecb-b731-4cc0-9791-980a4d8c2891">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e16c3321-9a86-4975-ba5e-4788ac070e54">
+		<cim:IdentifiedObject.name>BE-Line_1 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_1594f66e-86bd-45da-aa04-3c2bd8e07d76">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1574.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_43d42f99-7c35-4907-a6ea-372b41eb8f77">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1574.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6f35cf24-2d5e-4b9a-ac65-943610878a4b">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3ab4897f-cf5e-418b-8e1c-94f9cde91501">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_bc51e778-64a2-4176-8d7b-8bdbe0b089cb">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_31f7b62d-4707-4067-b1d5-44976db91f00">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3707e6e7-69e5-4f10-bc43-2812519c2842">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_50c2510a-8f27-44f3-a3a5-64ae99b6c077">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_701a0052-ddb1-484a-885c-600c74063a6a">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_328d2341-1ab1-417a-9246-8aa0e8124e9c">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_bfdc67ea-b21a-4f48-a425-0c715c7e16e0">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>2000.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_69ef4dd8-9f2a-48f7-a230-c4cd695f4876">
+		<cim:IdentifiedObject.name>BE-Line_2 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>2000.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e207f382-e138-4a26-a40d-6c01dda96879">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e537f16f-6107-47a6-a728-797ac246d777">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_ca002966-c9a3-4a17-a12d-1cd32c9d9a7e">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1515.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_235676b8-e13c-4400-878f-b0ddc4c9aeae">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1515.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_1b18dc2e-d876-4213-b9c2-ddfde01caa5a">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3cff44a0-b9a5-4b35-a724-8740d73c07c9">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_cde82226-7cea-4d13-b0b0-f545a0e08a18">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a94ca937-819e-4975-a1fd-34598e05d56e">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_2eb0f5f3-1377-4ea8-b794-a86c28039603">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_94489b05-9fba-4d28-a720-f2f731fcbeb4">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_858ebaaa-eec6-48e1-b579-b10986e0ddb6">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a4fce087-92c7-454e-a901-b3efceafca61">
+		<cim:IdentifiedObject.name>BE-Line_3 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d5a5feb2-8345-487c-a1bc-af3829329391">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1299.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_217293df-7f75-4838-8557-d422f7b83c2f">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1299.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e6c72199-8db4-4674-bdd8-d6808afb115e">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6db95b07-f943-465c-b6ff-844929c07c8b">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_4574ae6a-6ee5-4d9d-9cf3-0bdcc944b208">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3ebc30bc-3b24-4ee1-9534-da22e2cd66d1">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f49c1cf8-6dad-442b-8b6e-88d17969887f">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fd227658-0e1b-4ecd-952a-c6b0307b1ea1">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_382e1966-5b98-4257-a0e5-e0cce107f85d">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3ee6fbe2-5862-473e-b09d-a44522c6bf9e">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b0c127b9-ba6a-4c95-9c9f-a331e9237bb0">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_c1e9a43c-a753-4f7c-b847-b7807c3779b5">
+		<cim:IdentifiedObject.name>BE-Line_4 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_bea68f9e-5348-40dd-ac14-75c41a6a38bd">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1876.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_be0d07fc-d20a-430d-82e3-93d48d3f220f">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1876.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3b3fdb5e-dafe-41bb-acfb-eb21be018863">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1948.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a3ecec82-f9e9-4a3c-9cd9-23ae8756ba3c">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1948.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fc9a338c-df48-4c21-91ea-c9286542d388">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e80822fa-fc7f-4a11-a084-10b4893b7546">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_5f3bd045-4b3a-47f5-acce-6b45d332633b">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_51a7a0f8-8b3c-4a59-9890-55de5f7de19b">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_df47a1fa-8065-4c82-bc45-f62e92caaf3e">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_bcf693fe-ccc9-443d-90d6-21d3702b4186">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_2bb91774-4c1f-4dd6-aeb3-87a3009306c0">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_0068a5c1-9212-4366-8e0e-cf621a92a8b7">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_cdb0571a-cacd-4f39-9537-0bfdf3f0fd1b">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-6</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-6</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>2000.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_e3e9b93d-77e4-41f7-a8d9-af6481c99932"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a47ed63a-6b8a-4ccd-aae8-d6781f644ce5">
+		<cim:IdentifiedObject.name>BE-Line_5 - CL-6</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-6</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>2000.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_e3e9b93d-77e4-41f7-a8d9-af6481c99932"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_0f8bff64-4cfe-4c94-9471-da94b2efcc4f">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1312.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a634eecf-b900-4808-8b74-d91e36c383a0">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1312.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_61870312-e0be-4dd7-8941-22c108b61c30">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_5a4a910c-f57f-456b-b9ca-670ab3676adb">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f9f95a0f-f165-4717-b44a-384e7d6af5a1">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fdae97f0-ee12-4d0e-9bba-e994b2ca78fb">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_58ccdb26-c046-4189-a1c2-e542a168f853">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d39031b2-8181-4b02-a4fe-2a4a5296dd51">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_cd228cb6-24ad-45f3-b9a1-24361a743d22">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_5ba29c54-df69-4e8f-8835-58f7deb762d9">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_4dca5f0b-dadf-46c9-aa93-5ff360c120fd">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_89893083-697f-45cd-bdce-14f57fed5914">
+		<cim:IdentifiedObject.name>BE-Line_6 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_6 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6623e566-3111-4050-9b4e-c98d89ba3e69">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1312.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fa8eb432-3107-4562-95fa-7f35d75101b0">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1312.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_cce95c87-f08f-47b7-9cdf-f0189a92572f">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_367fe7fa-1b11-4090-af9a-0abc050fda58">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_88240efd-b544-4131-bc99-e6b77d4bac88">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d055ace9-3bd3-49d8-a0ae-99f4e21efe76">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_08322f60-4e75-4a00-a4e0-0c55bf588919">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_86143da2-d202-41e3-a1b4-7eb13ba09334">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_c90ed10b-9e23-48b5-a0f0-3ee7729dc83e">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_648d7a22-9468-4c53-9528-99c9f82d3e45">
+		<cim:IdentifiedObject.name>BE-Line_7 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-Line_7 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f6fbfd23-8043-4d2a-a547-73d14bd161cf">
+		<cim:IdentifiedObject.name>BE-TR2_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>938.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0b7c4239-3c1b-438e-994d-f2a402ba743c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fad252e8-cd6e-4226-9c0f-3a9f1e43904d">
+		<cim:IdentifiedObject.name>BE-TR2_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3411.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_dea05113-ef3e-4161-957d-4602c874839e">
+		<cim:IdentifiedObject.name>BE-TR2_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>998.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0b7c4239-3c1b-438e-994d-f2a402ba743c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_1e793cd6-1608-46af-a3f7-b4d1cabc9d58">
+		<cim:IdentifiedObject.name>BE-TR2_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3811.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_1b0850d6-317b-40a3-aa98-040b64f9350c">
+		<cim:IdentifiedObject.name>BE-TR2_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>958.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0b7c4239-3c1b-438e-994d-f2a402ba743c"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e1ae19e7-8bb7-42ce-8ae6-24893f16e366">
+		<cim:IdentifiedObject.name>BE-TR2_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3611.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_4f36a64e-0494-47b0-a552-93db9d01eb8a">
+		<cim:IdentifiedObject.name>BE-TR2_2 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_88aa13e4-d3fe-4c47-9e47-39f8bb805e73"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6c95290e-c4a6-4fa9-8d48-d4c847a1d2c4">
+		<cim:IdentifiedObject.name>BE-TR2_2 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3411.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d29ef207-67d3-47bb-82ea-9d82074dde55">
+		<cim:IdentifiedObject.name>BE-TR2_2 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1905.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_88aa13e4-d3fe-4c47-9e47-39f8bb805e73"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_9b2c1328-381e-4277-9042-94b0085f2b77">
+		<cim:IdentifiedObject.name>BE-TR2_2 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3811.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_9732c968-c1c4-446a-b47b-9038f5a59724">
+		<cim:IdentifiedObject.name>BE-TR2_2 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1805.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_88aa13e4-d3fe-4c47-9e47-39f8bb805e73"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6236459d-8471-44be-9b66-b271ac407165">
+		<cim:IdentifiedObject.name>BE-TR2_2 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3611.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a5d3cd27-798c-4910-9729-6fc745346601">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1408.100000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3674d58e-946d-4901-8084-eb21afe1565a">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>14746.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_7059bdb7-fa2d-4061-aea7-a88760835e2f">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1508.100000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a1cfb7e6-ed0d-4369-b555-007826ba82fb">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>15746.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3503e388-5b7c-4e29-ae10-1f45a2c0c96b">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1308.100000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_05b69cbf-0e24-4c98-bd81-9450c751be6f">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>13746.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_8a9d3c6a-e33f-4a3b-828a-4a696602e4d2">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1308.100000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_7166b977-0713-4afd-9674-d5073c972321">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>13746.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_ff466d18-e4f5-439b-a50a-daec2fa41e2c">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1308.100000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_78a00357-6831-4773-a317-f0092621fb0c">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>13746.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b659ed1b-c1a0-459e-a858-6c3f7431f4f2">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1308.100000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_33d5e916-21fd-4d24-802d-69c0eb173eaf">
+		<cim:IdentifiedObject.name>BE-TR2_3 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>13746.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_ddcb76e0-13ea-413f-9a8f-553d78782f76">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>968.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_52d7ccc6-b4a1-48eb-9cfa-f5870b8b7fce">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1805.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_50448009-0fad-4656-bce4-438fe76e18cf">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>18870.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_8b859dc8-193a-4a18-912a-1833f45fe926"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3e9ed732-dd10-4f10-bc9d-d399e1e75a78">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>998.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_11763596-6f4b-4cd5-a4a0-be649f368e86">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1905.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_df2d3155-4436-4542-8d3b-64241c7433be">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>19870.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e8889178-5295-439f-916c-e28eff9141be">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>938.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_7fe9c4b1-7ca5-40f1-9eb4-a51caaa33f7c">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_8117eb14-2b1e-4a66-8dfa-54d2fe69c186">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>17870.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f552f5f8-348a-4299-81e6-c8f5a39a6db3">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>938.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d91f4be3-9191-4cf9-a271-5fd1f54465ce">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f8bd3d90-ecc2-4f16-9de9-22ba0e62c1f3">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>17870.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_55d9cdaf-9b02-448b-9206-f12f3c8d2f64">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>938.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_56a462e6-5117-456b-9d0c-8d62b9a1f14a">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_c23d7e6c-1e09-452e-a82d-70599ec197b2">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-4</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>17870.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_c8852f92-33cc-44eb-b977-d282bb648d2f">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>938.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_f2b59bb4-79ce-4f17-8fc6-c006407b6358">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b2f157c0-ced9-4692-b430-4864d5a665e4">
+		<cim:IdentifiedObject.name>BE-TR3_1 - CL-5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-5</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element BE-TR3_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>17870.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae"/>
+	</cim:CurrentLimit>
+	<cim:CurveData rdf:ID="_51AB-2E-F1-031323239373533303630">
+		<cim:CurveData.xvalue>-100.000000</cim:CurveData.xvalue>
+		<cim:CurveData.y1value>-200.000000</cim:CurveData.y1value>
+		<cim:CurveData.y2value>200.000000</cim:CurveData.y2value>
+		<cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170"/>
+	</cim:CurveData>
+	<cim:CurveData rdf:ID="_51AB-2E-F1-131323239373533303630">
+		<cim:CurveData.xvalue>0e+000</cim:CurveData.xvalue>
+		<cim:CurveData.y1value>-300.000000</cim:CurveData.y1value>
+		<cim:CurveData.y2value>300.000000</cim:CurveData.y2value>
+		<cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170"/>
+	</cim:CurveData>
+	<cim:CurveData rdf:ID="_51AB-2E-F1-231323239373533303630">
+		<cim:CurveData.xvalue>100.000000</cim:CurveData.xvalue>
+		<cim:CurveData.y1value>-200.000000</cim:CurveData.y1value>
+		<cim:CurveData.y2value>200.000000</cim:CurveData.y2value>
+		<cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170"/>
+	</cim:CurveData>
+	<cim:EnergyConsumer rdf:ID="_cb459405-cc14-4215-a45c-416789205904">
+		<cim:IdentifiedObject.name>BE-Load_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Electrabel</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0"/>
+	</cim:EnergyConsumer>
+	<cim:EnergyConsumer rdf:ID="_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8">
+		<cim:IdentifiedObject.name>BE-Load_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>EVN</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c"/>
+	</cim:EnergyConsumer>
+	<cim:EnergyConsumer rdf:ID="_b1480a00-b427-4001-a26c-51954d2bb7e9">
+		<cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>L-1230804819</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_d0486169-2205-40b2-895e-b672ecb9e5fc"/>
+		<cim:EnergyConsumer.LoadResponse rdf:resource="#_8e3e7a69-a64a-43a8-906e-82cc63edfcd3"/>
+	</cim:EnergyConsumer>
+	<cim:EquivalentInjection rdf:ID="_24413233-26c3-4f7e-9f72-4461796938be">
+		<cim:IdentifiedObject.name>BE-Inj-XCA_AL11</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XCA_AL1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+	</cim:EquivalentInjection>
+	<cim:EquivalentInjection rdf:ID="_14b352cb-5574-40c5-bf83-0ed3574554a3">
+		<cim:IdentifiedObject.name>BE-Inj-XKA_MA11</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XKA_MA1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+	</cim:EquivalentInjection>
+	<cim:EquivalentInjection rdf:ID="_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf">
+		<cim:IdentifiedObject.name>BE-Inj-XWI_GY11</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XWI_GY1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+	</cim:EquivalentInjection>
+	<cim:EquivalentInjection rdf:ID="_87ea56f3-962a-427a-85d6-13b1f9295174">
+		<cim:IdentifiedObject.name>BE-Inj-XZE_ST23</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XZE_ST2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+	</cim:EquivalentInjection>
+	<cim:EquivalentInjection rdf:ID="_f7f61a91-eca2-4492-8bd7-9ec2b28fc837">
+		<cim:IdentifiedObject.name>BE-Inj-XZE_ST24</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XZE_ST2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+	</cim:EquivalentInjection>
+	<cim:GeneratingUnit rdf:ID="_5b7a4d43-09ec-4033-882d-64a76d557631">
+		<cim:IdentifiedObject.name>Gen-1229753024</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:GeneratingUnit.initialP>118.000000</cim:GeneratingUnit.initialP>
+		<cim:GeneratingUnit.nominalP>255.000000</cim:GeneratingUnit.nominalP>
+		<cim:GeneratingUnit.maxOperatingP>200.000000</cim:GeneratingUnit.maxOperatingP>
+		<cim:GeneratingUnit.minOperatingP>50.000000</cim:GeneratingUnit.minOperatingP>
+		<cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.offAGC"/>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+	</cim:GeneratingUnit>
+	<cim:GeneratingUnit rdf:ID="_18993b11-2966-4bce-bab9-d86103f83b53">
+		<cim:IdentifiedObject.name>Gen-1229753060</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:GeneratingUnit.initialP>90.000000</cim:GeneratingUnit.initialP>
+		<cim:GeneratingUnit.nominalP>255.000000</cim:GeneratingUnit.nominalP>
+		<cim:GeneratingUnit.maxOperatingP>200.000000</cim:GeneratingUnit.maxOperatingP>
+		<cim:GeneratingUnit.minOperatingP>50.000000</cim:GeneratingUnit.minOperatingP>
+		<cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.offAGC"/>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+	</cim:GeneratingUnit>
+	<cim:GeographicalRegion rdf:ID="_c1d5bfc68f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>BE</cim:IdentifiedObject.name>
+	</cim:GeographicalRegion>
+	<cim:Line rdf:ID="_2b659afe-2ac3-425c-9418-3383e09b4b39">
+		<cim:IdentifiedObject.name>container of BE-Line_1</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5c0378f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_b5d6ed2b-c961-4521-8aef-b943d7dc6c15">
+		<cim:IdentifiedObject.name>container of BE-Line_2</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfc88f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_185273ba-a4e8-4754-8038-3b33eb76132e">
+		<cim:IdentifiedObject.name>container of BE-Line_3</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfc88f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_f04af3a9-24e3-46dd-91c0-97fea3ecc6a7">
+		<cim:IdentifiedObject.name>container of BE-Line_4</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfc88f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_608059fa-f262-463d-a8a8-80844a2a7021">
+		<cim:IdentifiedObject.name>container of BE-Line_5</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfc88f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_cc4b99a5-e20d-407c-9d8e-a682b9723613">
+		<cim:IdentifiedObject.name>container of BE-Line_6</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfc88f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_a8aa134c-be99-4e28-8e51-2d01a3b3e078">
+		<cim:IdentifiedObject.name>container of BE-Line_7</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5c0378f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:LinearShuntCompensator rdf:ID="_d771118f-36e9-4115-a128-cc3d9ce3e3da">
+		<cim:IdentifiedObject.name>BE_S1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE_S1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>shunt with 4 sections</cim:IdentifiedObject.description>
+		<cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+		<cim:ShuntCompensator.maximumSections>1</cim:ShuntCompensator.maximumSections>
+		<cim:LinearShuntCompensator.bPerSection>0.024793</cim:LinearShuntCompensator.bPerSection>
+		<cim:LinearShuntCompensator.gPerSection>0e+000</cim:LinearShuntCompensator.gPerSection>
+		<cim:LinearShuntCompensator.b0PerSection>-0e+000</cim:LinearShuntCompensator.b0PerSection>
+		<cim:LinearShuntCompensator.g0PerSection>0e+000</cim:LinearShuntCompensator.g0PerSection>
+		<cim:ShuntCompensator.nomU>110.000000</cim:ShuntCompensator.nomU>
+		<cim:RegulatingCondEq.RegulatingControl rdf:resource="#_4d50f86d-0d12-4ca3-9430-56bb05f9eee6"/>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0"/>
+	</cim:LinearShuntCompensator>
+	<cim:LoadResponseCharacteristic rdf:ID="_8e3e7a69-a64a-43a8-906e-82cc63edfcd3">
+		<cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>L-1230804819</entsoe:IdentifiedObject.shortName>
+		<cim:LoadResponseCharacteristic.exponentModel>true</cim:LoadResponseCharacteristic.exponentModel>
+		<cim:LoadResponseCharacteristic.pConstantCurrent>0e+000</cim:LoadResponseCharacteristic.pConstantCurrent>
+		<cim:LoadResponseCharacteristic.pConstantImpedance>0e+000</cim:LoadResponseCharacteristic.pConstantImpedance>
+		<cim:LoadResponseCharacteristic.pConstantPower>1.000000</cim:LoadResponseCharacteristic.pConstantPower>
+		<cim:LoadResponseCharacteristic.pFrequencyExponent>0e+000</cim:LoadResponseCharacteristic.pFrequencyExponent>
+		<cim:LoadResponseCharacteristic.qConstantCurrent>0e+000</cim:LoadResponseCharacteristic.qConstantCurrent>
+		<cim:LoadResponseCharacteristic.qConstantImpedance>0e+000</cim:LoadResponseCharacteristic.qConstantImpedance>
+		<cim:LoadResponseCharacteristic.qConstantPower>1.000000</cim:LoadResponseCharacteristic.qConstantPower>
+		<cim:LoadResponseCharacteristic.pVoltageExponent>0e+000</cim:LoadResponseCharacteristic.pVoltageExponent>
+		<cim:LoadResponseCharacteristic.qFrequencyExponent>0e+000</cim:LoadResponseCharacteristic.qFrequencyExponent>
+		<cim:LoadResponseCharacteristic.qVoltageExponent>0e+000</cim:LoadResponseCharacteristic.qVoltageExponent>
+	</cim:LoadResponseCharacteristic>
+	<cim:NonlinearShuntCompensator rdf:ID="_002b0a40-3957-46db-b84a-30420083558f">
+		<cim:IdentifiedObject.name>BE_S2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE_S2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>another shunt</cim:IdentifiedObject.description>
+		<cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+		<cim:ShuntCompensator.maximumSections>5</cim:ShuntCompensator.maximumSections>
+		<cim:ShuntCompensator.nomU>380.000000</cim:ShuntCompensator.nomU>
+		<cim:RegulatingCondEq.RegulatingControl rdf:resource="#_bee06911-8d5c-44c4-b2d2-5c22a461b5a0"/>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe"/>
+	</cim:NonlinearShuntCompensator>
+	<cim:NonlinearShuntCompensatorPoint rdf:ID="_46e3d51d-0a41-4e3f-8ce5-63e7bb165b73">
+		<cim:NonlinearShuntCompensatorPoint.sectionNumber>5</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+		<cim:NonlinearShuntCompensatorPoint.b>0.000035</cim:NonlinearShuntCompensatorPoint.b>
+		<cim:NonlinearShuntCompensatorPoint.g>3e-007</cim:NonlinearShuntCompensatorPoint.g>
+		<cim:NonlinearShuntCompensatorPoint.b0>-0e+000</cim:NonlinearShuntCompensatorPoint.b0>
+		<cim:NonlinearShuntCompensatorPoint.g0>0e+000</cim:NonlinearShuntCompensatorPoint.g0>
+		<cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f"/>
+	</cim:NonlinearShuntCompensatorPoint>
+	<cim:NonlinearShuntCompensatorPoint rdf:ID="_7dc75c5a-74cc-434c-a125-860960b6ed35">
+		<cim:NonlinearShuntCompensatorPoint.sectionNumber>4</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+		<cim:NonlinearShuntCompensatorPoint.b>0.000069</cim:NonlinearShuntCompensatorPoint.b>
+		<cim:NonlinearShuntCompensatorPoint.g>6e-007</cim:NonlinearShuntCompensatorPoint.g>
+		<cim:NonlinearShuntCompensatorPoint.b0>-0e+000</cim:NonlinearShuntCompensatorPoint.b0>
+		<cim:NonlinearShuntCompensatorPoint.g0>0e+000</cim:NonlinearShuntCompensatorPoint.g0>
+		<cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f"/>
+	</cim:NonlinearShuntCompensatorPoint>
+	<cim:NonlinearShuntCompensatorPoint rdf:ID="_89e965d7-0348-4dc1-98d4-be3bf8891fad">
+		<cim:NonlinearShuntCompensatorPoint.sectionNumber>2</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+		<cim:NonlinearShuntCompensatorPoint.b>0.000173</cim:NonlinearShuntCompensatorPoint.b>
+		<cim:NonlinearShuntCompensatorPoint.g>2e-006</cim:NonlinearShuntCompensatorPoint.g>
+		<cim:NonlinearShuntCompensatorPoint.b0>-0e+000</cim:NonlinearShuntCompensatorPoint.b0>
+		<cim:NonlinearShuntCompensatorPoint.g0>0e+000</cim:NonlinearShuntCompensatorPoint.g0>
+		<cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f"/>
+	</cim:NonlinearShuntCompensatorPoint>
+	<cim:NonlinearShuntCompensatorPoint rdf:ID="_8b93ca77-3cc3-4c82-8524-2f8a13513e20">
+		<cim:NonlinearShuntCompensatorPoint.sectionNumber>3</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+		<cim:NonlinearShuntCompensatorPoint.b>0.000139</cim:NonlinearShuntCompensatorPoint.b>
+		<cim:NonlinearShuntCompensatorPoint.g>1e-006</cim:NonlinearShuntCompensatorPoint.g>
+		<cim:NonlinearShuntCompensatorPoint.b0>-0e+000</cim:NonlinearShuntCompensatorPoint.b0>
+		<cim:NonlinearShuntCompensatorPoint.g0>0e+000</cim:NonlinearShuntCompensatorPoint.g0>
+		<cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f"/>
+	</cim:NonlinearShuntCompensatorPoint>
+	<cim:NonlinearShuntCompensatorPoint rdf:ID="_ca954c3a-5194-49eb-9097-10c77cea36b9">
+		<cim:NonlinearShuntCompensatorPoint.sectionNumber>1</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+		<cim:NonlinearShuntCompensatorPoint.b>0.000346</cim:NonlinearShuntCompensatorPoint.b>
+		<cim:NonlinearShuntCompensatorPoint.g>7e-006</cim:NonlinearShuntCompensatorPoint.g>
+		<cim:NonlinearShuntCompensatorPoint.b0>-0e+000</cim:NonlinearShuntCompensatorPoint.b0>
+		<cim:NonlinearShuntCompensatorPoint.g0>0e+000</cim:NonlinearShuntCompensatorPoint.g0>
+		<cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f"/>
+	</cim:NonlinearShuntCompensatorPoint>
+	<cim:OperationalLimitSet rdf:ID="_56c9ef56-9268-47e6-bed2-044324c03830">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_7 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_57ae9251-c022-4c67-a8eb-611ad54c963c"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_ecc2f619-5716-4af0-9d76-0631a3832e4f">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_2 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_699545b9-82b9-4331-bc80-538d73b4ba56"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_99941f7a-11bb-4a7b-928b-ef8145db7799">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_3 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_231a4cf8-5069-4d53-96e4-e839f073f1ea"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_67fa7320-7477-47e9-89ff-e3a407644aef">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_4 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_4af71c73-fd57-45d2-aa83-f1b52fcc3bee">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_5 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_051d49ba-4360-4372-86bf-50eb8cf29778"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_6 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_05a17350-55f5-4a00-9a50-8c0048a25495"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_aef3c15e-c567-476a-83ad-3fe46c817fb2">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_1 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_1ef0715a-d5a9-477b-b6e7-b635529ac140"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_e40d809b-2f3f-4866-817d-7acec0fde34f">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_3 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_ca7974cf-b25e-4898-9221-7154233e5eb2"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_88aa13e4-d3fe-4c47-9e47-39f8bb805e73">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_2 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_4c19ace6-c825-4c5b-87d9-031e6e6a3379"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_0b7c4239-3c1b-438e-994d-f2a402ba743c">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_1 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_c3774d3f-f48c-4954-a0cf-b4572eb714fd"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_76e9ca77-f805-40ea-8120-5a6d58416d34"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_00672e1a-599a-44f3-aeaa-5a3c99c29ba1">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_7 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_7168dee1-15a7-4444-839f-feef071e956d">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_2 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_77f04391-aa23-49b6-b3e9-6089130bb5d5"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_0acd95d7-aff7-41f6-aa8a-863c42f4bc36">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_3 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_f3b56334-4638-49d3-a6a0-3f417422b8f5"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_b93ba071-c1d4-4c7a-960d-48dcd5d7c389">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_4 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_b639998f-3a5c-496d-96fd-759131b6c307">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_5 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_30cbcb48-f02e-4791-83ab-486d7688874c">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_6 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_a5b37323-8f73-449a-8931-f73193d95587">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_1 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_70d962fb-a492-4c36-8cad-b5c584df53bd"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_40b75fae-2597-40df-98d2-8a0d83c238fd">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_3 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_2 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_ab7ece75-d726-48c8-a924-b0a9325e6d51"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_1 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_a2f11542-aeb8-4d7c-9594-25ac63e148bb">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1">
+		<cim:IdentifiedObject.name>Limits at Port 3</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 3</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitType rdf:ID="_3e6aa424-8f24-49a5-bbe0-0868441e25ae">
+		<cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>patl</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.patl"/>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_5343c925-7df1-42b3-b9e0-6260a494c4cd">
+		<cim:IdentifiedObject.name>PATLT</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>patlt</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.patlt"/>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_6d00cfdb-d400-4acd-b32b-7a48617593e7">
+		<cim:IdentifiedObject.name>TATL10</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>tatl</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tatl"/>
+		<cim:OperationalLimitType.acceptableDuration>10.000000</cim:OperationalLimitType.acceptableDuration>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_8b859dc8-193a-4a18-912a-1833f45fe926">
+		<cim:IdentifiedObject.name>TATL20</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>tatl</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tatl"/>
+		<cim:OperationalLimitType.acceptableDuration>20.000000</cim:OperationalLimitType.acceptableDuration>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_e3e9b93d-77e4-41f7-a8d9-af6481c99932">
+		<cim:IdentifiedObject.name>TC</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>tc</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tc"/>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_955b2d6c-7874-40c9-93f1-7a45d3084166">
+		<cim:IdentifiedObject.name>TCT</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>tct</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tct"/>
+	</cim:OperationalLimitType>
+	<cim:PhaseTapChangerAsymmetrical rdf:ID="_36b83adb-3d45-4693-8967-96627b5f9ec9">
+		<cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_2</entsoe:IdentifiedObject.shortName>
+		<cim:TapChanger.neutralU>220.000000</cim:TapChanger.neutralU>
+		<cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+		<cim:TapChanger.highStep>25</cim:TapChanger.highStep>
+		<cim:TapChanger.neutralStep>13</cim:TapChanger.neutralStep>
+		<cim:TapChanger.normalStep>10</cim:TapChanger.normalStep>
+		<cim:PhaseTapChangerNonLinear.voltageStepIncrement>1.250000</cim:PhaseTapChangerNonLinear.voltageStepIncrement>
+		<cim:PhaseTapChangerNonLinear.xMin>10.396291</cim:PhaseTapChangerNonLinear.xMin>
+		<cim:PhaseTapChangerNonLinear.xMax>11.881475</cim:PhaseTapChangerNonLinear.xMax>
+		<cim:PhaseTapChangerAsymmetrical.windingConnectionAngle>5.000000</cim:PhaseTapChangerAsymmetrical.windingConnectionAngle>
+		<cim:PhaseTapChanger.TransformerEnd rdf:resource="#_3c59d1b0-1ee9-4ca3-9086-4fe102b51b21"/>
+		<cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+		<cim:TapChanger.TapChangerControl rdf:resource="#_77a5948c-3782-455d-aea1-20b062489b65"/>
+	</cim:PhaseTapChangerAsymmetrical>
+	<cim:PhaseTapChangerSymmetrical rdf:ID="_63454a73-f439-45bb-951a-e7b193986571">
+		<cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:TapChanger.neutralU>400.000000</cim:TapChanger.neutralU>
+		<cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+		<cim:TapChanger.highStep>25</cim:TapChanger.highStep>
+		<cim:TapChanger.neutralStep>13</cim:TapChanger.neutralStep>
+		<cim:TapChanger.normalStep>10</cim:TapChanger.normalStep>
+		<cim:PhaseTapChangerNonLinear.voltageStepIncrement>1.250000</cim:PhaseTapChangerNonLinear.voltageStepIncrement>
+		<cim:PhaseTapChangerNonLinear.xMin>12.099087</cim:PhaseTapChangerNonLinear.xMin>
+		<cim:PhaseTapChangerNonLinear.xMax>16.938722</cim:PhaseTapChangerNonLinear.xMax>
+		<cim:PhaseTapChanger.TransformerEnd rdf:resource="#_bf76ac9d-0144-48f5-a24a-34ae15a455fb"/>
+		<cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+		<cim:TapChanger.TapChangerControl rdf:resource="#_f43499bf-6bf3-483d-ae2a-e46d696a66b2"/>
+	</cim:PhaseTapChangerSymmetrical>
+	<cim:PowerTransformer rdf:ID="_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0">
+		<cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>T1 that is after maintenance</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>
+		<cim:PowerTransformer.beforeShortCircuitAnglePf>0e+000</cim:PowerTransformer.beforeShortCircuitAnglePf>
+		<cim:PowerTransformer.highSideMinOperatingU>0e+000</cim:PowerTransformer.highSideMinOperatingU>
+		<cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+		<cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+	</cim:PowerTransformer>
+	<cim:PowerTransformer rdf:ID="_b94318f6-6d24-4f56-96b9-df2531ad6543">
+		<cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>This is T2 in the center</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>
+		<cim:PowerTransformer.beforeShortCircuitAnglePf>0e+000</cim:PowerTransformer.beforeShortCircuitAnglePf>
+		<cim:PowerTransformer.highSideMinOperatingU>0e+000</cim:PowerTransformer.highSideMinOperatingU>
+		<cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+		<cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+	</cim:PowerTransformer>
+	<cim:PowerTransformer rdf:ID="_e482b89a-fa84-4ea9-8e70-a83d44790957">
+		<cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>This is free description</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>
+		<cim:PowerTransformer.beforeShortCircuitAnglePf>0e+000</cim:PowerTransformer.beforeShortCircuitAnglePf>
+		<cim:PowerTransformer.highSideMinOperatingU>0e+000</cim:PowerTransformer.highSideMinOperatingU>
+		<cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+		<cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+	</cim:PowerTransformer>
+	<cim:PowerTransformer rdf:ID="_84ed55f4-61f5-4d9d-8755-bba7b877a246">
+		<cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>new in 2015</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>
+		<cim:PowerTransformer.beforeShortCircuitAnglePf>0e+000</cim:PowerTransformer.beforeShortCircuitAnglePf>
+		<cim:PowerTransformer.highSideMinOperatingU>0e+000</cim:PowerTransformer.highSideMinOperatingU>
+		<cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+		<cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+	</cim:PowerTransformer>
+	<cim:PowerTransformerEnd rdf:ID="_bf76ac9d-0144-48f5-a24a-34ae15a455fb">
+		<cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>2.707692</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>14.518904</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>2.720000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>14.516604</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>650.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>400.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_c3774d3f-f48c-4954-a0cf-b4572eb714fd"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_e22f3c30-63f5-47bf-a8c4-fee2483d426c">
+		<cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0e+000</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>0e+000</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0e+000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>0e+000</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>650.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>110.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_3c59d1b0-1ee9-4ca3-9086-4fe102b51b21">
+		<cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_2</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0.822800</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>11.138883</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0.822800</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>11.138883</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>650.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>220.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_4c19ace6-c825-4c5b-87d9-031e6e6a3379"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_ba56158e-0c51-448d-999b-44cb0b3cebf5">
+		<cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_2</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0e+000</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>0e+000</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0e+000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>0e+000</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>650.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>110.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_ab7ece75-d726-48c8-a924-b0a9325e6d51"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_f58281c5-862a-465e-97ec-d809be6e24ab">
+		<cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_3</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0.104711</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>5.843419</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>-0.0000830339</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0000173295</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0.104711</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>5.843419</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>250.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>110.343750</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_ca7974cf-b25e-4898-9221-7154233e5eb2"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_35651e25-a77a-46a1-92f4-443d6acce90e">
+		<cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_3</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0e+000</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>0e+000</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0e+000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>0e+000</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>250.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>10.500000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_5f68a129-d5d8-4b71-9743-9ca2572ba26b">
+		<cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0.898462</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>17.204128</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0000024375</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0e+000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>17.230769</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>650.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>400.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_76e9ca77-f805-40ea-8120-5a6d58416d34"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_e1f661c0-971d-4ce5-ad39-0ec427f288ab">
+		<cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0.323908</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>5.949086</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0e+000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>5.956923</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>650.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>220.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_2e21d1ef-2287-434c-a767-1ca807cf2478">
+		<cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0.013332</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>0.059978</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0e+000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>0.061062</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>650.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>21.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>3</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3"/>
+	</cim:PowerTransformerEnd>
+	<cim:RatioTapChanger rdf:ID="_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e">
+		<cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_3</entsoe:IdentifiedObject.shortName>
+		<cim:TapChanger.neutralU>10.500000</cim:TapChanger.neutralU>
+		<cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+		<cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+		<cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+		<cim:TapChanger.normalStep>14</cim:TapChanger.normalStep>
+		<cim:RatioTapChanger.stepVoltageIncrement>0.800000</cim:RatioTapChanger.stepVoltageIncrement>
+		<cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+		<cim:TapChanger.TapChangerControl rdf:resource="#_97110e84-7da6-479c-846c-696fdaa83d56"/>
+		<cim:RatioTapChanger.tculControlMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode.volt"/>
+		<cim:RatioTapChanger.TransformerEnd rdf:resource="#_35651e25-a77a-46a1-92f4-443d6acce90e"/>
+	</cim:RatioTapChanger>
+	<cim:RatioTapChanger rdf:ID="_fe25f43a-7341-446e-a71a-8ab7119ba806">
+		<cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:TapChanger.neutralU>220.000000</cim:TapChanger.neutralU>
+		<cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+		<cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+		<cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+		<cim:TapChanger.normalStep>17</cim:TapChanger.normalStep>
+		<cim:RatioTapChanger.stepVoltageIncrement>0.625000</cim:RatioTapChanger.stepVoltageIncrement>
+		<cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+		<cim:TapChanger.TapChangerControl rdf:resource="#_38f972bc-b7fd-4e75-8c24-379a86fbb506"/>
+		<cim:RatioTapChanger.tculControlMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode.volt"/>
+		<cim:RatioTapChanger.TransformerEnd rdf:resource="#_e1f661c0-971d-4ce5-ad39-0ec427f288ab"/>
+	</cim:RatioTapChanger>
+	<cim:ReactiveCapabilityCurve rdf:ID="_59ff1e53-0e1a-44c0-ada5-7a0b3a660170">
+		<cim:Curve.curveStyle rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CurveStyle.constantYValue"/>
+		<cim:Curve.xUnit rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.W"/>
+		<cim:Curve.y1Unit rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.VAr"/>
+		<cim:Curve.y2Unit rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitSymbol.VAr"/>
+		<cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+	</cim:ReactiveCapabilityCurve>
+	<cim:RegulatingControl rdf:ID="_6ba406ce-78cf-4485-9b01-a34e584f1a8d">
+		<cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-G1</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89"/>
+	</cim:RegulatingControl>
+	<cim:RegulatingControl rdf:ID="_84bf5be8-eb59-4555-b131-fce4d2d7775d">
+		<cim:IdentifiedObject.name>BE-G2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-G2</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b"/>
+	</cim:RegulatingControl>
+	<cim:RegulatingControl rdf:ID="_4d50f86d-0d12-4ca3-9430-56bb05f9eee6">
+		<cim:IdentifiedObject.name>BE_S1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE_S1</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c"/>
+	</cim:RegulatingControl>
+	<cim:RegulatingControl rdf:ID="_bee06911-8d5c-44c4-b2d2-5c22a461b5a0">
+		<cim:IdentifiedObject.name>BE_S2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE_S2</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_22af3121-1a66-4546-bd80-4371f417c644"/>
+	</cim:RegulatingControl>
+	<cim:RegulatingControl rdf:ID="_caf65447-3cfb-48d7-aaaa-cd9af3d34261">
+		<cim:IdentifiedObject.name>SVC-1230797516</cim:IdentifiedObject.name>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_67bb74f1-8620-4a32-9d7d-a44092d11d22"/>
+	</cim:RegulatingControl>
+	<cim:SeriesCompensator rdf:ID="_df16b3dd-c905-4a6f-84ee-f067be86f5da">
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+		<cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_d0486169-2205-40b2-895e-b672ecb9e5fc"/>
+		<cim:SeriesCompensator.r>0e+000</cim:SeriesCompensator.r>
+		<cim:SeriesCompensator.r0>0e+000</cim:SeriesCompensator.r0>
+		<cim:SeriesCompensator.x>-31.830989</cim:SeriesCompensator.x>
+		<cim:SeriesCompensator.x0>-31.830989</cim:SeriesCompensator.x0>
+		<cim:SeriesCompensator.varistorRatedCurrent>0e+000</cim:SeriesCompensator.varistorRatedCurrent>
+		<cim:SeriesCompensator.varistorVoltageThreshold>250.000000</cim:SeriesCompensator.varistorVoltageThreshold>
+		<cim:SeriesCompensator.varistorPresent>true</cim:SeriesCompensator.varistorPresent>
+	</cim:SeriesCompensator>
+	<cim:StaticVarCompensator rdf:ID="_3c69652c-ff14-4550-9a87-b6fdaccbb5f4">
+		<cim:IdentifiedObject.name>SVC-1230797516</cim:IdentifiedObject.name>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_d0486169-2205-40b2-895e-b672ecb9e5fc"/>
+		<cim:StaticVarCompensator.capacitiveRating>5062.500000</cim:StaticVarCompensator.capacitiveRating>
+		<cim:StaticVarCompensator.inductiveRating>-5062.500000</cim:StaticVarCompensator.inductiveRating>
+		<cim:StaticVarCompensator.slope>0.102000</cim:StaticVarCompensator.slope>
+		<cim:StaticVarCompensator.sVCControlMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SVCControlMode.voltage"/>
+		<cim:StaticVarCompensator.voltageSetPoint>229.500000</cim:StaticVarCompensator.voltageSetPoint>
+		<cim:RegulatingCondEq.RegulatingControl rdf:resource="#_caf65447-3cfb-48d7-aaaa-cd9af3d34261"/>
+	</cim:StaticVarCompensator>
+	<cim:SubGeographicalRegion rdf:ID="_c1d5c0378f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>ELIA-Anvers</cim:IdentifiedObject.name>
+		<cim:SubGeographicalRegion.Region rdf:resource="#_c1d5bfc68f8011e08e4d00247eb1f55e"/>
+	</cim:SubGeographicalRegion>
+	<cim:SubGeographicalRegion rdf:ID="_c1d5bfc88f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>ELIA-Brussels</cim:IdentifiedObject.name>
+		<cim:SubGeographicalRegion.Region rdf:resource="#_c1d5bfc68f8011e08e4d00247eb1f55e"/>
+	</cim:SubGeographicalRegion>
+	<cim:Substation rdf:ID="_87f7002b-056f-4a6a-a872-1744eea757e3">
+		<cim:IdentifiedObject.name>Anvers</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>Anvers</entsoe:IdentifiedObject.shortName>
+		<cim:Substation.Region rdf:resource="#_c1d5c0378f8011e08e4d00247eb1f55e"/>
+	</cim:Substation>
+	<cim:Substation rdf:ID="_37e14a0f-5e34-4647-a062-8bfd9305fa9d">
+		<cim:IdentifiedObject.name>PP_Brussels</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>PP_Brussels</entsoe:IdentifiedObject.shortName>
+		<cim:Substation.Region rdf:resource="#_c1d5bfc88f8011e08e4d00247eb1f55e"/>
+	</cim:Substation>
+	<cim:SynchronousMachine rdf:ID="_3a3b27be-b18b-4385-b557-6735d733baf0">
+		<cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-G1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386"/>
+		<cim:SynchronousMachine.qPercent>50.000000</cim:SynchronousMachine.qPercent>
+		<cim:SynchronousMachine.maxQ>0e+000</cim:SynchronousMachine.maxQ>
+		<cim:SynchronousMachine.minQ>0e+000</cim:SynchronousMachine.minQ>
+		<cim:RotatingMachine.ratedS>300.000000</cim:RotatingMachine.ratedS>
+		<cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.generator"/>
+		<cim:RegulatingCondEq.RegulatingControl rdf:resource="#_6ba406ce-78cf-4485-9b01-a34e584f1a8d"/>
+		<cim:RotatingMachine.GeneratingUnit rdf:resource="#_18993b11-2966-4bce-bab9-d86103f83b53"/>
+		<cim:RotatingMachine.ratedU>10.500000</cim:RotatingMachine.ratedU>
+		<cim:RotatingMachine.ratedPowerFactor>0.850000</cim:RotatingMachine.ratedPowerFactor>
+		<cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind.turboSeries1"/>
+		<cim:SynchronousMachine.r0>0e+000</cim:SynchronousMachine.r0>
+		<cim:SynchronousMachine.r2>0e+000</cim:SynchronousMachine.r2>
+		<cim:SynchronousMachine.x0>0.130000</cim:SynchronousMachine.x0>
+		<cim:SynchronousMachine.x2>0.171000</cim:SynchronousMachine.x2>
+		<cim:SynchronousMachine.earthingStarPointR>0e+000</cim:SynchronousMachine.earthingStarPointR>
+		<cim:SynchronousMachine.earthingStarPointX>0e+000</cim:SynchronousMachine.earthingStarPointX>
+		<cim:SynchronousMachine.r>0e+000</cim:SynchronousMachine.r>
+		<cim:SynchronousMachine.satDirectSubtransX>0.200000</cim:SynchronousMachine.satDirectSubtransX>
+		<cim:SynchronousMachine.satDirectSyncX>2.000000</cim:SynchronousMachine.satDirectSyncX>
+		<cim:SynchronousMachine.satDirectTransX>0e+000</cim:SynchronousMachine.satDirectTransX>
+		<cim:SynchronousMachine.mu>0e+000</cim:SynchronousMachine.mu>
+		<cim:SynchronousMachine.ikk>0e+000</cim:SynchronousMachine.ikk>
+		<cim:SynchronousMachine.voltageRegulationRange>0e+000</cim:SynchronousMachine.voltageRegulationRange>
+		<cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+		<cim:SynchronousMachine.InitialReactiveCapabilityCurve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170"/>
+	</cim:SynchronousMachine>
+	<cim:SynchronousMachine rdf:ID="_550ebe0d-f2b2-48c1-991f-cebea43a21aa">
+		<cim:IdentifiedObject.name>BE-G2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-G2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85"/>
+		<cim:SynchronousMachine.qPercent>100.000000</cim:SynchronousMachine.qPercent>
+		<cim:SynchronousMachine.maxQ>200.000000</cim:SynchronousMachine.maxQ>
+		<cim:SynchronousMachine.minQ>-200.000000</cim:SynchronousMachine.minQ>
+		<cim:RotatingMachine.ratedS>300.000000</cim:RotatingMachine.ratedS>
+		<cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.generator"/>
+		<cim:RegulatingCondEq.RegulatingControl rdf:resource="#_84bf5be8-eb59-4555-b131-fce4d2d7775d"/>
+		<cim:RotatingMachine.GeneratingUnit rdf:resource="#_5b7a4d43-09ec-4033-882d-64a76d557631"/>
+		<cim:RotatingMachine.ratedU>21.000000</cim:RotatingMachine.ratedU>
+		<cim:RotatingMachine.ratedPowerFactor>0.850000</cim:RotatingMachine.ratedPowerFactor>
+		<cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind.turboSeries1"/>
+		<cim:SynchronousMachine.r0>0e+000</cim:SynchronousMachine.r0>
+		<cim:SynchronousMachine.r2>0e+000</cim:SynchronousMachine.r2>
+		<cim:SynchronousMachine.x0>0.130000</cim:SynchronousMachine.x0>
+		<cim:SynchronousMachine.x2>0.170000</cim:SynchronousMachine.x2>
+		<cim:SynchronousMachine.earthingStarPointR>0e+000</cim:SynchronousMachine.earthingStarPointR>
+		<cim:SynchronousMachine.earthingStarPointX>0e+000</cim:SynchronousMachine.earthingStarPointX>
+		<cim:SynchronousMachine.r>0e+000</cim:SynchronousMachine.r>
+		<cim:SynchronousMachine.satDirectSubtransX>0.200000</cim:SynchronousMachine.satDirectSubtransX>
+		<cim:SynchronousMachine.satDirectSyncX>2.000000</cim:SynchronousMachine.satDirectSyncX>
+		<cim:SynchronousMachine.satDirectTransX>0e+000</cim:SynchronousMachine.satDirectTransX>
+		<cim:SynchronousMachine.mu>0e+000</cim:SynchronousMachine.mu>
+		<cim:SynchronousMachine.ikk>0e+000</cim:SynchronousMachine.ikk>
+		<cim:SynchronousMachine.voltageRegulationRange>0e+000</cim:SynchronousMachine.voltageRegulationRange>
+		<cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+	</cim:SynchronousMachine>
+	<cim:TapChangerControl rdf:ID="_f43499bf-6bf3-483d-ae2a-e46d696a66b2">
+		<cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.activePower"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89"/>
+	</cim:TapChangerControl>
+	<cim:TapChangerControl rdf:ID="_77a5948c-3782-455d-aea1-20b062489b65">
+		<cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_2</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.activePower"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_ab7ece75-d726-48c8-a924-b0a9325e6d51"/>
+	</cim:TapChangerControl>
+	<cim:TapChangerControl rdf:ID="_97110e84-7da6-479c-846c-696fdaa83d56">
+		<cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_3</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a"/>
+	</cim:TapChangerControl>
+	<cim:TapChangerControl rdf:ID="_38f972bc-b7fd-4e75-8c24-379a86fbb506">
+		<cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0"/>
+	</cim:TapChangerControl>
+	<cim:Terminal rdf:ID="_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+		<cim:IdentifiedObject.name>BE-Busbar_1_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_800ada75-8c8c-4568-aec5-20f799e45f3c">
+		<cim:IdentifiedObject.name>BE-Busbar_2_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_ef45b632-3028-4afe-bc4c-a4fa323d83fe"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+		<cim:IdentifiedObject.name>BE-Busbar_3_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_5caf27ed-d2f8-458a-834a-6b3193a982e6"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+		<cim:IdentifiedObject.name>BE-Busbar_4_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_fd649fe1-bdf5-4062-98ea-bbb66f50402d"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+		<cim:IdentifiedObject.name>BE-Busbar_6_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_364c9ca2-0d1d-4363-8f46-e586f8f66a8c"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_beffa353-7d10-421d-9c08-036b744b1cee">
+		<cim:IdentifiedObject.name>BE-G1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-G1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+		<cim:IdentifiedObject.name>BE-G2 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-G2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_53072f42-f77b-47e2-bd9a-e097c910b173">
+		<cim:IdentifiedObject.name>BE-Inj-XCA_AL11 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XCA_AL1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_24413233-26c3-4f7e-9f72-4461796938be"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_c41978db-794b-4bae-953e-60fc519e87dd">
+		<cim:IdentifiedObject.name>BE-Inj-XKA_MA11 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XKA_MA1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_14b352cb-5574-40c5-bf83-0ed3574554a3"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_b9539c41-d114-4280-8a54-8ecec398091e">
+		<cim:IdentifiedObject.name>BE-Inj-XWI_GY11 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XWI_GY1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_d238885e-d9b6-4edc-8567-6a68c605ed67">
+		<cim:IdentifiedObject.name>BE-Inj-XZE_ST23 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XZE_ST2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_87ea56f3-962a-427a-85d6-13b1f9295174"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+		<cim:IdentifiedObject.name>BE-Inj-XZE_ST24 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-I-XZE_ST2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+		<cim:IdentifiedObject.name>BE-Line_1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_70d962fb-a492-4c36-8cad-b5c584df53bd">
+		<cim:IdentifiedObject.name>BE-Line_1 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_699545b9-82b9-4331-bc80-538d73b4ba56">
+		<cim:IdentifiedObject.name>BE-Line_2 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00010A</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+		<cim:IdentifiedObject.name>BE-Line_2 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00010A</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+		<cim:IdentifiedObject.name>BE-Line_3 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00008Y</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+		<cim:IdentifiedObject.name>BE-Line_3 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00008Y</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+		<cim:IdentifiedObject.name>BE-Line_4 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_4</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+		<cim:IdentifiedObject.name>BE-Line_4 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_4</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_051d49ba-4360-4372-86bf-50eb8cf29778">
+		<cim:IdentifiedObject.name>BE-Line_5 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_5</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+		<cim:IdentifiedObject.name>BE-Line_5 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_5</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_05a17350-55f5-4a00-9a50-8c0048a25495">
+		<cim:IdentifiedObject.name>BE-Line_6 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_6</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+		<cim:IdentifiedObject.name>BE-Line_6 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_6</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_57ae9251-c022-4c67-a8eb-611ad54c963c">
+		<cim:IdentifiedObject.name>BE-Line_7 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_7</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+		<cim:IdentifiedObject.name>BE-Line_7 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_7</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+		<cim:IdentifiedObject.name>BE-Load_1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_cb459405-cc14-4215-a45c-416789205904"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_a036b765-1669-4f64-acd3-1e8fbd513312">
+		<cim:IdentifiedObject.name>BE-Load_2 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-L_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_c3774d3f-f48c-4954-a0cf-b4572eb714fd">
+		<cim:IdentifiedObject.name>BE-TR2_1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_2cd21c77-b8b1-4896-95fb-240f45b9ac89">
+		<cim:IdentifiedObject.name>BE-TR2_1 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_4c19ace6-c825-4c5b-87d9-031e6e6a3379">
+		<cim:IdentifiedObject.name>BE-TR2_2 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_ab7ece75-d726-48c8-a924-b0a9325e6d51">
+		<cim:IdentifiedObject.name>BE-TR2_2 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_ca7974cf-b25e-4898-9221-7154233e5eb2">
+		<cim:IdentifiedObject.name>BE-TR2_3 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+		<cim:IdentifiedObject.name>BE-TR2_3 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_76e9ca77-f805-40ea-8120-5a6d58416d34">
+		<cim:IdentifiedObject.name>BE-TR3_1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+		<cim:IdentifiedObject.name>BE-TR3_1 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_ca0f7e2e-3442-4ada-a704-91f319c0ebe3">
+		<cim:IdentifiedObject.name>BE-TR3_1 - T3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>3</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+		<cim:IdentifiedObject.name>BE_S1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE_S1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_22af3121-1a66-4546-bd80-4371f417c644">
+		<cim:IdentifiedObject.name>BE_S2 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BE_S2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+		<cim:IdentifiedObject.name>L-1230804819 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>L-1230804819</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_8f1c492f-a7cc-4160-9a14-54f1743e4850">
+		<cim:IdentifiedObject.name>N1230992288_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_63f25be7-7592-4cf1-8401-5772046ef2ae"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_302fe23a-f64d-41bd-8a81-78130433916d">
+		<cim:IdentifiedObject.name>N1230992291_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_c8ce5e08-5ee3-42d9-aa44-5792db252d9f"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_3c6d83a3-b5f9-41a2-a3d9-cf15d903ed0a">
+		<cim:IdentifiedObject.name>N1230992411_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_8da0ff82-2f23-4231-ac9b-28b9c9141432"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_ad794c0e-b9ec-420b-ada1-97680e3dde05">
+		<cim:IdentifiedObject.name>N1230992414_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_d6986ea6-fadc-4113-806a-a8f95f62c216"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+		<cim:IdentifiedObject.name>SER-RLC-1230822986 - T1</cim:IdentifiedObject.name>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+		<cim:IdentifiedObject.name>SER-RLC-1230822986 - T2</cim:IdentifiedObject.name>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+		<cim:IdentifiedObject.name>SVC-1230797516 - T1</cim:IdentifiedObject.name>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4"/>
+	</cim:Terminal>
+	<cim:VoltageLevel rdf:ID="_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386">
+		<cim:IdentifiedObject.name>10.5</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>9.450000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>11.550000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75"/>
+	</cim:VoltageLevel>
+	<cim:VoltageLevel rdf:ID="_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0">
+		<cim:IdentifiedObject.name>110.0</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>99.000000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>121.000000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694"/>
+	</cim:VoltageLevel>
+	<cim:VoltageLevel rdf:ID="_929ba893-c9dc-44d7-b1fd-30834bd3ab85">
+		<cim:IdentifiedObject.name>21.0</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>18.900000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>23.100000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2"/>
+	</cim:VoltageLevel>
+	<cim:VoltageLevel rdf:ID="_d0486169-2205-40b2-895e-b672ecb9e5fc">
+		<cim:IdentifiedObject.name>220.0</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>202.500000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>247.500000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_87f7002b-056f-4a6a-a872-1744eea757e3"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+	</cim:VoltageLevel>
+	<cim:VoltageLevel rdf:ID="_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c">
+		<cim:IdentifiedObject.name>225.0</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>202.500000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>247.500000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+	</cim:VoltageLevel>
+	<cim:VoltageLevel rdf:ID="_69ef0dbd-da79-4eef-a02f-690cb8a28361">
+		<cim:IdentifiedObject.name>225.0</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>202.500000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>247.500000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_87f7002b-056f-4a6a-a872-1744eea757e3"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+	</cim:VoltageLevel>
+	<cim:VoltageLevel rdf:ID="_469df5f7-058f-4451-a998-57a48e8a56fe">
+		<cim:IdentifiedObject.name>380.0</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>342.000000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>418.000000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6"/>
+	</cim:VoltageLevel>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_GL_V2.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_GL_V2.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
+  <md:FullModel rdf:about="urn:uuid:8d6b5a63-e64e-4a25-955f-9c5e107382eb">
+    <md:Model.created>2014-10-24T16:53:10</md:Model.created>
+    <md:Model.scenarioTime>2014-03-28T10:13:02</md:Model.scenarioTime>
+    <md:Model.version>2</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:96adadbe-902b-4cd6-9fc8-01a56ecbee79"/>
+    <md:Model.DependentOn rdf:resource="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66"/>
+    <md:Model.description>CGMES Conformity Assessment: 'MicroGridTestConfiguration....T4 (MAS BE) Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://ELIA/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://entsoe.eu/CIM/GeographicalLocation/2/1</md:Model.profile>
+    <md:Model.Supersedes rdf:resource="urn:uuid:9e383122-10cf-4da3-9785-f404b3541588"/>
+  </md:FullModel>
+  <cim:CoordinateSystem rdf:ID="_b3c35c66-a931-46a3-a194-ccb572484ab3">
+    <cim:IdentifiedObject.name>WGS84</cim:IdentifiedObject.name>
+    <cim:CoordinateSystem.crsUrn>urn:ogc:def:crs:EPSG::4326</cim:CoordinateSystem.crsUrn>
+  </cim:CoordinateSystem>
+  <cim:Location rdf:ID="_8296afc2-a9fe-4f34-8402-3b6f99c4f227">
+    <cim:Location.PowerSystemResources rdf:resource="#_87f7002b-056f-4a6a-a872-1744eea757e3"/>
+    <cim:Location.CoordinateSystem rdf:resource="#_b3c35c66-a931-46a3-a194-ccb572484ab3"/>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_c574b5d4-a697-4ab6-9a39-99bc1f741ca7">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_8296afc2-a9fe-4f34-8402-3b6f99c4f227"/>
+    <cim:PositionPoint.xPosition>4.259260</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.325100</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_5ea7d675-2705-46da-8cb2-beaa26e53ea1">
+    <cim:Location.PowerSystemResources rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d"/>
+    <cim:Location.CoordinateSystem rdf:resource="#_b3c35c66-a931-46a3-a194-ccb572484ab3"/>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_3cf37eb6-1011-4b06-90d6-85c86ff1bae6">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_5ea7d675-2705-46da-8cb2-beaa26e53ea1"/>
+    <cim:PositionPoint.xPosition>4.300890</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803800</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_6d542baf-c8c4-4672-bda3-14ad9330f7f2">
+    <cim:Location.PowerSystemResources rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4"/>
+    <cim:Location.CoordinateSystem rdf:resource="#_b3c35c66-a931-46a3-a194-ccb572484ab3"/>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_b48ec4db-9e7a-40ff-be86-a03a1abaf21c">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_6d542baf-c8c4-4672-bda3-14ad9330f7f2"/>
+    <cim:PositionPoint.xPosition>4.888920</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.913800</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_22e69b3d-c17f-4548-8997-c3c1f1d12dd7">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_6d542baf-c8c4-4672-bda3-14ad9330f7f2"/>
+    <cim:PositionPoint.xPosition>4.847720</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.612900</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_010e7109-d1b3-4b3b-9ee4-fe29504295f5">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_6d542baf-c8c4-4672-bda3-14ad9330f7f2"/>
+    <cim:PositionPoint.xPosition>4.259260</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.325100</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_44567a93-5e71-49a4-8cb0-cb32a93a6f10">
+    <cim:Location.PowerSystemResources rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7"/>
+    <cim:Location.CoordinateSystem rdf:resource="#_b3c35c66-a931-46a3-a194-ccb572484ab3"/>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_db44afd5-c28d-4cf1-b2cf-e01f791b5f3a">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_44567a93-5e71-49a4-8cb0-cb32a93a6f10"/>
+    <cim:PositionPoint.xPosition>4.301130</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803500</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_72b1423a-4984-4696-85bb-7599671dc628">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_44567a93-5e71-49a4-8cb0-cb32a93a6f10"/>
+    <cim:PositionPoint.xPosition>4.345090</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.916900</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_4633ca78-99c0-4528-a441-e1a6ef985783">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_44567a93-5e71-49a4-8cb0-cb32a93a6f10"/>
+    <cim:PositionPoint.xPosition>4.295650</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.044800</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_3f369078-9196-4efb-b266-e10df0c81245">
+    <cim:PositionPoint.sequenceNumber>7</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_44567a93-5e71-49a4-8cb0-cb32a93a6f10"/>
+    <cim:PositionPoint.xPosition>4.383540</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.157000</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_d0ceb2d9-387c-462a-bf51-0193e7dc8a9f">
+    <cim:PositionPoint.sequenceNumber>9</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_44567a93-5e71-49a4-8cb0-cb32a93a6f10"/>
+    <cim:PositionPoint.xPosition>4.259260</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.325100</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_bfbcef07-4336-47b6-b843-b9ebcf50deb5">
+    <cim:Location.PowerSystemResources rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6"/>
+    <cim:Location.CoordinateSystem rdf:resource="#_b3c35c66-a931-46a3-a194-ccb572484ab3"/>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_77d9e317-d7ce-4fe0-ab2c-75e6c0d9a7f5">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_bfbcef07-4336-47b6-b843-b9ebcf50deb5"/>
+    <cim:PositionPoint.xPosition>4.301730</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803000</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_d1b7a5a8-2fd5-4b0b-9e04-254946b6be7b">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_bfbcef07-4336-47b6-b843-b9ebcf50deb5"/>
+    <cim:PositionPoint.xPosition>4.690460</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.899400</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_c214b78b-9fcc-4546-83d0-84c2ccbab41f">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_bfbcef07-4336-47b6-b843-b9ebcf50deb5"/>
+    <cim:PositionPoint.xPosition>5.088250</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.302600</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ac7aff0d-0e70-4cea-8759-7fa9612867e6">
+    <cim:PositionPoint.sequenceNumber>7</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_bfbcef07-4336-47b6-b843-b9ebcf50deb5"/>
+    <cim:PositionPoint.xPosition>5.072940</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.876500</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_4ae0e45c-c8c3-4143-826e-f00f95f095cf">
+    <cim:Location.PowerSystemResources rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b"/>
+    <cim:Location.CoordinateSystem rdf:resource="#_b3c35c66-a931-46a3-a194-ccb572484ab3"/>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_ed0c3e86-194c-4ea1-b684-87bc12b4e44f">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_4ae0e45c-c8c3-4143-826e-f00f95f095cf"/>
+    <cim:PositionPoint.xPosition>4.301730</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803000</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_7567cb7b-0da6-41d8-83b5-b2d896413d8e">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_4ae0e45c-c8c3-4143-826e-f00f95f095cf"/>
+    <cim:PositionPoint.xPosition>4.690460</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.899400</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_f89b8e7e-82e2-41ea-81f9-54c56fe02ef1">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_4ae0e45c-c8c3-4143-826e-f00f95f095cf"/>
+    <cim:PositionPoint.xPosition>5.088250</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.302600</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_b3034e8a-9a46-4eb7-b551-275e9749d00a">
+    <cim:PositionPoint.sequenceNumber>7</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_4ae0e45c-c8c3-4143-826e-f00f95f095cf"/>
+    <cim:PositionPoint.xPosition>5.071860</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.875600</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_e9c81248-2caf-4d5a-bdbf-fe4aa824eb60">
+    <cim:Location.PowerSystemResources rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006"/>
+    <cim:Location.CoordinateSystem rdf:resource="#_b3c35c66-a931-46a3-a194-ccb572484ab3"/>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_84669c4b-875f-4bdc-9106-265636f4ab20">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_e9c81248-2caf-4d5a-bdbf-fe4aa824eb60"/>
+    <cim:PositionPoint.xPosition>4.301730</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803000</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_af8dba33-2ca0-4d14-9d4e-ce120ed481c2">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_e9c81248-2caf-4d5a-bdbf-fe4aa824eb60"/>
+    <cim:PositionPoint.xPosition>4.690460</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.899400</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_a59a2efc-c535-4aac-a923-2f2ac158ab3e">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_e9c81248-2caf-4d5a-bdbf-fe4aa824eb60"/>
+    <cim:PositionPoint.xPosition>5.088250</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.302600</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ef7d4117-9952-4e77-9013-c5918714ed50">
+    <cim:PositionPoint.sequenceNumber>7</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_e9c81248-2caf-4d5a-bdbf-fe4aa824eb60"/>
+    <cim:PositionPoint.xPosition>5.070580</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.873100</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_fa7745a1-0b24-4b75-8c9b-9dc4ec22c1a0">
+    <cim:Location.PowerSystemResources rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29"/>
+    <cim:Location.CoordinateSystem rdf:resource="#_b3c35c66-a931-46a3-a194-ccb572484ab3"/>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_687188f3-d418-4867-867e-f9d387e0f538">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_fa7745a1-0b24-4b75-8c9b-9dc4ec22c1a0"/>
+    <cim:PositionPoint.xPosition>4.301130</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803500</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_b858edc4-7035-4f0d-92c2-42fa0fd8b38b">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_fa7745a1-0b24-4b75-8c9b-9dc4ec22c1a0"/>
+    <cim:PositionPoint.xPosition>4.345090</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.916900</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_69fc882f-db9c-4278-934b-cec0ac405d42">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_fa7745a1-0b24-4b75-8c9b-9dc4ec22c1a0"/>
+    <cim:PositionPoint.xPosition>4.295650</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.044800</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_19a5b141-6872-46d8-96e1-5864baa4ca48">
+    <cim:PositionPoint.sequenceNumber>7</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_fa7745a1-0b24-4b75-8c9b-9dc4ec22c1a0"/>
+    <cim:PositionPoint.xPosition>4.383540</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.157000</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_f2057e6a-b7de-4df6-9ef9-80840563d5b1">
+    <cim:PositionPoint.sequenceNumber>9</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_fa7745a1-0b24-4b75-8c9b-9dc4ec22c1a0"/>
+    <cim:PositionPoint.xPosition>4.259260</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.325100</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_41cc011b-3555-4656-aa30-5770f06d62dc">
+    <cim:Location.PowerSystemResources rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da"/>
+    <cim:Location.CoordinateSystem rdf:resource="#_b3c35c66-a931-46a3-a194-ccb572484ab3"/>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_04507171-af4a-4e7a-96fb-1707290c85f9">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_41cc011b-3555-4656-aa30-5770f06d62dc"/>
+    <cim:PositionPoint.xPosition>4.887980</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.912700</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_679e1662-09a0-4d43-b8f7-52d4d079f68f">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.Location rdf:resource="#_41cc011b-3555-4656-aa30-5770f06d62dc"/>
+    <cim:PositionPoint.xPosition>4.846830</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.612100</cim:PositionPoint.yPosition>
+  </cim:PositionPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_SSH_V2.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_SSH_V2.xml
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
+  <md:FullModel rdf:about="urn:uuid:75271ec4-af11-4a87-8137-d6d2b43b594d">
+    <md:Model.created>2014-10-24T16:53:10</md:Model.created>
+    <md:Model.scenarioTime>2014-03-28T10:13:02</md:Model.scenarioTime>
+    <md:Model.version>2</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:96adadbe-902b-4cd6-9fc8-01a56ecbee79"/>
+    <md:Model.description>CGMES Conformity Assessment: 'MicroGridTestConfiguration....T4 (MAS BE) Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://ELIA/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+    <md:Model.Supersedes rdf:resource="urn:uuid:52b712d1-f3b0-4a59-9191-79f2fb1e4c4e"/>
+  </md:FullModel>
+  <cim:Terminal rdf:about="#_57ae9251-c022-4c67-a8eb-611ad54c963c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca7974cf-b25e-4898-9221-7154233e5eb2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c19ace6-c825-4c5b-87d9-031e6e6a3379">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ab7ece75-d726-48c8-a924-b0a9325e6d51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3774d3f-f48c-4954-a0cf-b4572eb714fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76e9ca77-f805-40ea-8120-5a6d58416d34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9539c41-d114-4280-8a54-8ecec398091e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53072f42-f77b-47e2-bd9a-e097c910b173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c41978db-794b-4bae-953e-60fc519e87dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d238885e-d9b6-4edc-8567-6a68c605ed67">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c6d83a3-b5f9-41a2-a3d9-cf15d903ed0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad794c0e-b9ec-420b-ada1-97680e3dde05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f1c492f-a7cc-4160-9a14-54f1743e4850">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_302fe23a-f64d-41bd-8a81-78130433916d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:about="#_b1480a00-b427-4001-a26c-51954d2bb7e9">
+    <cim:EnergyConsumer.p>1.000000</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0e+000</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8">
+    <cim:EnergyConsumer.p>200.000000</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>50.000000</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_cb459405-cc14-4215-a45c-416789205904">
+    <cim:EnergyConsumer.p>200.000000</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>90.000000</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:GeneratingUnit rdf:about="#_5b7a4d43-09ec-4033-882d-64a76d557631">
+    <cim:GeneratingUnit.normalPF>0e+000</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa">
+    <cim:RotatingMachine.p>-118.000000</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-18.720301</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator"/>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_18993b11-2966-4bce-bab9-d86103f83b53">
+    <cim:GeneratingUnit.normalPF>0e+000</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_3a3b27be-b18b-4385-b557-6735d733baf0">
+    <cim:RotatingMachine.p>-90.000000</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-100.256000</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator"/>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+  </cim:SynchronousMachine>
+  <cim:RatioTapChanger rdf:about="#_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e">
+    <cim:TapChanger.step>14</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>true</cim:TapChanger.controlEnabled>
+  </cim:RatioTapChanger>
+  <cim:PhaseTapChangerAsymmetrical rdf:about="#_36b83adb-3d45-4693-8967-96627b5f9ec9">
+    <cim:TapChanger.step>10</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+  </cim:PhaseTapChangerAsymmetrical>
+  <cim:PhaseTapChangerSymmetrical rdf:about="#_63454a73-f439-45bb-951a-e7b193986571">
+    <cim:TapChanger.step>10</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>true</cim:TapChanger.controlEnabled>
+  </cim:PhaseTapChangerSymmetrical>
+  <cim:RatioTapChanger rdf:about="#_fe25f43a-7341-446e-a71a-8ab7119ba806">
+    <cim:TapChanger.step>17</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+  </cim:RatioTapChanger>
+  <cim:StaticVarCompensator rdf:about="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4">
+    <cim:StaticVarCompensator.q>0e+000</cim:StaticVarCompensator.q>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+  </cim:StaticVarCompensator>
+  <cim:NonlinearShuntCompensator rdf:about="#_002b0a40-3957-46db-b84a-30420083558f">
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+  </cim:NonlinearShuntCompensator>
+  <cim:LinearShuntCompensator rdf:about="#_d771118f-36e9-4115-a128-cc3d9ce3e3da">
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+  </cim:LinearShuntCompensator>
+  <cim:EquivalentInjection rdf:about="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf">
+    <cim:EquivalentInjection.p>-31.579291</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>120.813763</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_24413233-26c3-4f7e-9f72-4461796938be">
+    <cim:EquivalentInjection.p>-16.452662</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>64.018020</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_14b352cb-5574-40c5-bf83-0ed3574554a3">
+    <cim:EquivalentInjection.p>-11.518776</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>67.377544</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_87ea56f3-962a-427a-85d6-13b1f9295174">
+    <cim:EquivalentInjection.p>-89.462903</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>1.519011</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837">
+    <cim:EquivalentInjection.p>-86.814383</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>4.958972</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:TapChangerControl rdf:about="#_97110e84-7da6-479c-846c-696fdaa83d56">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>10.815000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:TapChangerControl rdf:about="#_77a5948c-3782-455d-aea1-20b062489b65">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.M"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>0e+000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:TapChangerControl rdf:about="#_f43499bf-6bf3-483d-ae2a-e46d696a66b2">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>35.00000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.M"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>-65.000000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:TapChangerControl rdf:about="#_38f972bc-b7fd-4e75-8c24-379a86fbb506">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>0e+000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:RegulatingControl rdf:about="#_84bf5be8-eb59-4555-b131-fce4d2d7775d">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>21.987000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_6ba406ce-78cf-4485-9b01-a34e584f1a8d">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>115.500000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_bee06911-8d5c-44c4-b2d2-5c22a461b5a0">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>380.000000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_4d50f86d-0d12-4ca3-9430-56bb05f9eee6">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>110.000000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_caf65447-3cfb-48d7-aaaa-cd9af3d34261">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>229.500000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_SV_V2.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_SV_V2.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
+  <md:FullModel rdf:about="urn:uuid:1a64ce59-b28c-4b43-bf21-50b51865d777">
+    <md:Model.created>2014-10-24T16:53:10</md:Model.created>
+    <md:Model.scenarioTime>2014-03-28T10:13:02</md:Model.scenarioTime>
+    <md:Model.version>2</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:96adadbe-902b-4cd6-9fc8-01a56ecbee79"/>
+    <md:Model.DependentOn rdf:resource="urn:uuid:2399cbd1-9a39-11e0-aa80-0800200c9a66"/>
+    <md:Model.DependentOn rdf:resource="urn:uuid:806f9f1b-ff69-4fb5-80f9-a8f393d31ebb"/>
+    <md:Model.description>CGMES Conformity Assessment: 'MicroGridTestConfiguration....T4 (MAS BE) Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://ELIA/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://entsoe.eu/CIM/StateVariables/4/1</md:Model.profile>
+    <md:Model.Supersedes rdf:resource="urn:uuid:c2960b34-0a04-4cd1-9c4d-f3112d85ec6c"/>
+  </md:FullModel>
+  <cim:SvVoltage rdf:ID="_f2245225-185f-4430-9c4b-bd10f0d962a4">
+    <cim:SvVoltage.v>414.114413</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-21.526500</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_5545c6fb-b25c-4a69-858f-12021f26cd03">
+    <cim:SvVoltage.v>224.156562</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-21.796200</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_7c1169ab-ea28-4920-9f58-d4c22ba004d9">
+    <cim:SvVoltage.v>412.382599</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-21.451000</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_f03d65b2a51049ffa533e433721145c1"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_c0703bf1-7724-453e-bd02-9b64e7c93cf6">
+    <cim:SvVoltage.v>413.803877</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-21.515800</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_9d25a1f9e5d14d47b6dcde99c4380b40"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_215fc597-b984-4c53-8307-882ddd422602">
+    <cim:SvVoltage.v>412.652394</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-21.462800</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_d4affe50316740bdbbf4ae9c7cbf3cfd"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_dc77cab8-4f97-4635-b39d-bce0850ea0ca">
+    <cim:SvVoltage.v>222.821488</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-10.434700</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_8d7bad8bcc634e0796e362390d9040b6"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_bda52e5a-2dc9-4a19-bbae-0c6b08eba090">
+    <cim:SvVoltage.v>222.239822</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-10.573800</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_1fa19c281c8f4e1eaad9e1cab70f923e"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_33d5d18a-f661-4a1b-89d2-85013edc4b7a">
+    <cim:SvVoltage.v>223.435281</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-17.412200</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_0a125acf-c6b3-4ed1-a07f-eb2210c8a8e4">
+    <cim:SvVoltage.v>223.435281</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-17.412200</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_1ad0b88c-7a63-4fa7-a176-e9d1b62bd1bf">
+    <cim:SvVoltage.v>10.816961</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-19.642100</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_a3c80107-6406-4c0f-a2f8-ced7d4dbc1fa">
+    <cim:SvVoltage.v>21.987000</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-20.588300</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee"/>
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_b8d38e10-504d-4641-9ab2-2ea9df35914d">
+    <cim:SvVoltage.v>115.500000</cim:SvVoltage.v>
+    <cim:SvVoltage.angle>-22.029800</cim:SvVoltage.angle>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6"/>
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_3b0bbd94-b006-45ea-88e0-b19951b5fbc1">
+    <cim:SvPowerFlow.p>-31.579291</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>120.813763</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_b9539c41-d114-4280-8a54-8ecec398091e"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_2dd4a2d0-4cd7-4536-80fa-2bfd05a2988c">
+    <cim:SvPowerFlow.p>-16.452661</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>64.018020</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_53072f42-f77b-47e2-bd9a-e097c910b173"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_0fe31dc9-5d25-49be-be07-cac406f7aac1">
+    <cim:SvPowerFlow.p>-11.518775</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>67.377544</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_c41978db-794b-4bae-953e-60fc519e87dd"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_8b3b9043-3ab8-467d-b0af-e8bded2a3a93">
+    <cim:SvPowerFlow.p>-89.462903</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>1.519011</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_d238885e-d9b6-4edc-8567-6a68c605ed67"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_fa28a7e8-3518-456d-b767-74b198551244">
+    <cim:SvPowerFlow.p>-86.814383</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>4.958972</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_3f94d1db-1acd-41c4-a55f-fbc45ab03492">
+    <cim:SvPowerFlow.p>1.000000</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>0e+000</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_65e17ff0-22aa-4d65-af70-6e0e3a2d9c1b">
+    <cim:SvPowerFlow.p>200.000000</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>50.000000</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_a036b765-1669-4f64-acd3-1e8fbd513312"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_17910af3-a8f0-4352-a643-5aaac9e43119">
+    <cim:SvPowerFlow.p>200.000000</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>90.000000</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_d9c7e0e3-d126-4133-9222-05caf4961674">
+    <cim:SvPowerFlow.p>-118.000000</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-85.603401</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_a8103011-c03d-4dd3-a8ea-e4bb2af7ea9d">
+    <cim:SvPowerFlow.p>-90.000000</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>84.484905</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_beffa353-7d10-421d-9c08-036b744b1cee"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_69ff8ceb-cd69-41da-bb6c-915423a72df0">
+    <cim:SvPowerFlow.p>1.187609</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-59.380452</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_22af3121-1a66-4546-bd80-4371f417c644"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_6c4c980b-557a-481c-aced-79300acd2c81">
+    <cim:SvPowerFlow.p>0e+000</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-330.750000</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c"/>
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_8ac688b7-d7c3-44cf-b235-f2ab7b3ff02d">
+    <cim:SvPowerFlow.p>0e+000</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-9.861397</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_67bb74f1-8620-4a32-9d7d-a44092d11d22"/>
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_8876196d-920e-48be-a6db-010f3adc317b">
+    <cim:SvTapStep.position>20</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e"/>
+  </cim:SvTapStep>
+  <cim:SvTapStep rdf:ID="_88300d54-5537-4e47-8337-6e3241c41176">
+    <cim:SvTapStep.position>10</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_36b83adb-3d45-4693-8967-96627b5f9ec9"/>
+  </cim:SvTapStep>
+  <cim:SvTapStep rdf:ID="_8032013b-8d2c-4292-ab70-63f3daaa72fb">
+    <cim:SvTapStep.position>13</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_63454a73-f439-45bb-951a-e7b193986571"/>
+  </cim:SvTapStep>
+  <cim:SvTapStep rdf:ID="_f013d1d7-0ac8-4a5a-93e4-b44cc458f569">
+    <cim:SvTapStep.position>17</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_fe25f43a-7341-446e-a71a-8ab7119ba806"/>
+  </cim:SvTapStep>
+  <cim:SvShuntCompensatorSections rdf:ID="_0410a4d0-9dc7-4fdd-bec2-f39715b90988">
+    <cim:SvShuntCompensatorSections.sections>1</cim:SvShuntCompensatorSections.sections>
+    <cim:SvShuntCompensatorSections.ShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f"/>
+  </cim:SvShuntCompensatorSections>
+  <cim:SvShuntCompensatorSections rdf:ID="_dc27f164-4d93-4453-abbe-9d8e8242c42e">
+    <cim:SvShuntCompensatorSections.sections>1</cim:SvShuntCompensatorSections.sections>
+    <cim:SvShuntCompensatorSections.ShuntCompensator rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da"/>
+  </cim:SvShuntCompensatorSections>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_TP_V2.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity/cas-1.1.3-data-4.0.3/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/MicroGridTestConfiguration_T4_BE_TP_V2.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
+  <md:FullModel rdf:about="urn:uuid:806f9f1b-ff69-4fb5-80f9-a8f393d31ebb">
+    <md:Model.created>2014-10-24T16:53:10</md:Model.created>
+    <md:Model.scenarioTime>2014-03-28T10:13:02</md:Model.scenarioTime>
+    <md:Model.version>2</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:96adadbe-902b-4cd6-9fc8-01a56ecbee79"/>
+    <md:Model.DependentOn rdf:resource="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66"/>
+    <md:Model.DependentOn rdf:resource="urn:uuid:2399cbd1-9a39-11e0-aa80-0800200c9a66"/>
+    <md:Model.description>CGMES Conformity Assessment: 'MicroGridTestConfiguration....T4 (MAS BE) Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://ELIA/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://entsoe.eu/CIM/Topology/4/1</md:Model.profile>
+    <md:Model.Supersedes rdf:resource="urn:uuid:f2f43818-09c8-4252-9611-7af80c398d20"/>
+  </md:FullModel>
+  <cim:TopologicalNode rdf:ID="_e44141af-f1dc-44d3-bfa4-b674e5c953d7">
+    <cim:IdentifiedObject.name>BE_TR_BUS2</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6"/>
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe"/>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_99b219f3-4593-428b-a4da-124a54630178">
+    <cim:IdentifiedObject.name>BE_TR_BUS4</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c"/>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_23b65c6b-2351-4673-89e9-1895c7291543">
+    <cim:IdentifiedObject.name>Series Compensator</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361"/>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_f70f6bad-eb8d-4b8f-8431-4ab93581514e">
+    <cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+    <entsoe:IdentifiedObject.shortName>BE-B_2</entsoe:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.description>BBRUS_21; this is UCTE code</cim:IdentifiedObject.description>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c"/>
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_d0486169-2205-40b2-895e-b672ecb9e5fc"/>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e">
+    <cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+    <entsoe:IdentifiedObject.shortName>BE-B_4</entsoe:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.description>BGENT_71; This is the old UCTE code from UCTE DEF</cim:IdentifiedObject.description>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75"/>
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386"/>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_f96d552a-618d-4d0c-a39a-2dea3c411dee">
+    <cim:IdentifiedObject.name>BE-Busbar_5</cim:IdentifiedObject.name>
+    <entsoe:IdentifiedObject.shortName>BE-B_5</entsoe:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.description>BGENT_72; this is old code</cim:IdentifiedObject.description>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2"/>
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85"/>
+  </cim:TopologicalNode>
+  <cim:TopologicalNode rdf:ID="_5c74cb26-ce2f-40c6-951d-89091eb781b6">
+    <cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+    <entsoe:IdentifiedObject.shortName>BE-B_6</entsoe:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.description>BBRUS151; BGENT_51</cim:IdentifiedObject.description>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694"/>
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0"/>
+  </cim:TopologicalNode>
+  <cim:Terminal rdf:about="#_57ae9251-c022-4c67-a8eb-611ad54c963c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_1fa19c281c8f4e1eaad9e1cab70f923e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+    <cim:Terminal.TopologicalNode rdf:resource="#_d4affe50316740bdbbf4ae9c7cbf3cfd"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+    <cim:Terminal.TopologicalNode rdf:resource="#_9d25a1f9e5d14d47b6dcde99c4380b40"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f03d65b2a51049ffa533e433721145c1"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+    <cim:Terminal.TopologicalNode rdf:resource="#_8d7bad8bcc634e0796e362390d9040b6"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca7974cf-b25e-4898-9221-7154233e5eb2">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:Terminal.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c19ace6-c825-4c5b-87d9-031e6e6a3379">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ab7ece75-d726-48c8-a924-b0a9325e6d51">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3774d3f-f48c-4954-a0cf-b4572eb714fd">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76e9ca77-f805-40ea-8120-5a6d58416d34">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:Terminal.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9539c41-d114-4280-8a54-8ecec398091e">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f03d65b2a51049ffa533e433721145c1"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53072f42-f77b-47e2-bd9a-e097c910b173">
+    <cim:Terminal.TopologicalNode rdf:resource="#_d4affe50316740bdbbf4ae9c7cbf3cfd"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c41978db-794b-4bae-953e-60fc519e87dd">
+    <cim:Terminal.TopologicalNode rdf:resource="#_9d25a1f9e5d14d47b6dcde99c4380b40"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d238885e-d9b6-4edc-8567-6a68c605ed67">
+    <cim:Terminal.TopologicalNode rdf:resource="#_8d7bad8bcc634e0796e362390d9040b6"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+    <cim:Terminal.TopologicalNode rdf:resource="#_1fa19c281c8f4e1eaad9e1cab70f923e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:Terminal.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c6d83a3-b5f9-41a2-a3d9-cf15d903ed0a">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad794c0e-b9ec-420b-ada1-97680e3dde05">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:Terminal.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f1c492f-a7cc-4160-9a14-54f1743e4850">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_302fe23a-f64d-41bd-8a81-78130433916d">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178"/>
+  </cim:Terminal>
+</rdf:RDF>

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -34,6 +34,7 @@ import com.powsybl.cgmes.conversion.elements.ExternalNetworkInjectionConversion;
 import com.powsybl.cgmes.conversion.elements.NodeConversion;
 import com.powsybl.cgmes.conversion.elements.PhaseTapChangerConversion;
 import com.powsybl.cgmes.conversion.elements.RatioTapChangerConversion;
+import com.powsybl.cgmes.conversion.elements.SeriesCompensatorConversion;
 import com.powsybl.cgmes.conversion.elements.ShuntConversion;
 import com.powsybl.cgmes.conversion.elements.StaticVarCompensatorConversion;
 import com.powsybl.cgmes.conversion.elements.SubstationConversion;
@@ -123,6 +124,7 @@ public class Conversion {
 
         convertACLineSegmentsToLines();
         convert(cgmes.equivalentBranches(), eqb -> new EquivalentBranchConversion(eqb, context));
+        convert(cgmes.seriesCompensators(), sc -> new SeriesCompensatorConversion(sc, context));
         convertTransformers();
         convert(cgmes.ratioTapChangers(), rtc -> new RatioTapChangerConversion(rtc, context));
         convert(cgmes.phaseTapChangers(), ptc -> new PhaseTapChangerConversion(ptc, context));

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
@@ -22,10 +22,10 @@ import com.powsybl.triplestore.api.PropertyBag;
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
-public class ACLineSegmentConversion extends AbstractConductingEquipmentConversion {
+public class ACLineSegmentConversion extends AbstractBranchConversion {
 
     public ACLineSegmentConversion(PropertyBag line, Conversion.Context context) {
-        super(CgmesNames.AC_LINE_SEGMENT, line, context, 2);
+        super(CgmesNames.AC_LINE_SEGMENT, line, context);
     }
 
     @Override
@@ -33,7 +33,7 @@ public class ACLineSegmentConversion extends AbstractConductingEquipmentConversi
         // An AC line segment end voltage level may be null
         // (when it is in the boundary and the boundary nodes are not converted)
         // So we do not use the generic validity check for conducting equipment
-        // We only ensure we have nodes at both ends
+        // or branch. We only ensure we have nodes at both ends
         for (int k = 1; k <= 2; k++) {
             if (nodeId(k) == null) {
                 missing(nodeIdPropertyName() + k);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractBranchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractBranchConversion.java
@@ -1,0 +1,33 @@
+package com.powsybl.cgmes.conversion.elements;
+
+import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.triplestore.api.PropertyBag;
+
+public abstract class AbstractBranchConversion extends AbstractConductingEquipmentConversion {
+
+    public AbstractBranchConversion(
+            String type,
+            PropertyBag p,
+            Conversion.Context context) {
+        super(type, p, context, 2);
+    }
+
+    @Override
+    public boolean valid() {
+        if (!super.valid()) {
+            return false;
+        }
+        String node1 = nodeId(1);
+        String node2 = nodeId(2);
+        if (context.boundary().containsNode(node1)
+                || context.boundary().containsNode(node2)) {
+            invalid("Has " + nodeIdPropertyName() + " on boundary");
+            return false;
+        }
+        if (!p.containsKey("r") || !p.containsKey("x")) {
+            invalid("No r,x attributes");
+            return false;
+        }
+        return true;
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentBranchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentBranchConversion.java
@@ -14,29 +14,10 @@ import com.powsybl.triplestore.api.PropertyBag;
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
-public class EquivalentBranchConversion extends AbstractConductingEquipmentConversion {
+public class EquivalentBranchConversion extends AbstractBranchConversion {
 
     public EquivalentBranchConversion(PropertyBag b, Conversion.Context context) {
-        super("EquivalentBranch", b, context, 2);
-    }
-
-    @Override
-    public boolean valid() {
-        if (!super.valid()) {
-            return false;
-        }
-        String node1 = nodeId(1);
-        String node2 = nodeId(2);
-        if (context.boundary().containsNode(node1)
-                || context.boundary().containsNode(node2)) {
-            invalid("Has TopologicalNode on boundary");
-            return false;
-        }
-        if (!p.containsKey("r") || !p.containsKey("x")) {
-            invalid("No r,x attribures");
-            return false;
-        }
-        return true;
+        super("EquivalentBranch", b, context);
     }
 
     @Override

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/PhaseTapChangerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/PhaseTapChangerConversion.java
@@ -264,6 +264,8 @@ public class PhaseTapChangerConversion extends AbstractIdentifiedObjectConversio
                 double rho = 1.0;
                 alphas.add(alpha);
                 rhos.add(rho);
+
+                LOG.debug("ACTUAL    n,dy,alpha,rho  {} {} {} {}", n, dy, alpha, rho);
             }
         }
     }
@@ -289,6 +291,7 @@ public class PhaseTapChangerConversion extends AbstractIdentifiedObjectConversio
         // using factor rho0square as a float
         double rho0 = tx.getRatedU2() / tx.getRatedU1();
         double rho0square = rho0 * rho0;
+        LOG.debug("ACTUAL    u2,u1,rho0square {}, {}, {}", tx.getRatedU2(), tx.getRatedU1(), rho0square);
 
         for (int i = 0; i < alphas.size(); i++) {
             double alpha = alphas.get(i);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
@@ -15,29 +15,10 @@ import com.powsybl.triplestore.api.PropertyBag;
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
-public class SeriesCompensatorConversion extends AbstractConductingEquipmentConversion {
+public class SeriesCompensatorConversion extends AbstractBranchConversion {
 
     public SeriesCompensatorConversion(PropertyBag sc, Conversion.Context context) {
-        super(CgmesNames.SERIES_COMPENSATOR, sc, context, 2);
-    }
-
-    @Override
-    public boolean valid() {
-        if (!super.valid()) {
-            return false;
-        }
-        String node1 = nodeId(1);
-        String node2 = nodeId(2);
-        if (context.boundary().containsNode(node1)
-                || context.boundary().containsNode(node2)) {
-            invalid("Has TopologicalNode on boundary");
-            return false;
-        }
-        if (!p.containsKey("r") || !p.containsKey("x")) {
-            invalid("No r,x attribures");
-            return false;
-        }
-        return true;
+        super(CgmesNames.SERIES_COMPENSATOR, sc, context);
     }
 
     @Override

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
@@ -8,6 +8,7 @@
 package com.powsybl.cgmes.conversion.elements;
 
 import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.iidm.network.Line;
 import com.powsybl.triplestore.api.PropertyBag;
 
@@ -17,7 +18,7 @@ import com.powsybl.triplestore.api.PropertyBag;
 public class SeriesCompensatorConversion extends AbstractConductingEquipmentConversion {
 
     public SeriesCompensatorConversion(PropertyBag sc, Conversion.Context context) {
-        super("SeriesCompensator", sc, context, 2);
+        super(CgmesNames.SERIES_COMPENSATOR, sc, context, 2);
     }
 
     @Override
@@ -46,8 +47,8 @@ public class SeriesCompensatorConversion extends AbstractConductingEquipmentConv
         String busId1 = busId(1);
         String busId2 = busId(2);
         final Line l = context.network().newLine()
-                .setId(context.namingStrategy().getId("SeriesCompensator", id))
-                .setName(context.namingStrategy().getName("SeriesCompensator", name))
+                .setId(context.namingStrategy().getId(CgmesNames.SERIES_COMPENSATOR, id))
+                .setName(context.namingStrategy().getName(CgmesNames.SERIES_COMPENSATOR, name))
                 .setEnsureIdUnicity(false)
                 .setBus1(terminalConnected(1) ? busId1 : null)
                 .setBus2(terminalConnected(2) ? busId2 : null)

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2017-2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.cgmes.conversion.elements;
+
+import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.iidm.network.Line;
+import com.powsybl.triplestore.api.PropertyBag;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+public class SeriesCompensatorConversion extends AbstractConductingEquipmentConversion {
+
+    public SeriesCompensatorConversion(PropertyBag sc, Conversion.Context context) {
+        super("SeriesCompensator", sc, context, 2);
+    }
+
+    @Override
+    public boolean valid() {
+        if (!super.valid()) {
+            return false;
+        }
+        String node1 = nodeId(1);
+        String node2 = nodeId(2);
+        if (context.boundary().containsNode(node1)
+                || context.boundary().containsNode(node2)) {
+            invalid("Has TopologicalNode on boundary");
+            return false;
+        }
+        if (!p.containsKey("r") || !p.containsKey("x")) {
+            invalid("No r,x attribures");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void convert() {
+        double r = p.asDouble("r");
+        double x = p.asDouble("x");
+        String busId1 = busId(1);
+        String busId2 = busId(2);
+        final Line l = context.network().newLine()
+                .setId(context.namingStrategy().getId("SeriesCompensator", id))
+                .setName(context.namingStrategy().getName("SeriesCompensator", name))
+                .setEnsureIdUnicity(false)
+                .setBus1(terminalConnected(1) ? busId1 : null)
+                .setBus2(terminalConnected(2) ? busId2 : null)
+                .setConnectableBus1(busId1)
+                .setConnectableBus2(busId2)
+                .setVoltageLevel1(iidmVoltageLevelId(1))
+                .setVoltageLevel2(iidmVoltageLevelId(2))
+                .setR(r)
+                .setX(x)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+        convertedTerminals(l.getTerminal1(), l.getTerminal2());
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
@@ -8,6 +8,7 @@
 package com.powsybl.cgmes.conversion.elements;
 
 import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.cgmes.model.PowerFlow;
 import com.powsybl.iidm.network.ShuntCompensator;
 import com.powsybl.triplestore.api.PropertyBag;
@@ -30,8 +31,8 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
         sections = Math.abs(sections);
         maximumSections = Math.max(maximumSections, sections);
         double bPerSection = 0;
-        if (p.containsKey("bPerSection")) {
-            bPerSection = p.asDouble("bPerSection", 0.0);
+        if (p.containsKey(CgmesNames.B_PER_SECTION)) {
+            bPerSection = p.asDouble(CgmesNames.B_PER_SECTION, 0.0);
         } else {
             PropertyBags ss = context.cgmes().nonlinearShuntCompensatorPoints(id);
             final int nlsections = sections;
@@ -46,7 +47,7 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
         }
         if (bPerSection == 0) {
             float bPerSectionFixed = Float.MIN_VALUE;
-            fixed("bPerSection", "Can not be zero", bPerSection, bPerSectionFixed);
+            fixed(CgmesNames.B_PER_SECTION, "Can not be zero", bPerSection, bPerSectionFixed);
             bPerSection = bPerSectionFixed;
         }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
@@ -34,8 +34,6 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
             bPerSection = p.asDouble("bPerSection", 0.0);
         } else {
             PropertyBags ss = context.cgmes().nonlinearShuntCompensatorPoints(id);
-            System.out.println("nonlinearSC");
-            System.out.println(ss.tabulateLocals());
             final int nlsections = sections;
             double sumSections = ss.stream()
                     .filter(s -> s.asInt("sectionNumber") <= nlsections)
@@ -45,7 +43,6 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
             maximumSections = 1;
             sections = 1;
             bPerSection = sumSections;
-            System.out.println("nonlinearSC, sumSections b = " + sumSections);
         }
         if (bPerSection == 0) {
             float bPerSectionFixed = Float.MIN_VALUE;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
@@ -5,13 +5,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
 package com.powsybl.cgmes.conversion.elements;
 
 import com.powsybl.cgmes.conversion.Conversion;
 import com.powsybl.cgmes.model.PowerFlow;
 import com.powsybl.iidm.network.ShuntCompensator;
 import com.powsybl.triplestore.api.PropertyBag;
+import com.powsybl.triplestore.api.PropertyBags;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -26,12 +26,27 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
     public void convert() {
         int maximumSections = p.asInt("maximumSections", 0);
         int normalSections = p.asInt("normalSections", 0);
-        double bPerSection = p.asDouble("bPerSection", 0.0);
         int sections = fromContinuous(p.asDouble("SVsections", normalSections));
-
-        // Adjustments
         sections = Math.abs(sections);
         maximumSections = Math.max(maximumSections, sections);
+        double bPerSection = 0;
+        if (p.containsKey("bPerSection")) {
+            bPerSection = p.asDouble("bPerSection", 0.0);
+        } else {
+            PropertyBags ss = context.cgmes().nonlinearShuntCompensatorPoints(id);
+            System.out.println("nonlinearSC");
+            System.out.println(ss.tabulateLocals());
+            final int nlsections = sections;
+            double sumSections = ss.stream()
+                    .filter(s -> s.asInt("sectionNumber") <= nlsections)
+                    .map(s -> s.asDouble("b"))
+                    .reduce(0.0, Double::sum);
+            // Convert to a shunt compensator with a single section
+            maximumSections = 1;
+            sections = 1;
+            bPerSection = sumSections;
+            System.out.println("nonlinearSC, sumSections b = " + sumSections);
+        }
         if (bPerSection == 0) {
             float bPerSectionFixed = Float.MIN_VALUE;
             fixed("bPerSection", "Can not be zero", bPerSection, bPerSectionFixed);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
@@ -84,12 +84,17 @@ public class CgmesConformity1ConversionTest {
                 TripleStoreFactory.onlyDefaultImplementation(),
                 new ComparisonConfig().tolerance(1e-5));
         t.setTestExportImportCgmes(true);
-        t.testConversion(expecteds.microBE(), actuals.microGridBaseCaseBE());
+        t.testConversion(expecteds.microBaseCaseBE(), actuals.microGridBaseCaseBE());
     }
 
     @Test
     public void microGridBaseCaseBE() throws IOException {
-        tester.testConversion(expecteds.microBE(), actuals.microGridBaseCaseBE());
+        tester.testConversion(expecteds.microBaseCaseBE(), actuals.microGridBaseCaseBE());
+    }
+
+    @Test
+    public void microGridType4BE() throws IOException {
+        tester.testConversion(expecteds.microType4BE(), actuals.microGridType4BE());
     }
 
     @Test

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -78,8 +78,8 @@ public class Comparison {
                 actual.getLoadStream(),
                 this::compareLoads);
         compare(
-                expected.getShuntStream(),
-                actual.getShuntStream(),
+                expected.getShuntCompensatorStream(),
+                actual.getShuntCompensatorStream(),
                 this::compareShunts);
         compare(
                 expected.getStaticVarCompensatorStream(),

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -87,6 +87,8 @@ public interface CgmesModel {
 
     PropertyBags shuntCompensators();
 
+    PropertyBags nonlinearShuntCompensatorPoints(String id);
+
     PropertyBags staticVarCompensators();
 
     PropertyBags synchronousMachines();

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -13,6 +13,8 @@ import java.util.Properties;
 import java.util.function.Consumer;
 
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.powsybl.commons.datasource.DataSource;
 import com.powsybl.triplestore.api.PropertyBags;
@@ -65,6 +67,8 @@ public interface CgmesModel {
     PropertyBags acLineSegments();
 
     PropertyBags equivalentBranches();
+
+    PropertyBags seriesCompensators();
 
     PropertyBags transformers();
 
@@ -210,9 +214,9 @@ public interface CgmesModel {
             if (value0 == null || value0.equals(value1)) {
                 return;
             }
-            throw new CgmesModelException(
-                    String.format("Inconsistent values for %s: previous %s, now %s",
-                            attribute, value0, value1));
+            LOG.warn("Inconsistent values for {}: previous {}, now {}", attribute, value0, value1);
         }
     }
+
+    static final Logger LOG = LoggerFactory.getLogger(CgmesModel.class);
 }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -216,7 +216,7 @@ public interface CgmesModel {
             }
             LOG.warn("Inconsistent values for {}: previous {}, now {}", attribute, value0, value1);
         }
-    }
 
-    static final Logger LOG = LoggerFactory.getLogger(CgmesModel.class);
+        private static final Logger LOG = LoggerFactory.getLogger(CgmesModel.class);
+    }
 }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNames.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNames.java
@@ -13,6 +13,7 @@ public final class CgmesNames {
     public static final String VOLTAGE_LEVEL = "VoltageLevel";
     public static final String TERMINAL = "Terminal";
     public static final String AC_LINE_SEGMENT = "ACLineSegment";
+    public static final String SERIES_COMPENSATOR = "SeriesCompensator";
 
     public static final String TRANSFORMER_WINDING_RATED_U = "transformerWindingRatedU";
     public static final String TRANSFORMER_END = "TransformerEnd";

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNames.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNames.java
@@ -26,6 +26,8 @@ public final class CgmesNames {
     public static final String DC_TERMINAL = "DCTerminal";
     public static final String RATED_UDC = "ratedUdc";
 
+    public static final String B_PER_SECTION = "bPerSection";
+
     private CgmesNames() {
     }
 }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -266,6 +266,12 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
     }
 
     @Override
+    public PropertyBags nonlinearShuntCompensatorPoints(String scId) {
+        Objects.requireNonNull(scId);
+        return namedQuery("nonlinearShuntCompensatorPoints", scId);
+    }
+
+    @Override
     public PropertyBags staticVarCompensators() {
         return namedQuery("staticVarCompensators");
     }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -226,6 +226,11 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
     }
 
     @Override
+    public PropertyBags seriesCompensators() {
+        return namedQuery("seriesCompensators");
+    }
+
+    @Override
     public PropertyBags transformers() {
         return namedQuery("transformers");
     }

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -381,6 +381,26 @@ WHERE {
 }
 
 
+# query: seriesCompensators
+SELECT *
+WHERE {
+{ GRAPH ?graph {
+    ?SeriesCompensator
+        a cim:SeriesCompensator ;
+        cim:SeriesCompensator.r ?r ;
+        cim:SeriesCompensator.x ?x ;
+        cim:IdentifiedObject.name ?name .
+    ?Terminal1
+        a cim:Terminal ;
+        cim:Terminal.ConductingEquipment ?SeriesCompensator .
+    ?Terminal2
+        a cim:Terminal ;
+        cim:Terminal.ConductingEquipment ?SeriesCompensator .
+    FILTER ( STR (?Terminal1) < STR (?Terminal2) )
+}}
+}
+
+
 # query: transformers
 SELECT *
 { GRAPH ?graph {

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -581,14 +581,18 @@ SELECT *
 WHERE {
 { GRAPH ?graph {
     ?ShuntCompensator
-        a cim:LinearShuntCompensator ;
+        a ?type ;
         cim:IdentifiedObject.name ?name ;
-        cim:LinearShuntCompensator.gPerSection ?gPerSection ;
-        cim:LinearShuntCompensator.bPerSection ?bPerSection ;
         cim:ShuntCompensator.normalSections ?normalSections ;
         cim:ShuntCompensator.maximumSections ?maximumSections ;
         cim:ShuntCompensator.nomU ?nomU .
+    VALUES ?type { cim:LinearShuntCompensator cim:NonlinearShuntCompensator } .
     ?Terminal cim:Terminal.ConductingEquipment ?ShuntCompensator .
+    OPTIONAL {
+        ?ShuntCompensator 
+            cim:LinearShuntCompensator.gPerSection ?gPerSection ;
+            cim:LinearShuntCompensator.bPerSection ?bPerSection 
+    }
     OPTIONAL {
         ?ShuntCompensator cim:RegulatingCondEq.RegulatingControl ?RegulatingControl .
         ?RegulatingControl
@@ -613,6 +617,18 @@ OPTIONAL { GRAPH ?graphSV  {
 OPTIONAL { GRAPH ?graphSSH  {
     ?ShuntCompensator cim:ShuntCompensator.sections ?SSHsections
 }}
+}
+
+# query: nonlinearShuntCompensatorPoints
+SELECT *
+WHERE {
+    ?NonlinearShuntCompensatorPoint
+        a cim:NonlinearShuntCompensatorPoint ;
+        cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator ?Shunt ;
+        cim:NonlinearShuntCompensatorPoint.sectionNumber ?sectionNumber ;
+        cim:NonlinearShuntCompensatorPoint.b ?b ;
+        cim:NonlinearShuntCompensatorPoint.g ?g  .
+    FILTER REGEX ( STR (?Shunt), "{0}")
 }
 
 # query: synchronousMachines

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -311,12 +311,11 @@ WHERE {
     VALUES ?type { cim:Switch cim:Breaker cim:Disconnector } .
     ?Terminal1
         a cim:Terminal ;
-        cim:Terminal.ConductingEquipment ?Switch ;
-        cim:ACDCTerminal.sequenceNumber "1" .
+        cim:Terminal.ConductingEquipment ?Switch .
     ?Terminal2
         a cim:Terminal ;
-        cim:Terminal.ConductingEquipment ?Switch ;
-        cim:ACDCTerminal.sequenceNumber "2" .
+        cim:Terminal.ConductingEquipment ?Switch .
+    FILTER ( STR(?Terminal1) < STR(?Terminal2) )
     OPTIONAL {
         ?EquipmentContainer a cim:VoltageLevel .
         BIND ( ?EquipmentContainer AS ?VoltageLevel )

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
@@ -358,6 +358,11 @@ public final class FakeCgmesModel implements CgmesModel {
     }
 
     @Override
+    public PropertyBags nonlinearShuntCompensatorPoints(String scId) {
+        return null;
+    }
+
+    @Override
     public PropertyBags staticVarCompensators() {
         return staticVarCompensators;
     }

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
@@ -31,6 +31,7 @@ public final class FakeCgmesModel implements CgmesModel {
     private PropertyBags switches;
     private PropertyBags acLineSegments;
     private PropertyBags equivalentBranches;
+    private PropertyBags seriesCompensators;
     private PropertyBags transformers;
     private PropertyBags transformerEnds;
     private PropertyBags ratioTapChangers;
@@ -64,6 +65,7 @@ public final class FakeCgmesModel implements CgmesModel {
         switches = new PropertyBags();
         acLineSegments = new PropertyBags();
         equivalentBranches = new PropertyBags();
+        seriesCompensators = new PropertyBags();
         transformers = new PropertyBags();
         transformerEnds = new PropertyBags();
         ratioTapChangers = new PropertyBags();
@@ -141,6 +143,11 @@ public final class FakeCgmesModel implements CgmesModel {
     @Override
     public PropertyBags equivalentBranches() {
         return equivalentBranches;
+    }
+
+    @Override
+    public PropertyBags seriesCompensators() {
+        return seriesCompensators;
     }
 
     public FakeCgmesModel transformers(String... ids) {


### PR DESCRIPTION
Convert CGMES Nonlinear Shunt Compensators (multiple sections with different admittance) to IIDM Shunt Compensators with a single section for the total susceptance (b) of sections in service.

As for Linear Shunt Compensators, conductance (g) is ignored. IIDM shunt compensators only have susceptance.