### PR TITLE
Fix TopologyVisitor implementation: add a default behavior to visitBattery

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TopologyVisitor.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TopologyVisitor.java
@@ -22,7 +22,9 @@ public interface TopologyVisitor {
 
     void visitGenerator(Generator generator);
 
-    void visitBattery(Battery battery);
+    default void visitBattery(Battery battery) {
+        // Nothing to do
+    }
 
     void visitLoad(Load load);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
In the PR #673, we add a new method to the interface TopologyVisitor that breaks the API compatibility.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR add a default behavior to the TopologyVisitor interface to avoid API breaks


**What is the current behavior?** *(You can also link to an open issue here)*
The compilation breaks


**What is the new behavior (if this is a feature change)?**
The compilation success


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
