### PR TITLE
upgrade to mapdb 3.0.6. This removes the bounded [,19.20) guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <jodatime.version>2.9.7</jodatime.version>
         <junit.version>4.12</junit.version>
         <logback.version>1.1.8</logback.version>
-        <mapdb.version>3.0.3</mapdb.version>
+        <mapdb.version>3.0.6</mapdb.version>
         <maven.core.version>3.3.9</maven.core.version>
         <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#816 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
upgrade mapdb from 3.0.3 to 3.0.6 : http://www.mapdb.org/changelog/
This doesn't introduce many changes except for bugfixes and the guava dependency range improvement.



**What is the current behavior?** *(You can also link to an open issue here)*
If you forget to choose a version for guava in your dependencyManagement (or other more complicated means of choosing, such as using exclusions), then when you make a maven project dependening on powsybl-afs-mapd, you get
 59 [INFO]          +- com.google.guava:guava:jar:19.0.0.redhat-1:compile (version selected from constraint [15.0,19.20))

It forces you to use a very old version of guava.



**What is the new behavior (if this is a feature change)?**
[INFO]          +- com.google.guava:guava:jar:27.1-jre:compile (version selected from constraint [15.0,))
A recent version of guava can be used.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
