### PR TITLE
Security analysis result builder: allow access to underlying context

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisResultBuilder.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisResultBuilder.java
@@ -142,6 +142,14 @@ public class SecurityAnalysisResultBuilder {
         return res;
     }
 
+    /**
+     * Provides access to the security analysis running context to children classes.
+     * @return the security analysis running context.
+     */
+    protected RunningContext getContext() {
+        return context;
+    }
+
     private interface ResultBuilder {
 
         void setComputationOk(boolean computationOk);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Feature.

**What is the current behavior?** *(You can also link to an open issue here)*

The result builder subclasses cannot access the underlying running context, which prevents them to add some implementation specific behaviour (adding specific "notifications" to interceptors).

**What is the new behavior (if this is a feature change)?**

The result builder subclasses may access the running context through the protected getter.

