### PR TITLE
CGMES Rotating Machine ratedS is optional

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SynchronousMachineConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SynchronousMachineConversion.java
@@ -32,8 +32,10 @@ public class SynchronousMachineConversion extends AbstractConductingEquipmentCon
         String generatingUnitType = p.getLocal("generatingUnitType");
         PowerFlow f = powerFlow();
 
+        // Default targetP from initial P defined in EQ GeneratingUnit
         double targetP = p.asDouble("initialP", 0);
         double targetQ = 0;
+        // Flow values may come from Terminal or Equipment (SSH RotatingMachine)
         if (f.defined()) {
             targetP = -f.p();
             targetQ = -f.q();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
@@ -49,7 +49,8 @@ import com.powsybl.triplestore.api.TripleStoreFactory;
  */
 public class ConversionTester {
 
-    public ConversionTester(Properties importParams, List<String> tripleStoreImplementations, ComparisonConfig networkComparison) {
+    public ConversionTester(Properties importParams, List<String> tripleStoreImplementations,
+            ComparisonConfig networkComparison) {
         this.importParams = importParams;
         this.tripleStoreImplementations = tripleStoreImplementations;
         this.networkComparison = networkComparison;
@@ -229,9 +230,10 @@ public class ConversionTester {
     }
 
     private void computeMissingFlows(Network network, LoadFlowParameters lfparams) {
-        float epsilonX = 0;
-        boolean applyXCorrection = false;
-        LoadFlowResultsCompletionParameters p = new LoadFlowResultsCompletionParameters(epsilonX, applyXCorrection);
+        LoadFlowResultsCompletionParameters p = new LoadFlowResultsCompletionParameters(
+                LoadFlowResultsCompletionParameters.EPSILON_X_DEFAULT,
+                LoadFlowResultsCompletionParameters.APPLY_REACTANCE_CORRECTION_DEFAULT,
+                LoadFlowResultsCompletionParameters.Z0_THRESHOLD_DIFF_VOLTAGE_ANGLE);
         LoadFlowResultsCompletion lf = new LoadFlowResultsCompletion(p, lfparams);
         try {
             lf.run(network, null);

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -644,8 +644,10 @@ WHERE {
 { GRAPH ?graph {
     ?SynchronousMachine
         a cim:SynchronousMachine ;
-        cim:RotatingMachine.GeneratingUnit ?GeneratingUnit ;
-        cim:RotatingMachine.ratedS ?ratedS .
+        cim:RotatingMachine.GeneratingUnit ?GeneratingUnit .
+    OPTIONAL {
+    	?SynchronousMachine cim:RotatingMachine.ratedS ?ratedS
+   	}
     ?GeneratingUnit
         a ?generatingUnitType ;
         cim:GeneratingUnit.minOperatingP ?minP ;
@@ -671,12 +673,12 @@ WHERE {
         OPTIONAL { GRAPH ?graphSSH2 {
             ?regulatingControlTerminal cim:ACDCTerminal.connected ?regulatingControlTerminalConnected
         }}
-# TODO SSH may contain following additional attributes:
-#   SynchronousMachine:RotatingMachine.p (should be the same value of GeneratingUnit.initialP ?)
-#   SynchronousMachine:RotatingMachine.q
-#   SynchronousMachine:SynchronousMachine.operatingMode
-#   SynchronousMachine:SynchronousMachine.referencePriority
     }
+    OPTIONAL { GRAPH ?graphSSH3 {
+    	?SynchronousMachine 
+    		cim:RotatingMachine.p ?p ;
+    		cim:RotatingMachine.q ?q 
+    }}
 }}
 }
 

--- a/cim1/cim1-converter/src/test/java/com/powsybl/cim1/converter/CIM1ConverterRatioTapChangerSide2FixTest.java
+++ b/cim1/cim1-converter/src/test/java/com/powsybl/cim1/converter/CIM1ConverterRatioTapChangerSide2FixTest.java
@@ -103,7 +103,8 @@ public class CIM1ConverterRatioTapChangerSide2FixTest {
     private void computeMissingFlows(Network network, LoadFlowParameters loadFlowParameters) {
         float epsilonX = 0f;
         boolean applyXCorrection = false;
-        LoadFlowResultsCompletionParameters p = new LoadFlowResultsCompletionParameters(epsilonX, applyXCorrection);
+        double z0Threshold = 0;
+        LoadFlowResultsCompletionParameters p = new LoadFlowResultsCompletionParameters(epsilonX, applyXCorrection, z0Threshold);
         LoadFlowResultsCompletion lf = new LoadFlowResultsCompletion(p, loadFlowParameters);
         lf.run(network, null);
     }

--- a/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/LoadFlowResultsCompletion.java
+++ b/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/LoadFlowResultsCompletion.java
@@ -6,6 +6,11 @@
  */
 package com.powsybl.loadflow.resultscompletion;
 
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.auto.service.AutoService;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Branch.Side;
@@ -20,10 +25,6 @@ import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.resultscompletion.z0flows.Z0FlowsCompletion;
 import com.powsybl.loadflow.resultscompletion.z0flows.Z0LineChecker;
 import com.powsybl.loadflow.validation.CandidateComputation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Objects;
 
 /**
  *
@@ -110,7 +111,13 @@ public class LoadFlowResultsCompletion implements CandidateComputation {
             Bus b2 = l.getTerminal2().getBusView().getBus();
             Objects.requireNonNull(b1);
             Objects.requireNonNull(b2);
-            return b1.getV() == b2.getV() && b1.getAngle() == b2.getAngle();
+            double threshold = parameters.getZ0ThresholdDiffVoltageAngle();
+            boolean r = Math.abs(b1.getV() - b2.getV()) < threshold
+                    && Math.abs(b1.getAngle() - b2.getAngle()) < threshold;
+            if (r) {
+                LOGGER.debug("Line Z0 {} ({}) dV = {}, dA = {}", l.getName(), l.getId(), Math.abs(b1.getV() - b2.getV()), Math.abs(b1.getAngle() - b2.getAngle()));
+            }
+            return r;
         };
         Z0FlowsCompletion z0FlowsCompletion = new Z0FlowsCompletion(network, z0checker);
         z0FlowsCompletion.complete();

--- a/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/LoadFlowResultsCompletionParameters.java
+++ b/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/LoadFlowResultsCompletionParameters.java
@@ -20,9 +20,11 @@ public class LoadFlowResultsCompletionParameters {
 
     public static final float EPSILON_X_DEFAULT = 0.1f;
     public static final boolean APPLY_REACTANCE_CORRECTION_DEFAULT = false;
+    public static final double Z0_THRESHOLD_DIFF_VOLTAGE_ANGLE = 1e-6;
 
     private final float epsilonX;
     private final boolean applyReactanceCorrection;
+    private final double z0ThresholdDiffVoltageAngle;
 
     public static LoadFlowResultsCompletionParameters load() {
         return load(PlatformConfig.defaultConfig());
@@ -34,18 +36,20 @@ public class LoadFlowResultsCompletionParameters {
                 .map(config -> {
                     float epsilonX = config.getFloatProperty("epsilon-x", LoadFlowResultsCompletionParameters.EPSILON_X_DEFAULT);
                     boolean applyReactanceCorrection = config.getBooleanProperty("apply-reactance-correction", LoadFlowResultsCompletionParameters.APPLY_REACTANCE_CORRECTION_DEFAULT);
-                    return new LoadFlowResultsCompletionParameters(epsilonX, applyReactanceCorrection);
+                    double z0ThresholdDiffVoltageAngle = config.getDoubleProperty("z0-threshold-diff-voltage-angle", LoadFlowResultsCompletionParameters.Z0_THRESHOLD_DIFF_VOLTAGE_ANGLE);
+                    return new LoadFlowResultsCompletionParameters(epsilonX, applyReactanceCorrection, z0ThresholdDiffVoltageAngle);
                 })
-                .orElseGet(() -> new LoadFlowResultsCompletionParameters(LoadFlowResultsCompletionParameters.EPSILON_X_DEFAULT, LoadFlowResultsCompletionParameters.APPLY_REACTANCE_CORRECTION_DEFAULT));
+                .orElseGet(() -> new LoadFlowResultsCompletionParameters(LoadFlowResultsCompletionParameters.EPSILON_X_DEFAULT, LoadFlowResultsCompletionParameters.APPLY_REACTANCE_CORRECTION_DEFAULT, LoadFlowResultsCompletionParameters.Z0_THRESHOLD_DIFF_VOLTAGE_ANGLE));
     }
 
-    public LoadFlowResultsCompletionParameters(float epsilonX, boolean applyReactanceCorrection) {
+    public LoadFlowResultsCompletionParameters(float epsilonX, boolean applyReactanceCorrection, double z0ThresholdDiffVoltageAngle) {
         this.epsilonX = epsilonX;
         this.applyReactanceCorrection = applyReactanceCorrection;
+        this.z0ThresholdDiffVoltageAngle = z0ThresholdDiffVoltageAngle;
     }
 
     public LoadFlowResultsCompletionParameters() {
-        this(EPSILON_X_DEFAULT, APPLY_REACTANCE_CORRECTION_DEFAULT);
+        this(EPSILON_X_DEFAULT, APPLY_REACTANCE_CORRECTION_DEFAULT, Z0_THRESHOLD_DIFF_VOLTAGE_ANGLE);
     }
 
     public float getEpsilonX() {
@@ -56,9 +60,14 @@ public class LoadFlowResultsCompletionParameters {
         return applyReactanceCorrection;
     }
 
+    public double getZ0ThresholdDiffVoltageAngle() {
+        return z0ThresholdDiffVoltageAngle;
+    }
+
     protected Map<String, Object> toMap() {
         return ImmutableMap.of("epsilonX", epsilonX,
-                               "applyReactanceCorrection", applyReactanceCorrection);
+                               "applyReactanceCorrection", applyReactanceCorrection,
+                               "z0ThresholdDiffVoltageAngle", z0ThresholdDiffVoltageAngle);
     }
 
     @Override


### PR DESCRIPTION
Observed in the same test case that contains switches between different voltage levels that are converted to IIDM low impedance lines. 

The voltage levels at the ends of these switches are simply separate containers: they have the same base voltage and are in the same substation (they could be "merged" in IIDM to avoid creating a low impedance line).

In addition, end buses of these switches do not have exactly the same voltage and angle. The difference between voltages is < 3e-7 kV and the diff between angles is < 9e-8 degrees.

To take into account this situation and complete flows through these switches, a threshold for the check of zero impedance lines has been added.