### PR TITLE
Fix limit violation detection based on current value

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Branch.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Branch.java
@@ -18,12 +18,26 @@ public interface Branch<I extends Branch<I>> extends Connectable<I> {
         TWO
     }
 
+    /**
+     * Represents a current overload on a {@link Branch}.
+     */
     interface Overload {
 
+        /**
+         * The temporary limit under which the current is.
+         * In particular, it determines the duration during which
+         * the current current value may be sustained.
+         */
         CurrentLimits.TemporaryLimit getTemporaryLimit();
 
+        /**
+         * The value of the current limit which has been overloaded, in Amperes.
+         */
         double getPreviousLimit();
 
+        /**
+         * The name of the current limit which has been overloaded.
+         */
         String getPreviousLimitName();
     }
 

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
@@ -221,6 +221,13 @@ public final class EurostagTutorialExample1Factory {
         return network;
     }
 
+    /**
+     * @deprecated Use {@link #createWithFixedCurrentLimits()} instead,
+     *             here current limits do not respect the convention of having
+     *             an infinite value temporary limit, which make overload detection
+     *             malfunction.
+     */
+    @Deprecated
     public static Network createWithCurrentLimits() {
         Network network = EurostagTutorialExample1Factory.create();
         network.setCaseDate(DateTime.parse("2018-01-01T11:00:00+01:00"));
@@ -271,6 +278,71 @@ public final class EurostagTutorialExample1Factory {
             .setValue(1200)
             .endTemporaryLimit()
             .add();
+        line.newCurrentLimits2().setPermanentLimit(500).add();
+
+        return network;
+    }
+
+    public static Network createWithFixedCurrentLimits() {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.setCaseDate(DateTime.parse("2018-01-01T11:00:00+01:00"));
+
+        network.getSubstation("P2").setCountry(Country.BE);
+
+        network.getVoltageLevel(VLGEN).newGenerator()
+                .setId("GEN2")
+                .setBus("NGEN")
+                .setConnectableBus("NGEN")
+                .setMinP(-9999.99)
+                .setMaxP(9999.99)
+                .setVoltageRegulatorOn(true)
+                .setTargetV(24.5)
+                .setTargetP(607.0)
+                .setTargetQ(301.0)
+                .add();
+
+        ((Bus) network.getIdentifiable("NHV1")).setV(380).getVoltageLevel().setLowVoltageLimit(400).setHighVoltageLimit(500);
+        ((Bus) network.getIdentifiable("NHV2")).setV(380).getVoltageLevel().setLowVoltageLimit(300).setHighVoltageLimit(500);
+
+        Line line = network.getLine("NHV1_NHV2_1");
+        line.getTerminal1().setP(560.0).setQ(550.0);
+        line.getTerminal2().setP(560.0).setQ(550.0);
+        line.newCurrentLimits1().setPermanentLimit(500).add();
+        line.newCurrentLimits2()
+                .setPermanentLimit(1100)
+                .beginTemporaryLimit()
+                .setName("10'")
+                .setAcceptableDuration(10 * 60)
+                .setValue(1200)
+                .endTemporaryLimit()
+                .beginTemporaryLimit()
+                .setName("1'")
+                .setAcceptableDuration(60)
+                .setValue(1500)
+                .endTemporaryLimit()
+                .beginTemporaryLimit()
+                .setName("N/A")
+                .setAcceptableDuration(0)
+                .setValue(Double.MAX_VALUE)
+                .endTemporaryLimit()
+                .add();
+
+        line = network.getLine("NHV1_NHV2_2");
+        line.getTerminal1().setP(560.0).setQ(550.0);
+        line.getTerminal2().setP(560.0).setQ(550.0);
+        line.newCurrentLimits1()
+                .setPermanentLimit(1100)
+                .beginTemporaryLimit()
+                .setName("20'")
+                .setAcceptableDuration(20 * 60)
+                .setValue(1200)
+                .endTemporaryLimit()
+                .beginTemporaryLimit()
+                .setName("N/A")
+                .setAcceptableDuration(60)
+                .setValue(Double.MAX_VALUE)
+                .endTemporaryLimit()
+                .add();
         line.newCurrentLimits2().setPermanentLimit(500).add();
 
         return network;

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
@@ -229,30 +229,8 @@ public final class EurostagTutorialExample1Factory {
      */
     @Deprecated
     public static Network createWithCurrentLimits() {
-        Network network = EurostagTutorialExample1Factory.create();
-        network.setCaseDate(DateTime.parse("2018-01-01T11:00:00+01:00"));
-
-        network.getSubstation("P2").setCountry(Country.BE);
-
-        network.getVoltageLevel(VLGEN).newGenerator()
-            .setId("GEN2")
-            .setBus("NGEN")
-            .setConnectableBus("NGEN")
-            .setMinP(-9999.99)
-            .setMaxP(9999.99)
-            .setVoltageRegulatorOn(true)
-            .setTargetV(24.5)
-            .setTargetP(607.0)
-            .setTargetQ(301.0)
-            .add();
-
-        ((Bus) network.getIdentifiable("NHV1")).setV(380).getVoltageLevel().setLowVoltageLimit(400).setHighVoltageLimit(500);
-        ((Bus) network.getIdentifiable("NHV2")).setV(380).getVoltageLevel().setLowVoltageLimit(300).setHighVoltageLimit(500);
-
+        Network network = createWithFixedCurrentLimits();
         Line line = network.getLine("NHV1_NHV2_1");
-        line.getTerminal1().setP(560.0).setQ(550.0);
-        line.getTerminal2().setP(560.0).setQ(550.0);
-        line.newCurrentLimits1().setPermanentLimit(500).add();
         line.newCurrentLimits2()
             .setPermanentLimit(1100)
             .beginTemporaryLimit()
@@ -268,8 +246,6 @@ public final class EurostagTutorialExample1Factory {
             .add();
 
         line = network.getLine("NHV1_NHV2_2");
-        line.getTerminal1().setP(560.0).setQ(550.0);
-        line.getTerminal2().setP(560.0).setQ(550.0);
         line.newCurrentLimits1()
             .setPermanentLimit(1100)
             .beginTemporaryLimit()
@@ -278,7 +254,6 @@ public final class EurostagTutorialExample1Factory {
             .setValue(1200)
             .endTemporaryLimit()
             .add();
-        line.newCurrentLimits2().setPermanentLimit(500).add();
 
         return network;
     }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/DefaultLimitViolationDetector.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/DefaultLimitViolationDetector.java
@@ -66,7 +66,7 @@ public class DefaultLimitViolationDetector extends AbstractLimitViolationDetecto
                     overload.getTemporaryLimit().getAcceptableDuration(),
                     overload.getPreviousLimit(),
                     limitReduction,
-                    branch.getTerminal(side).getI(),
+                    value,
                     side));
         } else if (currentLimitTypes.contains(Security.CurrentLimitType.PATL)) {
             checkPermanentLimit(branch, side, value, consumer);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisChecksTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisChecksTest.java
@@ -20,39 +20,67 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 /**
  * @author Teofil Calin BANC <teofil-calin.banc at rte-france.com>
  */
 public class SecurityAnalysisChecksTest {
 
-    Network network;
+    private Network network;
 
     @Before
     public void setUp() {
-        network = EurostagTutorialExample1Factory.createWithCurrentLimits();
+        network = EurostagTutorialExample1Factory.createWithFixedCurrentLimits();
     }
 
     @Test
     //test current limit violation
     public void checkCurrentLimits() {
-        Line line = network.getLine("NHV1_NHV2_1");
+        Line line1 = network.getLine("NHV1_NHV2_1");
 
+        // Permanent limit violation
         List<LimitViolation> violations = new ArrayList<>();
         LimitViolationDetector detector = new DefaultLimitViolationDetector(Collections.singleton(Security.CurrentLimitType.PATL));
-        detector.checkCurrent(line, Branch.Side.TWO, 1101, violations::add);
+        detector.checkCurrent(line1, Branch.Side.TWO, 1101, violations::add);
 
         Assertions.assertThat(violations)
                 .hasSize(1)
-                .allSatisfy(l -> assertEquals(1100, l.getLimit(), 0d));
+                .allSatisfy(l -> {
+                    assertEquals(1100, l.getLimit(), 0d);
+                    assertEquals(1101, l.getValue(), 0d);
+                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertEquals(Integer.MAX_VALUE, l.getAcceptableDuration());
+                });
 
-        violations = new ArrayList<>();
+        violations.clear();
         detector = new DefaultLimitViolationDetector(Collections.singleton(Security.CurrentLimitType.TATL));
-        detector.checkCurrent(line, Branch.Side.TWO, 1201, violations::add);
+        detector.checkCurrent(line1, Branch.Side.TWO, 1201, violations::add);
 
+        // Temporary limit violation
         Assertions.assertThat(violations)
                 .hasSize(1)
-                .allSatisfy(l -> assertEquals(1200, l.getLimit(), 0d));
+                .allSatisfy(l -> {
+                    assertEquals(1200, l.getLimit(), 0d);
+                    assertEquals(1201, l.getValue(), 0d);
+                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertEquals(60, l.getAcceptableDuration());
+                });
+
+        // Highest temporary limit violation, on side 1
+        Line line2 = network.getLine("NHV1_NHV2_2");
+        violations = new ArrayList<>();
+        detector = new DefaultLimitViolationDetector();
+        detector.checkCurrent(line2, Branch.Side.ONE, 1250, violations::add);
+        Assertions.assertThat(violations)
+                .hasSize(1)
+                .allSatisfy(l -> {
+                    assertEquals(1200, l.getLimit(), 0d);
+                    assertEquals(1250, l.getValue(), 0d);
+                    assertSame(Branch.Side.ONE, l.getSide());
+                    assertEquals(60, l.getAcceptableDuration());
+                });
     }
 
     @Test
@@ -65,17 +93,28 @@ public class SecurityAnalysisChecksTest {
         List<LimitViolation> violations = new ArrayList<>();
         vl.getBusView().getBusStream().forEach(b -> detector.checkVoltage(b, 380, violations::add));
 
-        assertEquals(1, violations.size());
-        LimitViolation violation = violations.get(0);
-        //check that is LimitViolationType.LOW_VOLTAGE limit violation
-        assertEquals(LimitViolationType.LOW_VOLTAGE, violation.getLimitType());
+        Assertions.assertThat(violations)
+                .hasSize(1)
+                .allSatisfy(v -> {
+                    assertEquals(LimitViolationType.LOW_VOLTAGE, v.getLimitType());
+                    assertEquals(400, v.getLimit(), 0d);
+                    assertEquals(380, v.getValue(), 0d);
+                    assertNull(v.getSide());
+                    assertEquals(Integer.MAX_VALUE, v.getAcceptableDuration());
+                });
 
         violations.clear();
         vl.getBusView().getBusStream().forEach(b -> detector.checkVoltage(b, 520, violations::add));
 
-        assertEquals(1, violations.size());
-        violation = violations.get(0);
         //check that is LimitViolationType.HIGH_VOLTAGE limit violation
-        assertEquals(LimitViolationType.HIGH_VOLTAGE, violation.getLimitType());
+        Assertions.assertThat(violations)
+                .hasSize(1)
+                .allSatisfy(v -> {
+                    assertEquals(LimitViolationType.HIGH_VOLTAGE, v.getLimitType());
+                    assertEquals(500, v.getLimit(), 0d);
+                    assertEquals(520, v.getValue(), 0d);
+                    assertNull(v.getSide());
+                    assertEquals(Integer.MAX_VALUE, v.getAcceptableDuration());
+                });
     }
 }


### PR DESCRIPTION
Fix limit violation detection based on current value

This fixes the limit violation detection based on current values (not on Branch objects).
At the same time, it adds :
 - unit tests and fix current limits in eurostag example 1 network (add last current limit)
 - javadoc on Overload

* **Please check if the PR fulfills these requirements** (please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

A bug.

* **What is the current behavior?** (You can also link to an open issue here)

The current value reported in limit violations by the default violation detector is wrong, when underlying network is not consistent with the checked current value. This is an important bug, since security analysis results will report completely wrong current values.

Plus, the eurostag example 1 tutorial has ill-modelled current limits : it has not "infinite value" current limit, which makes the temporary limit check malfunction (no violation is detected when violating the last limit in the list).

That requirement might be more explicit in the doc, or the model changed so that it is more intuitive.

* **What is the new behavior (if this is a feature change)?**

The current value is correctly reported.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

