### PR TITLE
time-series: TimeSeriesTable, allow to have more than 2gb of data

### DIFF
--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/BigDoubleBuffer.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/BigDoubleBuffer.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.timeseries;
+
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.util.Objects;
+import java.util.function.IntFunction;
+
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+public class BigDoubleBuffer {
+
+    private static final int BUFFER_SHIFT = 27;
+    private static final int BUFFER_SIZE_DOUBLES = 1 << BUFFER_SHIFT;
+    private static final int BUFFER_MASK = BUFFER_SIZE_DOUBLES - 1;
+    private static final int BUFFER_SIZE_BYTES = BUFFER_SIZE_DOUBLES * Double.BYTES;
+    private DoubleBuffer[] buffers;
+    private long size;
+
+    public BigDoubleBuffer(IntFunction<ByteBuffer> byteBufferAllocator, long size) {
+        Objects.requireNonNull(byteBufferAllocator);
+        if (size < 0) {
+            throw new IllegalArgumentException("Invalid buffer size: " + size);
+        }
+        long computedBufferCount = (size + BUFFER_SIZE_DOUBLES - 1) >> BUFFER_SHIFT;
+        if (computedBufferCount > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("size " + size + " is bigger than max allowed value " + (long) BUFFER_SIZE_DOUBLES * BUFFER_SIZE_DOUBLES);
+        }
+        int bufferCount = (int) computedBufferCount;
+        long computedLastBufferSizeBytes = (size & BUFFER_MASK) * Double.BYTES;
+        int lastBufferSizeBytes = (int) computedLastBufferSizeBytes;
+        if (size > 0 && lastBufferSizeBytes == 0) {
+            lastBufferSizeBytes = BUFFER_SIZE_BYTES;
+        }
+        buffers = new DoubleBuffer[bufferCount];
+        for (int i = 0; i < bufferCount - 1; i++) {
+            buffers[i] = byteBufferAllocator.apply(BUFFER_SIZE_BYTES).asDoubleBuffer();
+        }
+        if (lastBufferSizeBytes > 0) {
+            buffers[bufferCount - 1] = byteBufferAllocator.apply(lastBufferSizeBytes).asDoubleBuffer();
+        }
+        this.size = size;
+    }
+
+    public void put(long index, double value) {
+        long computedBufferIndex = index >> BUFFER_SHIFT;
+        long computedSecondIndex = index & BUFFER_MASK;
+        int bufferIndex = (int) computedBufferIndex;
+        int secondIndex = (int) computedSecondIndex;
+        buffers[bufferIndex].put(secondIndex, value);
+    }
+
+    public double get(long index) {
+        long computedBufferIndex = index >> BUFFER_SHIFT;
+        long computedSecondIndex = index & BUFFER_MASK;
+        int bufferIndex = (int) computedBufferIndex;
+        int secondIndex = (int) computedSecondIndex;
+        return buffers[bufferIndex].get(secondIndex);
+    }
+
+    public long capacity() {
+        return size;
+    }
+}

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/BigStringBuffer.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/BigStringBuffer.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.timeseries;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.function.IntFunction;
+
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+public class BigStringBuffer {
+
+    private static final int BUFFER_SHIFT = 28;
+    private static final int BUFFER_SIZE_INTS = 1 << BUFFER_SHIFT;
+    private static final int BUFFER_MASK = BUFFER_SIZE_INTS - 1;
+    private CompactStringBuffer[] buffers;
+    private long size;
+
+    public BigStringBuffer(IntFunction<ByteBuffer> byteBufferAllocator, long size) {
+        Objects.requireNonNull(byteBufferAllocator);
+        if (size < 0) {
+            throw new IllegalArgumentException("Invalid buffer size: " + size);
+        }
+        long computedBufferCount = (size + BUFFER_SIZE_INTS - 1) >> BUFFER_SHIFT;
+        if (computedBufferCount > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("size " + size + " is bigger than max allowed value " + (long) BUFFER_SIZE_INTS * BUFFER_SIZE_INTS);
+        }
+        int bufferCount = (int) computedBufferCount;
+        long computedLastBufferSizeInts = size & BUFFER_MASK;
+        int lastBufferSizeInts = (int) computedLastBufferSizeInts;
+        if (size > 0 && lastBufferSizeInts == 0) {
+            lastBufferSizeInts = BUFFER_SIZE_INTS;
+        }
+        buffers = new CompactStringBuffer[bufferCount];
+        for (int i = 0; i < bufferCount - 1; i++) {
+            buffers[i] = new CompactStringBuffer(byteBufferAllocator, BUFFER_SIZE_INTS);
+        }
+        if (lastBufferSizeInts > 0) {
+            buffers[bufferCount - 1] = new CompactStringBuffer(byteBufferAllocator, lastBufferSizeInts);
+        }
+        this.size = size;
+    }
+
+    public void putString(long index, String value) {
+        long computedBufferIndex = index >> BUFFER_SHIFT;
+        long computedSecondIndex = index & BUFFER_MASK;
+        int bufferIndex = (int) computedBufferIndex;
+        int secondIndex = (int) computedSecondIndex;
+        buffers[bufferIndex].putString(secondIndex, value);
+    }
+
+    public String getString(long index) {
+        long computedBufferIndex = index >> BUFFER_SHIFT;
+        long computedSecondIndex = index & BUFFER_MASK;
+        int bufferIndex = (int) computedBufferIndex;
+        int secondIndex = (int) computedSecondIndex;
+        return buffers[bufferIndex].getString(secondIndex);
+    }
+
+    public long capacity() {
+        return size;
+    }
+}

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CalculatedTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CalculatedTimeSeries.java
@@ -159,8 +159,10 @@ public class CalculatedTimeSeries implements DoubleTimeSeries {
         }
     }
 
-    @Override
-    public void fillBuffer(DoubleBuffer buffer, int timeSeriesOffset) {
+    //To remove if we ever get it from somewhere else
+    @FunctionalInterface private interface DoubleIntConsumer { public void accept(double a, int b); }
+
+    private void forEachMaterializedValueIndex(DoubleIntConsumer consumer) {
         if (metadata.getIndex() == InfiniteTimeSeriesIndex.INSTANCE) {
             throw new TimeSeriesException("Impossible to fill buffer because calculated time series has not been synchronized on a finite time index");
         }
@@ -170,16 +172,26 @@ public class CalculatedTimeSeries implements DoubleTimeSeries {
             DoublePoint point = it.next();
             if (prevPoint != null) {
                 for (int i = prevPoint.getIndex(); i < point.getIndex(); i++) {
-                    buffer.put(timeSeriesOffset + i, prevPoint.getValue());
+                    consumer.accept(prevPoint.getValue(), i);
                 }
             }
             prevPoint = point;
         }
         if (prevPoint != null) {
             for (int i = prevPoint.getIndex(); i < metadata.getIndex().getPointCount(); i++) {
-                buffer.put(timeSeriesOffset + i, prevPoint.getValue());
+                consumer.accept(prevPoint.getValue(), i);
             }
         }
+    }
+
+    @Override
+    public void fillBuffer(DoubleBuffer buffer, int timeSeriesOffset) {
+        forEachMaterializedValueIndex((v, i) -> buffer.put(i + timeSeriesOffset, v));
+    }
+
+    @Override
+    public void fillBuffer(BigDoubleBuffer buffer, long timeSeriesOffset) {
+        forEachMaterializedValueIndex((v, i) -> buffer.put(i + timeSeriesOffset, v));
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CalculatedTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CalculatedTimeSeries.java
@@ -186,11 +186,13 @@ public class CalculatedTimeSeries implements DoubleTimeSeries {
 
     @Override
     public void fillBuffer(DoubleBuffer buffer, int timeSeriesOffset) {
+        Objects.requireNonNull(buffer);
         forEachMaterializedValueIndex((v, i) -> buffer.put(i + timeSeriesOffset, v));
     }
 
     @Override
     public void fillBuffer(BigDoubleBuffer buffer, long timeSeriesOffset) {
+        Objects.requireNonNull(buffer);
         forEachMaterializedValueIndex((v, i) -> buffer.put(i + timeSeriesOffset, v));
     }
 

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompactStringBuffer.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompactStringBuffer.java
@@ -28,27 +28,24 @@ public class CompactStringBuffer {
             throw new IllegalArgumentException("Invalid buffer size: " + size);
         }
         this.buffer = byteBufferAllocator.apply(IntMath.checkedMultiply(size, Integer.BYTES)).asIntBuffer();
-        for (int i = 0; i < size; i++) {
-            buffer.put(-1);
-        }
     }
 
     public void putString(int index, String value) {
         int num;
         if (value == null) {
-            num = -1;
+            num = 0;
         } else {
-            num = dict.addIfNotAlreadyExist(value);
+            num = dict.addIfNotAlreadyExist(value) + 1;
         }
         buffer.put(index, num);
     }
 
     public String getString(int index) {
         int num = buffer.get(index);
-        if (num == -1) {
+        if (num == 0) {
             return null;
         } else {
-            return dict.get(num);
+            return dict.get(num - 1);
         }
     }
 

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedDoubleDataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedDoubleDataChunk.java
@@ -52,16 +52,29 @@ public class CompressedDoubleDataChunk extends AbstractCompressedDataChunk imple
         return TimeSeriesDataType.DOUBLE;
     }
 
-    @Override
-    public void fillBuffer(DoubleBuffer buffer, int timeSeriesOffset) {
-        Objects.requireNonNull(buffer);
+    //To remove if we ever get it from somewhere else
+    @FunctionalInterface private interface DoubleIntConsumer { public void accept(double a, int b); }
+
+    private void forEachMaterializedValueIndex(DoubleIntConsumer consumer) {
         int k = 0;
         for (int i = 0; i < stepValues.length; i++) {
             double value = stepValues[i];
             for (int j = 0; j < stepLengths[i]; j++) {
-                buffer.put(timeSeriesOffset + offset + k++, value);
+                consumer.accept(value, offset + k++);
             }
         }
+    }
+
+    @Override
+    public void fillBuffer(DoubleBuffer buffer, int timeSeriesOffset) {
+        Objects.requireNonNull(buffer);
+        forEachMaterializedValueIndex((v, i) -> buffer.put(timeSeriesOffset + i, v));
+    }
+
+    @Override
+    public void fillBuffer(BigDoubleBuffer buffer, long timeSeriesOffset) {
+        Objects.requireNonNull(buffer);
+        forEachMaterializedValueIndex((v, i) -> buffer.put(timeSeriesOffset + i, v));
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedStringDataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedStringDataChunk.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.function.ObjIntConsumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -73,16 +74,26 @@ public class CompressedStringDataChunk extends AbstractCompressedDataChunk imple
         return TimeSeriesDataType.STRING;
     }
 
-    @Override
-    public void fillBuffer(CompactStringBuffer buffer, int timeSeriesOffset) {
-        Objects.requireNonNull(buffer);
+    private void forEachMaterializedValueIndex(ObjIntConsumer<String> consumer) {
         int k = 0;
         for (int i = 0; i < stepValues.length; i++) {
             String value = stepValues[i];
             for (int j = 0; j < stepLengths[i]; j++) {
-                buffer.putString(timeSeriesOffset + offset + k++, value);
+                consumer.accept(value, offset + k++);
             }
         }
+    }
+
+    @Override
+    public void fillBuffer(CompactStringBuffer buffer, int timeSeriesOffset) {
+        Objects.requireNonNull(buffer);
+        forEachMaterializedValueIndex((v, i) -> buffer.putString(i, v));
+    }
+
+    @Override
+    public void fillBuffer(BigStringBuffer buffer, long timeSeriesOffset) {
+        Objects.requireNonNull(buffer);
+        forEachMaterializedValueIndex((v, i) -> buffer.putString(i, v));
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/DoubleDataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/DoubleDataChunk.java
@@ -14,4 +14,6 @@ import java.nio.DoubleBuffer;
 public interface DoubleDataChunk extends DataChunk<DoublePoint, DoubleDataChunk> {
 
     void fillBuffer(DoubleBuffer buffer, int timeSeriesOffset);
+
+    void fillBuffer(BigDoubleBuffer buffer, long timeSeriesOffset);
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/DoubleTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/DoubleTimeSeries.java
@@ -19,6 +19,8 @@ public interface DoubleTimeSeries extends TimeSeries<DoublePoint, DoubleTimeSeri
 
     void fillBuffer(DoubleBuffer buffer, int timeSeriesOffset);
 
+    void fillBuffer(BigDoubleBuffer buffer, long timeSeriesOffset);
+
     double[] toArray();
 
     static Iterator<DoubleMultiPoint> iterator(List<DoubleTimeSeries> timeSeriesList) {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StoredDoubleTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StoredDoubleTimeSeries.java
@@ -8,6 +8,7 @@ package com.powsybl.timeseries;
 
 import java.nio.DoubleBuffer;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -33,9 +34,18 @@ public class StoredDoubleTimeSeries extends AbstractTimeSeries<DoublePoint, Doub
         return new StoredDoubleTimeSeries(metadata, chunk);
     }
 
+    private void forEachChunk(Consumer<DoubleDataChunk> consumer) {
+        chunks.forEach(consumer);
+    }
+
     @Override
     public void fillBuffer(DoubleBuffer buffer, int timeSeriesOffset) {
-        chunks.forEach(chunk -> chunk.fillBuffer(buffer, timeSeriesOffset));
+        forEachChunk(chunk -> chunk.fillBuffer(buffer, timeSeriesOffset));
+    }
+
+    @Override
+    public void fillBuffer(BigDoubleBuffer buffer, long timeSeriesOffset) {
+        forEachChunk(chunk -> chunk.fillBuffer(buffer, timeSeriesOffset));
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StringDataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StringDataChunk.java
@@ -12,4 +12,6 @@ package com.powsybl.timeseries;
 public interface StringDataChunk extends DataChunk<StringPoint, StringDataChunk> {
 
     void fillBuffer(CompactStringBuffer buffer, int timeSeriesOffset);
+
+    void fillBuffer(BigStringBuffer buffer, long timeSeriesOffset);
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StringTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StringTimeSeries.java
@@ -8,6 +8,7 @@ package com.powsybl.timeseries;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -33,8 +34,16 @@ public class StringTimeSeries extends AbstractTimeSeries<StringPoint, StringData
         return new StringTimeSeries(metadata, chunk);
     }
 
+    private void forEachChunk(Consumer<StringDataChunk> consumer) {
+        chunks.forEach(consumer);
+    }
+
     public void fillBuffer(CompactStringBuffer buffer, int timeSeriesOffset) {
-        chunks.forEach(chunk -> chunk.fillBuffer(buffer, timeSeriesOffset));
+        forEachChunk(chunk -> chunk.fillBuffer(buffer, timeSeriesOffset));
+    }
+
+    public void fillBuffer(BigStringBuffer buffer, long timeSeriesOffset) {
+        forEachChunk(chunk -> chunk.fillBuffer(buffer, timeSeriesOffset));
     }
 
     public String[] toArray() {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/UncompressedDoubleDataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/UncompressedDoubleDataChunk.java
@@ -50,12 +50,25 @@ public class UncompressedDoubleDataChunk extends AbstractUncompressedDataChunk i
         return TimeSeriesDataType.DOUBLE;
     }
 
+    //To remove if we ever get it from somewhere else
+    @FunctionalInterface private interface DoubleIntConsumer { public void accept(double a, int b); }
+
+    private void forEachValueIndex(DoubleIntConsumer consumer) {
+        for (int i = 0; i < values.length; i++) {
+            consumer.accept(values[i], offset + i);
+        }
+    }
+
     @Override
     public void fillBuffer(DoubleBuffer buffer, int timeSeriesOffset) {
         Objects.requireNonNull(buffer);
-        for (int i = 0; i < values.length; i++) {
-            buffer.put(timeSeriesOffset + offset + i, values[i]);
-        }
+        forEachValueIndex((v, i) -> buffer.put(timeSeriesOffset + i, v));
+    }
+
+    @Override
+    public void fillBuffer(BigDoubleBuffer buffer, long timeSeriesOffset) {
+        Objects.requireNonNull(buffer);
+        forEachValueIndex((v, i) -> buffer.put(timeSeriesOffset + i, v));
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/UncompressedStringDataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/UncompressedStringDataChunk.java
@@ -11,6 +11,7 @@ import gnu.trove.list.array.TIntArrayList;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.function.ObjIntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -58,12 +59,22 @@ public class UncompressedStringDataChunk extends AbstractUncompressedDataChunk i
         return TimeSeriesDataType.STRING;
     }
 
+    private void forEachValueIndex(ObjIntConsumer<String> consumer) {
+        for (int i = 0; i < values.length; i++) {
+            consumer.accept(values[i], offset + i);
+        }
+    }
+
     @Override
     public void fillBuffer(CompactStringBuffer buffer, int timeSeriesOffset) {
         Objects.requireNonNull(buffer);
-        for (int i = 0; i < values.length; i++) {
-            buffer.putString(timeSeriesOffset + offset + i, values[i]);
-        }
+        forEachValueIndex((v, i) -> buffer.putString(timeSeriesOffset + i, v));
+    }
+
+    @Override
+    public void fillBuffer(BigStringBuffer buffer, long timeSeriesOffset) {
+        Objects.requireNonNull(buffer);
+        forEachValueIndex((v, i) -> buffer.putString(timeSeriesOffset + i, v));
     }
 
     @Override

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/BigDoubleBufferTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/BigDoubleBufferTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.timeseries;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+public class BigDoubleBufferTest {
+
+    private static final int BUFFER_SIZE_DOUBLES = 1 << 27;
+
+    private int allocatorCount;
+
+    private ByteBuffer testDoubleAllocator(int capacity) {
+        allocatorCount++;
+        ByteBuffer mockbyte = Mockito.mock(ByteBuffer.class);
+        DoubleBuffer mockdouble = Mockito.mock(DoubleBuffer.class);
+        when(mockbyte.asDoubleBuffer()).thenReturn(mockdouble);
+        Map<Integer, Double> map = new HashMap<>();
+        when(mockdouble.put(anyInt(), anyDouble())).thenAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            DoubleBuffer mock = (DoubleBuffer) invocation.getMock();
+            map.put((int) args[0], (double) args[1]);
+            return mock;
+        });
+        when(mockdouble.get(anyInt())).thenAnswer(invocation -> {
+            return map.get(invocation.getArguments()[0]);
+        });
+        return mockbyte;
+    }
+
+    @Before
+    public void before() {
+        allocatorCount = 0;
+    }
+
+    private void bufferTester(long size) {
+        BigDoubleBuffer buffer = new BigDoubleBuffer(this::testDoubleAllocator, size);
+        //Simple writes at the begining
+        for (int i = 0; i < 10; i++) {
+            buffer.put(i, i);
+        }
+        //writes around first buffer change
+        if (size > BUFFER_SIZE_DOUBLES + 10) {
+            for (int i = BUFFER_SIZE_DOUBLES - 10; i < BUFFER_SIZE_DOUBLES + 10; i++) {
+                buffer.put(i, i);
+            }
+        }
+        //writes at the end
+        for (long i = size - 10; i < size; i++) {
+            buffer.put(i, i);
+        }
+
+        for (int i = 0; i < 10; i++) {
+            assertEquals(i, buffer.get(i), 0);
+        }
+        if (size > BUFFER_SIZE_DOUBLES + 10) {
+            for (int i = BUFFER_SIZE_DOUBLES - 10; i < BUFFER_SIZE_DOUBLES + 10; i++) {
+                assertEquals(i, buffer.get(i), 0);
+            }
+        }
+        for (long i = size - 10; i < size; i++) {
+            assertEquals(i, buffer.get(i), 0);
+        }
+    }
+
+    @Test
+    public void testSimple() {
+        bufferTester(10);
+        assertEquals(1, allocatorCount);
+    }
+
+    @Test
+    public void testMultipleBuffers() {
+        bufferTester(200000000);
+        assertEquals(2, allocatorCount);
+    }
+
+    @Test
+    public void testHuge() {
+        bufferTester(10000000000L);
+        assertEquals(75, allocatorCount);
+    }
+
+    @Test
+    public void testSizeBufferMinus1() {
+        bufferTester(BUFFER_SIZE_DOUBLES - 1);
+        assertEquals(1, allocatorCount);
+    }
+
+    @Test
+    public void testSizeBufferExact() {
+        bufferTester(BUFFER_SIZE_DOUBLES);
+        assertEquals(1, allocatorCount);
+    }
+
+    @Test
+    public void testSizeBufferPlus1() {
+        bufferTester(BUFFER_SIZE_DOUBLES + 1);
+        assertEquals(2, allocatorCount);
+    }
+}

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/BigStringBufferTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/BigStringBufferTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.timeseries;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+public class BigStringBufferTest {
+
+    private static final int BUFFER_SIZE_INTS = 1 << 28;
+
+    private int allocatorCount;
+
+    private ByteBuffer testStringAllocator(int capacity) {
+        allocatorCount++;
+        ByteBuffer mockbyte = Mockito.mock(ByteBuffer.class);
+        IntBuffer mockint = Mockito.mock(IntBuffer.class);
+        when(mockbyte.asIntBuffer()).thenReturn(mockint);
+        Map<Integer, Integer> map = new HashMap<>();
+        when(mockint.put(anyInt(), anyInt())).thenAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            IntBuffer mock = (IntBuffer) invocation.getMock();
+            map.put((int) args[0], (int) args[1]);
+            return mock;
+        });
+        when(mockint.get(anyInt())).thenAnswer(invocation -> {
+            return map.get(invocation.getArguments()[0]);
+        });
+        return mockbyte;
+    }
+
+    @Before
+    public void before() {
+        allocatorCount = 0;
+    }
+
+    private void bufferTester(long size) {
+        BigStringBuffer buffer = new BigStringBuffer(this::testStringAllocator, size);
+        //Simple writes at the begining
+        for (int i = 0; i < 10; i++) {
+            buffer.putString(i, Integer.toString(i));
+        }
+        //writes around first buffer change
+        if (size > BUFFER_SIZE_INTS + 10) {
+            for (int i = BUFFER_SIZE_INTS - 10; i < BUFFER_SIZE_INTS + 10; i++) {
+                buffer.putString(i, Integer.toString(i));
+            }
+        }
+        //writes at the end
+        for (long i = size - 10; i < size; i++) {
+            buffer.putString(i, Long.toString(i));
+        }
+
+        for (int i = 0; i < 10; i++) {
+            assertEquals(Integer.toString(i), buffer.getString(i));
+        }
+        if (size > BUFFER_SIZE_INTS + 10) {
+            for (int i = BUFFER_SIZE_INTS - 10; i < BUFFER_SIZE_INTS + 10; i++) {
+                assertEquals(Integer.toString(i), buffer.getString(i));
+            }
+        }
+        for (long i = size - 10; i < size; i++) {
+            assertEquals(Long.toString(i), buffer.getString(i));
+        }
+    }
+
+    @Test
+    public void testSimple() {
+        bufferTester(10);
+        assertEquals(1, allocatorCount);
+    }
+
+    @Test
+    public void testMultipleBuffers() {
+        bufferTester(400000000);
+        assertEquals(2, allocatorCount);
+    }
+
+    @Test
+    public void testHuge() {
+        bufferTester(10000000000L);
+        assertEquals(38, allocatorCount);
+    }
+
+    @Test
+    public void testSizeBufferMinus1() {
+        bufferTester(BUFFER_SIZE_INTS - 1);
+        assertEquals(1, allocatorCount);
+    }
+
+    @Test
+    public void testSizeBufferExact() {
+        bufferTester(BUFFER_SIZE_INTS);
+        assertEquals(1, allocatorCount);
+    }
+
+    @Test
+    public void testSizeBufferPlus1() {
+        bufferTester(BUFFER_SIZE_INTS + 1);
+        assertEquals(2, allocatorCount);
+    }
+}


### PR DESCRIPTION
I still want to test a little more when using MemoryMappedBuffer.

time-series: TimeSeriesTable, allow to have more than 2gb of data

To do this, we use 1 giga (2^30) *bytes* segment into the table. This allows to use
memory mapped buffer for these segments (it would not have been possible if
we had use buffers of 2^30 *elements*) and to use bitshifts and masks to compute indices
(2^30 is the largest power of two no greater than Integer.MAX_VALUE (2^31-1))

Each timeseries is still constrained on its own to have a number of elements that fits in
an array (~2 billions). We keep the previous fillBuffer implementations because they allow to return a
single array without extra copying (and that's up to 16 gb for doubles; unbounded for strings)

We copypaste part of the previous fillBuffer implementation to avoid complicated metaprogramming.
This should also be better for performance.