### PR TITLE
Initial value for shunt sections

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
@@ -28,7 +28,7 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
     public void convert() {
         int maximumSections = p.asInt("maximumSections", 0);
         int normalSections = p.asInt("normalSections", 0);
-        int sections = fromContinuous(p.asDouble("SVsections", normalSections));
+        int sections = fromContinuous(p.asDouble("SVsections", p.asDouble("SSHsections", normalSections)));
         sections = Math.abs(sections);
         maximumSections = Math.max(maximumSections, sections);
         double bPerSection = 0;


### PR DESCRIPTION
Refine initial value for shunt sections:

First take number of sections given in the SV (State Variables). If that information is not available, use value from SSH (Steady State Hypothesis). If the property is not defined in SSH, use normal sections defined in the EQ profile (Equipment).