### PR TITLE
TerminalRefXml with writer param

### DIFF
--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
@@ -384,4 +384,15 @@ public final class EurostagTutorialExample1Factory {
         return network;
     }
 
+    public static Network createWithTerminalMockExt() {
+        Network network = create();
+        network.setCaseDate(DateTime.parse("2013-01-15T18:45:00.000+01:00"));
+
+        Load load = network.getLoad("LOAD");
+        TerminalMockExt terminalMockExt = new TerminalMockExt(load);
+        load.addExtension(TerminalMockExt.class, terminalMockExt);
+
+        return network;
+    }
+
 }

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/TerminalMockExt.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/TerminalMockExt.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.test;
+
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.Load;
+import com.powsybl.iidm.network.Terminal;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class TerminalMockExt extends AbstractExtension<Load> {
+
+    private Terminal terminal;
+
+    public TerminalMockExt(Load load) {
+        super(load);
+        terminal = load.getTerminal();
+    }
+
+    @Override
+    public String getName() {
+        return "terminalMock";
+    }
+
+    public Terminal getTerminal() {
+        return terminal;
+    }
+
+    public TerminalMockExt setTerminal(Terminal terminal) {
+        this.terminal = terminal;
+        return this;
+    }
+}

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/TerminalMockExt.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/TerminalMockExt.java
@@ -10,6 +10,8 @@ import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.Terminal;
 
+import java.util.Objects;
+
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
  */
@@ -32,7 +34,7 @@ public class TerminalMockExt extends AbstractExtension<Load> {
     }
 
     public TerminalMockExt setTerminal(Terminal terminal) {
-        this.terminal = terminal;
+        this.terminal = Objects.requireNonNull(terminal);
         return this;
     }
 }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TerminalRefXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TerminalRefXml.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 
 import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 
 import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
 
@@ -24,21 +25,25 @@ public final class TerminalRefXml {
     }
 
     public static void writeTerminalRef(Terminal t, NetworkXmlWriterContext context, String namespace, String elementName) throws XMLStreamException {
+        writeTerminalRef(t, context, namespace, elementName, context.getWriter());
+    }
+
+    public static void writeTerminalRef(Terminal t, NetworkXmlWriterContext context, String namespace, String elementName, XMLStreamWriter writer) throws XMLStreamException {
         Connectable c = t.getConnectable();
         if (!context.getFilter().test(c)) {
             throw new PowsyblException("Oups, terminal ref point to a filtered equipment " + c.getId());
         }
-        context.getWriter().writeEmptyElement(namespace, elementName);
-        context.getWriter().writeAttribute("id", context.getAnonymizer().anonymizeString(c.getId()));
+        writer.writeEmptyElement(namespace, elementName);
+        writer.writeAttribute("id", context.getAnonymizer().anonymizeString(c.getId()));
         if (c.getTerminals().size() > 1) {
             if (c instanceof Injection) {
                 // nothing to do
             } else if (c instanceof Branch) {
                 Branch branch = (Branch) c;
-                context.getWriter().writeAttribute("side", branch.getSide(t).name());
+                writer.writeAttribute("side", branch.getSide(t).name());
             } else if (c instanceof ThreeWindingsTransformer) {
                 ThreeWindingsTransformer twt = (ThreeWindingsTransformer) c;
-                context.getWriter().writeAttribute("side", twt.getSide(t).name());
+                writer.writeAttribute("side", twt.getSide(t).name());
             } else {
                 throw new AssertionError("Unexpected Connectable instance: " + c.getClass());
             }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
@@ -16,6 +16,7 @@ import com.powsybl.commons.xml.XmlWriterContext;
 import com.powsybl.iidm.export.ExportOptions;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.*;
+import org.joda.time.DateTime;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -25,9 +26,7 @@ import java.io.InputStream;
 
 import javax.xml.stream.XMLStreamException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -198,5 +197,25 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractConverterTes
             assertNotNull(source2);
             assertEquals(sourceData, source2.getSourceData());
         }
+    }
+
+    @Test
+    public void testTerminalExtension() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.setCaseDate(DateTime.parse("2013-01-15T18:45:00.000+01:00"));
+
+        Load load = network.getLoad("LOAD");
+        TerminalMockExt terminalMockExt = new TerminalMockExt(load);
+        assertSame(load.getTerminal(), terminalMockExt.getTerminal());
+        load.addExtension(TerminalMockExt.class, terminalMockExt);
+
+        Network network2 = roundTripXmlTest(network,
+                NetworkXml::writeAndValidate,
+                NetworkXml::read,
+                "/eurostag-tutorial-example1-with-terminalMock-ext.xml");
+        Load loadXml = network2.getLoad("LOAD");
+        TerminalMockExt terminalMockExtXml = loadXml.getExtension(TerminalMockExt.class);
+        assertNotNull(terminalMockExtXml);
+        assertSame(loadXml.getTerminal(), terminalMockExtXml.getTerminal());
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
@@ -16,7 +16,6 @@ import com.powsybl.commons.xml.XmlWriterContext;
 import com.powsybl.iidm.export.ExportOptions;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.*;
-import org.joda.time.DateTime;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -201,15 +200,7 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractConverterTes
 
     @Test
     public void testTerminalExtension() throws IOException {
-        Network network = EurostagTutorialExample1Factory.create();
-        network.setCaseDate(DateTime.parse("2013-01-15T18:45:00.000+01:00"));
-
-        Load load = network.getLoad("LOAD");
-        TerminalMockExt terminalMockExt = new TerminalMockExt(load);
-        assertSame(load.getTerminal(), terminalMockExt.getTerminal());
-        load.addExtension(TerminalMockExt.class, terminalMockExt);
-
-        Network network2 = roundTripXmlTest(network,
+        Network network2 = roundTripXmlTest(EurostagTutorialExample1Factory.createWithTerminalMockExt(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
                 "/eurostag-tutorial-example1-with-terminalMock-ext.xml");

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadZipModelXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadZipModelXmlSerializer.java
@@ -60,13 +60,13 @@ public class LoadZipModelXmlSerializer implements ExtensionXmlSerializer<Load, L
 
     @Override
     public void write(LoadZipModel zipModel, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeDouble("a1", zipModel.getA1(), context.getWriter());
-        XmlUtil.writeDouble("a2", zipModel.getA2(), context.getWriter());
-        XmlUtil.writeDouble("a3", zipModel.getA3(), context.getWriter());
-        XmlUtil.writeDouble("a4", zipModel.getA4(), context.getWriter());
-        XmlUtil.writeDouble("a5", zipModel.getA5(), context.getWriter());
-        XmlUtil.writeDouble("a6", zipModel.getA6(), context.getWriter());
-        XmlUtil.writeDouble("v0", zipModel.getV0(), context.getWriter());
+        XmlUtil.writeDouble("a1", zipModel.getA1(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("a2", zipModel.getA2(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("a3", zipModel.getA3(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("a4", zipModel.getA4(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("a5", zipModel.getA5(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("a6", zipModel.getA6(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("v0", zipModel.getV0(), context.getExtensionsWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalMockXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalMockXmlSerializer.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.xml;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionXmlSerializer;
+import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlUtil;
+import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.Load;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.TerminalMockExt;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.InputStream;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionXmlSerializer.class)
+public class TerminalMockXmlSerializer implements ExtensionXmlSerializer<Load, TerminalMockExt> {
+
+    @Override
+    public boolean hasSubElements() {
+        return true;
+    }
+
+    @Override
+    public InputStream getXsdAsStream() {
+        return getClass().getResourceAsStream("/xsd/terminalMock.xsd");
+    }
+
+    @Override
+    public String getNamespaceUri() {
+        return "http://www.itesla_project.eu/schema/iidm/ext/terminal_mock/1_0";
+    }
+
+    @Override
+    public String getNamespacePrefix() {
+        return "mock";
+    }
+
+    @Override
+    public void write(TerminalMockExt extension, XmlWriterContext context) throws XMLStreamException {
+        NetworkXmlWriterContext networkContext = (NetworkXmlWriterContext) context;
+        TerminalRefXml.writeTerminalRef(extension.getTerminal(), networkContext, getNamespaceUri(), "terminal", context.getExtensionsWriter());
+    }
+
+    @Override
+    public TerminalMockExt read(Load extendable, XmlReaderContext context) throws XMLStreamException {
+        NetworkXmlReaderContext networkContext = (NetworkXmlReaderContext) context;
+        TerminalMockExt terminalMockExt = new TerminalMockExt(extendable);
+        XmlUtil.readUntilEndElement(getExtensionName(), networkContext.getReader(), () -> {
+            if (networkContext.getReader().getLocalName().equals("terminal")) {
+                String id = networkContext.getAnonymizer().deanonymizeString(networkContext.getReader().getAttributeValue(null, "id"));
+                String side = networkContext.getReader().getAttributeValue(null, "side");
+                networkContext.getEndTasks().add(() -> {
+                    Network network = extendable.getTerminal().getVoltageLevel().getSubstation().getNetwork();
+                    terminalMockExt.setTerminal(TerminalRefXml.readTerminalRef(network, id, side));
+                });
+            } else {
+                throw new AssertionError("Unexpected element: " + networkContext.getReader().getLocalName());
+            }
+        });
+        return terminalMockExt;
+    }
+
+    @Override
+    public String getExtensionName() {
+        return "terminalMock";
+    }
+
+    @Override
+    public String getCategoryName() {
+        return "network";
+    }
+
+    @Override
+    public Class<? super TerminalMockExt> getExtensionClass() {
+        return TerminalMockExt.class;
+    }
+}

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLImporterExporterBaseExtensionsTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLImporterExporterBaseExtensionsTest.java
@@ -23,10 +23,9 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Chamseddine BENHAMED  <chamseddine.benhamed at rte-france.com>
  */
-public class XMLImporterExporterBaseEXtensionsTest extends AbstractConverterTest {
+public class XMLImporterExporterBaseExtensionsTest extends AbstractConverterTest {
 
-    public void importExport(String xiidmBaseRef, String xiidmExtRef) throws IOException {
-
+    private void importExport(String xiidmBaseRef, String xiidmExtRef) throws IOException {
         Properties exportProperties = new Properties();
         exportProperties.put(XMLExporter.EXPORT_MODE, String.valueOf(IidmImportExportMode.EXTENSIONS_IN_ONE_SEPARATED_FILE));
         List<String> exportExtensionsList = Arrays.asList("loadFoo", "loadBar");

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterBaseExtensionsTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterBaseExtensionsTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.*;
 
 public class XmlExporterBaseExtensionsTest extends AbstractConverterTest {
 
-    public void exporterTestBaseExtensions(Network network, String xiidmBaseRef, String xiidmExtRef) throws IOException {
+    private void exporterTestBaseExtensions(Network network, String xiidmBaseRef, String xiidmExtRef) throws IOException {
         Properties exportProperties = new Properties();
         exportProperties.put(XMLExporter.ANONYMISED, "false");
         exportProperties.put(XMLExporter.EXPORT_MODE, String.valueOf(IidmImportExportMode.EXTENSIONS_IN_ONE_SEPARATED_FILE));

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterBaseOneExtensionPerFileTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterBaseOneExtensionPerFileTest.java
@@ -9,12 +9,9 @@ package com.powsybl.iidm.xml;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.iidm.IidmImportExportMode;
-import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.MultipleExtensionsTestNetworkFactory;
-import com.powsybl.iidm.network.test.TerminalMockExt;
-import org.joda.time.DateTime;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -40,13 +37,13 @@ public class XmlExporterBaseOneExtensionPerFileTest extends AbstractConverterTes
         return dataSource;
     }
 
-    private void exporterOneFilePerExtensionType(Network network, String xiidmBaseRef, List<String> extensionsList) throws IOException {
+    private void exporterOneFilePerExtensionType(Network network, List<String> extensionsList) throws IOException {
         MemDataSource dataSource = export(network, extensionsList);
 
         // check the base exported file and compare it to iidmBaseRef reference file
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("", "xiidm"))) {
             assertNotNull(is);
-            compareXml(getClass().getResourceAsStream(xiidmBaseRef), is);
+            compareXml(getClass().getResourceAsStream("/multiple-extensions.xiidm"), is);
         }
 
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("-loadBar.xiidm"))) {
@@ -62,8 +59,8 @@ public class XmlExporterBaseOneExtensionPerFileTest extends AbstractConverterTes
 
     @Test(expected = NullPointerException.class)
     public void exportOneExtensionTypeTest() throws IOException {
-        List<String> extensionsList = Arrays.asList("loadBar");
-        exporterOneFilePerExtensionType(MultipleExtensionsTestNetworkFactory.create(), "/multiple-extensions.xiidm", extensionsList);
+        List<String> extensionsList = Collections.singletonList("loadBar");
+        exporterOneFilePerExtensionType(MultipleExtensionsTestNetworkFactory.create(), extensionsList);
     }
 
     @Test
@@ -77,19 +74,12 @@ public class XmlExporterBaseOneExtensionPerFileTest extends AbstractConverterTes
     @Test
     public void exportAllExtensionsTest() throws IOException {
         List<String> extensionsList = Arrays.asList("loadFoo", "loadBar");
-        exporterOneFilePerExtensionType(MultipleExtensionsTestNetworkFactory.create(), "/multiple-extensions.xiidm", extensionsList);
+        exporterOneFilePerExtensionType(MultipleExtensionsTestNetworkFactory.create(), extensionsList);
     }
 
     @Test
     public void exportTerminalExtTest() throws IOException {
-        Network network = EurostagTutorialExample1Factory.create();
-        network.setCaseDate(DateTime.parse("2013-01-15T18:45:00.000+01:00"));
-        Load load = network.getLoad("LOAD");
-        TerminalMockExt terminalMockExt = new TerminalMockExt(load);
-        assertSame(load.getTerminal(), terminalMockExt.getTerminal());
-        load.addExtension(TerminalMockExt.class, terminalMockExt);
-
-        MemDataSource dataSource = export(network, Collections.singletonList("terminalMock"));
+        MemDataSource dataSource = export(EurostagTutorialExample1Factory.createWithTerminalMockExt(), Collections.singletonList("terminalMock"));
 
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("", "xiidm"))) {
             assertNotNull(is);

--- a/iidm/iidm-xml-converter/src/test/resources/eurostag-tutorial-example1-terminalMock.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/eurostag-tutorial-example1-terminalMock.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" xmlns:mock="http://www.itesla_project.eu/schema/iidm/ext/terminal_mock/1_0" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:extension id="LOAD">
+        <mock:terminalMock>
+            <mock:terminal id="LOAD"/>
+        </mock:terminalMock>
+    </iidm:extension>
+</iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/eurostag-tutorial-example1-with-terminalMock-ext.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/eurostag-tutorial-example1-with-terminalMock-ext.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" xmlns:mock="http://www.itesla_project.eu/schema/iidm/ext/terminal_mock/1_0" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:extension id="LOAD">
+        <mock:terminalMock>
+            <mock:terminal id="LOAD"/>
+        </mock:terminalMock>
+    </iidm:extension>
+</iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/xsd/terminalMock.xsd
+++ b/iidm/iidm-xml-converter/src/test/resources/xsd/terminalMock.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0"
+           targetNamespace="http://www.itesla_project.eu/schema/iidm/ext/terminal_mock/1_0"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.itesla_project.eu/schema/iidm/1_0" schemaLocation="iidm.xsd"/>
+    <xs:element name="terminalMock">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminal" type="iidm:TerminalRef"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature

**What is the current behavior?** *(You can also link to an open issue here)*
Terminals don't have the writer passed as a parameter and thus, can only be written in the main XIIDM file.

**What is the new behavior (if this is a feature change)?**
A writer can be passed as a parameter and allows terminals to be written in other files than in the main XIIDM file. This is useful when they are written in extensions and that we are in `ONE_EXTENSION_PER_FILE` mode for example.


**Does this PR introduce a breaking change or deprecate an API?**
No
