### PR TITLE
Ignore current limit if there is no PATL

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Context.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Context.java
@@ -42,7 +42,7 @@ public class Context {
         terminalMapping = new TerminalMapping();
         tapChangerTransformers = new TapChangerTransformers();
         dcMapping = new DcMapping(this);
-        currentLimitsMapping = new CurrentLimitsMapping();
+        currentLimitsMapping = new CurrentLimitsMapping(this);
         nodeMapping = new NodeMapping();
 
         ratioTapChangerTables = new HashMap<>();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CurrentLimitsMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CurrentLimitsMapping.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.CurrentLimitsAdder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -21,7 +22,7 @@ public class CurrentLimitsMapping {
     private final Context context;
 
     CurrentLimitsMapping(Context context) {
-        this.context = context;
+        this.context = Objects.requireNonNull(context);
     }
 
     public CurrentLimitsAdder getCurrentLimitsAdder(String id, Supplier<CurrentLimitsAdder> supplier) {
@@ -29,13 +30,13 @@ public class CurrentLimitsMapping {
     }
 
     void addAll() {
-        adders.forEach((key, value) -> {
-            if (Double.isNaN(value.getPermanentLimit())) {
-                context.ignored(String.format("Operational Limit Set of %s", key), "An operational limit set must at least contain one value for permanent limit.");
-                return;
+        for (Map.Entry<String, CurrentLimitsAdder> entry : adders.entrySet()) {
+            if (Double.isNaN(entry.getValue().getPermanentLimit())) {
+                context.ignored(String.format("Operational Limit Set of %s", entry.getKey()), "An operational limit set must at least contain one value for permanent limit.");
+            } else {
+                entry.getValue().add();
             }
-            value.add();
-        });
+        }
         adders.clear();
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CurrentLimitsMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CurrentLimitsMapping.java
@@ -18,8 +18,10 @@ import java.util.function.Supplier;
 public class CurrentLimitsMapping {
 
     private final Map<String, CurrentLimitsAdder> adders = new HashMap<>();
+    private final Context context;
 
-    CurrentLimitsMapping() {
+    CurrentLimitsMapping(Context context) {
+        this.context = context;
     }
 
     public CurrentLimitsAdder getCurrentLimitsAdder(String id, Supplier<CurrentLimitsAdder> supplier) {
@@ -27,7 +29,13 @@ public class CurrentLimitsMapping {
     }
 
     void addAll() {
-        adders.values().forEach(CurrentLimitsAdder::add);
+        adders.forEach((key, value) -> {
+            if (Double.isNaN(value.getPermanentLimit())) {
+                context.ignored(String.format("Operational Limit Set of %s", key), "An operational limit set must at least contain one value for permanent limit.");
+                return;
+            }
+            value.add();
+        });
         adders.clear();
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** 
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add a feature: make the CGMES importer resilient to bad current limits


**What is the current behavior?** *(You can also link to an open issue here)*
When current limits without permanent limit (PATL) exist, they are imported causing an error while trying to pass a loadflow.

**What is the new behavior (if this is a feature change)?**
Now, current limits are ignored when there is no PATL exported.

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No.
