### PR TITLE
Allow test networks to be created using an alternative network factory

### DIFF
--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/BatteryNetworkFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/BatteryNetworkFactory.java
@@ -9,6 +9,8 @@ package com.powsybl.iidm.network.test;
 import com.powsybl.iidm.network.*;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
+
 /**
  * @author Ghiles Abdellah <ghiles.abdellah at rte-france.com>
  */
@@ -21,7 +23,13 @@ public final class BatteryNetworkFactory {
     }
 
     public static Network create() {
-        Network network = Network.create("fictitious", "test");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("fictitious", "test");
         network.setCaseDate(DateTime.parse("2017-06-25T17:43:00.000+01:00"));
         network.setForecastDistance(0);
 

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/DanglingLineNetworkFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/DanglingLineNetworkFactory.java
@@ -8,6 +8,8 @@ package com.powsybl.iidm.network.test;
 
 import com.powsybl.iidm.network.*;
 
+import java.util.Objects;
+
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */
@@ -17,7 +19,13 @@ public final class DanglingLineNetworkFactory {
     }
 
     public static Network create() {
-        Network network = Network.create("dangling-line", "test");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("dangling-line", "test");
 
         Substation substation = network.newSubstation()
             .setId("S")

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
@@ -22,7 +22,11 @@ public final class EurostagTutorialExample1Factory {
     }
 
     public static Network create() {
-        Network network = Network.create("sim1", "test");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Network network = networkFactory.createNetwork("sim1", "test");
         Substation p1 = network.newSubstation()
                 .setId("P1")
                 .setCountry(Country.FR)
@@ -184,7 +188,11 @@ public final class EurostagTutorialExample1Factory {
     }
 
     public static Network createWithMoreGenerators() {
-        Network network = create();
+        return createWithMoreGenerators(NetworkFactory.findDefault());
+    }
+
+    public static Network createWithMoreGenerators(NetworkFactory networkFactory) {
+        Network network = create(networkFactory);
 
         VoltageLevel vlgen = network.getVoltageLevel(VLGEN);
         Bus ngen = vlgen.getBusBreakerView().getBus("NGEN");
@@ -259,7 +267,12 @@ public final class EurostagTutorialExample1Factory {
     }
 
     public static Network createWithFixedCurrentLimits() {
-        Network network = EurostagTutorialExample1Factory.create();
+        return createWithFixedCurrentLimits(NetworkFactory.findDefault());
+    }
+
+    public static Network createWithFixedCurrentLimits(NetworkFactory networkFactory) {
+        Network network = create(networkFactory);
+
         network.setCaseDate(DateTime.parse("2018-01-01T11:00:00+01:00"));
 
         network.getSubstation("P2").setCountry(Country.BE);
@@ -324,7 +337,11 @@ public final class EurostagTutorialExample1Factory {
     }
 
     public static Network createWithMultipleConnectedComponents() {
-        Network network = create();
+        return createWithMultipleConnectedComponents(NetworkFactory.findDefault());
+    }
+
+    public static Network createWithMultipleConnectedComponents(NetworkFactory networkFactory) {
+        Network network = create(networkFactory);
 
         Substation p3 = network.newSubstation()
                 .setId("P3")
@@ -385,7 +402,11 @@ public final class EurostagTutorialExample1Factory {
     }
 
     public static Network createWithTerminalMockExt() {
-        Network network = create();
+        return createWithTerminalMockExt(NetworkFactory.findDefault());
+    }
+
+    public static Network createWithTerminalMockExt(NetworkFactory networkFactory) {
+        Network network = create(networkFactory);
         network.setCaseDate(DateTime.parse("2013-01-15T18:45:00.000+01:00"));
 
         Load load = network.getLoad("LOAD");

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/FictitiousSwitchFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/FictitiousSwitchFactory.java
@@ -9,6 +9,8 @@ package com.powsybl.iidm.network.test;
 import com.powsybl.iidm.network.*;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
+
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */
@@ -18,7 +20,13 @@ public final class FictitiousSwitchFactory {
     }
 
     public static Network create() {
-        Network network = Network.create("fictitious", "test");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("fictitious", "test");
         network.setCaseDate(DateTime.parse("2017-06-25T17:43:00.000+01:00"));
         network.setForecastDistance(0);
 

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/HvdcTestNetwork.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/HvdcTestNetwork.java
@@ -9,6 +9,8 @@ package com.powsybl.iidm.network.test;
 import com.powsybl.iidm.network.*;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
@@ -21,8 +23,14 @@ public final class HvdcTestNetwork {
     private HvdcTestNetwork() {
     }
 
-    private static Network createBase() {
-        Network network = Network.create("hvdctest", "test");
+    public static Network createBase() {
+        return createBase(NetworkFactory.findDefault());
+    }
+
+    private static Network createBase(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("hvdctest", "test");
         network.setCaseDate(DateTime.parse("2016-06-27T16:34:55.930+02:00"));
         Substation s1 = network.newSubstation()
                 .setId("S1")
@@ -85,7 +93,11 @@ public final class HvdcTestNetwork {
     }
 
     public static Network createVsc() {
-        Network network = createBase();
+        return createVsc(NetworkFactory.findDefault());
+    }
+
+    public static Network createVsc(NetworkFactory networkFactory) {
+        Network network = createBase(networkFactory);
         VoltageLevel vl1 = network.getVoltageLevel("VL1");
         VscConverterStation cs1 = vl1.newVscConverterStation()
                 .setId("C1")
@@ -129,7 +141,11 @@ public final class HvdcTestNetwork {
     }
 
     public static Network createLcc() {
-        Network network = createBase();
+        return createLcc(NetworkFactory.findDefault());
+    }
+
+    public static Network createLcc(NetworkFactory networkFactory) {
+        Network network = createBase(networkFactory);
         VoltageLevel vl1 = network.getVoltageLevel("VL1");
         ShuntCompensator shunt1 = vl1.newShuntCompensator()
                 .setId("C1_Filter1")

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/MultipleExtensionsTestNetworkFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/MultipleExtensionsTestNetworkFactory.java
@@ -9,6 +9,8 @@ package com.powsybl.iidm.network.test;
 import com.powsybl.iidm.network.*;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
+
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
  */
@@ -18,7 +20,13 @@ public final class MultipleExtensionsTestNetworkFactory {
     }
 
     public static Network create() {
-        Network network = Network.create("test", "test");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("test", "test");
         network.setCaseDate(DateTime.parse("2017-11-17T12:00:00+01:00"));
         Substation s = network.newSubstation()
                 .setId("S")

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NetworkTest1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NetworkTest1Factory.java
@@ -8,6 +8,8 @@ package com.powsybl.iidm.network.test;
 
 import com.powsybl.iidm.network.*;
 
+import java.util.Objects;
+
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -18,7 +20,13 @@ public final class NetworkTest1Factory {
     }
 
     public static Network create() {
-        Network network = Network.create("network1", "test");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("network1", "test");
         Substation substation1 = network.newSubstation()
                 .setId("substation1")
                 .setCountry(Country.FR)

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NoEquipmentNetworkFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NoEquipmentNetworkFactory.java
@@ -8,13 +8,21 @@ package com.powsybl.iidm.network.test;
 
 import com.powsybl.iidm.network.*;
 
+import java.util.Objects;
+
 public final class NoEquipmentNetworkFactory {
 
     private NoEquipmentNetworkFactory() {
     }
 
     public static Network create() {
-        Network network = Network.create("test", "test");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("test", "test");
         Substation substation = network.newSubstation()
                     .setId("sub")
                     .setCountry(Country.FR)

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/PhaseShifterTestCaseFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/PhaseShifterTestCaseFactory.java
@@ -9,6 +9,8 @@ package com.powsybl.iidm.network.test;
 import com.powsybl.iidm.network.*;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
+
 /**
  * A very small network to test phase shifters.
  *
@@ -27,7 +29,13 @@ public final class PhaseShifterTestCaseFactory {
     }
 
     public static Network create() {
-        Network network = Network.create("phaseShifterTestCase", "code");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("phaseShifterTestCase", "code");
         network.setCaseDate(DateTime.parse("2016-10-18T10:06:00.000+02:00"));
         Substation s1 = network.newSubstation()
                 .setId("S1")

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/ReactiveLimitsTestNetworkFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/ReactiveLimitsTestNetworkFactory.java
@@ -9,6 +9,8 @@ package com.powsybl.iidm.network.test;
 import com.powsybl.iidm.network.*;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
+
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
  */
@@ -18,7 +20,13 @@ public final class ReactiveLimitsTestNetworkFactory {
     }
 
     public static Network create() {
-        Network network = Network.create("ReactiveLimits", "???");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("ReactiveLimits", "???");
         network.setCaseDate(DateTime.parse("2016-01-01T10:00:00.000+02:00"));
         Substation s = network.newSubstation()
                 .setId("S")

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/SvcTestCaseFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/SvcTestCaseFactory.java
@@ -9,6 +9,8 @@ package com.powsybl.iidm.network.test;
 import com.powsybl.iidm.network.*;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
+
 /**
  * A very small network to test SVC modeling. 2 buses B1 and B2. A generator G1 regulating voltage is connected to B1.
  * B1 and B2 are connected by a line with a high reactance to cause an important voltage drop.
@@ -28,7 +30,13 @@ public final class SvcTestCaseFactory {
     }
 
     public static Network create() {
-        Network network = Network.create("svcTestCase", "code");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("svcTestCase", "code");
         network.setCaseDate(DateTime.parse("2016-06-29T14:54:03.427+02:00"));
         Substation s1 = network.newSubstation()
                 .setId("S1")
@@ -99,7 +107,11 @@ public final class SvcTestCaseFactory {
     }
 
     public static Network createWithMoreSVCs() {
-        Network network = create();
+        return createWithMoreSVCs(NetworkFactory.findDefault());
+    }
+
+    public static Network createWithMoreSVCs(NetworkFactory networkFactory) {
+        Network network = create(networkFactory);
 
         network.getVoltageLevel("VL2").newStaticVarCompensator()
                 .setId("SVC3")

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/ThreeWindingsTransformerNetworkFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/ThreeWindingsTransformerNetworkFactory.java
@@ -9,13 +9,21 @@ package com.powsybl.iidm.network.test;
 import com.powsybl.iidm.network.*;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
+
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */
 public final class ThreeWindingsTransformerNetworkFactory {
 
     public static Network create() {
-        Network network = Network.create("three-windings-transformer", "test");
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("three-windings-transformer", "test");
         network.setCaseDate(DateTime.parse("2018-03-05T13:30:30.486+01:00"));
         Substation substation = network.newSubstation()
             .setId("SUBSTATION")


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
iidm-test module contains numbers of test network, mainly used for unit testing. In a recent PR (#814), we have changed import API to allow an alternative network factory. There is no way with actual code to use test network with an alternative network factory.


**What is the new behavior (if this is a feature change)?**
Create method of test network has been overloaded to allow passing an alternative network factory.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No, it is backward compatible.

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
