### PR TITLE
Fix listenable app storage data updated events

### DIFF
--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/DefaultListenableAppStorage.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/DefaultListenableAppStorage.java
@@ -7,11 +7,11 @@
 package com.powsybl.afs.storage;
 
 import com.powsybl.afs.storage.events.*;
+import com.powsybl.commons.io.ForwardingOutputStream;
 import com.powsybl.commons.util.WeakListenerList;
 import com.powsybl.timeseries.DoubleDataChunk;
 import com.powsybl.timeseries.StringDataChunk;
 import com.powsybl.timeseries.TimeSeriesMetadata;
-import org.apache.commons.io.output.ProxyOutputStream;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -89,7 +89,7 @@ public class DefaultListenableAppStorage extends ForwardingAppStorage implements
      */
     @Override
     public OutputStream writeBinaryData(String nodeId, String name) {
-        return new ProxyOutputStream(super.writeBinaryData(nodeId, name)) {
+        return new ForwardingOutputStream<OutputStream>(super.writeBinaryData(nodeId, name)) {
             @Override
             public void close() throws IOException {
                 super.close();

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/ListenableAppStorage.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/ListenableAppStorage.java
@@ -13,10 +13,19 @@ import com.powsybl.afs.storage.events.AppStorageListener;
  * A listenable {@link AppStorage}. Listeners will be notified of {@linkplain com.powsybl.afs.storage.events.NodeEvent NodeEvents} happening on the storage:
  * node creation, removal, etc.
  *
+ * WARNING: you will need to keep a reference to your listeners,
+ *          otherwise they may be garbage collected.
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface ListenableAppStorage extends AppStorage {
 
+    /**
+     * Add an {@link AppStorageListener} which will be notified of events happening on this storage.
+     *
+     * WARNING: you will need to keep a reference to your listeners,
+     *          otherwise they may be garbage collected.
+     */
     void addListener(AppStorageListener l);
 
     void removeListener(AppStorageListener l);


### PR DESCRIPTION
* data updated events are now now created on close of the writing stream, not on creation of the stream
* Add a warning about weak references for app storage listeners in javadoc