### PR TITLE
CGMES: allow unnamed connectivity nodes

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractIdentifiedObjectConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractIdentifiedObjectConversion.java
@@ -24,7 +24,7 @@ public abstract class AbstractIdentifiedObjectConversion extends AbstractObjectC
         this.name = p.get("name");
         if (this.name == null) {
             missing("name");
-         }
+        }
     }
 
     public AbstractIdentifiedObjectConversion(String type, PropertyBags propertiess, Context context) {
@@ -34,7 +34,7 @@ public abstract class AbstractIdentifiedObjectConversion extends AbstractObjectC
         this.name = ps.get(0).get("name");
         if (this.name == null) {
             missing("name");
-         }
+        }
     }
 
     public String id() {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractIdentifiedObjectConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractIdentifiedObjectConversion.java
@@ -22,6 +22,9 @@ public abstract class AbstractIdentifiedObjectConversion extends AbstractObjectC
 
         this.id = properties.getId(type);
         this.name = p.get("name");
+        if (this.name == null) {
+            missing("name");
+         }
     }
 
     public AbstractIdentifiedObjectConversion(String type, PropertyBags propertiess, Context context) {
@@ -29,6 +32,9 @@ public abstract class AbstractIdentifiedObjectConversion extends AbstractObjectC
 
         this.id = ps.get(0).getId(type);
         this.name = ps.get(0).get("name");
+        if (this.name == null) {
+            missing("name");
+         }
     }
 
     public String id() {

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -157,9 +157,10 @@ OPTIONAL { GRAPH ?graphTPT {
 SELECT *
 WHERE {
 { GRAPH ?graphCN2 {
-	?ConnectivityNode
-		cim:IdentifiedObject.name ?name ;
-		cim:ConnectivityNode.ConnectivityNodeContainer ?ConnectivityNodeContainer
+	?ConnectivityNode cim:ConnectivityNode.ConnectivityNodeContainer ?ConnectivityNodeContainer
+	OPTIONAL {
+		?ConnectivityNode cim:IdentifiedObject.name ?name
+	}
 }}
 OPTIONAL { GRAPH ?graphTPCN {
 	?ConnectivityNode cim:ConnectivityNode.TopologicalNode ?TopologicalNode 

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -228,7 +228,9 @@ WHERE
 { GRAPH ?graph {
     {
         ?Terminal a cim:Terminal .
-        ?OperationalLimitSet cim:OperationalLimitSet.Terminal ?Terminal .
+        ?OperationalLimitSet 
+        	cim:OperationalLimitSet.Terminal ?Terminal ;
+        	cim:IdentifiedObject.name ?name
     }
     # operational limit sets can also be attached directly to equipments
     UNION
@@ -406,6 +408,7 @@ WHERE {
 { GRAPH ?graphEQ {
     ?RatioTapChanger
         a cim:RatioTapChanger ;
+        cim:IdentifiedObject.name ?name ;
         cim:TapChanger.lowStep ?lowStep ;
         cim:TapChanger.highStep ?highStep ;
         cim:TapChanger.neutralStep ?neutralStep ;
@@ -489,6 +492,7 @@ WHERE {
 { GRAPH ?graph {
     ?PhaseTapChanger
         a ?phaseTapChangerType ;
+        cim:IdentifiedObject.name ?name ;
         cim:TapChanger.lowStep ?lowStep ;
         cim:TapChanger.highStep ?highStep ;
         cim:TapChanger.neutralStep ?neutralStep ;


### PR DESCRIPTION
Consider name an optional attribute for connectivity nodes.

Although the attribute is required for all objects (defined in IdentifiedObject class), some TSOs may produce models that do not have names for some connectivity nodes.