### PR TITLE
CGMES using RDF4J triple store engine: non-fatal errors on invalid identifiers

### DIFF
--- a/triple-store/triple-store-impl-rdf4j/src/main/java/com/powsybl/triplestore/impl/rdf4j/TripleStoreRDF4J.java
+++ b/triple-store/triple-store-impl-rdf4j/src/main/java/com/powsybl/triplestore/impl/rdf4j/TripleStoreRDF4J.java
@@ -36,7 +36,9 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.XMLParserSettings;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +63,13 @@ public class TripleStoreRDF4J extends AbstractPowsyblTripleStore {
     public void read(String base, String contextName, InputStream is) {
         try (RepositoryConnection conn = repo.getConnection()) {
             conn.setIsolationLevel(IsolationLevels.NONE);
+
+            // Report invalid identifiers but do not fail
+            // (sometimes RDF identifiers contain spaces or begin with #)
+            // This is the default behavior for other triple store engines (Jena)
+            conn.getParserConfig().addNonFatalError(XMLParserSettings.FAIL_ON_INVALID_NCNAME);
+            conn.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
+
             Resource context = context(conn, contextName);
             // We add data with a context (graph) to keep the source of information
             // When we write we want to keep data split by graph


### PR DESCRIPTION
Allow identifiers containing spaces or beginning with a #. 

Some TSOs may produce RDF XML files with identifiers that do not pass strict XML syntax rules for names.

Jena triple store was logging the errors without failing. The configuration of the RDF4J XML parser has been updated to follow the same strategy.