### PR TITLE
Make ImportersTest.importAllParallel thread-safe (small correction)

### DIFF
--- a/iidm/iidm-converter-api/src/test/java/com/powsybl/iidm/import_/ImportersTest.java
+++ b/iidm/iidm-converter-api/src/test/java/com/powsybl/iidm/import_/ImportersTest.java
@@ -142,7 +142,7 @@ public class ImportersTest extends AbstractConvertersTest {
 
     @Test
     public void importAllParallel() throws InterruptedException, ExecutionException, IOException {
-        List<Boolean> isLoadPresent = new ArrayList<>();
+        List<Boolean> isLoadPresent = Collections.synchronizedList(new ArrayList<>());
         Importers.importAll(fileSystem.getPath(WORK_DIR), testImporter, true, n -> isLoadPresent.add(n.getLoad("LOAD") != null));
         assertEquals(2, isLoadPresent.size());
         isLoadPresent.forEach(Assert::assertTrue);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Small fix for a test added in #653.


**What is the current behavior?** *(You can also link to an open issue here)*
Since `ArrayList` is not thread safe, the test `importAll` sometimes fails.


**What is the new behavior (if this is a feature change)?**
With `Collections.synchronizedList` there should not be a problem anymore.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No.