### PR TITLE
Add unit test to CGMES conversion using only EQ, TP, SSH

### DIFF
--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Catalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1Catalog.java
@@ -59,6 +59,22 @@ public class CgmesConformity1Catalog {
                         "MicroGridTestConfiguration_TP_BD.xml"));
     }
 
+    public TestGridModel microGridType4BEOnlyEqTpSsh() {
+        String base = ENTSOE_CONFORMITY_1
+                + "/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_T4_BE_BB_Complete_v2/";
+        String baseBoundary = ENTSOE_CONFORMITY_1
+                + "/MicroGrid/Type4_T4/CGMES_v2.4.15_MicroGridTestConfiguration_BD_v2/";
+        return new TestGridModelResources(
+                "MicroGrid-Type4-BE",
+                expectedMicroGridType4BE(),
+                new ResourceSet(base,
+                        "MicroGridTestConfiguration_T4_BE_EQ_V2.xml",
+                        "MicroGridTestConfiguration_T4_BE_SSH_V2.xml",
+                        "MicroGridTestConfiguration_T4_BE_TP_V2.xml"),
+                new ResourceSet(baseBoundary, "MicroGridTestConfiguration_EQ_BD.xml",
+                        "MicroGridTestConfiguration_TP_BD.xml"));
+    }
+
     public final TestGridModelResources microGridBaseCaseNL() {
         String base = ENTSOE_CONFORMITY_1 + "/MicroGrid/BaseCase/CGMES_v2.4.15_MicroGridTestConfiguration_BC_NL_v2/";
         String baseBoundary = ENTSOE_CONFORMITY_1

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergyConsumerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergyConsumerConversion.java
@@ -36,10 +36,10 @@ public class EnergyConsumerConversion extends AbstractConductingEquipmentConvers
     }
 
     private double p0() {
-        return p.getId("pfixed") != null ? p.asDouble("pfixed") : powerFlow().p();
+        return p.containsKey("pfixed") ? p.asDouble("pfixed") : powerFlow().p();
     }
 
     private double q0() {
-        return p.getId("qfixed") != null ? p.asDouble("qfixed") : powerFlow().q();
+        return p.containsKey("qfixed") ? p.asDouble("qfixed") : powerFlow().q();
     }
 }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
@@ -107,6 +107,11 @@ public class CgmesConformity1ConversionTest {
     }
 
     @Test
+    public void microGridType4BEOnlyEqTpSsh() throws IOException {
+        tester.testConversion(null, actuals.microGridType4BEOnlyEqTpSsh());
+    }
+
+    @Test
     public void microGridBaseCaseNL() throws IOException {
         tester.testConversion(null, actuals.microGridBaseCaseNL());
     }

--- a/triple-store/triple-store-api/src/main/java/com/powsybl/triplestore/api/TripleStoreFactory.java
+++ b/triple-store/triple-store-api/src/main/java/com/powsybl/triplestore/api/TripleStoreFactory.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.util.ServiceLoaderCache;
 
 /**
@@ -35,7 +36,7 @@ public final class TripleStoreFactory {
                 return ts.create();
             }
         }
-        return null;
+        throw new PowsyblException("No implementation available for triple store " + impl);
     }
 
     public static List<String> allImplementations() {


### PR DESCRIPTION
This PR adds a unit test to check conversion bug fixed in #685

A variant of Conformity test configuration MicroGrid has been created, using only EQ, TP and SSH files. 

In The `EnergyConsumerConversion`, `containsKey` has been used to replace `getId` when checking if a property exists.

Additionally, a `PowsyblException` is now thrown if no implementation is found for the required triple store engine, instead of returning `null`.

