### PR TITLE
Fix issue with empty column in sparse matrix

### DIFF
--- a/math/src/main/java/com/powsybl/math/matrix/SparseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/SparseMatrix.java
@@ -65,9 +65,9 @@ class SparseMatrix extends AbstractMatrix {
 
     /**
      * Column start index in {@link #values} array.
-     * Length of this vector is the number of column.
+     * Length of this vector is the number of column, plus one last element at the end for value count.
      */
-    private final int[] columnStart; // plus value count in the last element
+    private final int[] columnStart;
 
     /**
      * Row index for each of the {@link #values}.
@@ -242,8 +242,19 @@ class SparseMatrix extends AbstractMatrix {
     public void iterateNonZeroValueOfColumn(int j, ElementHandler handler) {
         int first = columnStart[j];
         if (first != -1) {
-            int last = j < columnStart.length - 1 ? columnStart[j + 1] : values.size();
-            for (int v = first; v < last; v++) {
+            // to find last column value, we have to go until next non empty column
+            int lastExclusive = -1;
+            if (j < columnCount - 1) {
+                for (int k = j + 1; k < columnCount; k++) {
+                    if (columnStart[k] != -1) {
+                        lastExclusive = columnStart[k];
+                    }
+                }
+            }
+            if (lastExclusive == -1) {
+                lastExclusive = values.size();
+            }
+            for (int v = first; v < lastExclusive; v++) {
                 int i = rowIndices.getQuick(v);
                 double value = values.getQuick(v);
                 handler.onElement(i, j, value);

--- a/math/src/test/java/com/powsybl/math/matrix/AbstractMatrixTest.java
+++ b/math/src/test/java/com/powsybl/math/matrix/AbstractMatrixTest.java
@@ -194,6 +194,14 @@ public abstract class AbstractMatrixTest {
     }
 
     @Test
+    public void testIssueWithEmptyColumns() {
+        Matrix a = getMatrixFactory().create(2, 2, 2);
+        a.set(0, 0, 1d);
+        // second column is empty
+        assertEquals(1, a.toDense().get(0, 0), 0d);
+    }
+
+    @Test
     public void testDeprecated() {
         Matrix a = getMatrixFactory().create(2, 2, 2);
         assertEquals(a.getRowCount(), a.getM());

--- a/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
+++ b/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
@@ -65,5 +66,11 @@ public class SparseMatrixTest extends AbstractMatrixTest {
         a.set(0, 0, 1d);
         a.set(0, 1, 1d);
         a.set(1, 0, 1d);
+    }
+
+    @Test
+    public void testInitSparseMatrixFromCpp() {
+        SparseMatrix m = new SparseMatrix(2, 5, new int[] {0, -1, 2, -1, 3, 4}, new int[] {0, 1, 0, 1}, new double[] {1d, 2d, 3d, 4d});
+        assertArrayEquals(new int[] {2, 0, 1, 0, 1}, m.getColumnValueCount());
     }
 }

--- a/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
+++ b/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
@@ -52,6 +52,7 @@ public class SparseMatrixTest extends AbstractMatrixTest {
                 "rowCount=3",
                 "columnCount=2",
                 "columnStart=[0, 2, 3]",
+                "columnValueCount=[2, 1]",
                 "rowIndices={0, 2, 1}",
                 "values={1.0, 2.0, 3.0}")
                 + System.lineSeparator();


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Iteration over non zero of sparse matrice is wrong when it contains an empty column.


**What is the new behavior (if this is a feature change)?**
Iteration over non zero of sparse matrice is correct when it contains an empty column.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No, just an implementation fix


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
