### PR TITLE
Does not automatically throw an exception when setting a null regulation terminal for a tap changer

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
@@ -111,10 +111,7 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
     }
 
     public C setRegulationTerminal(Terminal regulationTerminal) {
-        if (regulationTerminal == null) {
-            throw new ValidationException(parent, "regulation terminal is null");
-        }
-        if (((TerminalExt) regulationTerminal).getVoltageLevel().getNetwork() != getNetwork()) {
+        if (regulationTerminal != null && ((TerminalExt) regulationTerminal).getVoltageLevel().getNetwork() != getNetwork()) {
             throw new ValidationException(parent, "regulation terminal is not part of the network");
         }
         this.regulationTerminal = (TerminalExt) regulationTerminal;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Even when it is possible (when the tap changer is not regulating and/or when the tap changer is fixed), a null regulation terminal cannot be set on a `RatioTapChangerImpl` or `PhaseTapChangerImpl` object whereas it is **allowed** in these conditions in adders.


**What is the new behavior (if this is a feature change)?**
It is allowed to set a null regulation terminal on a tap changer if the latter is not regulating and/or it is fixed.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
