### PR TITLE
PrintBalanceSummary with a Writer as parameter (the other is deprecated)

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
@@ -328,22 +328,22 @@ public final class Networks {
     }
 
     private static void logOtherCC(Writer writer, String title, Supplier<String> tableSupplier, ConnectedPower balanceOtherCC) throws IOException {
-        writer.write(String.format("Active balance at step '%s':%n%s", title, tableSupplier.get()));
+        writer.write("Active balance at step '" + title + "':" + System.lineSeparator() + tableSupplier.get());
 
         if (!balanceOtherCC.connectedLoads.isEmpty()) {
-            writer.write(String.format("Connected loads in other CC: %s%n", String.join(", ", balanceOtherCC.connectedLoads)));
+            writer.write("Connected loads in other CC: " + String.join(", ", balanceOtherCC.connectedLoads) + System.lineSeparator());
         }
         if (!balanceOtherCC.disconnectedLoads.isEmpty()) {
-            writer.write(String.format("Disconnected loads in other CC: %s%n", String.join(", ", balanceOtherCC.disconnectedLoads)));
+            writer.write("Disconnected loads in other CC: " + String.join(", ", balanceOtherCC.disconnectedLoads) + System.lineSeparator());
         }
         if (!balanceOtherCC.connectedGenerators.isEmpty()) {
-            writer.write(String.format("Connected generators in other CC: %s%n", String.join(", ", balanceOtherCC.connectedGenerators)));
+            writer.write("Connected generators in other CC: " + String.join(", ", balanceOtherCC.connectedGenerators) + System.lineSeparator());
         }
         if (!balanceOtherCC.disconnectedGenerators.isEmpty()) {
-            writer.write(String.format("Disconnected generators in other CC: %s%n", String.join(", ", balanceOtherCC.disconnectedGenerators)));
+            writer.write("Disconnected generators in other CC: " + String.join(", ", balanceOtherCC.disconnectedGenerators) + System.lineSeparator());
         }
         if (!balanceOtherCC.disconnectedShunts.isEmpty()) {
-            writer.write(String.format("Disconnected shunts in other CC: %s%n", String.join(", ", balanceOtherCC.disconnectedShunts)));
+            writer.write("Disconnected shunts in other CC: " + String.join(", ", balanceOtherCC.disconnectedShunts) + System.lineSeparator());
         }
     }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
@@ -317,19 +317,19 @@ public final class Networks {
         writer.write("Active balance at step '" + title + "':" + System.lineSeparator() + tableSupplier.get());
 
         if (!balanceOtherCC.connectedLoads.isEmpty()) {
-            writer.write("Connected loads in other CC: " + String.join(", ", balanceOtherCC.connectedLoads) + System.lineSeparator());
+            writer.write("Connected loads in other CC: " + balanceOtherCC.connectedLoads + System.lineSeparator());
         }
         if (!balanceOtherCC.disconnectedLoads.isEmpty()) {
-            writer.write("Disconnected loads in other CC: " + String.join(", ", balanceOtherCC.disconnectedLoads) + System.lineSeparator());
+            writer.write("Disconnected loads in other CC: " + balanceOtherCC.disconnectedLoads + System.lineSeparator());
         }
         if (!balanceOtherCC.connectedGenerators.isEmpty()) {
-            writer.write("Connected generators in other CC: " + String.join(", ", balanceOtherCC.connectedGenerators) + System.lineSeparator());
+            writer.write("Connected generators in other CC: " + balanceOtherCC.connectedGenerators + System.lineSeparator());
         }
         if (!balanceOtherCC.disconnectedGenerators.isEmpty()) {
-            writer.write("Disconnected generators in other CC: " + String.join(", ", balanceOtherCC.disconnectedGenerators) + System.lineSeparator());
+            writer.write("Disconnected generators in other CC: " + balanceOtherCC.disconnectedGenerators + System.lineSeparator());
         }
         if (!balanceOtherCC.disconnectedShunts.isEmpty()) {
-            writer.write("Disconnected shunts in other CC: " + String.join(", ", balanceOtherCC.disconnectedShunts) + System.lineSeparator());
+            writer.write("Disconnected shunts in other CC: " + balanceOtherCC.disconnectedShunts + System.lineSeparator());
         }
     }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
@@ -98,26 +98,12 @@ public final class Networks {
      */
     @Deprecated
     public static void printBalanceSummary(String title, Network network, Logger logger) throws IOException {
-        try (OutputStream os = new OutputStream() {
-            private String mem = "";
-            private boolean closed = false;
-
-            @Override
-            public void write(int i) {
-                byte[] bytes = new byte[1];
-                bytes[0] = (byte) (i & 0xff);
-                mem = mem + new String(bytes);
+        Objects.requireNonNull(logger);
+        if (logger.isDebugEnabled()) {
+            try (Writer writer = new StringWriter()) {
+                printBalanceSummary(title, network, writer);
+                logger.debug(writer.toString());
             }
-
-            @Override
-            public void close() {
-                if (!closed) {
-                    logger.debug(mem);
-                    closed = true;
-                }
-            }
-        }; Writer writer = new OutputStreamWriter(os)) {
-            printBalanceSummary(title, network, writer);
         }
     }
 

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
@@ -11,10 +11,9 @@ import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.util.Networks;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.helpers.FormattingTuple;
-import org.slf4j.helpers.MessageFormatter;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
@@ -25,20 +24,18 @@ import static org.junit.Assert.assertEquals;
 public class NetworksTest {
 
     @Test
-    public void printBalanceSummaryTest()  {
+    public void printBalanceSummaryTest() throws IOException {
         StringBuilder buffer = new StringBuilder();
 
-        Logger logger = Mockito.mock(Logger.class);
-        Mockito.when(logger.isDebugEnabled()).thenReturn(true);
+        Writer writer = Mockito.mock(Writer.class);
         Mockito.doAnswer(invocationOnMock -> {
             Object[] args = invocationOnMock.getArguments();
-            FormattingTuple formatter = MessageFormatter.format(Objects.toString(args[0]), args[1], args[2]);
-            buffer.append(formatter.getMessage());
+            buffer.append(Objects.toString(args[0]));
             return null;
-        }).when(logger).debug(Mockito.anyString(), Mockito.any(), Mockito.any());
+        }).when(writer).write(Mockito.anyString());
 
         Network network = EurostagTutorialExample1Factory.create();
-        Networks.printBalanceSummary("", network, logger);
+        Networks.printBalanceSummary("", network, writer);
         assertEquals("Active balance at step '':\n" +
                      "+-----------------------+--------------------------------+----------------------------------+\n" +
                      "|                       | Main CC connected/disconnected | Others CC connected/disconnected |\n" +

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
@@ -10,11 +10,10 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.util.Networks;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.Writer;
-import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 
@@ -25,29 +24,27 @@ public class NetworksTest {
 
     @Test
     public void printBalanceSummaryTest() throws IOException {
-        StringBuilder buffer = new StringBuilder();
-
-        Writer writer = Mockito.mock(Writer.class);
-        Mockito.doAnswer(invocationOnMock -> {
-            Object[] args = invocationOnMock.getArguments();
-            buffer.append(Objects.toString(args[0]));
-            return null;
-        }).when(writer).write(Mockito.anyString());
-
-        Network network = EurostagTutorialExample1Factory.create();
-        Networks.printBalanceSummary("", network, writer);
-        assertEquals("Active balance at step '':" + System.lineSeparator() +
-                     "+-----------------------+--------------------------------+----------------------------------+\n" +
-                     "|                       | Main CC connected/disconnected | Others CC connected/disconnected |\n" +
-                     "+-----------------------+--------------------------------+----------------------------------+\n" +
-                     "| Bus count             |               4                |                0                 |\n" +
-                     "| Load count            | 1           | 0                | 0           | 0                  |\n" +
-                     "| Load (MW)             | 600.0       | 0.0              | 0.0         | 0.0                |\n" +
-                     "| Generator count       | 1           | 0                | 0           | 0                  |\n" +
-                     "| Max generation (MW)   | 9999.99     | 0.0              | 0.0         | 0.0                |\n" +
-                     "| Generation (MW)       | 607.0       | 0.0              | 0.0         | 0.0                |\n" +
-                     "| Shunt at nom V (MVar) | 0.0 0.0 (0) | 0.0 0.0 (0)      | 0.0 0.0 (0) | 0.0 0.0 (0)        |\n" +
-                     "+-----------------------+-------------+------------------+-------------+--------------------+" + System.lineSeparator(),
-                buffer.toString());
+        try (Writer writer = new StringWriter()) {
+            Network network = EurostagTutorialExample1Factory.createWithMultipleConnectedComponents();
+            Networks.printBalanceSummary("", network, writer);
+            assertEquals("Active balance at step '':" + System.lineSeparator() +
+                            "+-----------------------+--------------------------------+----------------------------------+\n" +
+                            "|                       | Main CC connected/disconnected | Others CC connected/disconnected |\n" +
+                            "+-----------------------+--------------------------------+----------------------------------+\n" +
+                            "| Bus count             |               4                |                5                 |\n" +
+                            "| Load count            | 1           | 0                | 1           | 1                  |\n" +
+                            "| Load (MW)             | 600.0       | 0.0              | 600.0       | 600.0              |\n" +
+                            "| Generator count       | 1           | 0                | 1           | 1                  |\n" +
+                            "| Max generation (MW)   | 9999.99     | 0.0              | 9999.99     | 9999.99            |\n" +
+                            "| Generation (MW)       | 607.0       | 0.0              | 607.0       | 607.0              |\n" +
+                            "| Shunt at nom V (MVar) | 0.0 0.0 (0) | 0.0 0.0 (0)      | 0.0 0.0 (0) | 0.00576 0.0 (1)    |\n" +
+                            "+-----------------------+-------------+------------------+-------------+--------------------+" + System.lineSeparator() +
+                            "Connected loads in other CC: LOAD2" + System.lineSeparator() +
+                            "Disconnected loads in other CC: LOAD3" + System.lineSeparator() +
+                            "Connected generators in other CC: GEN2" + System.lineSeparator() +
+                            "Disconnected generators in other CC: GEN3" + System.lineSeparator() +
+                            "Disconnected shunts in other CC: SHUNT" + System.lineSeparator(),
+                    writer.toString());
+        }
     }
 }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
@@ -31,7 +31,7 @@ public class NetworksTest {
                             "+-----------------------+--------------------------------+----------------------------------+\n" +
                             "|                       | Main CC connected/disconnected | Others CC connected/disconnected |\n" +
                             "+-----------------------+--------------------------------+----------------------------------+\n" +
-                            "| Bus count             |               4                |                5                 |\n" +
+                            "| Bus count             |               4                |                3                 |\n" +
                             "| Load count            | 1           | 0                | 1           | 1                  |\n" +
                             "| Load (MW)             | 600.0       | 0.0              | 600.0       | 600.0              |\n" +
                             "| Generator count       | 1           | 0                | 1           | 1                  |\n" +

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
@@ -36,7 +36,7 @@ public class NetworksTest {
 
         Network network = EurostagTutorialExample1Factory.create();
         Networks.printBalanceSummary("", network, writer);
-        assertEquals("Active balance at step '':\n" +
+        assertEquals("Active balance at step '':" + System.lineSeparator() +
                      "+-----------------------+--------------------------------+----------------------------------+\n" +
                      "|                       | Main CC connected/disconnected | Others CC connected/disconnected |\n" +
                      "+-----------------------+--------------------------------+----------------------------------+\n" +

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworksTest.java
@@ -39,11 +39,11 @@ public class NetworksTest {
                             "| Generation (MW)       | 607.0       | 0.0              | 607.0       | 607.0              |\n" +
                             "| Shunt at nom V (MVar) | 0.0 0.0 (0) | 0.0 0.0 (0)      | 0.0 0.0 (0) | 0.00576 0.0 (1)    |\n" +
                             "+-----------------------+-------------+------------------+-------------+--------------------+" + System.lineSeparator() +
-                            "Connected loads in other CC: LOAD2" + System.lineSeparator() +
-                            "Disconnected loads in other CC: LOAD3" + System.lineSeparator() +
-                            "Connected generators in other CC: GEN2" + System.lineSeparator() +
-                            "Disconnected generators in other CC: GEN3" + System.lineSeparator() +
-                            "Disconnected shunts in other CC: SHUNT" + System.lineSeparator(),
+                            "Connected loads in other CC: [LOAD2]" + System.lineSeparator() +
+                            "Disconnected loads in other CC: [LOAD3]" + System.lineSeparator() +
+                            "Connected generators in other CC: [GEN2]" + System.lineSeparator() +
+                            "Disconnected generators in other CC: [GEN3]" + System.lineSeparator() +
+                            "Disconnected shunts in other CC: [SHUNT]" + System.lineSeparator(),
                     writer.toString());
         }
     }

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
@@ -337,38 +337,25 @@ public final class EurostagTutorialExample1Factory {
                 .setTopologyKind(TopologyKind.BUS_BREAKER)
                 .add();
 
-        Bus nload2 = vlhv3.getBusBreakerView().newBus().setId("NLOAD2").add();
-        Bus nload3 = vlhv3.getBusBreakerView().newBus().setId("NLOAD3").add();
-        Bus ngen2 = vlhv3.getBusBreakerView().newBus().setId("NGEN2").add();
-        Bus ngen3 = vlhv3.getBusBreakerView().newBus().setId("NGEN3").add();
+        Bus nconnected = vlhv3.getBusBreakerView().newBus().setId("N1").add();
+        Bus ndisconnected = vlhv3.getBusBreakerView().newBus().setId("N2").add();
         Bus nshunt = vlhv3.getBusBreakerView().newBus().setId("NSHUNT").add();
 
-        vlhv3.getBusBreakerView().newSwitch().setId("S1")
-                .setOpen(false)
-                .setBus1(ngen2.getId())
-                .setBus2(nload2.getId())
-                .add();
-        vlhv3.getBusBreakerView().newSwitch().setId("S2")
-                .setOpen(false)
-                .setBus1(ngen3.getId())
-                .setBus2(nload3.getId())
-                .add();
-
         vlhv3.newLoad().setId("LOAD2")
-                .setBus(nload2.getId())
-                .setConnectableBus(nload2.getId())
+                .setBus(nconnected.getId())
+                .setConnectableBus(nconnected.getId())
                 .setP0(600.0)
                 .setQ0(200.0)
                 .add();
         vlhv3.newLoad().setId("LOAD3")
-                .setConnectableBus(nload3.getId())
+                .setConnectableBus(ndisconnected.getId())
                 .setP0(600.0)
                 .setQ0(200.0)
                 .add();
 
         vlhv3.newGenerator().setId("GEN2")
-                .setBus(ngen2.getId())
-                .setConnectableBus(ngen2.getId())
+                .setBus(nconnected.getId())
+                .setConnectableBus(nconnected.getId())
                 .setMinP(-9999.99)
                 .setMaxP(9999.99)
                 .setVoltageRegulatorOn(true)
@@ -377,7 +364,7 @@ public final class EurostagTutorialExample1Factory {
                 .setTargetQ(301.0)
                 .add();
         vlhv3.newGenerator().setId("GEN3")
-                .setConnectableBus(ngen3.getId())
+                .setConnectableBus(ndisconnected.getId())
                 .setMinP(-9999.99)
                 .setMaxP(9999.99)
                 .setVoltageRegulatorOn(true)

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
@@ -323,4 +323,78 @@ public final class EurostagTutorialExample1Factory {
         return network;
     }
 
+    public static Network createWithMultipleConnectedComponents() {
+        Network network = create();
+
+        Substation p3 = network.newSubstation()
+                .setId("P3")
+                .setCountry(Country.FR)
+                .add();
+
+        VoltageLevel vlhv3 = p3.newVoltageLevel()
+                .setId("VLHV3")
+                .setNominalV(24.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+
+        Bus nload2 = vlhv3.getBusBreakerView().newBus().setId("NLOAD2").add();
+        Bus nload3 = vlhv3.getBusBreakerView().newBus().setId("NLOAD3").add();
+        Bus ngen2 = vlhv3.getBusBreakerView().newBus().setId("NGEN2").add();
+        Bus ngen3 = vlhv3.getBusBreakerView().newBus().setId("NGEN3").add();
+        Bus nshunt = vlhv3.getBusBreakerView().newBus().setId("NSHUNT").add();
+
+        vlhv3.getBusBreakerView().newSwitch().setId("S1")
+                .setOpen(false)
+                .setBus1(ngen2.getId())
+                .setBus2(nload2.getId())
+                .add();
+        vlhv3.getBusBreakerView().newSwitch().setId("S2")
+                .setOpen(false)
+                .setBus1(ngen3.getId())
+                .setBus2(nload3.getId())
+                .add();
+
+        vlhv3.newLoad().setId("LOAD2")
+                .setBus(nload2.getId())
+                .setConnectableBus(nload2.getId())
+                .setP0(600.0)
+                .setQ0(200.0)
+                .add();
+        vlhv3.newLoad().setId("LOAD3")
+                .setConnectableBus(nload3.getId())
+                .setP0(600.0)
+                .setQ0(200.0)
+                .add();
+
+        vlhv3.newGenerator().setId("GEN2")
+                .setBus(ngen2.getId())
+                .setConnectableBus(ngen2.getId())
+                .setMinP(-9999.99)
+                .setMaxP(9999.99)
+                .setVoltageRegulatorOn(true)
+                .setTargetV(24.5)
+                .setTargetP(607.0)
+                .setTargetQ(301.0)
+                .add();
+        vlhv3.newGenerator().setId("GEN3")
+                .setConnectableBus(ngen3.getId())
+                .setMinP(-9999.99)
+                .setMaxP(9999.99)
+                .setVoltageRegulatorOn(true)
+                .setTargetV(24.5)
+                .setTargetP(607.0)
+                .setTargetQ(301.0)
+                .add();
+
+        vlhv3.newShuntCompensator()
+                .setId("SHUNT")
+                .setConnectableBus(nshunt.getId())
+                .setMaximumSectionCount(1)
+                .setCurrentSectionCount(1)
+                .setbPerSection(1e-5)
+                .add();
+
+        return network;
+    }
+
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Fixes #756 

**Other information:**
The "new" behaviour of `Networks.printBalanceSummary(String, Network, Logger)` is not exactly the same as before but it is quite equivalent.