### PR TITLE
Throw an explicit exception when the loadNetwork methods do not find any appropriate importer

### DIFF
--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importers.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importers.java
@@ -388,7 +388,7 @@ public final class Importers {
         if (importer != null) {
             return importer.importData(dataSource, parameters);
         }
-        return null;
+        throw new PowsyblException("Unsupported file format or invalid file.");
     }
 
     public static Network loadNetwork(Path file, ComputationManager computationManager, ImportConfig config, Properties parameters) {
@@ -410,7 +410,7 @@ public final class Importers {
         if (importer != null) {
             return importer.importData(dataSource, parameters);
         }
-        return null;
+        throw new PowsyblException("Unsupported file format or invalid file.");
     }
 
     public static Network loadNetwork(String filename, InputStream data, ComputationManager computationManager, ImportConfig config, Properties parameters) {

--- a/iidm/iidm-converter-api/src/test/java/com/powsybl/iidm/import_/ImportersTest.java
+++ b/iidm/iidm-converter-api/src/test/java/com/powsybl/iidm/import_/ImportersTest.java
@@ -182,8 +182,9 @@ public class ImportersTest extends AbstractConvertersTest {
 
     @Test
     public void loadNullNetwork1() {
-        Network network = Importers.loadNetwork(badPath, computationManager, importConfigMock, null, loader);
-        assertNull(network);
+        expected.expect(PowsyblException.class);
+        expected.expectMessage("Unsupported file format or invalid file.");
+        Importers.loadNetwork(badPath, computationManager, importConfigMock, null, loader);
     }
 
     @Test
@@ -195,8 +196,9 @@ public class ImportersTest extends AbstractConvertersTest {
 
     @Test
     public void loadNullNetwork2() throws IOException {
-        Network network = Importers.loadNetwork("baz.txt", Importers.createDataSource(badPath).newInputStream(null, "txt"), computationManager, importConfigMock, null, loader);
-        assertNull(network);
+        expected.expect(PowsyblException.class);
+        expected.expectMessage("Unsupported file format or invalid file.");
+        Importers.loadNetwork("baz.txt", Importers.createDataSource(badPath).newInputStream(null, "txt"), computationManager, importConfigMock, null, loader);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** 
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?** 
When no importer is found while trying to load a network, `null` is returned.

**What is the new behavior (if this is a feature change)?**
When no importer is found while trying to load a network, an exception indicating that either the file format is unsupported or the file is invalid is thrown.

**Does this PR introduce a breaking change?**
Not really a breaking change but the exception must be handled in some ways when using `Importers.loadNetwork` if you don't want it to be thrown.
