### PR TITLE
substation id may be null 

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/SubstationIdMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/SubstationIdMapping.java
@@ -109,7 +109,9 @@ public class SubstationIdMapping {
             String node = context.nodeBreaker() ? t.connectivityNode() : t.topologicalNode();
             if (node != null && !context.boundary().containsNode(node)) {
                 String sid = context.cgmes().substation(t);
-                substationsIds.add(context.namingStrategy().getId(CgmesNames.SUBSTATION, sid));
+                if (sid != null) {
+                    substationsIds.add(context.namingStrategy().getId(CgmesNames.SUBSTATION, sid));
+                }
             }
         }
         return substationsIds;


### PR DESCRIPTION
if terminal node is in the boundary and the boundary has not been loaded