### PR TITLE
Extensions should be able to handle variants properly

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
@@ -58,6 +58,8 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
 
     @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
+        super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
+
         for (TerminalExt t : terminals) {
             t.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
         }
@@ -65,6 +67,8 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
 
     @Override
     public void reduceVariantArraySize(int number) {
+        super.reduceVariantArraySize(number);
+
         for (TerminalExt t : terminals) {
             t.reduceVariantArraySize(number);
         }
@@ -72,6 +76,8 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
 
     @Override
     public void deleteVariantArrayElement(int index) {
+        super.deleteVariantArrayElement(index);
+
         for (TerminalExt t : terminals) {
             t.deleteVariantArrayElement(index);
         }
@@ -79,6 +85,8 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
 
     @Override
     public void allocateVariantArrayElement(int[] indexes, int sourceIndex) {
+        super.allocateVariantArrayElement(indexes, sourceIndex);
+
         for (TerminalExt t : terminals) {
             t.allocateVariantArrayElement(indexes, sourceIndex);
         }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
@@ -15,7 +15,7 @@ import java.util.*;
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractExtendable<I> implements Identifiable<I>, Validable {
+abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractExtendable<I> implements Identifiable<I>, Validable, MultiVariantObject {
 
     protected String id;
 
@@ -63,4 +63,35 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
         return id;
     }
 
+    @Override
+    public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
+        getExtensions().stream()
+                .filter(e -> e instanceof MultiVariantObject)
+                .map(e -> (MultiVariantObject) e)
+                .forEach(e -> e.extendVariantArraySize(initVariantArraySize, number, sourceIndex));
+    }
+
+    @Override
+    public void reduceVariantArraySize(int number) {
+        getExtensions().stream()
+                .filter(e -> e instanceof MultiVariantObject)
+                .map(e -> (MultiVariantObject) e)
+                .forEach(e -> e.reduceVariantArraySize(number));
+    }
+
+    @Override
+    public void deleteVariantArrayElement(int index) {
+        getExtensions().stream()
+                .filter(e -> e instanceof MultiVariantObject)
+                .map(e -> (MultiVariantObject) e)
+                .forEach(e -> e.deleteVariantArrayElement(index));
+    }
+
+    @Override
+    public void allocateVariantArrayElement(int[] indexes, int sourceIndex) {
+        getExtensions().stream()
+                .filter(e -> e instanceof MultiVariantObject)
+                .map(e -> (MultiVariantObject) e)
+                .forEach(e -> e.allocateVariantArrayElement(indexes, sourceIndex));
+    }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MultiVariantObject.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MultiVariantObject.java
@@ -7,7 +7,7 @@
 package com.powsybl.iidm.network.impl;
 
 /**
- * An interface implemented by network objets that have attributes depending on
+ * An interface implemented by network objects that have attributes depending on
  * the variant.
  * <p>
  * A class implementing this interface internally manages an array of variants and
@@ -16,14 +16,14 @@ package com.powsybl.iidm.network.impl;
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-interface MultiVariantObject {
+public interface MultiVariantObject {
 
     /**
      * Called to extend the variant array.
      *
      * @param initVariantArraySize initial variant array size
      * @param number number of element to add
-     * @param sourceIndex
+     * @param sourceIndex the variant index to use to initialize new variants
      */
     void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex);
 
@@ -42,10 +42,10 @@ interface MultiVariantObject {
     void deleteVariantArrayElement(int index);
 
     /**
-     * Called to allocate a variant array element.
+     * Called to allocate a variant array element. All new variants will be initialize using values of the variant sourceIndex.
      *
      * @param indexes the indexes of the variant array to allocate
-     * @param sourceIndex
+     * @param sourceIndex the variant index to use to initialize new variants
      */
     void allocateVariantArrayElement(int[] indexes, int sourceIndex);
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VariantManagerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VariantManagerImpl.java
@@ -55,6 +55,12 @@ class VariantManagerImpl implements VariantManager {
         return Collections.unmodifiableSet(id2index.keySet());
     }
 
+    /**
+     * Get the size of the variant array
+     * This size is different from the number of variants that also count unused but not released variants.
+     *
+     * @return the size of the variant array
+     */
     int getVariantArraySize() {
         return variantArraySize;
     }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This pull-request fixes #675 : extensions should be able to handle variants properly

* **What is the current behavior?** (You can also link to an open issue here)
IIDM Extensions cannot handle variants.

* **What is the new behavior (if this is a feature change)?**
When a variant is added, removed or cloned, we iterator over all multi-variant extensions.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
The following interfaces have been moved from `powsybl-iidm-impl` to `powsybl-iidm-api`:
- MultiVariantObject
- VariantManagerHolder
The `VariantManger::getVariantArraySize()` is now public.

* **Other information**:
The API of VariantManager exposes some methods that are implementation specific:
- `VariantManager::getVariantArraySize`
- `VariantManagerHolder::getVariantIndex`
These methods defines that the implementation rely on an array or a list of variants, but is it always the case?


