### PR TITLE
Fix graph issues

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -1003,6 +1003,12 @@ public interface VoltageLevel extends Container<VoltageLevel> {
     BusView getBusView();
 
     /**
+     * Clean the topology. The behavior of this method is implementation specific
+     * and depends on the type of VoltageLevel (Node/Breaker or Bus/Breaker)
+     */
+    void cleanTopology();
+
+    /**
      * Print an ASCII representation of the topology on the standard ouput.
      */
     void printTopology();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
@@ -64,7 +64,6 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         for (TerminalExt terminal : terminals) {
             VoltageLevelExt vl = terminal.getVoltageLevel();
             vl.detach(terminal);
-            vl.clean();
         }
         network.getListeners().notifyRemoval(this);
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -757,7 +757,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     }
 
     @Override
-    public void clean() {
+    public void cleanTopology() {
         // nothing to do
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -724,7 +724,6 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                         + "' not found in substation voltage level '" + id + "'");
             }
             SwitchImpl aSwitch = graph.removeEdge(e);
-            clean();
 
             getNetwork().getIndex().remove(aSwitch);
             getNetwork().getListeners().notifyRemoval(aSwitch);
@@ -944,7 +943,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     }
 
     @Override
-    public void clean() {
+    public void cleanTopology() {
         GraphUtil.removeIsolatedVertices(graph);
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
@@ -50,8 +50,6 @@ interface VoltageLevelExt extends VoltageLevel, MultiVariantObject {
      */
     void detach(TerminalExt terminal);
 
-    void clean();
-
     boolean connect(TerminalExt terminal);
 
     boolean disconnect(TerminalExt terminal);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerTest.java
@@ -189,7 +189,7 @@ public class NodeBreakerTest {
 
         VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
         assertEquals(10, topo.getNodeCount());
-        vl.clean();
+        vl.cleanTopology();
 
         // Check useless nodes have been removed from the topology
         assertEquals(6, topo.getNodeCount());
@@ -203,13 +203,16 @@ public class NodeBreakerTest {
         assertNotNull(vl);
 
         VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
-        vl.clean();
+        vl.cleanTopology();
 
         assertEquals(6, topo.getNodeCount());
         assertNotNull(topo.getSwitch("load1Disconnector1"));
         assertNotNull(topo.getSwitch("load1Breaker1"));
+
+        // Remove switches and clean the topology
         topo.removeSwitch("load1Disconnector1");
         topo.removeSwitch("load1Breaker1");
+        vl.cleanTopology();
 
         // Check the 2 switches and the intermediate node have been removed from the topology.
         assertNull(topo.getSwitch("load1Disconnector1"));

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/VertexCountBugTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/VertexCountBugTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.iidm.xml;
+
+import com.powsybl.iidm.network.*;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ */
+public class VertexCountBugTest {
+
+    private static Network createNetwork() {
+        Network network = NetworkFactory.create("test", "test");
+        Substation s = network.newSubstation()
+                .setId("S")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl = s.newVoltageLevel()
+                .setId("VL")
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .setNominalV(100.0)
+                .add();
+        vl.getNodeBreakerView()
+                .setNodeCount(3);
+
+        vl.getNodeBreakerView().newBusbarSection()
+                .setId("BBS")
+                .setNode(0)
+                .add();
+
+        vl.getNodeBreakerView().newBreaker()
+                .setId("SW2")
+                .setNode1(0)
+                .setNode2(2);
+
+        vl.newGenerator()
+                .setId("G")
+                .setNode(1)
+                .setMinP(0.0)
+                .setMaxP(100.0)
+                .setTargetP(100.0)
+                .setVoltageRegulatorOn(false)
+                .setTargetQ(60.0)
+                .add();
+
+        vl.newLoad()
+                .setId("L")
+                .setNode(2)
+                .setP0(100.0)
+                .setQ0(60.0)
+                .add();
+
+        return network;
+    }
+
+    @Test
+    public void test() {
+        Network network = createNetwork();
+        VoltageLevel vl = network.getVoltageLevel("VL");
+        VoltageLevel.NodeBreakerView view = vl.getNodeBreakerView();
+        assertEquals(3, view.getNodeCount());
+
+        // Remove the generator and assert
+        network.getGenerator("G").remove();
+        assertEquals(3, view.getNodeCount());
+
+        Network copy = NetworkXml.copy(network);
+        vl = copy.getVoltageLevel("VL");
+        view = vl.getNodeBreakerView();
+        assertEquals(3, view.getNodeCount());
+        assertArrayEquals(new int[]{0, 1, 2}, view.getNodes());
+
+        vl.cleanTopology();
+        assertEquals(2, view.getNodeCount());
+        assertArrayEquals(new int[]{0, 2}, view.getNodes());
+    }
+
+    @Test
+    public void reuseVertex() {
+        Network network = createNetwork();
+        network.getGenerator("G").remove();
+
+        // Create the generator again and reuse old vertex
+        VoltageLevel vl = network.getVoltageLevel("VL");
+        vl.newGenerator()
+                .setId("G")
+                .setNode(1)
+                .setMinP(0.0)
+                .setMaxP(100.0)
+                .setTargetP(100.0)
+                .setVoltageRegulatorOn(false)
+                .setTargetQ(60.0)
+                .add();
+
+        assertEquals(3, vl.getNodeBreakerView().getNodeCount());
+        assertArrayEquals(new int[]{0, 1, 2}, vl.getNodeBreakerView().getNodes());
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
This PR aims to fix two different bugs:
- when a `Connectable` is removed from a voltage level, the vertex in the topology graph cannot be reused.
- when a `Connectable` is removed from a voltage level, the vertex is removed if it is isolated. When we export the network to an XML, and import the file, the `nodeCount` can be lesser than the index of a vertex. Then, an exception is thrown


**What is the new behavior (if this is a feature change)?**
The NodeBreakerVoltageLevel create a Vertex object, if necessary, when a connectable is attached to the VoltageLevel or if a switch/internal connection is added.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
I don't think so.


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
