### PR TITLE
Network reduction

### DIFF
--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -245,6 +245,12 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-reducer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-test</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
@@ -614,6 +614,15 @@ public interface Network extends Container<Network> {
     HvdcLine getHvdcLine(String id);
 
     /**
+     * Get an HVDC line from a converter station
+     * @param converterStation a HVDC converter station
+     * @return the HVDC line or null if not found
+     */
+    default HvdcLine getHvdcLine(HvdcConverterStation converterStation) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
      * Get a builder to create a new HVDC line.
      * @return a builder to create a new HVDC line
      */

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Substation.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Substation.java
@@ -103,4 +103,10 @@ public interface Substation extends Container<Substation> {
      */
     Substation addGeographicalTag(String tag);
 
+    /**
+     * Remove this substation from the network.
+     */
+    default void remove() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -963,6 +963,13 @@ public interface VoltageLevel extends Container<VoltageLevel> {
     int getLccConverterStationCount();
 
     /**
+     * Remove this voltage level from the network.
+     */
+    default void remove() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
      * Visit equipments of the voltage level.
      * @param visitor
      */

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
@@ -9,8 +9,10 @@ package com.powsybl.iidm.network.impl;
 import com.google.common.collect.FluentIterable;
 import com.powsybl.iidm.network.*;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -338,6 +340,28 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     @Override
     protected String getTypeDescription() {
         return "Voltage level";
+    }
+
+    /**
+     * Throw a {@link com.powsybl.commons.PowsyblException} if this voltage level contains at least one {@link Branch} or
+     * one {@link ThreeWindingsTransformer} or one {@link HvdcConverterStation}.
+     */
+    protected void checkRemovability() {
+        Set<ConnectableType> types = EnumSet.of(
+                ConnectableType.LINE,
+                ConnectableType.TWO_WINDINGS_TRANSFORMER,
+                ConnectableType.THREE_WINDINGS_TRANSFORMER);
+
+        for (Connectable connectable : getConnectables()) {
+            ConnectableType type = connectable.getType();
+            if (types.contains(type)) {
+                // Reject lines, 2WT and 3WT
+                throw new AssertionError("The voltage level '" + getId() + "' cannot be removed because of a remaining " + type);
+            } else if ((type == ConnectableType.HVDC_CONVERTER_STATION) && (getNetwork().getHvdcLine((HvdcConverterStation) connectable) != null)) {
+                // Reject all converter stations connected to a HVDC line
+                throw new AssertionError("The voltage level '" + getId() + "' cannot be removed because of a remaining HVDC line");
+            }
+        }
     }
 
     protected abstract Iterable<Terminal> getTerminals();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.network.impl;
 import com.google.common.base.Functions;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.util.Networks;
@@ -827,6 +828,27 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     @Override
     public void allocateVariantArrayElement(int[] indexes, final int sourceIndex) {
         variants.allocate(indexes, () -> variants.copy(sourceIndex));
+    }
+
+    @Override
+    public void remove() {
+        checkRemovability();
+
+        // Remove all connectables
+        List<Connectable> connectables = Lists.newArrayList(getConnectables());
+        for (Connectable connectable : connectables) {
+            connectable.remove();
+        }
+
+        // Remove the topology
+        removeAllSwitches();
+        removeAllBuses();
+
+        // Remove this voltage level from the network
+        getSubstation().remove(this);
+        getNetwork().getObjectStore().remove(this);
+
+        getNetwork().getListeners().notifyRemoval(this);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -577,6 +577,14 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
     }
 
     @Override
+    public HvdcLine getHvdcLine(HvdcConverterStation converterStation) {
+        return getHvdcLineStream()
+                .filter(l -> l.getConverterStation1() == converterStation || l.getConverterStation2() == converterStation)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
     public int getHvdcLineCount() {
         return objectStore.getAll(HvdcLineImpl.class).size();
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -9,10 +9,7 @@ package com.powsybl.iidm.network.impl;
 import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.*;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.util.Colors;
 import com.powsybl.math.graph.*;
@@ -880,7 +877,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
         int node = ((NodeTerminal) terminal).getNode();
 
-        assert node >= 0 && node < graph.getVertexCount();
+        assert node >= 0 && node < graph.getMaxVertex();
         assert graph.getVertexObject(node) == terminal;
 
         graph.setVertexObject(node, null);
@@ -1027,6 +1024,33 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     @Override
     public void allocateVariantArrayElement(int[] indexes, final int sourceIndex) {
         variants.allocate(indexes, VariantImpl::new);
+    }
+
+    @Override
+    public void remove() {
+        checkRemovability();
+
+        // Remove all connectables
+        List<Connectable> connectables = Lists.newArrayList(getConnectables());
+        for (Connectable connectable : connectables) {
+            connectable.remove();
+        }
+
+        // Remove the topology
+        removeAllSwitches();
+
+        getSubstation().remove(this);
+        getNetwork().getObjectStore().remove(this);
+
+        getNetwork().getListeners().notifyRemoval(this);
+    }
+
+    private void removeAllSwitches() {
+        for (SwitchImpl s : graph.getEdgesObject()) {
+            getNetwork().getObjectStore().remove(s);
+        }
+        graph.removeAllEdges();
+        switches.clear();
     }
 
     @Override

--- a/iidm/iidm-reducer/pom.xml
+++ b/iidm/iidm-reducer/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>powsybl-iidm</artifactId>
+        <groupId>com.powsybl</groupId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>powsybl-iidm-reducer</artifactId>
+    <name>IIDM Reducer</name>
+    <description>A network reducer for IIDM model</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.powsybl.iidm.reducer</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Compilation dependencies -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-impl</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-xml-converter</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/AbstractNetworkReducer.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/AbstractNetworkReducer.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public abstract class AbstractNetworkReducer implements NetworkReducer {
+
+    private final NetworkFilter filter;
+
+    public AbstractNetworkReducer(NetworkFilter filter) {
+        this.filter = Objects.requireNonNull(filter);
+    }
+
+    public final void reduce(Network network) {
+        // Remove all unwanted lines
+        List<Line> lines = network.getLineStream()
+                .filter(l -> !filter.accept(l))
+                .collect(Collectors.toList());
+        lines.forEach(this::reduce);
+
+        // Remove all unwanted two windings transformers
+        List<TwoWindingsTransformer> twoWindingsTransformers = network.getTwoWindingsTransformerStream()
+                .filter(t -> !filter.accept(t))
+                .collect(Collectors.toList());
+        twoWindingsTransformers.forEach(this::reduce);
+
+        // Remove all three windings transformers
+        List<ThreeWindingsTransformer> threeWindingsTransformers = network.getThreeWindingsTransformerStream()
+                .filter(t -> !filter.accept(t))
+                .collect(Collectors.toList());
+        threeWindingsTransformers.forEach(this::reduce);
+
+        // Remove all unwanted HVDC lines
+        List<HvdcLine> hvdcLines = network.getHvdcLineStream()
+                .filter(h -> !filter.accept(h))
+                .collect(Collectors.toList());
+        hvdcLines.forEach(this::reduce);
+
+        // Remove all unwanted voltage levels
+        List<VoltageLevel> voltageLevels = network.getVoltageLevelStream()
+                .filter(vl -> !filter.accept(vl))
+                .collect(Collectors.toList());
+        voltageLevels.forEach(this::reduce);
+
+        // Remove all unwanted substations
+        List<Substation> substations = network.getSubstationStream()
+                .filter(s -> !filter.accept(s))
+                .collect(Collectors.toList());
+        substations.forEach(this::reduce);
+    }
+
+    protected final NetworkFilter getFilter() {
+        return filter;
+    }
+
+    protected abstract void reduce(Substation substation);
+
+    protected abstract void reduce(VoltageLevel voltageLevel);
+
+    protected abstract void reduce(Line line);
+
+    protected abstract void reduce(TwoWindingsTransformer transformer);
+
+    protected abstract void reduce(ThreeWindingsTransformer transformer);
+
+    protected abstract void reduce(HvdcLine hvdcLine);
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkFilter.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkFilter.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+/**
+ * A default implementation of {@link NetworkFilter} that keeps everything.
+ *
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class DefaultNetworkFilter implements NetworkFilter {
+
+    @Override
+    public boolean accept(Substation substation) {
+        return true;
+    }
+
+    @Override
+    public boolean accept(VoltageLevel voltageLevel) {
+        return true;
+    }
+
+    @Override
+    public boolean accept(Line line) {
+        return true;
+    }
+
+    @Override
+    public boolean accept(TwoWindingsTransformer transformer) {
+        return true;
+    }
+
+    @Override
+    public boolean accept(ThreeWindingsTransformer transformer) {
+        return true;
+    }
+
+    @Override
+    public boolean accept(HvdcLine hvdcLine) {
+        return true;
+    }
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+import java.util.*;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class DefaultNetworkReducer extends AbstractNetworkReducer {
+
+    private final ReductionOptions options;
+
+    private final List<NetworkReducerObserver> observers = new ArrayList<>();
+
+    public DefaultNetworkReducer(NetworkFilter filter, ReductionOptions options) {
+        this(filter, options, Collections.emptyList());
+    }
+
+    public DefaultNetworkReducer(NetworkFilter filter, ReductionOptions options, NetworkReducerObserver... observers) {
+        this(filter, options, Arrays.asList(observers));
+    }
+
+    public DefaultNetworkReducer(NetworkFilter filter, ReductionOptions options, List<NetworkReducerObserver> observers) {
+        super(filter);
+        this.options = Objects.requireNonNull(options);
+        this.observers.addAll(Objects.requireNonNull(observers));
+    }
+
+    @Override
+    protected void reduce(Substation substation) {
+        substation.remove();
+        observers.forEach(o -> o.substationRemoved(substation));
+    }
+
+    @Override
+    protected void reduce(VoltageLevel voltageLevel) {
+        voltageLevel.remove();
+        observers.forEach(o -> o.voltageLevelRemoved(voltageLevel));
+    }
+
+    @Override
+    protected void reduce(Line line) {
+        Terminal terminal1 = line.getTerminal1();
+        Terminal terminal2 = line.getTerminal2();
+        VoltageLevel vl1 = terminal1.getVoltageLevel();
+        VoltageLevel vl2 = terminal2.getVoltageLevel();
+
+        if (getFilter().accept(vl1)) {
+            reduce(line, vl1, terminal1);
+        } else if (getFilter().accept(vl2)) {
+            reduce(line, vl2, terminal2);
+        } else {
+            line.remove();
+            observers.forEach(o -> o.lineRemoved(line));
+        }
+    }
+
+    @Override
+    protected void reduce(TwoWindingsTransformer transformer) {
+        Terminal terminal1 = transformer.getTerminal1();
+        Terminal terminal2 = transformer.getTerminal2();
+        VoltageLevel vl1 = terminal1.getVoltageLevel();
+        VoltageLevel vl2 = terminal2.getVoltageLevel();
+
+        if (getFilter().accept(vl1)) {
+            replaceTransformerByLoad(transformer, vl1, terminal1);
+        } else if (getFilter().accept(vl2)) {
+            replaceTransformerByLoad(transformer, vl2, terminal2);
+        } else {
+            transformer.remove();
+            observers.forEach(o -> o.transformerRemoved(transformer));
+        }
+    }
+
+    @Override
+    protected void reduce(ThreeWindingsTransformer transformer) {
+        VoltageLevel vl1 = transformer.getLeg1().getTerminal().getVoltageLevel();
+        VoltageLevel vl2 = transformer.getLeg2().getTerminal().getVoltageLevel();
+        VoltageLevel vl3 = transformer.getLeg3().getTerminal().getVoltageLevel();
+        if (getFilter().accept(vl1) || getFilter().accept(vl2) || getFilter().accept(vl3)) {
+            throw new UnsupportedOperationException("Reduction of three-windings transformers is not supported");
+        } else {
+            transformer.remove();
+            observers.forEach(o -> o.transformerRemoved(transformer));
+        }
+    }
+
+    @Override
+    protected void reduce(HvdcLine hvdcLine) {
+        VoltageLevel vl1 = hvdcLine.getConverterStation1().getTerminal().getVoltageLevel();
+        VoltageLevel vl2 = hvdcLine.getConverterStation2().getTerminal().getVoltageLevel();
+        if (getFilter().accept(vl1) || getFilter().accept(vl2)) {
+            throw new UnsupportedOperationException("Reduction of HVDC lines is not supported");
+        } else {
+            hvdcLine.remove();
+            observers.forEach(o -> o.hvdcLineRemoved(hvdcLine));
+        }
+    }
+
+    private void reduce(Line line, VoltageLevel vl, Terminal terminal) {
+        if (options.isWithDanglingLines()) {
+            replaceLineByDanglingLine(line, vl, terminal);
+        } else {
+            replaceLineByLoad(line, vl, terminal);
+        }
+    }
+
+    private void replaceLineByLoad(Line line, VoltageLevel vl, Terminal terminal) {
+        Load load = replaceBranchByLoad(line, vl, terminal);
+        observers.forEach(o -> o.lineReduced(line, load));
+    }
+
+    private void replaceLineByDanglingLine(Line line, VoltageLevel vl, Terminal terminal) {
+        Branch.Side side = line.getSide(terminal);
+
+        DanglingLineAdder dlAdder = vl.newDanglingLine()
+                .setId(line.getId())
+                .setName(line.getName())
+                .setR(line.getR() / 2)
+                .setX(line.getX() / 2)
+                .setB(side == Branch.Side.ONE ? line.getB1() : line.getB2())
+                .setG(side == Branch.Side.ONE ? line.getG1() : line.getG2())
+                .setP0(terminal.getP())
+                .setQ0(terminal.getQ());
+        fillNodeOrBus(dlAdder, terminal);
+
+        line.remove();
+
+        DanglingLine dl = dlAdder.add();
+        dl.getTerminal()
+                .setP(terminal.getP())
+                .setQ(terminal.getQ());
+
+        observers.forEach(o -> o.lineReduced(line, dl));
+    }
+
+    private void replaceTransformerByLoad(TwoWindingsTransformer transformer, VoltageLevel vl, Terminal terminal) {
+        Load load = replaceBranchByLoad(transformer, vl, terminal);
+        observers.forEach(o -> o.transformerReduced(transformer, load));
+    }
+
+    private Load replaceBranchByLoad(Branch<?> branch, VoltageLevel vl, Terminal terminal) {
+        LoadAdder loadAdder = vl.newLoad()
+                .setId(branch.getId())
+                .setName(branch.getName())
+                .setLoadType(LoadType.FICTITIOUS)
+                .setP0(terminal.getP())
+                .setQ0(terminal.getQ());
+        fillNodeOrBus(loadAdder, terminal);
+
+        branch.remove();
+
+        Load load = loadAdder.add();
+        load.getTerminal()
+                .setP(terminal.getP())
+                .setQ(terminal.getQ());
+
+        return load;
+    }
+
+    private static void fillNodeOrBus(InjectionAdder adder, Terminal terminal) {
+        if (terminal.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER) {
+            adder.setNode(terminal.getNodeBreakerView().getNode());
+        } else {
+            adder.setBus(terminal.getBusBreakerView().getBus().getId());
+            adder.setConnectableBus(terminal.getBusBreakerView().getConnectableBus().getId());
+        }
+    }
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducerBuilder.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducerBuilder.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class DefaultNetworkReducerBuilder {
+
+    private NetworkFilter filter;
+
+    private ReductionOptions options = new ReductionOptions();
+
+    private List<NetworkReducerObserver> observers = new ArrayList<>();
+
+    public DefaultNetworkReducerBuilder setNetworkFilter(NetworkFilter filter) {
+        this.filter = Objects.requireNonNull(filter);
+        return this;
+    }
+
+    public DefaultNetworkReducerBuilder setReductionOptions(ReductionOptions options) {
+        this.options = Objects.requireNonNull(options);
+        return this;
+    }
+
+    public DefaultNetworkReducerBuilder setWithDanglingLines(boolean withDanglingLines) {
+        options.setWithDanglingLlines(withDanglingLines);
+        return this;
+    }
+
+    public DefaultNetworkReducerBuilder setObservers(Collection<NetworkReducerObserver> observers) {
+        Objects.requireNonNull(observers);
+        this.observers.clear();
+        this.observers.addAll(observers);
+        return this;
+    }
+
+    public DefaultNetworkReducerBuilder addObserver(NetworkReducerObserver observer) {
+        observers.add(Objects.requireNonNull(observer));
+        return this;
+    }
+
+    public DefaultNetworkReducer build() {
+        return new DefaultNetworkReducer(filter, options, observers);
+    }
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducerObserver.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducerObserver.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class DefaultNetworkReducerObserver implements NetworkReducerObserver {
+
+    @Override
+    public void substationRemoved(Substation substation) {
+        // Nothing to do
+    }
+
+    @Override
+    public void voltageLevelRemoved(VoltageLevel voltageLevel) {
+        // Nothing to do
+    }
+
+    @Override
+    public void lineReduced(Line line, Injection injection) {
+        // Nothing to do
+    }
+
+    @Override
+    public void lineRemoved(Line line) {
+        // Nothing to do
+    }
+
+    @Override
+    public void transformerReduced(TwoWindingsTransformer transformer, Injection injection) {
+        // Nothing to do
+    }
+
+    @Override
+    public void transformerRemoved(TwoWindingsTransformer transformer) {
+        // Nothing to do
+    }
+
+    @Override
+    public void transformerReduced(ThreeWindingsTransformer transformer, Injection injection) {
+        // Nothing to do
+    }
+
+    @Override
+    public void transformerRemoved(ThreeWindingsTransformer transformer) {
+        // Nothing to do
+    }
+
+    @Override
+    public void hvdcLineReduced(HvdcLine hvdcLine, Injection injection) {
+        // Nothing to do
+    }
+
+    @Override
+    public void hvdcLineRemoved(HvdcLine hvdcLine) {
+        // Nothing to do
+    }
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/IdentifierNetworkFilter.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/IdentifierNetworkFilter.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class IdentifierNetworkFilter implements NetworkFilter {
+
+    private final Set<String> ids = new HashSet<>();
+
+    public IdentifierNetworkFilter(Collection<String> ids) {
+        Objects.requireNonNull(ids);
+
+        this.ids.addAll(ids);
+    }
+
+    /**
+     * Keep this substation if the IDs list contains the ID of this substation or one of its voltage levels.
+     * @param substation The substation to test
+     * @return true if the IDs list contains the ID of this substation or one of its voltage levels, false otherwise
+     */
+    @Override
+    public boolean accept(Substation substation) {
+        Objects.requireNonNull(substation);
+        if (ids.contains(substation.getId())) {
+            return true;
+        }
+
+        return substation.getVoltageLevelStream()
+                .map(VoltageLevel::getId)
+                .anyMatch(ids::contains);
+    }
+
+    /**
+     * Keep this voltage level if the IDs list contains the ID of this voltage level.
+     * @param voltageLevel The voltage level to test
+     * @return true if the IDs list contains the ID of this voltage level, false otherwise
+     */
+    @Override
+    public boolean accept(VoltageLevel voltageLevel) {
+        Objects.requireNonNull(voltageLevel);
+        return ids.contains(voltageLevel.getId()) || ids.contains(voltageLevel.getSubstation().getId());
+    }
+
+    @Override
+    public boolean accept(Line line) {
+        Objects.requireNonNull(line);
+        return accept(line.getTerminal1().getVoltageLevel()) &&
+                accept(line.getTerminal2().getVoltageLevel());
+    }
+
+    @Override
+    public boolean accept(TwoWindingsTransformer transformer) {
+        Objects.requireNonNull(transformer);
+        return accept(transformer.getTerminal1().getVoltageLevel()) &&
+                accept(transformer.getTerminal2().getVoltageLevel());
+    }
+
+    @Override
+    public boolean accept(ThreeWindingsTransformer transformer) {
+        Objects.requireNonNull(transformer);
+        return accept(transformer.getLeg1().getTerminal().getVoltageLevel()) &&
+                accept(transformer.getLeg2().getTerminal().getVoltageLevel()) &&
+                accept(transformer.getLeg3().getTerminal().getVoltageLevel());
+    }
+
+    @Override
+    public boolean accept(HvdcLine hvdcLine) {
+        Objects.requireNonNull(hvdcLine);
+        return accept(hvdcLine.getConverterStation1().getTerminal().getVoltageLevel()) &&
+                accept(hvdcLine.getConverterStation2().getTerminal().getVoltageLevel());
+    }
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NetworkFilter.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NetworkFilter.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public interface NetworkFilter {
+
+    /**
+     * Return true if the given {@link Substation} should be kept in the network, false otherwise
+     */
+    boolean accept(Substation substation);
+
+    /**
+     * Return true if the given {@link VoltageLevel} should be kept in the network, false otherwise
+     */
+    boolean accept(VoltageLevel voltageLevel);
+
+    /**
+     * Return true if the given {@link Line} should be kept in the network, false otherwise
+     */
+    boolean accept(Line line);
+
+    /**
+     * Return true if the given {@link TwoWindingsTransformer} should be kept in the network, false otherwise
+     */
+    boolean accept(TwoWindingsTransformer transformer);
+
+    /**
+     * Return true if the given {@link ThreeWindingsTransformer} should be kept in the network, false otherwise
+     */
+    boolean accept(ThreeWindingsTransformer transformer);
+
+    /**
+     * Return true if the given {@link HvdcLine} should be kept in the network, false otherwise
+     */
+    boolean accept(HvdcLine hvdcLine);
+
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NetworkReducer.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NetworkReducer.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.Network;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public interface NetworkReducer {
+
+    void reduce(Network network);
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NetworkReducerObserver.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NetworkReducerObserver.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public interface NetworkReducerObserver {
+
+    void substationRemoved(Substation substation);
+
+    void voltageLevelRemoved(VoltageLevel voltageLevel);
+
+    void lineReduced(Line line, Injection injection);
+
+    void lineRemoved(Line line);
+
+    void transformerReduced(TwoWindingsTransformer transformer, Injection injection);
+
+    void transformerRemoved(TwoWindingsTransformer transformer);
+
+    void transformerReduced(ThreeWindingsTransformer transformer, Injection injection);
+
+    void transformerRemoved(ThreeWindingsTransformer transformer);
+
+    void hvdcLineReduced(HvdcLine hvdcLine, Injection injection);
+
+    void hvdcLineRemoved(HvdcLine hvdcLine);
+
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NominalVoltageNetworkFilter.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NominalVoltageNetworkFilter.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+import java.util.Objects;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class NominalVoltageNetworkFilter implements NetworkFilter {
+
+    private final double minNominalVoltage;
+
+    private final double maxNominalVoltage;
+
+    public NominalVoltageNetworkFilter(double minNominalVoltage, double maxNominalVoltage) {
+        this.minNominalVoltage = Double.max(0, minNominalVoltage);
+        this.maxNominalVoltage = Double.max(this.minNominalVoltage, maxNominalVoltage);
+    }
+
+    @Override
+    public boolean accept(Substation substation) {
+        Objects.requireNonNull(substation);
+        return substation.getVoltageLevelStream()
+                .anyMatch(this::accept);
+    }
+
+    @Override
+    public boolean accept(VoltageLevel voltageLevel) {
+        Objects.requireNonNull(voltageLevel);
+        return voltageLevel.getNominalV() >= minNominalVoltage && voltageLevel.getNominalV() <= maxNominalVoltage;
+    }
+
+    @Override
+    public boolean accept(Line line) {
+        return accept((Branch) line);
+    }
+
+    @Override
+    public boolean accept(TwoWindingsTransformer transformer) {
+        return accept((Branch) transformer);
+    }
+
+    private boolean accept(Branch<?> branch) {
+        Objects.requireNonNull(branch);
+        VoltageLevel vl1 = branch.getTerminal1().getVoltageLevel();
+        VoltageLevel vl2 = branch.getTerminal2().getVoltageLevel();
+
+        return accept(vl1) && accept(vl2);
+    }
+
+    @Override
+    public boolean accept(ThreeWindingsTransformer transformer) {
+        Objects.requireNonNull(transformer);
+        VoltageLevel vl1 = transformer.getLeg1().getTerminal().getVoltageLevel();
+        VoltageLevel vl2 = transformer.getLeg2().getTerminal().getVoltageLevel();
+        VoltageLevel vl3 = transformer.getLeg3().getTerminal().getVoltageLevel();
+
+        return accept(vl1) && accept(vl2) && accept(vl3);
+    }
+
+    @Override
+    public boolean accept(HvdcLine hvdcLine) {
+        Objects.requireNonNull(hvdcLine);
+        VoltageLevel vl1 = hvdcLine.getConverterStation1().getTerminal().getVoltageLevel();
+        VoltageLevel vl2 = hvdcLine.getConverterStation2().getTerminal().getVoltageLevel();
+
+        return accept(vl1) && accept(vl2);
+    }
+}

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/ReductionOptions.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/ReductionOptions.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class ReductionOptions {
+
+    private boolean withDanglingLines = false;
+
+    boolean isWithDanglingLines() {
+        return withDanglingLines;
+    }
+
+    ReductionOptions setWithDanglingLlines(boolean withDanglingLines) {
+        this.withDanglingLines = withDanglingLines;
+        return this;
+    }
+
+}

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkFilterTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkFilterTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.HvdcTestNetwork;
+import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class DefaultNetworkFilterTest {
+
+    private final NetworkFilter filter = new DefaultNetworkFilter();
+
+    @Test
+    public void testDefault() {
+        Network network = EurostagTutorialExample1Factory.create();
+        assertTrue(network.getSubstationStream().allMatch(filter::accept));
+        assertTrue(network.getVoltageLevelStream().allMatch(filter::accept));
+        assertTrue(network.getLineStream().allMatch(filter::accept));
+        assertTrue(network.getTwoWindingsTransformerStream().allMatch(filter::accept));
+
+    }
+
+    @Test
+    public void testHvdc() {
+        Network network = HvdcTestNetwork.createVsc();
+        assertTrue(network.getHvdcLineStream().allMatch(filter::accept));
+    }
+
+    @Test
+    public void test3WT() {
+        Network network = ThreeWindingsTransformerNetworkFactory.create();
+        assertTrue(network.getThreeWindingsTransformerStream().allMatch(filter::accept));
+    }
+}

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.config.InMemoryPlatformConfig;
+import com.powsybl.commons.config.PlatformConfig;
+import com.powsybl.commons.datasource.ReadOnlyDataSource;
+import com.powsybl.commons.datasource.ResourceDataSource;
+import com.powsybl.commons.datasource.ResourceSet;
+import com.powsybl.iidm.network.DanglingLine;
+import com.powsybl.iidm.network.Load;
+import com.powsybl.iidm.network.LoadType;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.HvdcTestNetwork;
+import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import com.powsybl.iidm.xml.XMLImporter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class DefaultNetworkReducerTest {
+
+    private FileSystem fileSystem;
+
+    private PlatformConfig platformConfig;
+
+    private ReadOnlyDataSource dataSource;
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
+        platformConfig = new InMemoryPlatformConfig(fileSystem);
+
+        dataSource = new ResourceDataSource("eurostag-tutorial1-lf", new ResourceSet("/", "eurostag-tutorial1-lf.xml"));
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        fileSystem.close();
+    }
+
+    @Test
+    public void testLoad() {
+        Network network = new XMLImporter(platformConfig).importData(dataSource, new Properties());
+
+        NetworkReducerObserverImpl observer = new NetworkReducerObserverImpl();
+
+        NetworkReducer reducer = new DefaultNetworkReducerBuilder()
+                .setNetworkFilter(new IdentifierNetworkFilter(Collections.singleton("P1")))
+                .addObserver(observer)
+                .build();
+        reducer.reduce(network);
+
+        assertEquals(1, network.getSubstationCount());
+        assertEquals(2, network.getVoltageLevelCount());
+        assertEquals(1, network.getTwoWindingsTransformerCount());
+        assertEquals(0, network.getLineCount());
+        assertEquals(1, network.getGeneratorCount());
+        assertEquals(2, network.getLoadCount());
+        assertEquals(0, network.getDanglingLineCount());
+
+        Load load1 = network.getLoad("NHV1_NHV2_1");
+        assertNotNull(load1);
+        assertEquals(LoadType.FICTITIOUS, load1.getLoadType());
+        assertEquals(302.4440612792969, load1.getP0(), 0.0);
+        assertEquals(98.74027252197266, load1.getQ0(), 0.0);
+        assertEquals(302.4440612792969, load1.getTerminal().getP(), 0.0);
+        assertEquals(98.74027252197266, load1.getTerminal().getQ(), 0.0);
+
+        Load load2 = network.getLoad("NHV1_NHV2_2");
+        assertNotNull(load2);
+        assertEquals(LoadType.FICTITIOUS, load2.getLoadType());
+        assertEquals(302.4440612792969, load2.getP0(), 0.0);
+        assertEquals(98.74027252197266, load2.getQ0(), 0.0);
+        assertEquals(302.4440612792969, load2.getTerminal().getP(), 0.0);
+        assertEquals(98.74027252197266, load2.getTerminal().getQ(), 0.0);
+
+        assertEquals(1, observer.getSubstationRemovedCount());
+        assertEquals(2, observer.getVoltageLevelRemovedCount());
+        assertEquals(2, observer.getLineReducedCount());
+        assertEquals(0, observer.getLineRemovedCount());
+        assertEquals(0, observer.getTwoWindingsTransformerReducedCount());
+        assertEquals(1, observer.getTwoWindingsTransformerRemovedCount());
+        assertEquals(0, observer.getThreeWindingsTransformerReducedCount());
+        assertEquals(0, observer.getThreeWindingsTransformerRemovedCount());
+        assertEquals(0, observer.getHvdcLineReducedCount());
+        assertEquals(0, observer.getHvdcLineRemovedCount());
+    }
+
+    @Test
+    public void testLoad2() {
+        Network network = new XMLImporter(platformConfig).importData(dataSource, new Properties());
+
+        NetworkReducerObserverImpl observer = new NetworkReducerObserverImpl();
+
+        NetworkReducer reducer = new DefaultNetworkReducerBuilder()
+                .setNetworkFilter(new NominalVoltageNetworkFilter(225.0, 400.0))
+                .addObserver(observer)
+                .build();
+        reducer.reduce(network);
+
+        assertEquals(2, network.getSubstationCount());
+        assertEquals(2, network.getVoltageLevelCount());
+        assertEquals(0, network.getTwoWindingsTransformerCount());
+        assertEquals(2, network.getLineCount());
+        assertEquals(0, network.getGeneratorCount());
+        assertEquals(2, network.getLoadCount());
+        assertEquals(0, network.getDanglingLineCount());
+
+        Load load1 = network.getLoad("NGEN_NHV1");
+        assertNotNull(load1);
+        assertEquals(LoadType.FICTITIOUS, load1.getLoadType());
+        assertEquals(-604.8909301757812, load1.getP0(), 0.0);
+        assertEquals(-197.48046875, load1.getQ0(), 0.0);
+        assertEquals(-604.8909301757812, load1.getTerminal().getP(), 0.0);
+        assertEquals(-197.48046875, load1.getTerminal().getQ(), 0.0);
+
+        Load load2 = network.getLoad("NHV2_NLOAD");
+        assertNotNull(load2);
+        assertEquals(LoadType.FICTITIOUS, load2.getLoadType());
+        assertEquals(600.8677978515625, load2.getP0(), 0.0);
+        assertEquals(274.3769836425781, load2.getQ0(), 0.0);
+        assertEquals(600.8677978515625, load2.getTerminal().getP(), 0.0);
+        assertEquals(274.3769836425781, load2.getTerminal().getQ(), 0.0);
+
+        assertEquals(0, observer.getSubstationRemovedCount());
+        assertEquals(2, observer.getVoltageLevelRemovedCount());
+        assertEquals(0, observer.getLineReducedCount());
+        assertEquals(0, observer.getLineRemovedCount());
+        assertEquals(2, observer.getTwoWindingsTransformerReducedCount());
+        assertEquals(0, observer.getTwoWindingsTransformerRemovedCount());
+        assertEquals(0, observer.getThreeWindingsTransformerReducedCount());
+        assertEquals(0, observer.getThreeWindingsTransformerRemovedCount());
+        assertEquals(0, observer.getHvdcLineReducedCount());
+        assertEquals(0, observer.getHvdcLineRemovedCount());
+    }
+
+    @Test
+    public void testDanglingLine() {
+        Network network = new XMLImporter(platformConfig).importData(dataSource, new Properties());
+
+        NetworkReducer reducer = new DefaultNetworkReducerBuilder()
+                .setNetworkFilter(new IdentifierNetworkFilter(Collections.singleton("P2")))
+                .setWithDanglingLines(true)
+                .build();
+
+        reducer.reduce(network);
+
+        assertEquals(1, network.getSubstationCount());
+        assertEquals(2, network.getVoltageLevelCount());
+        assertEquals(1, network.getTwoWindingsTransformerCount());
+        assertEquals(0, network.getLineCount());
+        assertEquals(0, network.getGeneratorCount());
+        assertEquals(1, network.getLoadCount());
+        assertEquals(2, network.getDanglingLineCount());
+
+        DanglingLine dl1 = network.getDanglingLine("NHV1_NHV2_1");
+        assertNotNull(dl1);
+        assertEquals(1.5, dl1.getR(), 0.0);
+        assertEquals(16.5, dl1.getX(), 0.0);
+        assertEquals(0.0, dl1.getG(), 0.0);
+        assertEquals(1.93e-4, dl1.getB(), 0.0);
+        assertEquals(-300.43389892578125, dl1.getP0(), 0.0);
+        assertEquals(-137.18849182128906, dl1.getQ0(), 0.0);
+        assertEquals(-300.43389892578125, dl1.getTerminal().getP(), 0.0);
+        assertEquals(-137.18849182128906, dl1.getTerminal().getQ(), 0.0);
+
+        DanglingLine dl2 = network.getDanglingLine("NHV1_NHV2_2");
+        assertNotNull(dl2);
+        assertEquals(1.5, dl2.getR(), 0.0);
+        assertEquals(16.5, dl2.getX(), 0.0);
+        assertEquals(0.0, dl2.getG(), 0.0);
+        assertEquals(1.93e-4, dl2.getB(), 0.0);
+        assertEquals(-300.43389892578125, dl2.getP0(), 0.0);
+        assertEquals(-137.18849182128906, dl2.getQ0(), 0.0);
+        assertEquals(-300.43389892578125, dl2.getTerminal().getP(), 0.0);
+        assertEquals(-137.18849182128906, dl2.getTerminal().getQ(), 0.0);
+    }
+
+    @Test
+    public void testHvdc() {
+        Network network = HvdcTestNetwork.createLcc();
+        assertEquals(1, network.getHvdcLineCount());
+
+        NetworkReducerObserverImpl observer = new NetworkReducerObserverImpl();
+
+        // Keeping both end of the HVDC is OK
+        NetworkReducer reducer = new DefaultNetworkReducerBuilder()
+                .setNetworkFilter(new IdentifierNetworkFilter(Arrays.asList("VL1", "VL2")))
+                .addObserver(observer)
+                .build();
+        reducer.reduce(network);
+        assertEquals(1, network.getHvdcLineCount());
+
+        assertEquals(0, observer.getHvdcLineReducedCount());
+        assertEquals(0, observer.getHvdcLineRemovedCount());
+
+        // Keeping none of the ends of the HVDC is OK
+        reducer = new DefaultNetworkReducerBuilder()
+                .setNetworkFilter(new IdentifierNetworkFilter(Collections.emptyList()))
+                .setObservers(Collections.singleton(observer))
+                .build();
+        reducer.reduce(network);
+        assertEquals(0, network.getHvdcLineCount());
+
+        assertEquals(0, observer.getHvdcLineReducedCount());
+        assertEquals(1, observer.getHvdcLineRemovedCount());
+    }
+
+    @Test
+    public void testHvdcFailure() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage("Reduction of HVDC lines is not supported");
+
+        Network network = HvdcTestNetwork.createLcc();
+        NetworkReducer reducer = new DefaultNetworkReducerBuilder()
+                    .setNetworkFilter(new IdentifierNetworkFilter(Collections.singleton("VL1")))
+                    .setReductionOptions(new ReductionOptions())
+                    .build();
+        reducer.reduce(network);
+    }
+
+    @Test
+    public void test3WT() {
+        Network network = ThreeWindingsTransformerNetworkFactory.create();
+        assertEquals(1, network.getThreeWindingsTransformerCount());
+
+        NetworkReducerObserverImpl observer = new NetworkReducerObserverImpl();
+
+        // Keeping all the ends of the 3WT is OK
+        NetworkReducer reducer = new DefaultNetworkReducerBuilder()
+                .setNetworkFilter(new IdentifierNetworkFilter(Arrays.asList("VL_132", "VL_33", "VL_11")))
+                .addObserver(observer)
+                .build();
+        reducer.reduce(network);
+        assertEquals(1, network.getThreeWindingsTransformerCount());
+
+        assertEquals(0, observer.getThreeWindingsTransformerReducedCount());
+        assertEquals(0, observer.getThreeWindingsTransformerRemovedCount());
+
+        // Keeping none of the ends of the 3WT is OK
+        reducer = new DefaultNetworkReducerBuilder()
+                .setNetworkFilter(new IdentifierNetworkFilter(Collections.emptyList()))
+                .setObservers(Collections.singleton(observer))
+                .build();
+        reducer.reduce(network);
+        assertEquals(0, network.getThreeWindingsTransformerCount());
+
+        assertEquals(0, observer.getThreeWindingsTransformerReducedCount());
+        assertEquals(1, observer.getThreeWindingsTransformerRemovedCount());
+    }
+
+    @Test
+    public void test3WTFailure() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage("Reduction of three-windings transformers is not supported");
+
+        Network network = ThreeWindingsTransformerNetworkFactory.create();
+        NetworkReducer reducer = new DefaultNetworkReducerBuilder()
+                .setNetworkFilter(new IdentifierNetworkFilter(Arrays.asList("VL_132", "VL_11")))
+                .setReductionOptions(new ReductionOptions())
+                .build();
+        reducer.reduce(network);
+    }
+}

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/EurostagNetworkFilter.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/EurostagNetworkFilter.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+class EurostagNetworkFilter implements NetworkFilter {
+
+    @Override
+    public boolean accept(Substation substation) {
+        return substation.getId().equals("P1");
+    }
+
+    @Override
+    public boolean accept(VoltageLevel voltageLevel) {
+        return true;
+    }
+
+    @Override
+    public boolean accept(Line line) {
+        return false;
+    }
+
+    @Override
+    public boolean accept(TwoWindingsTransformer transformer) {
+        return true;
+    }
+
+    @Override
+    public boolean accept(ThreeWindingsTransformer transformer) {
+        return true;
+    }
+
+    @Override
+    public boolean accept(HvdcLine hvdcLine) {
+        return true;
+    }
+}

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/IdentifierNetworkFilterTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/IdentifierNetworkFilterTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.HvdcTestNetwork;
+import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class IdentifierNetworkFilterTest {
+
+    @Test
+    public void test() {
+        Network network = EurostagTutorialExample1Factory.create();
+
+        NetworkFilter filter = new IdentifierNetworkFilter(Collections.singleton("P2"));
+        assertFalse(filter.accept(network.getSubstation("P1")));
+        assertFalse(filter.accept(network.getVoltageLevel("VLGEN")));
+        assertFalse(filter.accept(network.getVoltageLevel("VLHV1")));
+        assertFalse(filter.accept(network.getTwoWindingsTransformer("NGEN_NHV1")));
+
+        assertTrue(filter.accept(network.getSubstation("P2")));
+        assertTrue(filter.accept(network.getVoltageLevel("VLLOAD")));
+        assertTrue(filter.accept(network.getVoltageLevel("VLHV2")));
+        assertTrue(filter.accept(network.getTwoWindingsTransformer("NHV2_NLOAD")));
+
+        assertFalse(filter.accept(network.getLine("NHV1_NHV2_1")));
+        assertFalse(filter.accept(network.getLine("NHV1_NHV2_2")));
+    }
+
+    @Test
+    public void testHvdc() {
+        Network network = HvdcTestNetwork.createLcc();
+
+        NetworkFilter filter1 = new IdentifierNetworkFilter(Arrays.asList("VL1", "VL2"));
+        NetworkFilter filter2 = new IdentifierNetworkFilter(Collections.singleton("VL1"));
+
+        assertTrue(filter1.accept(network.getHvdcLine("L")));
+        assertFalse(filter2.accept(network.getHvdcLine("L")));
+    }
+
+    @Test
+    public void test3WT() {
+        Network network = ThreeWindingsTransformerNetworkFactory.create();
+
+        NetworkFilter filter1 = new IdentifierNetworkFilter(Arrays.asList("VL_132", "VL_33", "VL_11"));
+        NetworkFilter filter2 = new IdentifierNetworkFilter(Arrays.asList("VL_132", "VL_33"));
+
+        assertTrue(filter1.accept(network.getThreeWindingsTransformer("3WT")));
+        assertFalse(filter2.accept(network.getThreeWindingsTransformer("3WT")));
+    }
+}

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/NetworkReducerObserverImpl.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/NetworkReducerObserverImpl.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.*;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class NetworkReducerObserverImpl extends DefaultNetworkReducerObserver {
+
+    private int substationRemovedCount = 0;
+
+    private int voltageLevelRemovedCount = 0;
+
+    private int lineRemovedCount = 0;
+
+    private int lineReducedCount = 0;
+
+    private int twoWindingsTransformerRemovedCount = 0;
+
+    private int twoWindingsTransformerReducedCount = 0;
+
+    private int threeWindingsTransformerRemovedCount = 0;
+
+    private int threeWindingsTransformerReducedCount = 0;
+
+    private int hvdcLineRemovedCount = 0;
+
+    private int hvdcLineReducedCount = 0;
+
+    int getSubstationRemovedCount() {
+        return substationRemovedCount;
+    }
+
+    int getVoltageLevelRemovedCount() {
+        return voltageLevelRemovedCount;
+    }
+
+    int getLineRemovedCount() {
+        return lineRemovedCount;
+    }
+
+    int getLineReducedCount() {
+        return lineReducedCount;
+    }
+
+    int getTwoWindingsTransformerRemovedCount() {
+        return twoWindingsTransformerRemovedCount;
+    }
+
+    int getTwoWindingsTransformerReducedCount() {
+        return twoWindingsTransformerReducedCount;
+    }
+
+    int getThreeWindingsTransformerRemovedCount() {
+        return threeWindingsTransformerRemovedCount;
+    }
+
+    int getThreeWindingsTransformerReducedCount() {
+        return threeWindingsTransformerReducedCount;
+    }
+
+    int getHvdcLineRemovedCount() {
+        return hvdcLineRemovedCount;
+    }
+
+    int getHvdcLineReducedCount() {
+        return hvdcLineReducedCount;
+    }
+
+    @Override
+    public void substationRemoved(Substation substation) {
+        super.substationRemoved(substation);
+
+        substationRemovedCount++;
+    }
+
+    @Override
+    public void voltageLevelRemoved(VoltageLevel voltageLevel) {
+        super.voltageLevelRemoved(voltageLevel);
+
+        voltageLevelRemovedCount++;
+    }
+
+    @Override
+    public void lineReduced(Line line, Injection injection) {
+        super.lineReduced(line, injection);
+
+        lineReducedCount++;
+    }
+
+    @Override
+    public void lineRemoved(Line line) {
+        super.lineRemoved(line);
+
+        lineRemovedCount++;
+    }
+
+    @Override
+    public void transformerReduced(TwoWindingsTransformer transformer, Injection injection) {
+        super.transformerReduced(transformer, injection);
+
+        twoWindingsTransformerReducedCount++;
+    }
+
+    @Override
+    public void transformerRemoved(TwoWindingsTransformer transformer) {
+        super.transformerRemoved(transformer);
+
+        twoWindingsTransformerRemovedCount++;
+    }
+
+    @Override
+    public void transformerReduced(ThreeWindingsTransformer transformer, Injection injection) {
+        super.transformerReduced(transformer, injection);
+
+        threeWindingsTransformerReducedCount++;
+    }
+
+    @Override
+    public void transformerRemoved(ThreeWindingsTransformer transformer) {
+        super.transformerRemoved(transformer);
+
+        threeWindingsTransformerRemovedCount++;
+    }
+
+    @Override
+    public void hvdcLineReduced(HvdcLine hvdcLine, Injection injection) {
+        super.hvdcLineReduced(hvdcLine, injection);
+
+        hvdcLineReducedCount++;
+    }
+
+    @Override
+    public void hvdcLineRemoved(HvdcLine hvdcLine) {
+        super.hvdcLineRemoved(hvdcLine);
+
+        hvdcLineRemovedCount++;
+    }
+
+}

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/NominalVoltageNetworkFilterTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/NominalVoltageNetworkFilterTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.HvdcTestNetwork;
+import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class NominalVoltageNetworkFilterTest {
+
+    @Test
+    public void testVHV() {
+        NetworkFilter filter = new NominalVoltageNetworkFilter(200.0, 400.0);
+
+        Network network = EurostagTutorialExample1Factory.create();
+        assertEquals(2, network.getSubstationStream().filter(filter::accept).count());
+        assertEquals(2, network.getVoltageLevelStream().filter(filter::accept).count());
+        assertEquals(2, network.getLineStream().filter(filter::accept).count());
+        assertEquals(0, network.getTwoWindingsTransformerStream().filter(filter::accept).count());
+    }
+
+    @Test
+    public void testHvdc() {
+        NetworkFilter filter1 = new NominalVoltageNetworkFilter(380.0, 420.0);
+        NetworkFilter filter2 = new NominalVoltageNetworkFilter(0.0, 100.0);
+
+        Network network = HvdcTestNetwork.createLcc();
+        assertTrue(filter1.accept(network.getHvdcLine("L")));
+        assertFalse(filter2.accept(network.getHvdcLine("L")));
+
+        network = HvdcTestNetwork.createVsc();
+        assertTrue(filter1.accept(network.getHvdcLine("L")));
+        assertFalse(filter2.accept(network.getHvdcLine("L")));
+    }
+
+    @Test
+    public void test3WT() {
+        NetworkFilter filter1 = new NominalVoltageNetworkFilter(0.0, 400.0);
+        NetworkFilter filter2 = new NominalVoltageNetworkFilter(120.0, 400.0);
+
+        Network network = ThreeWindingsTransformerNetworkFactory.create();
+        assertTrue(filter1.accept(network.getThreeWindingsTransformer("3WT")));
+        assertFalse(filter2.accept(network.getThreeWindingsTransformer("3WT")));
+    }
+}

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/ReductionOptionsTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/ReductionOptionsTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ */
+public class ReductionOptionsTest {
+
+    @Test
+    public void test() {
+        ReductionOptions options = new ReductionOptions();
+        assertFalse(options.isWithDanglingLines());
+
+        options.setWithDanglingLlines(true);
+        assertTrue(options.isWithDanglingLines());
+    }
+}

--- a/iidm/iidm-reducer/src/test/resources/eurostag-tutorial1-lf.xml
+++ b/iidm/iidm-reducer/src/test/resources/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.2665846" x="11.104493" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04725" x="4.0497246" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.1507666"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/iidm/pom.xml
+++ b/iidm/pom.xml
@@ -27,6 +27,7 @@
         <module>iidm-api</module>
         <module>iidm-converter-api</module>
         <module>iidm-impl</module>
+        <module>iidm-reducer</module>
         <module>iidm-test</module>
         <module>iidm-util</module>
         <module>iidm-xml-converter</module>


### PR DESCRIPTION
- IIDM API improvements to remove voltage levels, substations and HVDC lines
- Add powsybl-iidm-reducer module
    - NetworkFilter: select the identifiables to keep by ID or by nominal voltage range
    - NetworkReducer: replace branches or two-windings transformer by loads or dangling lines
    - NetworkReducerObserver: be notified if an identifiable is removed or replaced