### PR TITLE
In z0 results completion, consider all loops

### DIFF
--- a/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/z0flows/Z0BusGroup.java
+++ b/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/z0flows/Z0BusGroup.java
@@ -33,7 +33,7 @@ public class Z0BusGroup {
     }
 
     public boolean valid() {
-        return buses.size() > 1 || loops != null && loops.size() > 1;
+        return buses.size() > 1 || loops != null && !loops.isEmpty();
     }
 
     public void exploreZ0(Set<Bus> processed) {


### PR DESCRIPTION
Consider that a z0 bus group is valid if it contains more than one bus or any number of loops.