### PR TITLE
Solve issue in UCTE importer causing tie lines' current limits absence in IIDM network

### DIFF
--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -860,11 +860,11 @@ public class UcteImporter implements Importer {
 
                 if (dl1.getCurrentLimits() != null) {
                     mergeLine.newCurrentLimits1()
-                            .setPermanentLimit(dl1.getCurrentLimits().getPermanentLimit());
+                            .setPermanentLimit(dl1.getCurrentLimits().getPermanentLimit()).add();
                 }
                 if (dl2.getCurrentLimits() != null) {
                     mergeLine.newCurrentLimits2()
-                            .setPermanentLimit(dl2.getCurrentLimits().getPermanentLimit());
+                            .setPermanentLimit(dl2.getCurrentLimits().getPermanentLimit()).add();
                 }
 
                 mergeLine.addExtension(MergedXnode.class, new MergedXnode(mergeLine, rdp, xdp, xnodeP1, xnodeQ1, xnodeP2, xnodeQ2, xnodeCode));

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
@@ -115,6 +115,8 @@ public class UcteImporterTest {
         assertEquals("ESNODE11 XXNODE11 1 + FRNODE11 XXNODE11 1", l.getId());
         MergedXnode mergedXnode = l.getExtension(MergedXnode.class);
         assertNotNull(mergedXnode);
+        assertNotNull(l.getCurrentLimits1());
+        assertNotNull(l.getCurrentLimits2());
     }
 
     @Test


### PR DESCRIPTION
Solve issue in UCTE importer causing tie lines' current limits absence in IIDM network