### PR TITLE
Fix checks for generator

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/GeneratorAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/GeneratorAdder.java
@@ -57,7 +57,7 @@ public interface GeneratorAdder extends InjectionAdder<GeneratorAdder> {
      *      - network of regulatingTerminal's voltageLevel is the network of the generator
      *      - targetP is not equal to Double.NaN -> targetP is set
      *      - targetP is not equal to Double.NaN -> targetP is set
-     *      - minP <= targetP <= maxP
+     *      - minP <= maxP
      *      - ratedS is set and ratedS > 0
      * @return {@link Generator}
      */

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GeneratorAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GeneratorAdderImpl.java
@@ -114,7 +114,7 @@ class GeneratorAdderImpl extends AbstractInjectionAdder<GeneratorAdderImpl> impl
         ValidationUtil.checkRegulatingTerminal(this, regulatingTerminal, getNetwork());
         ValidationUtil.checkActivePowerSetpoint(this, targetP);
         ValidationUtil.checkVoltageControl(this, voltageRegulatorOn, targetV, targetQ);
-        ValidationUtil.checkActivePowerLimits(this, minP, maxP, targetP);
+        ValidationUtil.checkActivePowerLimits(this, minP, maxP);
         ValidationUtil.checkRatedS(this, ratedS);
         GeneratorImpl generator
                 = new GeneratorImpl(getNetwork().getRef(),

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GeneratorImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GeneratorImpl.java
@@ -96,7 +96,7 @@ class GeneratorImpl extends AbstractConnectable<Generator> implements Generator,
     @Override
     public GeneratorImpl setMaxP(double maxP) {
         ValidationUtil.checkMaxP(this, maxP);
-        ValidationUtil.checkActivePowerLimits(this, minP, maxP, getTargetP());
+        ValidationUtil.checkActivePowerLimits(this, minP, maxP);
         double oldValue = this.maxP;
         this.maxP = maxP;
         notifyUpdate("maxP", oldValue, maxP);
@@ -111,7 +111,7 @@ class GeneratorImpl extends AbstractConnectable<Generator> implements Generator,
     @Override
     public GeneratorImpl setMinP(double minP) {
         ValidationUtil.checkMinP(this, minP);
-        ValidationUtil.checkActivePowerLimits(this, minP, maxP, getTargetP());
+        ValidationUtil.checkActivePowerLimits(this, minP, maxP);
         double oldValue = this.minP;
         this.minP = minP;
         notifyUpdate("minP", oldValue, minP);
@@ -152,7 +152,6 @@ class GeneratorImpl extends AbstractConnectable<Generator> implements Generator,
     @Override
     public GeneratorImpl setTargetP(double targetP) {
         ValidationUtil.checkActivePowerSetpoint(this, targetP);
-        ValidationUtil.checkActivePowerLimits(this, minP, maxP, targetP);
         double oldValue = this.targetP.set(getNetwork().getVariantIndex(), targetP);
         notifyUpdate("targetP", oldValue, targetP);
         return this;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ValidationUtil.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ValidationUtil.java
@@ -32,16 +32,20 @@ public final class ValidationUtil {
         }
     }
 
-    static void checkActivePowerLimits(Validable validable, double minP, double maxP, double p) {
+    static void checkActivePowerLimits(Validable validable, double minP, double maxP) {
         if (minP > maxP) {
-            throw new ValidationException(validable,
-                    "invalid active limits [" + minP + ", " + maxP + "]");
+            throw new ValidationException(validable, "invalid active limits [" + minP + ", " + maxP + "]");
         }
+    }
+
+    static void checkActivePowerLimits(Validable validable, double minP, double maxP, double p) {
+        checkActivePowerLimits(validable, minP, maxP);
+
         if (p > maxP) {
-            throw new ValidationException(validable, "invalid active power p > maxP : " + p + " > " + maxP);
+            throw new ValidationException(validable, "invalid active power p > maxP: " + p + " > " + maxP);
         }
         if (p < minP) {
-            throw new ValidationException(validable, "invalid active power p < minP : " + p + " < " + minP);
+            throw new ValidationException(validable, "invalid active power p < minP: " + p + " < " + minP);
         }
     }
 

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/BatteryTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/BatteryTest.java
@@ -17,8 +17,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
  * @author Ghiles Abdellah <ghiles.abdellah at rte-france.com>
@@ -93,6 +92,31 @@ public class BatteryTest {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("invalid active limits");
         createBattery("invalid", 11, 12, 20.0, 11.0);
+    }
+
+    /**
+     * This test goal is to check if the conditions:
+     * . minP <= p0 <= maxP
+     * . minP <= maxP
+     * Are performed by the Battery adders and setters.
+     * <p>
+     * For a Battery it is expected that the current power is between this bounds
+     */
+    @Test
+    public void invalidPowerBounds() {
+        try {
+            createBattery("invalid", 0.0, 12.0, 10.0, 20.0);
+            fail("Should throw an exception");
+        } catch (ValidationException e) {
+            assertEquals("Battery 'invalid': invalid active power p < minP: 0.0 < 10.0", e.getMessage());
+        }
+
+        try {
+            createBattery("invalid", 30.0, 12.0, 10.0, 20.0);
+            fail("Should throw an exception");
+        } catch (ValidationException e) {
+            assertEquals("Battery 'invalid': invalid active power p > maxP: 30.0 > 20.0", e.getMessage());
+        }
     }
 
     @Test

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/GeneratorTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/GeneratorTest.java
@@ -103,6 +103,24 @@ public class GeneratorTest {
                 30.0, 40.0, false, 20.0);
     }
 
+    /**
+     * This test goal is to check if targetP is allowed to be freely set outside of the bounds defined by minP and maxP.
+     * <p>
+     * For a Battery it is expected that the current power is between this bounds but it is not mandatory for a Generator
+     */
+    @Test
+    public void invalidPowerBounds() {
+        // targetP < minP
+        Generator invalidMinGenerator = createGenerator("invalid_min", EnergySource.HYDRO, 20.0, 10.0, 20.0,
+                0.0, 40.0, false, 20.0);
+        invalidMinGenerator.remove();
+
+        // targetP > maxP
+        createGenerator("invalid_max", EnergySource.HYDRO, 20.0, 10.0, 20.0,
+                30.0, 40.0, false, 20.0);
+
+    }
+
     @Test
     public void invalidRatedS() {
         thrown.expect(ValidationException.class);
@@ -250,9 +268,9 @@ public class GeneratorTest {
         }
     }
 
-    private void createGenerator(String id, EnergySource source, double maxP, double minP, double ratedS,
+    private Generator createGenerator(String id, EnergySource source, double maxP, double minP, double ratedS,
                                  double activePowerSetpoint, double reactivePowerSetpoint, boolean regulatorOn, double voltageSetpoint) {
-        voltageLevel.newGenerator()
+        return voltageLevel.newGenerator()
                 .setId(id)
                 .setVoltageRegulatorOn(regulatorOn)
                 .setEnergySource(source)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
update the checks done on the power values associated with the Generator objects


**What is the current behavior?** *(You can also link to an open issue here)*
The PR : https://github.com/powsybl/powsybl-core/pull/817
introduced a some tests that are not valid for a generator : minP <= targetP <= maxP.
the targetP value can be outside of this bounds

**What is the new behavior (if this is a feature change)?**
targetP is allowed to be outside of this bound just like before the PR https://github.com/powsybl/powsybl-core/pull/817
