### PR TITLE
Use ISO codes available at boundary nodes in ENTSO-E extensions

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Context.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Context.java
@@ -17,10 +17,7 @@ import org.slf4j.LoggerFactory;
 import com.powsybl.cgmes.conversion.Conversion.Config;
 import com.powsybl.cgmes.conversion.elements.ACLineSegmentConversion;
 import com.powsybl.cgmes.model.CgmesModel;
-import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.triplestore.api.PropertyBags;
 
 /**
@@ -117,29 +114,6 @@ public class Context {
 
     public PropertyBags ratioTapChangerTable(String tableId) {
         return ratioTapChangerTables.get(tableId);
-    }
-
-    public VoltageLevel createSubstationVoltageLevel(String nodeId, double nominalV) {
-        String substationId = boundarySubstationId(nodeId);
-        String vlId = boundaryVoltageLevelId(nodeId);
-        String substationName = "boundary";
-        String vlName = "boundary";
-        return network()
-                .newSubstation()
-                .setId(namingStrategy().getId("Substation", substationId))
-                .setName(substationName)
-                // TODO(mathbagu): Country should be optional. This will be done in another PR.
-                // A non-null country code must be set
-                // This is an arbitrary country code, Bangladesh code BD also matches with
-                // BounDary
-                .setCountry(Country.BD)
-                .add()
-                .newVoltageLevel()
-                .setId(namingStrategy().getId("VoltageLevel", vlId))
-                .setName(vlName)
-                .setNominalV(nominalV)
-                .setTopologyKind(TopologyKind.BUS_BREAKER)
-                .add();
     }
 
     public void startLinesConversion() {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
@@ -9,6 +9,10 @@ package com.powsybl.cgmes.conversion;
 
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.powsybl.cgmes.conversion.elements.AbstractIdentifiedObjectConversion;
 import com.powsybl.iidm.network.Country;
 
 /**
@@ -34,6 +38,7 @@ public final class CountryConversion {
             return Optional.of(Country.valueOf(gr));
         } catch (IllegalArgumentException ignored) {
             // Ignore
+            LOG.warn("{} does not match any Country enum", gr);
         }
         return Optional.empty();
     }
@@ -82,6 +87,16 @@ public final class CountryConversion {
         return Optional.empty();
     }
 
+    public static Country defaultCountry(AbstractIdentifiedObjectConversion c) {
+        LOG.warn("Default country converting {}", c.what());
+        return defaultCountry();
+    }
+
+    public static Country defaultCountryForBoundary(AbstractIdentifiedObjectConversion c) {
+        LOG.warn("Default boundary country converting {}", c.what());
+        return defaultCountryForBoundary();
+    }
+
     public static Country defaultCountry() {
         return Country.values()[0];
     }
@@ -89,4 +104,6 @@ public final class CountryConversion {
     public static Country defaultCountryForBoundary() {
         return Country.BD;
     }
+
+    private static final Logger LOG = LoggerFactory.getLogger(CountryConversion.class);
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
@@ -88,12 +88,16 @@ public final class CountryConversion {
     }
 
     public static Country defaultCountry(AbstractIdentifiedObjectConversion c) {
-        LOG.warn("Default country converting {}", c.what());
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("Default country converting {}", c.what());
+        }
         return defaultCountry();
     }
 
     public static Country defaultCountryForBoundary(AbstractIdentifiedObjectConversion c) {
-        LOG.warn("Default boundary country converting {}", c.what());
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("Default boundary country converting {}", c.what());
+        }
         return defaultCountryForBoundary();
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
@@ -94,13 +94,6 @@ public final class CountryConversion {
         return defaultCountry();
     }
 
-    public static Country defaultCountryForBoundary(AbstractIdentifiedObjectConversion c) {
-        if (LOG.isWarnEnabled()) {
-            LOG.warn("Default boundary country converting {}", c.what());
-        }
-        return defaultCountryForBoundary();
-    }
-
     public static Country defaultCountry() {
         return Country.values()[0];
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
@@ -98,9 +98,5 @@ public final class CountryConversion {
         return Country.values()[0];
     }
 
-    public static Country defaultCountryForBoundary() {
-        return Country.BD;
-    }
-
     private static final Logger LOG = LoggerFactory.getLogger(CountryConversion.class);
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CountryConversion.java
@@ -24,10 +24,10 @@ public final class CountryConversion {
             return Optional.empty();
         }
         if (gr.equals("D1")
-                || gr.equals("D2")
-                || gr.equals("D4")
-                || gr.equals("D7")
-                || gr.equals("D8")) {
+            || gr.equals("D2")
+            || gr.equals("D4")
+            || gr.equals("D7")
+            || gr.equals("D8")) {
             return Optional.of(Country.DE);
         }
         try {
@@ -36,14 +36,13 @@ public final class CountryConversion {
             // Ignore
         }
         return Optional.empty();
-
     }
 
     public static Optional<Country> fromSubregionName(String name) {
         if (name == null) {
             return Optional.empty();
         }
-        switch (name) {
+        switch (name.trim().toUpperCase()) {
             case "NO1":
             case "NO2":
             case "NO3":
@@ -71,7 +70,23 @@ public final class CountryConversion {
         }
     }
 
+    public static Optional<Country> fromIsoCode(String iso) {
+        if (iso == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Country.valueOf(iso.trim().toUpperCase()));
+        } catch (IllegalArgumentException ignored) {
+            // Ignore
+        }
+        return Optional.empty();
+    }
+
     public static Country defaultCountry() {
         return Country.values()[0];
+    }
+
+    public static Country defaultCountryForBoundary() {
+        return Country.BD;
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractIdentifiedObjectConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractIdentifiedObjectConversion.java
@@ -70,7 +70,7 @@ public abstract class AbstractIdentifiedObjectConversion extends AbstractObjectC
     }
 
     @Override
-    protected String what() {
+    public String what() {
         if (name != null) {
             return String.format("%s %s (%s)", type, name, id);
         } else {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractObjectConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractObjectConversion.java
@@ -45,7 +45,7 @@ public abstract class AbstractObjectConversion {
 
     public abstract void convert();
 
-    protected abstract String what();
+    public abstract String what();
 
     protected abstract String complete(String what);
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
@@ -84,8 +84,8 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
     private Country boundaryCountryCode() {
         // Selection of country code when ENTSO-E extensions are present
         return CountryConversion.fromIsoCode(p.getLocal("fromEndIsoCode"))
-                .orElse(CountryConversion.fromIsoCode(p.getLocal("toEndIsoCode"))
-                        .orElse(CountryConversion.defaultCountryForBoundary()));
+                .orElseGet(() -> CountryConversion.fromIsoCode(p.getLocal("toEndIsoCode"))
+                        .orElseGet(() -> CountryConversion.defaultCountryForBoundary(this)));
     }
 
     @Override

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import com.powsybl.cgmes.conversion.Context;
 import com.powsybl.cgmes.conversion.CountryConversion;
 import com.powsybl.cgmes.model.CgmesNames;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.BusbarSection;
 import com.powsybl.iidm.network.Country;
@@ -84,8 +85,14 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
     private Country boundaryCountryCode() {
         // Selection of country code when ENTSO-E extensions are present
         return CountryConversion.fromIsoCode(p.getLocal("fromEndIsoCode"))
-                .orElseGet(() -> CountryConversion.fromIsoCode(p.getLocal("toEndIsoCode"))
-                        .orElseGet(() -> CountryConversion.defaultCountryForBoundary(this)));
+            .orElseGet(() -> CountryConversion.fromIsoCode(p.getLocal("toEndIsoCode"))
+                .orElseThrow(() -> {
+                    String countryCodes = String.format("Country. ISO codes %s %s",
+                        p.getLocal("fromEndIsoCode"),
+                        p.getLocal("toEndIsoCode"));
+                    invalid(countryCodes);
+                    return new PowsyblException("Invalid " + countryCodes);
+                }));
     }
 
     @Override

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
@@ -13,11 +13,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.powsybl.cgmes.conversion.Context;
+import com.powsybl.cgmes.conversion.CountryConversion;
 import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.BusbarSection;
+import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Switch;
 import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.triplestore.api.PropertyBag;
 
@@ -38,11 +41,7 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
     @Override
     public void convertInsideBoundary() {
         if (context.config().convertBoundary()) {
-            String bv = p.getId("BaseVoltage");
-            double v = context.cgmes().nominalVoltage(bv);
-            LOG.info("Boundary node will be converted {}, nominalVoltage {}", id, v);
-            VoltageLevel voltageLevel = context.createSubstationVoltageLevel(id, v);
-            newBus(voltageLevel);
+            newBus(newBoundarySubstationVoltageLevel());
         } else {
             // TODO(Luma): when the boundary nodes are not converted to IIDM buses
             // they are not exported (the SV is built from buses of IIDM network)
@@ -55,6 +54,38 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
                 }
             }
         }
+    }
+
+    private VoltageLevel newBoundarySubstationVoltageLevel() {
+        double nominalVoltage = context.cgmes().nominalVoltage(p.getId("BaseVoltage"));
+        LOG.warn("Boundary node will be converted {}, nominalVoltage {}", id, nominalVoltage);
+        String substationId = Context.boundarySubstationId(this.id);
+        String vlId = Context.boundaryVoltageLevelId(this.id);
+        String substationName = "boundary";
+        String vlName = "boundary";
+        return context.network()
+            .newSubstation()
+            .setId(context.namingStrategy().getId("Substation", substationId))
+            .setName(substationName)
+            // TODO(mathbagu): Country should be optional. This will be done in another PR.
+            // A non-null country code must be set
+            // This is an arbitrary country code, Bangladesh code BD also matches with
+            // BounDary
+            .setCountry(boundaryCountryCode())
+            .add()
+            .newVoltageLevel()
+            .setId(context.namingStrategy().getId("VoltageLevel", vlId))
+            .setName(vlName)
+            .setNominalV(nominalVoltage)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
+    }
+
+    private Country boundaryCountryCode() {
+        // Selection of country code when ENTSO-E extensions are present
+        return CountryConversion.fromIsoCode(p.getLocal("fromEndIsoCode"))
+                .orElse(CountryConversion.fromIsoCode(p.getLocal("toEndIsoCode"))
+                        .orElse(CountryConversion.defaultCountryForBoundary()));
     }
 
     @Override
@@ -141,7 +172,9 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
                 LOG.error("Can't find a Bus from Terminal to set Voltage, Angle. Connectivity Node {}", id);
                 return;
             }
-            LOG.warn("Can't find a calculated Bus to set Voltage, Angle, but found a configured Bus {}. Connectivity node {}", bus, id);
+            LOG.warn(
+                "Can't find a calculated Bus to set Voltage, Angle, but found a configured Bus {}. Connectivity node {}",
+                bus, id);
         }
         setVoltageAngle(bus);
     }
@@ -163,19 +196,19 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
         // against the topology present in the CGMES model
         if (context.config().createBusbarSectionForEveryConnectivityNode()) {
             BusbarSection bus = nbv.newBusbarSection()
-                    .setId(context.namingStrategy().getId("Bus", id))
-                    .setName(context.namingStrategy().getName("Bus", name))
-                    .setNode(iidmNode)
-                    .add();
+                .setId(context.namingStrategy().getId("Bus", id))
+                .setName(context.namingStrategy().getName("Bus", name))
+                .setNode(iidmNode)
+                .add();
             LOG.debug("    BusbarSection added at node {} : {} {} : {}", iidmNode, id, name, bus);
         }
     }
 
     private void newBus(VoltageLevel voltageLevel) {
         Bus bus = voltageLevel.getBusBreakerView().newBus()
-                .setId(context.namingStrategy().getId("Bus", id))
-                .setName(context.namingStrategy().getName("Bus", name))
-                .add();
+            .setId(context.namingStrategy().getId("Bus", id))
+            .setName(context.namingStrategy().getName("Bus", name))
+            .add();
         if (checkValidVoltageAngle(bus)) {
             setVoltageAngle(bus);
         }
@@ -187,16 +220,16 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
         boolean valid = valid(v, angle);
         if (!valid) {
             String reason = String.format(
-                    "v = %f, angle = %f. Node %s",
-                    v,
-                    angle,
-                    id);
+                "v = %f, angle = %f. Node %s",
+                v,
+                angle,
+                id);
             String location = bus == null
-                    ? "No bus"
-                    : String.format("Bus %s, Substation %s, Voltage level %s",
-                            bus.getId(),
-                            bus.getVoltageLevel().getSubstation().getName(),
-                            bus.getVoltageLevel().getName());
+                ? "No bus"
+                : String.format("Bus %s, Substation %s, Voltage level %s",
+                    bus.getId(),
+                    bus.getVoltageLevel().getSubstation().getName(),
+                    bus.getVoltageLevel().getName());
             String message = String.format("%s. %s", reason, location);
             context.invalid("SvVoltage", message);
         }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SubstationConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SubstationConversion.java
@@ -35,8 +35,8 @@ public class SubstationConversion extends AbstractIdentifiedObjectConversion {
         String regionName = p.get("regionName");
 
         Country country = CountryConversion.fromRegionName(regionName)
-                .orElse(CountryConversion.fromSubregionName(subRegionName)
-                        .orElse(CountryConversion.defaultCountry()));
+                .orElseGet(() -> CountryConversion.fromSubregionName(subRegionName)
+                        .orElseGet(() -> CountryConversion.defaultCountry(this)));
         String geo = subRegion;
 
         // TODO add naminStrategy (for regions and substations)

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
@@ -21,14 +21,19 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.google.common.collect.ImmutableSet;
 import com.powsybl.cgmes.conformity.test.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.test.CgmesConformity1NetworkCatalog;
+import com.powsybl.cgmes.conversion.CgmesImport;
+import com.powsybl.cgmes.conversion.CountryConversion;
 import com.powsybl.cgmes.conversion.test.ConversionTester;
 import com.powsybl.cgmes.conversion.test.network.compare.ComparisonConfig;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Substation;
 import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.mock.LoadFlowFactoryMock;
@@ -43,14 +48,14 @@ public class CgmesConformity1ConversionTest {
         actuals = new CgmesConformity1Catalog();
         expecteds = new CgmesConformity1NetworkCatalog();
         tester = new ConversionTester(
-                TripleStoreFactory.onlyDefaultImplementation(),
-                new ComparisonConfig());
+            TripleStoreFactory.onlyDefaultImplementation(),
+            new ComparisonConfig());
     }
 
     @Test
     public void microGridBaseCaseBEReport() throws IOException {
         ConversionTester t = new ConversionTester(TripleStoreFactory.onlyDefaultImplementation(),
-                new ComparisonConfig());
+            new ComparisonConfig());
         Map<String, TxData> actual = new HashMap<>();
         t.setOnlyReport(true);
         t.setReportConsumer(line -> {
@@ -75,11 +80,11 @@ public class CgmesConformity1ConversionTest {
     @Test
     public void microGridBaseCaseBERoundtripBoundary() throws IOException {
         Properties importParams = new Properties();
-        importParams.put("convertBoundary", "true");
+        importParams.put(CgmesImport.CONVERT_BOUNDARY, "true");
         ConversionTester t = new ConversionTester(
-                importParams,
-                TripleStoreFactory.onlyDefaultImplementation(),
-                new ComparisonConfig());
+            importParams,
+            TripleStoreFactory.onlyDefaultImplementation(),
+            new ComparisonConfig());
         t.setTestExportImportCgmes(true);
         Network expected = null;
         t.testConversion(expected, actuals.microGridBaseCaseBE());
@@ -90,8 +95,8 @@ public class CgmesConformity1ConversionTest {
         // TODO When we convert boundaries values for P0, Q0 at dangling lines
         // are recalculated and we need to increase the tolerance
         ConversionTester t = new ConversionTester(
-                TripleStoreFactory.onlyDefaultImplementation(),
-                new ComparisonConfig().tolerance(1e-5));
+            TripleStoreFactory.onlyDefaultImplementation(),
+            new ComparisonConfig().tolerance(1e-5));
         t.setTestExportImportCgmes(true);
         t.testConversion(expecteds.microBaseCaseBE(), actuals.microGridBaseCaseBE());
     }
@@ -132,12 +137,33 @@ public class CgmesConformity1ConversionTest {
         // that will be computed by IIDM from CGMES node-breaker ConnectivityNodes,
         // have proper balances
         ConversionTester t = new ConversionTester(
-                TripleStoreFactory.onlyDefaultImplementation(),
-                new ComparisonConfig());
+            TripleStoreFactory.onlyDefaultImplementation(),
+            new ComparisonConfig());
         t.setValidateBusBalances(true);
         t.testConversion(null, actuals.miniNodeBreaker());
         t.lastConvertedNetwork().getVoltageLevels()
-                .forEach(vl -> assertEquals(TopologyKind.NODE_BREAKER, vl.getTopologyKind()));
+            .forEach(vl -> assertEquals(TopologyKind.NODE_BREAKER, vl.getTopologyKind()));
+    }
+
+    @Test
+    public void miniNodeBreakerBoundary() throws IOException {
+        Properties importParams = new Properties();
+        importParams.put(CgmesImport.CONVERT_BOUNDARY, "true");
+        ConversionTester t = new ConversionTester(
+            importParams,
+            TripleStoreFactory.onlyDefaultImplementation(),
+            new ComparisonConfig());
+        Network expected = null;
+        t.testConversion(expected, actuals.microGridBaseCaseBE());
+        assertEquals(
+            ImmutableSet.of(
+                Country.AT,
+                Country.BE,
+                Country.ES,
+                Country.NL),
+            t.lastConvertedNetwork().getSubstationStream()
+                .map(Substation::getCountry)
+                .collect(Collectors.toSet()));
     }
 
     @Test
@@ -156,40 +182,41 @@ public class CgmesConformity1ConversionTest {
 
         // Small Grid Node Breaker HVDC should be imported without errors
         Importers.importData("CGMES",
-                actuals.smallNodeBreakerHvdc().dataSource(),
-                null,
-                computationManager);
+            actuals.smallNodeBreakerHvdc().dataSource(),
+            null,
+            computationManager);
     }
 
     @Test
     // This is to test that we have stable Identifiers for calculated buses
-    // If no topology change has been made, running a LoadFlow (even a Mock LoadFlow)
+    // If no topology change has been made, running a LoadFlow (even a Mock
+    // LoadFlow)
     // must produce identical identifiers for calculated buses
     public void smallNodeBreakerStableBusNaming() throws IOException {
         ComputationManager computationManager = Mockito.mock(ComputationManager.class);
 
         Network network = Importers.importData("CGMES",
-                actuals.smallNodeBreaker().dataSource(),
-                null,
-                computationManager);
+            actuals.smallNodeBreaker().dataSource(),
+            null,
+            computationManager);
 
         // Initial bus identifiers
         List<String> initialBusIds = network.getBusView().getBusStream()
-                .map(Bus::getId).collect(Collectors.toList());
+            .map(Bus::getId).collect(Collectors.toList());
 
         // Compute a "mock" LoadFlow and obtain bus identifiers
         String lfVariantId = "lf";
         network.getVariantManager()
-                .cloneVariant(network.getVariantManager().getWorkingVariantId(),
-                        lfVariantId);
+            .cloneVariant(network.getVariantManager().getWorkingVariantId(),
+                lfVariantId);
         new LoadFlowFactoryMock()
-                .create(network,
-                        computationManager,
-                        1)
-                .run(lfVariantId, new LoadFlowParameters()).join();
+            .create(network,
+                computationManager,
+                1)
+            .run(lfVariantId, new LoadFlowParameters()).join();
         network.getVariantManager().setWorkingVariant(lfVariantId);
         List<String> afterLoadFlowBusIds = network.getBusView().getBusStream()
-                .map(Bus::getId).collect(Collectors.toList());
+            .map(Bus::getId).collect(Collectors.toList());
 
         assertEquals(initialBusIds, afterLoadFlowBusIds);
     }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableSet;
 import com.powsybl.cgmes.conformity.test.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.test.CgmesConformity1NetworkCatalog;
 import com.powsybl.cgmes.conversion.CgmesImport;
-import com.powsybl.cgmes.conversion.CountryConversion;
 import com.powsybl.cgmes.conversion.test.ConversionTester;
 import com.powsybl.cgmes.conversion.test.network.compare.ComparisonConfig;
 import com.powsybl.computation.ComputationManager;

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -161,6 +161,8 @@ WHERE {
 	OPTIONAL {
 		?ConnectivityNode cim:IdentifiedObject.name ?name
 	}
+	OPTIONAL { ?ConnectivityNode entsoe:ConnectivityNode.fromEndIsoCode ?fromEndIsoCode }
+	OPTIONAL { ?ConnectivityNode entsoe:ConnectivityNode.toEndIsoCode ?toEndIsoCode }
 }}
 OPTIONAL { GRAPH ?graphTPCN {
 	?ConnectivityNode cim:ConnectivityNode.TopologicalNode ?TopologicalNode 
@@ -182,6 +184,8 @@ WHERE {
 		cim:IdentifiedObject.name ?name ;
 		cim:TopologicalNode.BaseVoltage ?BaseVoltage ;
 		cim:TopologicalNode.ConnectivityNodeContainer ?ConnectivityNodeContainer
+	OPTIONAL { ?TopologicalNode entsoe:TopologicalNode.fromEndIsoCode ?fromEndIsoCode }
+	OPTIONAL { ?TopologicalNode entsoe:TopologicalNode.toEndIsoCode ?toEndIsoCode }
 }}
 OPTIONAL { GRAPH ?graphSVT {
 	?SvVoltageT 

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/BusesValidation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/BusesValidation.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ShuntCompensator;
@@ -68,11 +69,11 @@ public final class BusesValidation {
         Objects.requireNonNull(busesWriter);
         LOGGER.info("Checking buses of network {}", network.getId());
         return network.getBusView()
-                      .getBusStream()
-                      .sorted(Comparator.comparing(Bus::getId))
-                      .map(bus -> checkBuses(bus, config, busesWriter))
-                      .reduce(Boolean::logicalAnd)
-                      .orElse(true);
+                .getBusStream()
+                .sorted(Comparator.comparing(Bus::getId))
+                .map(bus -> checkBuses(bus, config, busesWriter))
+                .reduce(Boolean::logicalAnd)
+                .orElse(true);
     }
 
     public static boolean checkBuses(Bus bus, ValidationConfig config, Writer writer) {
@@ -84,6 +85,22 @@ public final class BusesValidation {
             return checkBuses(bus, config, bussWriter);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void p(String eqt, Identifiable<?> id, Terminal t) {
+        if (LOGGER.isWarnEnabled()) {
+            LOGGER.warn(String.format("    %-5s  %10.4f  %10.4f  %s",
+                    eqt,
+                    t.getP(),
+                    t.getQ(),
+                    id.getId()));
+        }
+    }
+
+    private static void p(String cat, double p, double q) {
+        if (LOGGER.isWarnEnabled()) {
+            LOGGER.warn(String.format("    %-5s  %10.4f  %10.4f", cat, p, q));
         }
     }
 
@@ -110,8 +127,48 @@ public final class BusesValidation {
         double tltP = bus.getThreeWindingsTransformerStream().map(tlt -> getThreeWindingsTransformerTerminal(tlt, bus)).mapToDouble(Terminal::getP).sum();
         double tltQ = bus.getThreeWindingsTransformerStream().map(tlt -> getThreeWindingsTransformerTerminal(tlt, bus)).mapToDouble(Terminal::getQ).sum();
         boolean mainComponent = bus.isInMainConnectedComponent();
-        return checkBuses(bus.getId(), loadP, loadQ, genP, genQ, shuntP, shuntQ, svcP, svcQ, vscCSP, vscCSQ, lineP, lineQ,
-                          danglingLineP, danglingLineQ, twtP, twtQ, tltP, tltQ, mainComponent, config, busesWriter);
+        // return checkBuses(bus.getId(), loadP, loadQ, genP, genQ, shuntP, shuntQ, svcP, svcQ,
+        // vscCSP, vscCSQ, lineP, lineQ,
+        // danglingLineP, danglingLineQ, twtP, twtQ, tltP, tltQ, mainComponent, config,
+        // busesWriter);
+        boolean r = checkBuses(bus.getId(), loadP, loadQ, genP, genQ, shuntP, shuntQ, svcP, svcQ,
+                vscCSP, vscCSQ, lineP, lineQ,
+                danglingLineP, danglingLineQ, twtP, twtQ, tltP, tltQ, mainComponent, config,
+                busesWriter);
+        String ref = "";
+        if (bus.getVoltageLevel() != null) {
+            ref = bus.getVoltageLevel().getName() + ref;
+            if (bus.getVoltageLevel().getSubstation() != null) {
+                ref = bus.getVoltageLevel().getSubstation().getName() + " " + ref;
+            }
+        }
+        boolean debug = ref.contains("BUS  ") || ref.contains("PP_Brussels") || ref.contains("FNOD")
+                || ref.contains("kV") || config.isVerbose();
+        debug = debug || ref.contains("f2b64879");
+        if (!r || debug) {
+            LOGGER.warn("Check {}. Details of {} bus {}, (V,A) = ({}, {})",
+                    r ? "succeeded" : "failed",
+                    ref,
+                    bus.getId(),
+                    bus.getV(),
+                    bus.getAngle());
+            bus.getLoadStream().forEach(l -> p("load", l, l.getTerminal()));
+            bus.getGeneratorStream().forEach(g -> p("gen", g, g.getTerminal()));
+            bus.getLineStream().forEach(l -> p("line", l, getBranchTerminal(l, bus)));
+            bus.getTwoWindingsTransformerStream()
+                    .forEach(t -> p("2wtx", t, getBranchTerminal(t, bus)));
+            bus.getDanglingLineStream().forEach(d -> p("dngl", d, d.getTerminal()));
+            bus.getShuntCompensatorStream().forEach(s -> p("shunt", s, s.getTerminal()));
+            bus.getThreeWindingsTransformerStream()
+                    .forEach(t -> p("3wtx", t, getThreeWindingsTransformerTerminal(t, bus)));
+
+            double incomingP = genP + shuntP + svcP + vscCSP + lineP + danglingLineP + twtP + tltP;
+            double incomingQ = genQ + shuntQ + svcQ + vscCSQ + lineQ + danglingLineQ + twtQ + tltQ;
+            double sump = Math.abs(incomingP + loadP);
+            double sumq = Math.abs(incomingQ + loadQ);
+            p("SUM", sump, sumq);
+        }
+        return r;
     }
 
     private static Terminal getBranchTerminal(Branch branch, Bus bus) {
@@ -141,7 +198,7 @@ public final class BusesValidation {
 
         try (ValidationWriter busesWriter = ValidationUtils.createValidationWriter(id, config, writer, ValidationType.BUSES)) {
             return checkBuses(id, loadP, loadQ, genP, genQ, shuntP, shuntQ, svcP, svcQ, vscCSP, vscCSQ, lineP, lineQ,
-                              danglingLineP, danglingLineQ, twtP, twtQ, tltP, tltQ, mainComponent, config, busesWriter);
+                    danglingLineP, danglingLineQ, twtP, twtQ, tltP, tltQ, mainComponent, config, busesWriter);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -167,7 +224,7 @@ public final class BusesValidation {
         }
         try {
             busesWriter.write(id, incomingP, incomingQ, loadP, loadQ, genP, genQ, shuntP, shuntQ, svcP, svcQ, vscCSP, vscCSQ,
-                              lineP, lineQ, danglingLineP, danglingLineQ, twtP, twtQ, tltP, tltQ, mainComponent, validated);
+                    lineP, lineQ, danglingLineP, danglingLineQ, twtP, twtQ, tltP, tltQ, mainComponent, validated);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
This change uses the country ISO codes available at boundary nodes (Connectivity or Topological nodes) in ENTSO-E extensions for CGMES when the CGMES import is configured to convert boundaries to the IIDM model.

Currently the country set in the Substations created in IIDM for the boundary nodes is a default value.

With this change, the Country for Substations related to the boundary will be set based on attributes of the CGMES nodes. The attributes `fromEndIsoCode` / `toEndIsoCode` are used to exchange the ISO code of the region to which the "From" /  "To" side of the Boundary point belongs to or it is connected to. Not enough information is present in the model to determine which "side" should be used, so the country will be assigned from the first code that can be mapped to a valid IIDM Country enum value.
