### PR TITLE
Regulartimeseries pointcount

### DIFF
--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
@@ -45,6 +45,10 @@ public class RegularTimeSeriesIndex extends AbstractTimeSeriesIndex {
         if (spacing > endTime - startTime) {
             throw new IllegalArgumentException("Spacing " + spacing + " is longer than interval " + (endTime - startTime));
         }
+        long computedPointCount = computePointCount(startTime, endTime, spacing);
+        if (computedPointCount > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Point Count " + computedPointCount + " is bigger than max allowed value " + Integer.MAX_VALUE);
+        }
         this.startTime = startTime;
         this.endTime = endTime;
         this.spacing = spacing;
@@ -110,9 +114,13 @@ public class RegularTimeSeriesIndex extends AbstractTimeSeriesIndex {
         return spacing;
     }
 
+    private long computePointCount(long startTime, long endTime, long spacing) {
+        return Math.round(((double) (endTime - startTime)) / spacing) + 1;
+    }
+
     @Override
     public int getPointCount() {
-        return (int) Math.round(((double) (endTime - startTime)) / spacing) + 1;
+        return (int) computePointCount();
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
@@ -123,7 +123,7 @@ public class RegularTimeSeriesIndex extends AbstractTimeSeriesIndex {
         return spacing;
     }
 
-    private long computePointCount(long startTime, long endTime, long spacing) {
+    private static long computePointCount(long startTime, long endTime, long spacing) {
         return Math.round(((double) (endTime - startTime)) / spacing) + 1;
     }
 

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
@@ -112,7 +112,7 @@ public class RegularTimeSeriesIndex extends AbstractTimeSeriesIndex {
 
     @Override
     public int getPointCount() {
-        return Math.round(((float) (endTime - startTime)) / spacing) + 1;
+        return (int) Math.round(((double) (endTime - startTime)) / spacing) + 1;
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
@@ -32,6 +32,14 @@ public class RegularTimeSeriesIndex extends AbstractTimeSeriesIndex {
 
     private final long spacing; // in ms
 
+    // computed from the previous fields; startTime and endTime are inclusive,
+    // with rounding to have easier interactions with calendar dates (the
+    // number of milliseconds in a calendar date is not fixed, because of leap
+    // seconds, daylight saving time, and leap years), so if we didn't round
+    // and took the floor or the ceiling, it would give surprising results
+    // between 2 calendar dates.
+    private final int pointCount;
+
     public RegularTimeSeriesIndex(long startTime, long endTime, long spacing) {
         if (startTime < 0) {
             throw new IllegalArgumentException("Bad start time value " + startTime);
@@ -52,6 +60,7 @@ public class RegularTimeSeriesIndex extends AbstractTimeSeriesIndex {
         this.startTime = startTime;
         this.endTime = endTime;
         this.spacing = spacing;
+        this.pointCount = (int) computedPointCount;
     }
 
     public static RegularTimeSeriesIndex create(Instant start, Instant end, Duration spacing) {
@@ -120,7 +129,7 @@ public class RegularTimeSeriesIndex extends AbstractTimeSeriesIndex {
 
     @Override
     public int getPointCount() {
-        return (int) computePointCount();
+        return pointCount;
     }
 
     @Override

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/RegularTimeSeriesIndexTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/RegularTimeSeriesIndexTest.java
@@ -106,4 +106,12 @@ public class RegularTimeSeriesIndexTest {
             Instant.parse("2009-01-01T00:00:00Z").toEpochMilli(),
             millisInYear).getPointCount());
     }
+
+    @Test
+    public void testPointCountHuge() {
+        // 1 data every 30 seconds for ~30years, ~30years+30s, ~30years+60s
+        assertEquals(30 * 365 * 24 * 120 + 1, new RegularTimeSeriesIndex(0, 30L * 365 * 24 * 60 * 60 * 1000 + 0 * 30 * 1000, 30 * 1000).getPointCount());
+        assertEquals(30 * 365 * 24 * 120 + 2, new RegularTimeSeriesIndex(0, 30L * 365 * 24 * 60 * 60 * 1000 + 1 * 30 * 1000, 30 * 1000).getPointCount());
+        assertEquals(30 * 365 * 24 * 120 + 3, new RegularTimeSeriesIndex(0, 30L * 365 * 24 * 60 * 60 * 1000 + 2 * 30 * 1000, 30 * 1000).getPointCount());
+    }
 }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/RegularTimeSeriesIndexTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/RegularTimeSeriesIndexTest.java
@@ -83,6 +83,12 @@ public class RegularTimeSeriesIndexTest {
                                       Duration.ofMinutes(15));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testContructorErrorPointCount() {
+        RegularTimeSeriesIndex.create(Interval.parse("2000-01-01T00:00:00Z/2100-01-01T00:10:00Z"),
+                                      Duration.ofSeconds(1));
+    }
+
     @Test
     public void testPointCountSimple() {
         //2 data points at 0 and 10

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/RegularTimeSeriesIndexTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/RegularTimeSeriesIndexTest.java
@@ -82,4 +82,28 @@ public class RegularTimeSeriesIndexTest {
         RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-01-01T00:10:00Z"),
                                       Duration.ofMinutes(15));
     }
+
+    @Test
+    public void testPointCountSimple() {
+        //2 data points at 0 and 10
+        assertEquals(2, new RegularTimeSeriesIndex(0, 10, 10).getPointCount());
+    }
+
+    @Test
+    public void testPointCountRounded() {
+        //We allow some imprecision to simplify calendar dates
+        assertEquals(3, new RegularTimeSeriesIndex(0, 19, 10).getPointCount());
+        assertEquals(3, new RegularTimeSeriesIndex(0, 20, 10).getPointCount());
+        assertEquals(3, new RegularTimeSeriesIndex(0, 21, 10).getPointCount());
+        //Concrete example:
+        // 1 data every year for 10 years (rounding hides the year length differences):
+        // millisInYear is not exact because of leap years, but even when taking leap years into account,
+        // the number of seconds in a year in not predictable because of leap seconds.
+        // Still it's a good enough approximation give the correct result.
+        long millisInYear = 365L * 86400 * 1000;
+        assertEquals(10, new RegularTimeSeriesIndex(
+            Instant.parse("2000-01-01T00:00:00Z").toEpochMilli(),
+            Instant.parse("2009-01-01T00:00:00Z").toEpochMilli(),
+            millisInYear).getPointCount());
+    }
 }


### PR DESCRIPTION
getPointCount was wrong for huge values. I added tests for normal and huge values. I added a check that pointCount fits in a int in the constructor. I stored the computed value instead of recomputing it everytime.

For the fix for the huge values error, we could have used:
```
        return (int) ((endTime - startTime + (spacing / 2)) / spacing) + 1;
```
This works for values upto 2^63ms ie ~300 million years.
But I went for code that is more similar to what was existing, using a double instead of a float to do the computation (works for values upto 2^53 ie ~300 thousands years)
