### PR TITLE
Fix buffer filling issue with string compressed time series

### DIFF
--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedStringDataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedStringDataChunk.java
@@ -87,13 +87,13 @@ public class CompressedStringDataChunk extends AbstractCompressedDataChunk imple
     @Override
     public void fillBuffer(CompactStringBuffer buffer, int timeSeriesOffset) {
         Objects.requireNonNull(buffer);
-        forEachMaterializedValueIndex((v, i) -> buffer.putString(i, v));
+        forEachMaterializedValueIndex((v, i) -> buffer.putString(timeSeriesOffset + i, v));
     }
 
     @Override
     public void fillBuffer(BigStringBuffer buffer, long timeSeriesOffset) {
         Objects.requireNonNull(buffer);
-        forEachMaterializedValueIndex((v, i) -> buffer.putString(i, v));
+        forEachMaterializedValueIndex((v, i) -> buffer.putString(timeSeriesOffset + i, v));
     }
 
     @Override

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/StringTimeSeriesLostColumnsIssue.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/StringTimeSeriesLostColumnsIssue.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.timeseries;
+
+import org.junit.Test;
+import org.threeten.extra.Interval;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class StringTimeSeriesLostColumnsIssue {
+
+    @Test
+    public void test() throws IOException {
+        String csv = String.join(System.lineSeparator(),
+                "Time;Version;TITLE1;TITLE2",
+                "2016-01-01T01:00:00Z;1;VALUE;VALUE",
+                "2016-01-01T02:00:00Z;1;VALUE;VALUE") + System.lineSeparator();
+
+        Map<Integer, List<TimeSeries>> tsMap = TimeSeries.parseCsv(csv, ';');
+
+        TimeSeriesIndex index = RegularTimeSeriesIndex.create(Interval.parse("2016-01-01T01:00:00Z/2016-01-01T02:00:00Z"), Duration.ofHours(1));
+        TimeSeriesTable table = new TimeSeriesTable(1, 1, index);
+        table.load(1, tsMap.get(1));
+        String csv2 = table.toCsvString(';', ZoneId.of("UTC"));
+
+        assertEquals(csv, csv2);
+    }
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix bug #690 


* **What is the current behavior?** (You can also link to an open issue here)
When string compressed time series are added to time series table, time series offset in the buffer is not taken into account and consequently data are always written at first time series offset (zero).

* **What is the new behavior (if this is a feature change)?**

Time series offset is now correctly used for string compressed time series like it is for string uncompressed time series.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A


* **Other information**:

