### PR TITLE
hasEquipmentCore returns false when there are results for model_profiles query but no EQ core profile

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -85,6 +85,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
                     return true;
                 }
             }
+            return false; // If we have a query for model profiles but none of the profiles contains "EquipmentCore", equipment core is not available
         }
         // If we do not have a query for model profiles we assume equipment core is
         // available


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
If there is a query in the catalog for model profiles which returns non null results but there is not EQ core profile, no error is returned before trying to convert the CGMES file.


* **What is the new behavior (if this is a feature change)?**
If there is a query in the catalog for model profiles which returns non null results but there is not EQ core profile, an explicit error is returned before trying to convert the CGMES file.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
N/A
