### PR TITLE
triple-store-impl-rdf4j: exclude dependency to logback-classic

### DIFF
--- a/triple-store/triple-store-impl-rdf4j/pom.xml
+++ b/triple-store/triple-store-impl-rdf4j/pom.xml
@@ -47,6 +47,16 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-runtime</artifactId>
+            <!--
+              The exclusion should no longer be necessary when upgrading to rdf4j 3+
+              see https://github.com/eclipse/rdf4j/issues/1346
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove a spurious dependency to logback classic. A library should not force the user to use a specific slf4j implementation


* **What is the current behavior?** (You can also link to an open issue here)
Logback classic is put on the classpath and used (randomly) by slf4j to log. Since it has a default log level of DEBUG and is not configured because the user didn't choose it, a huge amount of log is output on the console.


* **What is the new behavior (if this is a feature change)?**
The user controls the logs. For example, for a lot of unit tests we use slf4j-simple with a default log level of INFO which outputs reasonable amounts of logs


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
2.4.0 has the bad behavior. This PR reverts to the 2.3.0 behavior
