### PR TITLE
Fix ConcurrentModificationException in Java >= 9

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/NodeMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/NodeMapping.java
@@ -7,12 +7,12 @@
 
 package com.powsybl.cgmes.conversion;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.powsybl.cgmes.model.CgmesTerminal;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.VoltageLevel;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -25,9 +25,9 @@ public class NodeMapping {
     }
 
     public int iidmNodeForTerminal(CgmesTerminal t, VoltageLevel vl) {
-        int iidmNodeForConductingEquipment = cgmes2iidm.computeIfAbsent(t.id(), id -> add(id, vl));
+        int iidmNodeForConductingEquipment = cgmes2iidm.computeIfAbsent(t.id(), id -> newNode(vl));
         // Add internal connection from terminal to connectivity node
-        int iidmNodeForConnectivityNode = cgmes2iidm.computeIfAbsent(t.connectivityNode(), id -> add(id, vl));
+        int iidmNodeForConnectivityNode = cgmes2iidm.computeIfAbsent(t.connectivityNode(), id -> newNode(vl));
 
         // For node-breaker models we create an internal connection between
         // the terminal and its connectivity node
@@ -60,14 +60,7 @@ public class NodeMapping {
     }
 
     public int iidmNodeForConnectivityNode(String id, VoltageLevel vl) {
-        return cgmes2iidm.computeIfAbsent(id, k -> add(k, vl));
-    }
-
-    private int add(String id, VoltageLevel vl) {
-        // The identifier id could be a connectivityNode id or a Terminal id
-        int iidmNode = newNode(vl);
-        cgmes2iidm.put(id, iidmNode);
-        return iidmNode;
+        return cgmes2iidm.computeIfAbsent(id, k -> newNode(vl));
     }
 
     private int newNode(VoltageLevel vl) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements** (please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)
- [x] The commit message follows our guidelines

* **Does this PR already have an issue describing the problem ?** If so, link to this issue using `'#XXX'` and skip the rest
No

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Some CGMES unit test throw a ConcurrentModificationException  coming from HashMap implementation because of an additional check added in JDK9. In the actual code a put(...) in done inside computeIfAbsent method which can lead to Map internal structure corruption.
see [https://stackoverflow.com/questions/54824656/since-java-9-hashmap-computeifabsent-throws-concurrentmodificationexception-on](https://stackoverflow.com/questions/54824656/since-java-9-hashmap-computeifabsent-throws-concurrentmodificationexception-on)  for more detailed explanation and also [https://bugs.openjdk.java.net/browse/JDK-8071667](https://bugs.openjdk.java.net/browse/JDK-8071667) for JDK related issue.


* **What is the new behavior (if this is a feature change)?**
There is no more exception.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
