### PR TITLE
Take ltcFlag into account during conversion

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMapping.java
@@ -120,7 +120,6 @@ public class RegulatingControlMapping {
             adder.setRegulating(control.enabled || p.asBoolean("tapChangerControlEnabled", false))
                     .setTargetV(control.targetValue);
         }
-        adder.setLoadTapChangingCapabilities(true);
         setRegulatingTerminal(p, control, defaultTerminal, adder);
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/RatioTapChangerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/RatioTapChangerConversion.java
@@ -35,6 +35,7 @@ public class RatioTapChangerConversion extends AbstractIdentifiedObjectConversio
         highStep = rtc.asInt("highStep");
         neutralStep = rtc.asInt("neutralStep");
         position = fromContinuous(p.asDouble("SVtapStep", neutralStep));
+        ltcFlag = rtc.asBoolean("ltcFlag", false);
     }
 
     @Override
@@ -83,7 +84,10 @@ public class RatioTapChangerConversion extends AbstractIdentifiedObjectConversio
         } else {
             addStepsFromStepVoltageIncrement(rtca);
         }
+
+        rtca.setLoadTapChangingCapabilities(ltcFlag);
         context.regulatingControlMapping().setRegulatingControl(p, terminal(), rtca);
+
         rtca.add();
     }
 
@@ -242,6 +246,7 @@ public class RatioTapChangerConversion extends AbstractIdentifiedObjectConversio
     private final int highStep;
     private final int neutralStep;
     private final int position;
+    private final boolean ltcFlag;
 
     private static final Logger LOG = LoggerFactory.getLogger(RatioTapChangerConversion.class);
 }

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -418,11 +418,11 @@ WHERE {
         cim:TapChanger.normalStep ?normalStep ;
         cim:TapChanger.neutralU ?neutralU ;
         cim:RatioTapChanger.stepVoltageIncrement ?stepVoltageIncrement ;
+        cim:TapChanger.ltcFlag ?ltcFlag ;
         cim:RatioTapChanger.TransformerEnd ?TransformerEnd .
     OPTIONAL {
         ?RatioTapChanger
              cim:TapChanger.TapChangerControl ?TapChangerControl ;
-             cim:TapChanger.ltcFlag ?ltcFlag ;
              # ??? FIXME what is the difference between tculControlMode and TapChangerControl RegulatingControl.mode ?
              cim:RatioTapChanger.tculControlMode ?tculControlMode
     }
@@ -484,6 +484,7 @@ WHERE {
         cim:TapChanger.neutralStep ?neutralStep ;
         cim:TapChanger.normalStep ?normalStep ;
         cim:TapChanger.neutralU ?neutralU ;
+        cim:TapChanger.ltcFlag ?ltcFlag ;
         cim:PhaseTapChanger.TransformerEnd ?TransformerEnd .
     ?TransformerEnd
         a cim:PowerTransformerEnd ;
@@ -502,7 +503,6 @@ WHERE {
     }
     OPTIONAL {
         ?PhaseTapChanger
-            cim:TapChanger.ltcFlag ?ltcFlag ;
             cim:TapChanger.TapChangerControl ?TapChangerControl
     }
 }}


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Improvement CGMES import

**What is the current behavior?** *(You can also link to an open issue here)*
For RTC and PTC, CGMES `ltcFlag` attribute is never considered.

**What is the new behavior (if this is a feature change)?**
For RTC, `loadTapChangingCapabilities` is set from CGMES `ltcFlag` attribute.
For PTC, if CGMES `ltcFlag` attribute is set to `false`, the PTC is `FIXED_TAP`.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No.
