### PR TITLE
Fix regression : XML platform config does not work anymore

### DIFF
--- a/cgmes/cgmes-conformity/pom.xml
+++ b/cgmes/cgmes-conformity/pom.xml
@@ -73,11 +73,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-cgmes-model</artifactId>
             <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <commonslang3.version>3.4</commonslang3.version>
         <commonsmath3.version>3.6.1</commonsmath3.version>
         <gdata.version>1.41.1_1</gdata.version>
-        <graphvizjava.version>0.8.0</graphvizjava.version>
+        <graphvizjava.version>0.8.4</graphvizjava.version>
         <groovy.version>2.4.12</groovy.version>
         <guava.version>20.0</guava.version>
         <jackson.version>2.8.11.3</jackson.version>
@@ -163,7 +163,6 @@
         <tyrus.version>1.13.1</tyrus.version>
         <wildfly.dist.version>11.0.0.Final</wildfly.dist.version>
         <wildflyarquilliancontainerembedded.version>2.1.0.Final</wildflyarquilliancontainerembedded.version>
-        <xmlapis.version>1.4.01</xmlapis.version>
         <xmlunit.version>2.3.0</xmlunit.version>
     </properties>
 
@@ -744,11 +743,6 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <version>${xmlapis.version}</version>
             </dependency>
 
             <!-- Runtime dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -745,6 +745,11 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
             </dependency>
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>${xmlapis.version}</version>
+            </dependency>
 
             <!-- Runtime dependencies -->
             <dependency>
@@ -801,12 +806,6 @@
                 <groupId>org.xmlunit</groupId>
                 <artifactId>xmlunit-core</artifactId>
                 <version>${xmlunit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <version>${xmlapis.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/triple-store/triple-store-impl-jena/pom.xml
+++ b/triple-store/triple-store-impl-jena/pom.xml
@@ -54,5 +54,9 @@
             <artifactId>powsybl-triple-store-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/triple-store/triple-store-impl-jena/pom.xml
+++ b/triple-store/triple-store-impl-jena/pom.xml
@@ -54,9 +54,5 @@
             <artifactId>powsybl-triple-store-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Signed-off-by: yichen88 <tang.yichenyves@gmail.com>

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines

**What kind of change does this PR introduce?**

Bug fix / regression.

**What is the current behavior?**

Install powsybl-core through an execution of `install.sh`, and run the command `itools` with a `config.xml` file as the source of configuration.

The command should issues a `NoClassDefFoundError` exception:
```
Exception in thread "main" java.lang.NoClassDefFoundError: org/w3c/dom/ElementTraversal
```

**What is the new behavior (if this is a feature change)?**

The command correctly reads the XML configuration.

**Other information**:

The jar `xercesImpl-2.11.0.jar` was introduced by the Jena implementation of the triple store.
That jar uses the class `org/w3c/dom/ElementTraversal` which does not exist in all versions of java XML API. We introduce a dependency to xml-apis 1.04.01 to ensure that class exists when the Jena implementation, and therefore xercesImpl-2.11.0, is used.

Also tried to exclude xerces from Jena dependencies, but then the tests on the triple store implementation fail with another class not found exception.

See [this discussion](https://stackoverflow.com/questions/10234201/appengine-error-java-lang-noclassdeffounderror-org-w3c-dom-elementtraversal) on stackoverflow.