### PR TITLE
Remove generics from ContingenciesProviderFactory interface.

### DIFF
--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingenciesProviderFactory.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingenciesProviderFactory.java
@@ -14,13 +14,13 @@ import java.nio.file.Path;
  */
 public interface ContingenciesProviderFactory {
 
-    <T extends ContingenciesProvider> T create();
+    ContingenciesProvider create();
 
-    default <T extends ContingenciesProvider> T create(Path contingenciesFile) {
+    default ContingenciesProvider create(Path contingenciesFile) {
         return create();
     }
 
-    default <T extends ContingenciesProvider> T create(InputStream data) {
+    default ContingenciesProvider create(InputStream data) {
         return create();
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

API fix.

**What is the current behavior?** *(You can also link to an open issue here)*

The generic return type in `ContingenciesProviderFactory` does not seem to bring anything really useful,
while on the other side it prevents (or makes clumsy) the use of most
fluent APIS which rely on a known return type (streams, optionals ...).

It also causes "unchecked" warnings in implementations.

It seems very unlikely that this change actually breaks some client code.

**What is the new behavior (if this is a feature change)?**

The factory returns a plain `ContingencyProvider`.

**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*

It seems very unlikely that this change actually breaks some client code.
I think it could only happen if the generic type is explicit in the method call:
```java
factory.<MyContingencyProviderImpl>create()
```
Not sure when one would need to use this.