### PR TITLE
[WIP] Make security/impact analysis thread-safe

### DIFF
--- a/security-analysis/security-analysis-afs-local/src/main/java/com/powsybl/security/afs/local/LocalSecurityAnalysisRunningService.java
+++ b/security-analysis/security-analysis-afs-local/src/main/java/com/powsybl/security/afs/local/LocalSecurityAnalysisRunningService.java
@@ -60,6 +60,8 @@ public class LocalSecurityAnalysisRunningService implements SecurityAnalysisRunn
 
             SecurityAnalysis securityAnalysis = factorySupplier.get().create(network, computationManager, 0);
 
+            network.getStateManager().allowStateMultiThreadAccess(true);
+
             // add all interceptors
             for (String interceptorName : SecurityAnalysisInterceptors.getExtensionNames()) {
                 securityAnalysis.addInterceptor(SecurityAnalysisInterceptors.createInterceptor(interceptorName));
@@ -77,6 +79,9 @@ public class LocalSecurityAnalysisRunningService implements SecurityAnalysisRunn
                         }
                         return null;
                     }).join();
+
+            network.getStateManager().allowStateMultiThreadAccess(false);
+
         } finally {
             runner.stopTask(taskId);
         }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisTool.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisTool.java
@@ -198,6 +198,7 @@ public class SecurityAnalysisTool implements Tool {
 
 
         SecurityAnalysis securityAnalysis;
+        network.getStateManager().allowStateMultiThreadAccess(true);
         if (line.hasOption(EXTERNAL)) {
             Integer taskCount = getOptionValue(line, TASK_COUNT).map(Integer::parseInt).orElse(null);
             ExternalSecurityAnalysisConfig config = ExternalSecurityAnalysisConfig.load();
@@ -215,6 +216,8 @@ public class SecurityAnalysisTool implements Tool {
         String currentState = network.getStateManager().getWorkingStateId();
 
         SecurityAnalysisResult result = securityAnalysis.run(currentState, parameters, contingenciesProvider).join();
+
+        network.getStateManager().allowStateMultiThreadAccess(false);
 
         if (!result.getPreContingencyResult().isComputationOk()) {
             context.getErrorStream().println("Pre-contingency state divergence");

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalyzer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalyzer.java
@@ -101,6 +101,10 @@ public class SecurityAnalyzer {
         SecurityAnalysis securityAnalysis = securityAnalysisFactory.create(network, filter, computationManager, priority);
         interceptors.forEach(securityAnalysis::addInterceptor);
 
-        return securityAnalysis.run(network.getStateManager().getWorkingStateId(), parameters, contingenciesProvider).join();
+        SecurityAnalysisResult result =  securityAnalysis.run(network.getStateManager().getWorkingStateId(), parameters, contingenciesProvider).join();
+
+        network.getStateManager().allowStateMultiThreadAccess(false);
+
+        return result;
     }
 }

--- a/simulation-api/src/main/java/com/powsybl/simulation/ImpactAnalysisTool.java
+++ b/simulation-api/src/main/java/com/powsybl/simulation/ImpactAnalysisTool.java
@@ -267,6 +267,8 @@ public class ImpactAnalysisTool implements Tool {
                 = runImpactAnalysis(network, contingencyIds, context.getShortTimeExecutionComputationManager(),
                 simulatorFactory, contingenciesProvider, context.getOutputStream());
 
+        network.getStateManager().allowStateMultiThreadAccess(false);
+
         if (securityIndexesPerContingency != null) {
             if (outputCsvFile == null) {
                 prettyPrint(securityIndexesPerContingency, context.getOutputStream());


### PR DESCRIPTION
Fix bug "State not set" when launching parallelized security analysis

- Allow multi thread access before starting the analysis
- Return to mono-thread in order to keep the state index consistent