### PR TITLE
At least one set of data with EquipmentCore profile in the CGMES model

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -9,6 +9,7 @@ package com.powsybl.cgmes.conversion;
 
 import com.powsybl.cgmes.conversion.elements.*;
 import com.powsybl.cgmes.model.CgmesModel;
+import com.powsybl.cgmes.model.CgmesModelException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.NetworkFactory;
 import com.powsybl.triplestore.api.PropertyBag;
@@ -71,6 +72,10 @@ public class Conversion {
 
         if (LOG.isDebugEnabled() && cgmes.baseVoltages() != null) {
             LOG.debug(cgmes.baseVoltages().tabulate());
+        }
+        // Check that at least we have an EquipmentCore profile
+        if (!cgmes.hasEquipmentCore()) {
+            throw new CgmesModelException("Data source does not contain EquipmentCore data");
         }
         Network network = createNetwork();
         Context context = createContext(network);

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -24,6 +24,8 @@ public interface CgmesModel {
 
     Properties getProperties();
 
+    boolean hasEquipmentCore();
+
     String modelId();
 
     String version();

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNames.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNames.java
@@ -12,6 +12,8 @@ package com.powsybl.cgmes.model;
  */
 public final class CgmesNames {
 
+    public static final String FULL_MODEL = "FullModel";
+
     public static final String SUBSTATION = "Substation";
     public static final String VOLTAGE_LEVEL = "VoltageLevel";
     public static final String TERMINAL = "Terminal";

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -68,6 +68,28 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
     // Queries
 
     @Override
+    public boolean hasEquipmentCore() {
+        if (queryCatalog.containsKey("modelProfiles")) {
+            PropertyBags r = namedQuery("modelProfiles");
+            if (r == null) {
+                return false;
+            }
+            for (PropertyBag m : r) {
+                String p = m.get("profile");
+                if (p != null && p.contains("/EquipmentCore/")) {
+                    if (LOG.isInfoEnabled()) {
+                        LOG.info("Model contains Equipment Core data profile in model {}", m.get("FullModel"));
+                    }
+                    return true;
+                }
+            }
+        }
+        // If we do not have a query for model profiles we assume equipment core is available
+        // (This covers the case for CIM14 files)
+        return true;
+    }
+
+    @Override
     public boolean isNodeBreaker() {
         // Optimization hint: consider caching the results of the query for model
         // profiles

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import com.powsybl.cgmes.model.AbstractCgmesModel;
 import com.powsybl.cgmes.model.CgmesModelException;
+import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.cgmes.model.CgmesNamespace;
 import com.powsybl.cgmes.model.Subset;
 import com.powsybl.commons.datasource.DataSource;
@@ -69,8 +70,8 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
 
     @Override
     public boolean hasEquipmentCore() {
-        if (queryCatalog.containsKey("modelProfiles")) {
-            PropertyBags r = namedQuery("modelProfiles");
+        if (queryCatalog.containsKey(MODEL_PROFILES)) {
+            PropertyBags r = namedQuery(MODEL_PROFILES);
             if (r == null) {
                 return false;
             }
@@ -78,13 +79,15 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
                 String p = m.get("profile");
                 if (p != null && p.contains("/EquipmentCore/")) {
                     if (LOG.isInfoEnabled()) {
-                        LOG.info("Model contains Equipment Core data profile in model {}", m.get("FullModel"));
+                        LOG.info("Model contains Equipment Core data profile in model {}",
+                                m.get(CgmesNames.FULL_MODEL));
                     }
                     return true;
                 }
             }
         }
-        // If we do not have a query for model profiles we assume equipment core is available
+        // If we do not have a query for model profiles we assume equipment core is
+        // available
         // (This covers the case for CIM14 files)
         return true;
     }
@@ -93,8 +96,8 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
     public boolean isNodeBreaker() {
         // Optimization hint: consider caching the results of the query for model
         // profiles
-        if (queryCatalog.containsKey("modelProfiles")) {
-            PropertyBags r = namedQuery("modelProfiles");
+        if (queryCatalog.containsKey(MODEL_PROFILES)) {
+            PropertyBags r = namedQuery(MODEL_PROFILES);
             if (r == null) {
                 return false;
             }
@@ -439,5 +442,6 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
     private final TripleStore tripleStore;
     private final QueryCatalog queryCatalog;
 
+    private static final String MODEL_PROFILES = "modelProfiles";
     private static final Logger LOG = LoggerFactory.getLogger(CgmesModelTripleStore.class);
 }

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
@@ -88,6 +88,10 @@ public final class FakeCgmesModel implements CgmesModel {
         numObjectsByType = new PropertyBags();
     }
 
+    public boolean hasEquipmentCore() {
+        return true;
+    }
+
     public FakeCgmesModel modelId(String modelId) {
         this.modelId = modelId;
         return this;


### PR DESCRIPTION
Some data sources may miss the EQ file. 

Throw an error if we can not find EQ data inside the current CGMES model.