### PR TITLE
fix traversal of node breaker topology for XML export of internal connections

### DIFF
--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerInternalConnectionsTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerInternalConnectionsTest.java
@@ -1,0 +1,205 @@
+package com.powsybl.iidm.network.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.NetworkFactory;
+import com.powsybl.iidm.network.Substation;
+import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.iidm.network.VoltageLevel;
+
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+
+public class NodeBreakerInternalConnectionsTest {
+
+    @Test
+    public void testTraversalInternalConnections() {
+        Network network = NetworkFactory.create("testTraversalInternalConnections", "test");
+        InternalConnections all = new InternalConnections();
+        createNetwork(network, all);
+        VoltageLevel vl = network.getVoltageLevel("S5 10kV");
+
+        InternalConnections foundStoppingAtTerminals = findInternalConnectionsTraverseStoppingAtTerminals(vl);
+        // If we stop traversal at terminals
+        // some internal connections are expected to be missing
+        InternalConnections expectedMissing = new InternalConnections();
+        expectedMissing.add(5, 2);
+        expectedMissing.add(4, 3);
+        // Compute all missing connections
+        Set<String> actualMissing = all.stream()
+                .filter(c -> !foundStoppingAtTerminals.contains(c))
+                .collect(Collectors.toSet());
+        assertEquals(expectedMissing, actualMissing);
+
+        InternalConnections actual = findInternalConnections(vl);
+        InternalConnections expected = all;
+        assertEquals(expected, actual);
+    }
+
+    private void createNetwork(Network network, InternalConnections internalConnections) {
+        Substation s = network.newSubstation()
+                .setId("S5")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl = s.newVoltageLevel()
+                .setId("S5 10kV")
+                .setNominalV(10.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        vl.getNodeBreakerView().setNodeCount(14);
+        vl.getNodeBreakerView().newBusbarSection()
+                .setId("NODE13")
+                .setNode(0)
+                .add();
+        vl.getNodeBreakerView().newBusbarSection()
+                .setId("NODE14")
+                .setNode(3)
+                .add();
+        vl.getNodeBreakerView().newBusbarSection()
+                .setId("NODE15")
+                .setNode(2)
+                .add();
+        vl.getNodeBreakerView().newBusbarSection()
+                .setId("NODE16")
+                .setNode(1)
+                .add();
+        vl.getNodeBreakerView().newSwitch()
+                .setId("BREAKER4")
+                .setNode1(4)
+                .setNode2(5)
+                .setKind(SwitchKind.BREAKER)
+                .add();
+        vl.getNodeBreakerView().newSwitch()
+                .setId("DISCONNECTOR7")
+                .setNode1(6)
+                .setNode2(7)
+                .setKind(SwitchKind.DISCONNECTOR)
+                .add();
+        vl.getNodeBreakerView().newSwitch()
+                .setId("DISCONNECTOR8")
+                .setNode1(8)
+                .setNode2(9)
+                .setKind(SwitchKind.DISCONNECTOR)
+                .add();
+        vl.newLoad()
+                .setId("M3")
+                .setNode(11)
+                .setP0(5)
+                .setQ0(3)
+                .add();
+        vl.newLoad()
+                .setId("M2a")
+                .setNode(12)
+                .setP0(2)
+                .setQ0(1)
+                .add();
+        vl.newLoad()
+                .setId("M2b")
+                .setNode(13)
+                .setP0(2)
+                .setQ0(1)
+                .add();
+        VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
+        addInternalConnection(topo, internalConnections, 7, 0);
+        addInternalConnection(topo, internalConnections, 6, 3);
+        addInternalConnection(topo, internalConnections, 4, 3);
+        addInternalConnection(topo, internalConnections, 5, 2);
+        addInternalConnection(topo, internalConnections, 9, 2);
+        addInternalConnection(topo, internalConnections, 8, 1);
+        Substation s4 = network.newSubstation()
+                .setId("S4")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl4 = s4.newVoltageLevel()
+                .setId("S4 10kV")
+                .setNominalV(10.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        vl4.getNodeBreakerView().setNodeCount(1);
+        network.newLine()
+                .setId("L6")
+                .setVoltageLevel1("S4 10kV")
+                .setNode1(0)
+                .setVoltageLevel2("S5 10kV")
+                .setNode2(10)
+                .setR(0.082)
+                .setX(0.086)
+                .setG1(0)
+                .setB1(0)
+                .setG2(0)
+                .setB2(0)
+                .add();
+    }
+
+    private void addInternalConnection(
+            VoltageLevel.NodeBreakerView topo,
+            InternalConnections internalConnections,
+            int node1,
+            int node2) {
+        topo.newInternalConnection()
+                .setNode1(node1)
+                .setNode2(node2)
+                .add();
+        internalConnections.add(node1, node2);
+    }
+
+    static class InternalConnections extends HashSet<String> {
+        void add(int node1, int node2) {
+            add(node1 + "-" + node2);
+            add(node2 + "-" + node1);
+        }
+    }
+
+    private InternalConnections findInternalConnectionsTraverseStoppingAtTerminals(VoltageLevel vl) {
+        InternalConnections cs = new InternalConnections();
+
+        VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
+        int[] nodes = topo.getNodes();
+        final TIntSet explored = new TIntHashSet();
+        for (int n : nodes) {
+            if (explored.contains(n) || topo.getTerminal(n) == null) {
+                continue;
+            }
+            explored.add(n);
+            topo.traverse(n, (n1, sw, n2) -> {
+                explored.add(n2);
+                if (sw == null) {
+                    cs.add(n1, n2);
+                }
+                return topo.getTerminal(n2) == null;
+            });
+        }
+        return cs;
+    }
+
+    private InternalConnections findInternalConnections(VoltageLevel vl) {
+        InternalConnections cs = new InternalConnections();
+
+        VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
+        int[] nodes = topo.getNodes();
+        final TIntSet explored = new TIntHashSet();
+        for (int n : nodes) {
+            if (explored.contains(n)) {
+                continue;
+            }
+            explored.add(n);
+            topo.traverse(n, (n1, sw, n2) -> {
+                explored.add(n2);
+                if (sw == null) {
+                    cs.add(n1, n2);
+                }
+                return true;
+            });
+        }
+        return cs;
+    }
+}

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -101,7 +101,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
         // associated object
         final TIntSet explored = new TIntHashSet();
         for (int n : nodes) {
-            if (explored.contains(n) || topo.getTerminal(n) == null) {
+            if (explored.contains(n)) {
                 continue;
             }
             explored.add(n);
@@ -110,7 +110,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
                 if (sw == null) {
                     writeNodeBreakerTopologyInternalConnection(n1, n2, context);
                 }
-                return topo.getTerminal(n2) == null;
+                return true;
             });
         }
     }

--- a/iidm/iidm-xml-converter/src/test/resources/internalConnections.xiidm
+++ b/iidm/iidm-xml-converter/src/test/resources/internalConnections.xiidm
@@ -6,7 +6,7 @@
                 <iidm:busbarSection id="b1" node="2"/>
                 <iidm:switch id="br1" kind="BREAKER" retained="false" open="false" node1="1" node2="2"/>
                 <iidm:internalConnection node1="0" node2="1"/>
-                <iidm:internalConnection node1="4" node2="3"/>
+                <iidm:internalConnection node1="3" node2="4"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="g1" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="10.0" targetV="400.0" node="0">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
@@ -19,7 +19,7 @@
                 <iidm:busbarSection id="b2" node="2"/>
                 <iidm:switch id="br2" kind="BREAKER" retained="false" open="false" node1="1" node2="2"/>
                 <iidm:internalConnection node1="0" node2="1"/>
-                <iidm:internalConnection node1="4" node2="3"/>
+                <iidm:internalConnection node1="3" node2="4"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="l2" loadType="UNDEFINED" p0="10.0" q0="1.0" node="0"/>
         </iidm:voltageLevel>


### PR DESCRIPTION
Added unit test in IIDM implementation to show the difference between the original and fixed traversal of node breaker topology.