### PR TITLE
[WIP] Create a node terminal even if there is no connectable.

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
@@ -10,10 +10,10 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -68,13 +68,17 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
     @Override
     public Stream<TerminalExt> getConnectedTerminalStream() {
         checkValidity();
-        return terminals.stream().map(Function.identity());
+        return terminals.stream()
+                .filter(t -> t.getConnectable() != null)
+                .map(Function.identity());
     }
 
     @Override
     public Collection<TerminalExt> getTerminals() {
         checkValidity();
-        return Collections.unmodifiableCollection(terminals);
+        return terminals.stream()
+                .filter(t -> t.getConnectable() != null)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -911,9 +911,11 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             return;
         }
         int node = ((NodeTerminal) terminal).getNode();
-        if (getTerminal(graph, node) != null) {
+
+        NodeTerminal oldTerminal = getTerminal(graph, node);
+        if (oldTerminal != null) {
             throw new ValidationException(terminal.getConnectable(),
-                    "an equipment (" + getTerminal(graph, node).getConnectable().getId()
+                    "an equipment (" + oldTerminal.getConnectable().getId()
                             + ") is already connected to node " + node + " of voltage level "
                             + NodeBreakerVoltageLevel.this.id);
         }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MainConnectedComponentWithSwitchTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MainConnectedComponentWithSwitchTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.impl;
+
+import com.powsybl.iidm.network.*;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MainConnectedComponentWithSwitchTest {
+
+    @Test
+    public void test() {
+
+        Network network = NetworkFactory.create("test_mcc", "test");
+
+        Substation s1 = network.newSubstation()
+                .setId("A")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("B")
+                .setNominalV(225.0)
+                .setLowVoltageLimit(0.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        vl1.getNodeBreakerView().setNodeCount(3);
+        vl1.getNodeBreakerView().newBusbarSection()
+                .setId("C")
+                .setNode(0)
+                .add();
+        vl1.getNodeBreakerView().newSwitch()
+                .setId("D")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(1)
+                .add();
+        vl1.getNodeBreakerView().newSwitch()
+                .setId("E")
+                .setKind(SwitchKind.BREAKER)
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(1)
+                .setNode2(2)
+                .add();
+
+        Substation s2 = network.newSubstation()
+                .setId("F")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("G")
+                .setNominalV(225.0)
+                .setLowVoltageLimit(0.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        vl2.getNodeBreakerView().setNodeCount(5);
+        vl2.getNodeBreakerView().newBusbarSection()
+                .setId("H")
+                .setNode(0)
+                .add();
+        vl2.getNodeBreakerView().newBusbarSection()
+                .setId("I")
+                .setNode(1)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("J")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setRetained(true)
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(2)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("K")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setRetained(true)
+                .setOpen(false)
+                .setNode1(1)
+                .setNode2(3)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("L")
+                .setKind(SwitchKind.BREAKER)
+                .setRetained(true)
+                .setOpen(false)
+                .setNode1(2)
+                .setNode2(3)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("M")
+                .setKind(SwitchKind.BREAKER)
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(4)
+                .add();
+
+        network.newLine()
+                .setId("N")
+                .setR(0.001)
+                .setX(0.1)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .setVoltageLevel1("B")
+                .setNode1(2)
+                .setVoltageLevel2("G")
+                .setNode2(4)
+                .add();
+
+        network.getBusView().getBuses().forEach(b -> {
+            if (b.getVoltageLevel() == vl1) {
+                b.setV(230.0).setAngle(0.5);
+            } else {
+                b.setV(220.0).setAngle(0.7);
+            }
+        });
+
+        assertEquals(2, network.getBusView().getBusStream().count());
+        for (Bus b : network.getBusView().getBuses()) {
+            assertTrue(b.isInMainConnectedComponent());
+        }
+
+        assertEquals(5, network.getBusBreakerView().getBusStream().count());
+        for (Bus b : network.getBusBreakerView().getBuses()) {
+            assertTrue(b.isInMainConnectedComponent());
+            if (b.getVoltageLevel() == vl1) {
+                assertEquals(230.0, b.getV(), 0.0);
+                assertEquals(0.5, b.getAngle(), 0.0);
+            } else {
+                assertEquals(220.0, b.getV(), 0.0);
+                assertEquals(0.7, b.getAngle(), 0.0);
+            }
+        }
+    }
+}

--- a/math/src/main/java/com/powsybl/math/graph/GraphUtil.java
+++ b/math/src/main/java/com/powsybl/math/graph/GraphUtil.java
@@ -104,11 +104,14 @@ public final class GraphUtil {
         return new ConnectedComponentsComputationResult(componentNumber, componentSize);
     }
 
-    /**
-     * Remove from the {@param graph} vertices which are not connected to any edge,
-     * and which have no associated object.
-     */
-    public static <V, E> void removeIsolatedVertices(UndirectedGraph<V, E> graph) {
+    @FunctionalInterface
+    public interface VertexChecker<V, E> {
+
+        boolean isValid(UndirectedGraph<V, E> graph, int vertex);
+
+    }
+
+    public static <V, E> void removeIsolatedVertices(UndirectedGraph<V, E> graph, VertexChecker checker) {
         Objects.requireNonNull(graph, "Graph is null.");
 
         TIntSet connectedVertices = new TIntHashSet();
@@ -118,9 +121,17 @@ public final class GraphUtil {
         }
 
         for (int v : graph.getVertices()) {
-            if (!connectedVertices.contains(v) && graph.getVertexObject(v) == null) {
+            if (!connectedVertices.contains(v) && !checker.isValid(graph, v)) {
                 graph.removeVertex(v);
             }
         }
+    }
+
+    /**
+     * Remove from the {@param graph} vertices which are not connected to any edge,
+     * and which have no associated object.
+     */
+    public static <V, E> void removeIsolatedVertices(UndirectedGraph<V, E> graph) {
+        removeIsolatedVertices(graph, (g, v) -> g.getVertexObject(v) != null);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#490 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
A NodeTerminal instance is created for each vertex in the Node/Breaker topology even if there is no connectable connected to this vertex.


**What is the current behavior?** *(You can also link to an open issue here)*
When two retained switches follow themselves, the Bus/Breaker view creates 3 buses. The bus in the middle has no NodeTerminal, so it is impossible to get/set voltage, angle connected and synchronous components.


**What is the new behavior (if this is a feature change)?**
A NodeTerminal is created for all valid vertices.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:
As a NodeTerminal is created for each vertex, the memory consumption for a Network is higher. For a french grid, the number of NodeTerminal is 83 973 (instead of 46495) and the retained size of the network is 13% higher (191 Mo instead of 169 Mo).

I tried to be smarter, adding attributes in ConfiguredBusImpl to store voltage, angle connected and synchronous components. It's not working because there is no link between buses of the Bus/Breaker view and the Bus view.

(if any of the questions/checkboxes don't apply, please delete them entirely)
