### PR TITLE
CGMES default boundary files

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -104,10 +104,12 @@ public class CgmesImport implements Importer {
                 p,
                 BOUNDARY_LOCATION_PARAMETER,
                 defaultValueConfig));
-        if (!loc.toFile().exists()) {
+        // Check that the Data Source has valid CGMES names
+        ReadOnlyDataSource ds = new GenericReadOnlyDataSource(loc, DataSourceUtil.getBaseName(loc));
+        if ((new CgmesOnDataSource(ds)).names().isEmpty()) {
             return null;
         }
-        return new GenericReadOnlyDataSource(loc, DataSourceUtil.getBaseName(loc));
+        return ds;
     }
 
     private String tripleStore(Properties p) {

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -98,9 +98,13 @@ public abstract class AbstractCgmesModel implements CgmesModel {
         if (cachedBaseVoltages == null) {
             cachedBaseVoltages = new HashMap<>();
             baseVoltages()
-                    .forEach(bv -> cachedBaseVoltages.put(bv.getId("BaseVoltage"), bv.asDouble("nominalVoltage")));
+                .forEach(bv -> cachedBaseVoltages.put(bv.getId("BaseVoltage"), bv.asDouble("nominalVoltage")));
         }
-        return cachedBaseVoltages.get(baseVoltageId);
+        if (cachedBaseVoltages.containsKey(baseVoltageId)) {
+            return cachedBaseVoltages.get(baseVoltageId);
+        } else {
+            return Double.NaN;
+        }
     }
 
     private CgmesContainer container(CgmesTerminal t) {
@@ -131,26 +135,26 @@ public abstract class AbstractCgmesModel implements CgmesModel {
         powerTransformerRatioTapChanger = new HashMap<>();
         powerTransformerPhaseTapChanger = new HashMap<>();
         transformerEnds()
-                .forEach(end -> {
-                    String id = end.getId("PowerTransformer");
-                    PropertyBags ends = gends.computeIfAbsent(id, x -> new PropertyBags());
-                    ends.add(end);
-                    if (end.getId("PhaseTapChanger") != null) {
-                        powerTransformerPhaseTapChanger.put(id, end.getId("PhaseTapChanger"));
-                    } else if (end.getId("RatioTapChanger") != null) {
-                        powerTransformerRatioTapChanger.put(id, end.getId("RatioTapChanger"));
-                    }
-                });
+            .forEach(end -> {
+                String id = end.getId("PowerTransformer");
+                PropertyBags ends = gends.computeIfAbsent(id, x -> new PropertyBags());
+                ends.add(end);
+                if (end.getId("PhaseTapChanger") != null) {
+                    powerTransformerPhaseTapChanger.put(id, end.getId("PhaseTapChanger"));
+                } else if (end.getId("RatioTapChanger") != null) {
+                    powerTransformerRatioTapChanger.put(id, end.getId("RatioTapChanger"));
+                }
+            });
         gends.entrySet()
-                .forEach(tends -> {
-                    PropertyBags tends1 = new PropertyBags(
-                            tends.getValue().stream()
-                                    .sorted(Comparator
-                                            .comparing(WindingType::fromTransformerEnd)
-                                            .thenComparing(end -> end.asInt("endNumber", -1)))
-                                    .collect(Collectors.toList()));
-                    tends.setValue(tends1);
-                });
+            .forEach(tends -> {
+                PropertyBags tends1 = new PropertyBags(
+                    tends.getValue().stream()
+                        .sorted(Comparator
+                            .comparing(WindingType::fromTransformerEnd)
+                            .thenComparing(end -> end.asInt("endNumber", -1)))
+                        .collect(Collectors.toList()));
+                tends.setValue(tends1);
+            });
         return gends;
     }
 

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -36,6 +36,8 @@ public interface CgmesModel {
 
     boolean isNodeBreaker();
 
+    boolean hasBoundary();
+
     CgmesTerminal terminal(String terminalId);
 
     PropertyBags numObjectsByType();

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModelFactory.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModelFactory.java
@@ -35,17 +35,17 @@ public final class CgmesModelFactory {
         CgmesOnDataSource cds = new CgmesOnDataSource(ds);
         TripleStore tripleStore = TripleStoreFactory.create(tripleStoreImpl);
         CgmesModelTripleStore cgmes = new CgmesModelTripleStore(cds.cimNamespace(), tripleStore);
-        read(cgmes, cds);
+        read(cgmes, cds, cds.baseName());
         // Only try to read boundary data from additional sources if the main data
         // source does not contain boundary info
         if (!cgmes.hasBoundary() && dsBoundary != null) {
-            read(cgmes, new CgmesOnDataSource(dsBoundary));
+            // Read boundary using same baseName of the main data
+            read(cgmes, new CgmesOnDataSource(dsBoundary), cds.baseName());
         }
         return cgmes;
     }
 
-    private static void read(CgmesModelTripleStore cgmes, CgmesOnDataSource cds) {
-        String base = cds.baseName();
+    private static void read(CgmesModelTripleStore cgmes, CgmesOnDataSource cds, String base) {
         for (String name : cds.names()) {
             LOG.info("Reading [{}]", name);
             try (InputStream is = cds.dataSource().newInputStream(name)) {

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModelFactory.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModelFactory.java
@@ -28,10 +28,19 @@ public final class CgmesModelFactory {
     }
 
     public static CgmesModelTripleStore create(ReadOnlyDataSource ds, String tripleStoreImpl) {
+        return create(ds, null, tripleStoreImpl);
+    }
+
+    public static CgmesModelTripleStore create(ReadOnlyDataSource ds, ReadOnlyDataSource dsBoundary, String tripleStoreImpl) {
         CgmesOnDataSource cds = new CgmesOnDataSource(ds);
         TripleStore tripleStore = TripleStoreFactory.create(tripleStoreImpl);
         CgmesModelTripleStore cgmes = new CgmesModelTripleStore(cds.cimNamespace(), tripleStore);
         read(cgmes, cds);
+        // Only try to read boundary data from additional sources if the main data
+        // source does not contain boundary info
+        if (!cgmes.hasBoundary() && dsBoundary != null) {
+            read(cgmes, new CgmesOnDataSource(dsBoundary));
+        }
         return cgmes;
     }
 

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -80,7 +80,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
                 if (p != null && p.contains("/EquipmentCore/")) {
                     if (LOG.isInfoEnabled()) {
                         LOG.info("Model contains Equipment Core data profile in model {}",
-                                m.get(CgmesNames.FULL_MODEL));
+                            m.get(CgmesNames.FULL_MODEL));
                     }
                     return true;
                 }
@@ -90,6 +90,36 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
         // available
         // (This covers the case for CIM14 files)
         return true;
+    }
+
+    @Override
+    public boolean hasBoundary() {
+        // The Model has boundary if we are able to find models
+        // that have EquipmentBoundary profile
+        // and models that have TopologyBoundary profile
+        boolean hasEquipmentBoundary = false;
+        boolean hasTopologyBoundary = false;
+        if (queryCatalog.containsKey(MODEL_PROFILES)) {
+            PropertyBags r = namedQuery(MODEL_PROFILES);
+            if (r == null) {
+                return false;
+            }
+            for (PropertyBag m : r) {
+                String p = m.get("profile");
+                String mid = m.get(CgmesNames.FULL_MODEL);
+                if (p != null && p.contains("/EquipmentBoundary/")) {
+                    LOG.info("Model contains EquipmentBoundary data in model {}", mid);
+                    hasEquipmentBoundary = true;
+                }
+                if (p != null && p.contains("/TopologyBoundary/")) {
+                    LOG.info("Model contains TopologyBoundary data in model {}", mid);
+                    hasTopologyBoundary = true;
+                }
+            }
+        }
+        // If we do not have a query for model profiles we assume no boundary exist
+        // (Maybe for CIM14 data sources we should rely on file names ?)
+        return hasEquipmentBoundary && hasTopologyBoundary;
     }
 
     @Override

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -76,7 +76,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
                 return false;
             }
             for (PropertyBag m : r) {
-                String p = m.get("profile");
+                String p = m.get(PROFILE);
                 if (p != null && p.contains("/EquipmentCore/")) {
                     if (LOG.isInfoEnabled()) {
                         LOG.info("Model contains Equipment Core data profile in model {}",
@@ -105,7 +105,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
                 return false;
             }
             for (PropertyBag m : r) {
-                String p = m.get("profile");
+                String p = m.get(PROFILE);
                 String mid = m.get(CgmesNames.FULL_MODEL);
                 if (p != null && p.contains("/EquipmentBoundary/")) {
                     LOG.info("Model contains EquipmentBoundary data in model {}", mid);
@@ -132,7 +132,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
                 return false;
             }
             for (PropertyBag m : r) {
-                String p = m.get("profile");
+                String p = m.get(PROFILE);
                 if (p != null && p.contains("/EquipmentOperation/")) {
                     if (LOG.isInfoEnabled()) {
                         LOG.info("Model is considered node-breaker because {} has profile {}", m.get("FullModel"), p);
@@ -473,5 +473,6 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
     private final QueryCatalog queryCatalog;
 
     private static final String MODEL_PROFILES = "modelProfiles";
+    private static final String PROFILE = "profile";
     private static final Logger LOG = LoggerFactory.getLogger(CgmesModelTripleStore.class);
 }

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
@@ -111,6 +111,10 @@ public final class FakeCgmesModel implements CgmesModel {
         return isNodeBreaker;
     }
 
+    public boolean hasBoundary() {
+        return false;
+    }
+
     public FakeCgmesModel substations(String... ids) {
         fakeObjectsFromIdentifiers("Substation", ids, substations);
         // Add a default SubRegion to every substation

--- a/commons/src/main/java/com/powsybl/commons/datasource/GenericReadOnlyDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/GenericReadOnlyDataSource.java
@@ -10,6 +10,7 @@ package com.powsybl.commons.datasource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -22,6 +23,7 @@ public class GenericReadOnlyDataSource implements ReadOnlyDataSource {
     public GenericReadOnlyDataSource(Path directory, String baseName, DataSourceObserver observer) {
         dataSources = new DataSource[] {
             new FileDataSource(directory, baseName, observer),
+            new ZipFileDataSource(directory),
             new ZipFileDataSource(directory, baseName + ".zip", baseName, observer),
             new GzFileDataSource(directory, baseName, observer),
             new Bzip2FileDataSource(directory, baseName, observer)
@@ -79,6 +81,14 @@ public class GenericReadOnlyDataSource implements ReadOnlyDataSource {
 
     @Override
     public Set<String> listNames(String regex) throws IOException {
-        throw new UnsupportedOperationException("Not implemented");
+        Set<String> names = new HashSet<>();
+        for (ReadOnlyDataSource dataSource : dataSources) {
+            try {
+                names.addAll(dataSource.listNames(regex));
+            } catch (Exception x) {
+                // Nothing
+            }
+        }
+        return names;
     }
 }


### PR DESCRIPTION
Default boundary files can be specified for CGMES conversion.

Currently CGMES conversion expects boundary files to be included in the main data source received for the import.

With this change, the user can specify location of boundary files using a new parameter for the import: `iidm.import.cgmes.boundary-location`. The default value for this parameter is `PlatformConfig.defaultConfig().getConfigDir().resolve("CGMES").resolve("boundary")`, that corresponds to: `~/.itools/CGMES/boundary`.

The boundary files will be read only if the main data source of the import DOES NOT contain boundary data. A CGMES data source contains boundary data if the profiles `EquipmentBoundary` and `TopologyBoundary` are referenced in the models.

Boundary data will be read using a `GenericReadOnlyDataSource`, that has been extended to support a `ZipFileDataSource` from a single file. Thus, the location of boundaries given as a parameter could correspond to a directory name (with the xml files as regular files inside it) or to a .zip package (containing the zipped xml files).