### PR TITLE
Itoolsbat

### DIFF
--- a/itools-packager/src/main/resources/itools.bat
+++ b/itools-packager/src/main/resources/itools.bat
@@ -29,12 +29,12 @@ for /f "delims=" %%x in (%installDir%\etc\itools.conf) do (
 set args=
 set parallel=false
 :continue
-if "%1"=="" ( goto done ) else (
-  if "%1" == "--config-name" (
+if "%~1"=="" ( goto done ) else (
+  if "%~1" == "--config-name" (
     set powsybl_config_name=%2
     shift
   ) else (
-    if "%1" == "--parallel" (
+    if "%~1" == "--parallel" (
       set parallel=true
       shift
       echo WARNING : '--parallel' option not currently supported on Windows

--- a/itools-packager/src/main/resources/itools.bat
+++ b/itools-packager/src/main/resources/itools.bat
@@ -36,7 +36,6 @@ if "%~1"=="" ( goto done ) else (
   ) else (
     if "%~1" == "--parallel" (
       set parallel=true
-      shift
       echo WARNING : '--parallel' option not currently supported on Windows
     ) else (
         set args=%args% %1 %2


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
itools-packager: fix itools.bat for filenames with spaces
itools-packager: fix --parallel, it takes no arguments 


* **What is the current behavior?** (You can also link to an open issue here)
for files with whitespace, the script crashes on comparisions with something like
bin\itools.bat convert-network --input-file "D:\foo\bar baz\kop" ...
"baz\kop inattendu"

for --parallel, the script eats the next argument.


* **What is the new behavior (if this is a feature change)?**
Both work normally


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes for parallel, but it was a bug and it was different on windows and unix and --parallel doesn't do anything on windows anyway


* **Other information**:

