### PR TITLE
distribution-core/pom.xml: cleanup duplicate dependency

### DIFF
--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -251,12 +251,6 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>powsybl-iidm-reducer</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-test</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
Added by mistake in 2de6618ccd and 0778ac6596.
maven logs:
	[WARNING] Some problems were encountered while building the effective model for com.powsybl:powsybl-distribution-core:pom:2.4.0-SNAPSHOT
	[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: ${project.groupId}:powsybl-iidm-reducer:jar -> duplicate declaration of version ${project.version} @ com.powsybl:powsybl-distribution-core:[unknown-version], /home/harperjon/powsybl/powsybl-core/distribution-core/pom.xml, line 252, column 21