### PR TITLE
Fix Bug in setP0 and setQ0 of EnergyConsumer for CGMES conversion

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergyConsumerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergyConsumerConversion.java
@@ -8,7 +8,6 @@
 package com.powsybl.cgmes.conversion.elements;
 
 import com.powsybl.cgmes.conversion.Context;
-import com.powsybl.cgmes.model.PowerFlow;
 import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.LoadAdder;
 import com.powsybl.iidm.network.LoadType;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergyConsumerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergyConsumerConversion.java
@@ -26,14 +26,21 @@ public class EnergyConsumerConversion extends AbstractConductingEquipmentConvers
     @Override
     public void convert() {
         LoadType loadType = id.contains("fict") ? LoadType.FICTITIOUS : LoadType.UNDEFINED;
-        PowerFlow f = powerFlow();
         LoadAdder adder = voltageLevel().newLoad()
-                .setP0(f.p())
-                .setQ0(f.q())
+                .setP0(p0())
+                .setQ0(q0())
                 .setLoadType(loadType);
         identify(adder);
         connect(adder);
         Load load = adder.add();
         convertedTerminals(load.getTerminal());
+    }
+
+    private double p0() {
+        return p.getId("pfixed") != null ? p.asDouble("pfixed") : powerFlow().p();
+    }
+
+    private double q0() {
+        return p.getId("qfixed") != null ? p.asDouble("qfixed") : powerFlow().q();
     }
 }

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -559,7 +559,14 @@ WHERE {
         a ?type ;
         cim:IdentifiedObject.name ?name .
     VALUES ?type { cim:EnergyConsumer cim:ConformLoad cim:NonConformLoad }
-    ?Terminal cim:Terminal.ConductingEquipment ?EnergyConsumer
+    ?Terminal cim:Terminal.ConductingEquipment ?EnergyConsumer .
+    OPTIONAL { ?EnergyConsumer cim:EnergyConsumer.pfixed ?pfixed }
+    OPTIONAL { ?EnergyConsumer cim:EnergyConsumer.qfixed ?qfixed }
+}}
+{ GRAPH ?graphSSH {
+    ?EnergyConsumer
+        cim:EnergyConsumer.p ?p ;
+        cim:EnergyConsumer.q ?q
 }}
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When the terminal of an `EnergyConsumer` is not mapped, the power flow returns a `NaN ` value for
constant active and reactive power which is forbidden. This caused standard `MicroGrid` files of CIMDesk to fail.

* **What is the new behavior (if this is a feature change)?**
 `pfixed` and  `qfixed` are used if present as constant active and reactive power. Else, p and q of mapped terminal are used if present. Else, p and q of SSH graph linked to the `EnergyConsumer` equipment are used.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A


* **Other information**:
N/A
