### PR TITLE
Fix bug in setting of bus name (issue #697)

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractBus.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractBus.java
@@ -22,7 +22,11 @@ abstract class AbstractBus extends AbstractIdentifiable<Bus> implements Bus {
     protected VoltageLevelExt voltageLevel;
 
     AbstractBus(String id, VoltageLevelExt voltageLevel) {
-        super(id, id);
+        this(id, id, voltageLevel);
+    }
+
+    AbstractBus(String id, String name, VoltageLevelExt voltageLevel) {
+        super(id, name);
         this.voltageLevel = voltageLevel;
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusAdderImpl.java
@@ -8,8 +8,6 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.iidm.network.BusAdder;
 
-import java.util.Optional;
-
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -35,8 +33,7 @@ class BusAdderImpl extends AbstractIdentifiableAdder<BusAdderImpl> implements Bu
     @Override
     public ConfiguredBus add() {
         String id = checkAndGetUniqueId();
-        String name = Optional.ofNullable(getName()).orElse(id);
-        ConfiguredBusImpl bus = new ConfiguredBusImpl(id, name, voltageLevel);
+        ConfiguredBusImpl bus = new ConfiguredBusImpl(id, getName(), voltageLevel);
         voltageLevel.addBus(bus);
         getNetwork().getListeners().notifyCreation(bus);
         return bus;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusAdderImpl.java
@@ -8,6 +8,8 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.iidm.network.BusAdder;
 
+import java.util.Optional;
+
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -33,7 +35,8 @@ class BusAdderImpl extends AbstractIdentifiableAdder<BusAdderImpl> implements Bu
     @Override
     public ConfiguredBus add() {
         String id = checkAndGetUniqueId();
-        ConfiguredBusImpl bus = new ConfiguredBusImpl(id, voltageLevel);
+        String name = Optional.ofNullable(getName()).orElse(id);
+        ConfiguredBusImpl bus = new ConfiguredBusImpl(id, name, voltageLevel);
         voltageLevel.addBus(bus);
         getNetwork().getListeners().notifyCreation(bus);
         return bus;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConfiguredBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConfiguredBusImpl.java
@@ -35,8 +35,8 @@ class ConfiguredBusImpl extends AbstractBus implements ConfiguredBus, MultiVaria
 
     private final TIntArrayList synchronousComponentNumber;
 
-    ConfiguredBusImpl(String id, VoltageLevelExt voltageLevel) {
-        super(id, voltageLevel);
+    ConfiguredBusImpl(String id, String name, VoltageLevelExt voltageLevel) {
+        super(id, name, voltageLevel);
         network = voltageLevel.getNetwork().getRef();
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         terminals = new ArrayList<>(variantArraySize);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/BusTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/BusTest.java
@@ -31,9 +31,13 @@ public class BusTest {
         // ConfiguredBus
         Bus bus = voltageLevel.getBusBreakerView()
                     .newBus()
-                    .setName("bus1")
+                    .setName("bus1Name")
                     .setId("bus1")
                 .add();
+
+        assertEquals("bus1", bus.getId());
+        assertEquals("bus1Name", bus.getName());
+
         LccConverterStation lccConverterStation = voltageLevel.newLccConverterStation()
                                                     .setId("lcc")
                                                     .setName("lcc")


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix during creation of a bus


* **What is the current behavior?** (You can also link to an open issue here)
When a bus is created, `bus.getName()` returns the value entered with `setId` in the busAdder.


* **What is the new behavior (if this is a feature change)?**
When a bus is created, `bus.getName()` returns the value entered with `setName` in the busAdder if it exists, the bus ID if it does not.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Fixes #697 
