### PR TITLE
pom.xml: fix builds when git is not in path. fixes #596

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,7 @@
                     <configuration>
                         <doCheck>false</doCheck>
                         <doUpdate>false</doUpdate>
+                        <revisionOnScmFailure>UNKNOWN_BUILD</revisionOnScmFailure>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
* The behavior with a normal setup (a real git checkout, and having git in the path) doesn't change.
* The behavior with a zip source export and having git in path changes
Before:
	```super("powsybl-core", "2.4.0-SNAPSHOT", "${buildNumber}", "UNKNOWN_BRANCH", Long.parseLong("1549457054776"));```
After:
	```super("powsybl-core", "2.4.0-SNAPSHOT", "UNKNOWN_BUILD", "UNKNOWN_BRANCH", Long.parseLong("1549457164750"));```
* The behavior without git in path goes from a build error to the same output as using a zip export and having git in the path.

Documentation: http://www.mojohaus.org/buildnumber-maven-plugin/create-mojo.html#revisionOnScmFailure