### PR TITLE
return a LinkedHashSet from method getDependencies

### DIFF
--- a/afs/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
+++ b/afs/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
@@ -680,7 +680,7 @@ public class MapDbAppStorage implements AppStorage {
         if (dependencyNodes == null) {
             return Collections.emptySet();
         }
-        return dependencyNodes.stream().map(this::getNodeInfo).collect(Collectors.toSet());
+        return new LinkedHashSet<>(dependencyNodes.stream().map(this::getNodeInfo).collect(Collectors.toSet()));
     }
 
     @Override

--- a/afs/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
+++ b/afs/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
@@ -680,7 +680,7 @@ public class MapDbAppStorage implements AppStorage {
         if (dependencyNodes == null) {
             return Collections.emptySet();
         }
-        return new LinkedHashSet<>(dependencyNodes.stream().map(this::getNodeInfo).collect(Collectors.toSet()));
+        return dependencyNodes.stream().map(this::getNodeInfo).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @Override


### PR DESCRIPTION
to return an ordered list from getDependencies() method we use a LinkedHashSet instead of HashSet