### PR TITLE
 pom.xml: move enforcer's dependencyConvergence from top pom to distribution-core pom.

### DIFF
--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -404,6 +404,35 @@
 
     <profiles>
         <profile>
+            <id>checks</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>${maven.enforcer.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <fail>false</fail>
+                                    <rules>
+                                      <dependencyConvergence/>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>jacoco</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,6 @@
                                 <configuration>
                                     <fail>false</fail>
                                     <rules>
-                                        <dependencyConvergence/>
                                         <requireMavenVersion>
                                             <version>${maven.core.version}</version>
                                         </requireMavenVersion>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Remove dependency convergence rule for maven enforcer to reduce verbosity of logs


**What is the current behavior?** *(You can also link to an open issue here)*
7000 out of the 12000 lines of logs of a build are trees of dependency conflicts


**What is the new behavior (if this is a feature change)?**
no dependency convergence checks. No logs but also no checks.


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)

I looked into reducing the verbosity of the logs without totally removing the checks but didn't find a solution. maven-enforcer-plugin uses only one logger so using -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.enforcer=error hides everyhing. There are no explicit configuration options to reduce verbosity
