### PR TITLE
Find a NodeTerminal for empty CalculatedBus

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
@@ -35,13 +35,13 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
     /**
      * Find a terminal to retrieve voltage, angle or connected and synchronous component numbers.
      * If the terminals list contains at least one element, we use the first terminal as reference.
-     * Otherwise this method try to find a terminal which does not belong to this bus, but to the same "electrical" bus
+     * Otherwise this method tries to find a terminal which does not belong to this bus, but to the same "electrical" bus
      * and therefore can be used as reference.
      *
      * @param voltageLevel The {@literal VoltageLevel} instance to traverse
-     * @param nodes The nodes belong to this bus
+     * @param nodes The nodes which belong to this bus
      * @param terminals The terminals belong to this bus
-     * @return The first terminal of the {@param terminals} list, or a terminal which belongs to an equivalent "electrical" bus.
+     * @return The first terminal of the {@code terminals} list, or a terminal which belongs to an equivalent "electrical" bus.
      */
     private static NodeTerminal findTerminal(NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes, List<NodeTerminal> terminals) {
         if (!terminals.isEmpty()) {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
@@ -8,11 +8,9 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
+import gnu.trove.list.array.TIntArrayList;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -26,9 +24,38 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
 
     private final List<NodeTerminal> terminals;
 
-    CalculatedBusImpl(String id, VoltageLevelExt voltageLevel, List<NodeTerminal> terminals) {
+    private NodeTerminal terminalRef;
+
+    CalculatedBusImpl(String id, NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes, List<NodeTerminal> terminals) {
         super(id, voltageLevel);
         this.terminals = Objects.requireNonNull(terminals);
+        this.terminalRef = findTerminal(voltageLevel, nodes, terminals);
+    }
+
+    private static NodeTerminal findTerminal(NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes, List<NodeTerminal> terminals) {
+        if (!terminals.isEmpty()) {
+            return terminals.get(0);
+        }
+
+        NodeTerminal[] terminal = new NodeTerminal[1];
+
+        // Traverse the graph until a valid NodeTerminal is found
+        VoltageLevel.NodeBreakerView.Traverser traverser = (node1, sw, node2) -> {
+            if (sw.isOpen()) {
+                return false;
+            }
+            terminal[0] = (NodeTerminal) voltageLevel.getNodeBreakerView().getTerminal(node2);
+            return terminal[0] == null;
+        };
+
+        for (int i = 0; i < nodes.size(); ++i) {
+            voltageLevel.getNodeBreakerView().traverse(nodes.getQuick(i), traverser);
+            if (terminal[0] != null) {
+                return terminal[0];
+            }
+        }
+
+        return null;
     }
 
     private void checkValidity() {
@@ -46,6 +73,7 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
         valid = false;
         voltageLevel = null;
         terminals.clear();
+        terminalRef = null;
     }
 
     @Override
@@ -89,10 +117,7 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
     @Override
     public double getV() {
         checkValidity();
-        if (terminals.isEmpty()) {
-            return Double.NaN;
-        }
-        return terminals.get(0).getV();
+        return terminalRef == null ? Double.NaN : terminalRef.getV();
     }
 
     @Override
@@ -107,10 +132,7 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
     @Override
     public double getAngle() {
         checkValidity();
-        if (terminals.isEmpty()) {
-            return Double.NaN;
-        }
-        return terminals.get(0).getAngle();
+        return terminalRef == null ? Double.NaN : terminalRef.getAngle();
     }
 
     @Override
@@ -138,7 +160,7 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
         checkValidity();
         NetworkImpl.ConnectedComponentsManager ccm = voltageLevel.getNetwork().getConnectedComponentsManager();
         ccm.update();
-        return terminals.isEmpty() ? null : ccm.getComponent(terminals.get(0).getConnectedComponentNumber());
+        return terminalRef == null ? null : ccm.getComponent(terminalRef.getConnectedComponentNumber());
     }
 
     @Override
@@ -154,7 +176,7 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
         checkValidity();
         NetworkImpl.SynchronousComponentsManager scm = voltageLevel.getNetwork().getSynchronousComponentsManager();
         scm.update();
-        return terminals.isEmpty() ? null : scm.getComponent(terminals.get(0).getSynchronousComponentNumber());
+        return terminalRef == null ? null : scm.getComponent(terminalRef.getSynchronousComponentNumber());
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
@@ -32,6 +32,17 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
         this.terminalRef = findTerminal(voltageLevel, nodes, terminals);
     }
 
+    /**
+     * Find a terminal to retrieve voltage, angle or connected and synchronous component numbers.
+     * If the terminals list contains at least one element, we use the first terminal as reference.
+     * Otherwise this method try to find a terminal which does not belong to this bus, but to the same "electrical" bus
+     * and therefore can be used as reference.
+     *
+     * @param voltageLevel The {@literal VoltageLevel} instance to traverse
+     * @param nodes The nodes belong to this bus
+     * @param terminals The terminals belong to this bus
+     * @return The first terminal of the {@param terminals} list, or a terminal which belongs to an equivalent "electrical" bus.
+     */
     private static NodeTerminal findTerminal(NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes, List<NodeTerminal> terminals) {
         if (!terminals.isEmpty()) {
             return terminals.get(0);
@@ -48,14 +59,9 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
             return terminal[0] == null;
         };
 
-        for (int i = 0; i < nodes.size(); ++i) {
-            voltageLevel.getNodeBreakerView().traverse(nodes.getQuick(i), traverser);
-            if (terminal[0] != null) {
-                return terminal[0];
-            }
-        }
+        voltageLevel.getNodeBreakerView().traverse(nodes.getQuick(0), traverser);
 
-        return null;
+        return terminal[0];
     }
 
     private void checkValidity() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -322,7 +322,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                     }
                 }
                 if (getBusChecker().isValid(graph, nodes, terminals)) {
-                    CalculatedBusImpl bus = new CalculatedBusImpl(busId, NodeBreakerVoltageLevel.this, terminals);
+                    CalculatedBusImpl bus = new CalculatedBusImpl(busId, NodeBreakerVoltageLevel.this, nodes, terminals);
                     id2bus.put(busId, bus);
                     for (int i = 0; i < nodes.size(); i++) {
                         node2bus[nodes.getQuick(i)] = bus;

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MainConnectedComponentWithSwitchTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MainConnectedComponentWithSwitchTest.java
@@ -12,6 +12,10 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * @author Nicolas Lhuillier <nicolas.lhuillier@rte-france.com>
+ * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ */
 public class MainConnectedComponentWithSwitchTest {
 
     @Test

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MainConnectedComponentWithSwitchTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MainConnectedComponentWithSwitchTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.impl;
+
+import com.powsybl.iidm.network.*;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MainConnectedComponentWithSwitchTest {
+
+    @Test
+    public void test() {
+
+        Network network = Network.create("test_mcc", "test");
+
+        Substation s1 = network.newSubstation()
+                .setId("A")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("B")
+                .setNominalV(225.0)
+                .setLowVoltageLimit(0.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        vl1.getNodeBreakerView().setNodeCount(3);
+        vl1.getNodeBreakerView().newBusbarSection()
+                .setId("C")
+                .setNode(0)
+                .add();
+        vl1.getNodeBreakerView().newSwitch()
+                .setId("D")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(1)
+                .add();
+        vl1.getNodeBreakerView().newSwitch()
+                .setId("E")
+                .setKind(SwitchKind.BREAKER)
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(1)
+                .setNode2(2)
+                .add();
+
+        Substation s2 = network.newSubstation()
+                .setId("F")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("G")
+                .setNominalV(225.0)
+                .setLowVoltageLimit(0.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        vl2.getNodeBreakerView().setNodeCount(5);
+        vl2.getNodeBreakerView().newBusbarSection()
+                .setId("H")
+                .setNode(0)
+                .add();
+        vl2.getNodeBreakerView().newBusbarSection()
+                .setId("I")
+                .setNode(1)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("J")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setRetained(true)
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(2)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("K")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setRetained(true)
+                .setOpen(false)
+                .setNode1(1)
+                .setNode2(3)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("L")
+                .setKind(SwitchKind.BREAKER)
+                .setRetained(true)
+                .setOpen(false)
+                .setNode1(2)
+                .setNode2(3)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("M")
+                .setKind(SwitchKind.BREAKER)
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(4)
+                .add();
+
+        network.newLine()
+                .setId("N")
+                .setR(0.001)
+                .setX(0.1)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .setVoltageLevel1("B")
+                .setNode1(2)
+                .setVoltageLevel2("G")
+                .setNode2(4)
+                .add();
+
+        network.getBusView().getBuses().forEach(b -> {
+            if (b.getVoltageLevel() == vl1) {
+                b.setV(230.0).setAngle(0.5);
+            } else {
+                b.setV(220.0).setAngle(0.7);
+            }
+        });
+
+        assertEquals(2, network.getBusView().getBusStream().count());
+        for (Bus b : network.getBusView().getBuses()) {
+            assertTrue(b.isInMainConnectedComponent());
+        }
+
+        assertEquals(5, network.getBusBreakerView().getBusStream().count());
+        for (Bus b : network.getBusBreakerView().getBuses()) {
+            assertTrue(b.isInMainConnectedComponent());
+            if (b.getVoltageLevel() == vl1) {
+                assertEquals(230.0, b.getV(), 0.0);
+                assertEquals(0.5, b.getAngle(), 0.0);
+            } else {
+                assertEquals(220.0, b.getV(), 0.0);
+                assertEquals(0.7, b.getAngle(), 0.0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#490 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
When a `CalculatedBus` is empty (i.e. contains no NodeTerminal), we traverse the graph to try finding a NodeTerminal connected to this bus. We use this NodeTerminal to retrieve voltage, angle, connected and synchronous component number


**What is the current behavior?** *(You can also link to an open issue here)*
When a `CalculatedBus` is empty, it's impossible to retrieve voltage, angle connected and synchronous component number.

**What is the new behavior (if this is a feature change)?**
When it's possible, we retrieve the information from a NodeTerminal outside the current node, but connected (topologically speaking).

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:
This PR replace the #784. The memory consumption for a french grid is stable with the master version (~169 Mb).


