### PR TITLE
Add a security analysis preprocessor based on an aggregation of DSLs.

### DIFF
--- a/dsl/src/main/groovy/com/powsybl/dsl/DslLoader.groovy
+++ b/dsl/src/main/groovy/com/powsybl/dsl/DslLoader.groovy
@@ -30,7 +30,7 @@ class DslLoader {
     }
 
     static GroovyShell createShell(Binding binding) {
-        def astCustomizer = new ASTTransformationCustomizer(new PowsyblDslAstTransformation())
+        def astCustomizer = new ASTTransformationCustomizer(new ExpressionDslAstTransformation())
         def imports = new ImportCustomizer()
         def config = new CompilerConfiguration()
         config.addCompilationCustomizers(astCustomizer, imports)

--- a/dsl/src/main/groovy/com/powsybl/dsl/ExpressionDslLoader.groovy
+++ b/dsl/src/main/groovy/com/powsybl/dsl/ExpressionDslLoader.groovy
@@ -77,7 +77,7 @@ class ExpressionDslLoader extends DslLoader {
 
         // comparison
 
-        java.lang.Object.metaClass.compareTo2 = { Object value, String op ->
+        Object.metaClass.compareTo2 = { Object value, String op ->
             switch (op) {
                 case ">":
                     return delegate > value

--- a/dsl/src/main/java/com/powsybl/dsl/ExpressionDslAstTransformation.java
+++ b/dsl/src/main/java/com/powsybl/dsl/ExpressionDslAstTransformation.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2017, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dsl;
+
+import com.powsybl.commons.ast.AbstractAstTransformation;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
+import org.codehaus.groovy.ast.expr.*;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+
+/**
+ * An AST transformation which replaces calls to operators (for example "&&")
+ * by calls to custom methods (for example and2).
+ *
+ * This allows to actually overload the behaviour of those operators. See {@link ExpressionDslLoader}.
+ *
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+@GroovyASTTransformation
+public class ExpressionDslAstTransformation extends AbstractAstTransformation {
+
+    private static final boolean DEBUG = false;
+
+    public void visit(ASTNode[] nodes, SourceUnit sourceUnit) {
+        visit(sourceUnit, new CustomClassCodeExpressionTransformer(sourceUnit), DEBUG);
+    }
+
+    class CustomClassCodeExpressionTransformer extends ClassCodeExpressionTransformer {
+        SourceUnit sourceUnit;
+
+        CustomClassCodeExpressionTransformer(SourceUnit sourceUnit) {
+            this.sourceUnit = sourceUnit;
+        }
+
+        @Override
+        protected SourceUnit getSourceUnit() {
+            return sourceUnit;
+        }
+
+        @Override
+        public Expression transform(Expression exp) {
+            if (exp instanceof BinaryExpression) {
+                BinaryExpression binExpr = (BinaryExpression) exp;
+                String op = binExpr.getOperation().getText();
+                switch (op) {
+                    case ">":
+                    case ">=":
+                    case "<":
+                    case "<=":
+                    case "==":
+                    case "!=":
+                        return new MethodCallExpression(transform(binExpr.getLeftExpression()),
+                                "compareTo2",
+                                new ArgumentListExpression(transform(binExpr.getRightExpression()), new ConstantExpression(op)));
+                    case "&&":
+                        return new MethodCallExpression(transform(binExpr.getLeftExpression()),
+                                "and2",
+                                new ArgumentListExpression(transform(binExpr.getRightExpression())));
+                    case "||":
+                        return new MethodCallExpression(transform(binExpr.getLeftExpression()),
+                                "or2",
+                                new ArgumentListExpression(transform(binExpr.getRightExpression())));
+                    default:
+                        break;
+                }
+            } else if (exp instanceof NotExpression) {
+                return new MethodCallExpression(transform(((NotExpression) exp).getExpression()),
+                        "not",
+                        new ArgumentListExpression());
+            }
+
+            // propagate visit inside transformed expression
+            Expression newExpr = super.transform(exp);
+            if (newExpr != null) {
+                newExpr.visit(this);
+            }
+
+            return newExpr;
+        }
+    }
+}

--- a/dsl/src/main/java/com/powsybl/dsl/GroovyAggregateDsl.java
+++ b/dsl/src/main/java/com/powsybl/dsl/GroovyAggregateDsl.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dsl;
+
+import com.google.common.collect.ImmutableList;
+import groovy.lang.Binding;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link GroovyDsl} which is composed of a collection of DSLs.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class GroovyAggregateDsl<C> implements GroovyDsl<C> {
+
+    private final List<GroovyDsl<C>> parts;
+
+    /**
+     * Builds a DSL which is the aggregation of the provided parts.
+     * Enabling this DSL is equivalent to enabling all parts.
+     *
+     * @param parts the DSLs which compose this DSL
+     */
+    public GroovyAggregateDsl(Collection<? extends GroovyDsl<C>> parts) {
+        this.parts = ImmutableList.copyOf(Objects.requireNonNull(parts));
+    }
+
+    /**
+     * Enables all underlying DSLs.
+     */
+    public void enable(Binding binding, C context) {
+        parts.forEach(dsl -> dsl.enable(binding, context));
+    }
+}

--- a/dsl/src/main/java/com/powsybl/dsl/GroovyDsl.java
+++ b/dsl/src/main/java/com/powsybl/dsl/GroovyDsl.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dsl;
+
+import groovy.lang.Binding;
+
+/**
+ * A groovy DSL has the ability to define groovy variables and methods into a groovy {@link Binding},
+ * allowing to build expressive languages usable for arbitrary purposes
+ * (contingency definitions, ... ).
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public interface GroovyDsl<C>  {
+
+    /**
+     * Gives the {@link Binding} the ability to interpret some keywords,
+     * typically by binding functions to keywords.
+     *
+     * <p>Those functions may use the provided context for getting input data as well as
+     * providing / updating output data, when an actual script will be evaluated.
+     *
+     * @param binding The groovy binding to be enhanced with this DSL.
+     * @param context The context available for interpretation.
+     */
+    void enable(Binding binding, C context);
+
+}

--- a/dsl/src/main/java/com/powsybl/dsl/GroovyDslInterpreter.java
+++ b/dsl/src/main/java/com/powsybl/dsl/GroovyDslInterpreter.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.dsl;
+
+import com.google.common.io.CharSource;
+import groovy.lang.Binding;
+import groovy.lang.GroovyCodeSource;
+import groovy.lang.GroovyShell;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * An object with the ability to interpret a groovy script,
+ * based on a language defined through an instance of {@link GroovyDsl}.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class GroovyDslInterpreter<Context> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GroovyDslInterpreter.class);
+
+    private final GroovyDsl<Context> dsl;
+
+    public GroovyDslInterpreter(GroovyDsl<Context> dsl) {
+        this.dsl = Objects.requireNonNull(dsl);
+    }
+
+    public void interprete(String script, Context context) {
+        GroovyCodeSource src = new GroovyCodeSource(Objects.requireNonNull(script), "script", GroovyShell.DEFAULT_CODE_BASE);
+        interprete(src, context);
+    }
+
+    public void interprete(CharSource charSource, Context context) {
+        Objects.requireNonNull(charSource);
+        try {
+            interprete(charSource.read(), context);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void interprete(GroovyCodeSource script, Context context) {
+        LOGGER.debug("Starting configuration of security analysis inputs, based on groovy DSL.");
+
+        Binding binding = new Binding();
+        dsl.enable(binding, context);
+
+        LOGGER.debug("Evaluating security analysis configuration DSL file.");
+        DslLoader.createShell(binding).evaluate(script);
+    }
+}

--- a/dsl/src/main/java/com/powsybl/dsl/ast/BooleanLiteralNode.java
+++ b/dsl/src/main/java/com/powsybl/dsl/ast/BooleanLiteralNode.java
@@ -20,6 +20,10 @@ public class BooleanLiteralNode extends AbstractLiteralNode {
         this.value = value;
     }
 
+    public static BooleanLiteralNode of(boolean value) {
+        return value ? TRUE : FALSE;
+    }
+
     @Override
     public LiteralType getType() {
         return LiteralType.BOOLEAN;

--- a/dsl/src/test/java/com/powsybl/dsl/GroovyDslInterpreterTest.java
+++ b/dsl/src/test/java/com/powsybl/dsl/GroovyDslInterpreterTest.java
@@ -1,0 +1,53 @@
+package com.powsybl.dsl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharSource;
+import groovy.lang.Binding;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class GroovyDslInterpreterTest {
+
+    /**
+     * Dummy DSL which gives access to a provided list as a groovy variable.
+     */
+    private static class ListGroovyDsl implements GroovyDsl<List<Integer>> {
+
+        private final String name;
+
+        ListGroovyDsl(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void enable(Binding binding, List<Integer> context) {
+            binding.setVariable(name, context);
+        }
+    }
+
+    @Test
+    public void checkAggregateOf2Dsls() {
+        GroovyDsl<List<Integer>> language = new GroovyAggregateDsl<>(ImmutableList.of(new ListGroovyDsl("list1"), new ListGroovyDsl("list2")));
+
+        GroovyDslInterpreter<List<Integer>> interpreter = new GroovyDslInterpreter<>(language);
+        List<Integer> data = new ArrayList<>();
+        interpreter.interprete("list1.add(2)\nlist2.add(1)", data);
+
+        assertEquals(2, data.size());
+        assertEquals(2, (int) data.get(0));
+        assertEquals(1, (int) data.get(1));
+
+        interpreter.interprete(CharSource.wrap("list1.add(8)\nlist2.add(12)"), data);
+        assertEquals(4, data.size());
+        assertEquals(8, (int) data.get(2));
+        assertEquals(12, (int) data.get(3));
+    }
+
+}

--- a/security-analysis/pom.xml
+++ b/security-analysis/pom.xml
@@ -27,6 +27,7 @@
         <module>security-analysis-afs</module>
         <module>security-analysis-afs-local</module>
         <module>security-analysis-api</module>
+        <module>security-analysis-dsl</module>
     </modules>
 
 </project>

--- a/security-analysis/security-analysis-dsl/pom.xml
+++ b/security-analysis/security-analysis-dsl/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>powsybl-security-analysis</artifactId>
+        <groupId>com.powsybl</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>powsybl-security-analysis-dsl</artifactId>
+    <name>Security analysis DSL based preprocessor</name>
+    <description>Security analysis preprocessing based on a groovy DSL</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.powsybl.security.dsl</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Compilation dependencies -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-contingency-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-contingency-dsl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-dsl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-security-analysis-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-impl</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/security-analysis/security-analysis-dsl/src/main/groovy/com/powsybl/security/dsl/LimitFactorsLoader.groovy
+++ b/security-analysis/security-analysis-dsl/src/main/groovy/com/powsybl/security/dsl/LimitFactorsLoader.groovy
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl
+
+
+import com.powsybl.dsl.DslException
+import com.powsybl.dsl.DslLoader
+import com.powsybl.dsl.ExpressionDslLoader
+import com.powsybl.dsl.ast.ExpressionNode
+import com.powsybl.security.LimitViolationDetector
+import com.powsybl.security.dsl.ast.LimitsVariableNode
+import org.codehaus.groovy.control.CompilationFailedException
+
+import java.util.function.Consumer
+
+/**
+ * Implementation of the current limits DSL.
+ * Defines the methods to define factors for specified current limits, for instance:
+ *
+ * <pre>
+ * current_limits {
+ *     N_situation {
+ *         permanent {
+ *             factor 0.95
+ *         }
+ *
+ *         temporary {
+ *             factor 1.0
+ *         }
+ *     }
+ *
+ *     contingency('contingency1') {
+ *       factor 0.99
+ *     }
+ *
+ *     any_contingency {
+ *         factor 0.98
+ *     }
+ * }
+ * </pre>
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+class LimitFactorsLoader extends DslLoader {
+
+
+    LimitFactorsLoader(GroovyCodeSource dslSrc) {
+        super(dslSrc)
+    }
+
+    LimitFactorsLoader(File dslFile) {
+        super(dslFile)
+    }
+
+    LimitFactorsLoader(String script) {
+        super(script)
+    }
+
+    static class LimitSpec {
+
+        /**
+         * Variable which may be referenced as "voltage" from the DSL
+         */
+        static LimitsVariableNode voltage = LimitsVariableNode.voltage()
+        /**
+         * Variable which may be referenced as "duration" from the DSL
+         */
+        static LimitsVariableNode duration =  LimitsVariableNode.duration()
+
+        LimitFactorsNode node
+
+        LimitSpec(LimitMatcher selector) {
+            this.node = new ConditionNode(selector)
+        }
+
+        LimitSpec() {
+            this.node = new LimitFactorsNode()
+        }
+
+        void where(ExpressionNode node, @DelegatesTo(LimitSpec) Closure cl) {
+            executeClosure new ExpressionLimitMatcher(node), cl
+        }
+
+        void factor(float f) {
+            node.addChild(new FinalFactorNode(f))
+        }
+
+        void executeClosure(LimitMatcher selector, @DelegatesTo(LimitSpec) Closure cl) {
+            def cloned = cl.clone()
+            cloned.resolveStrategy = Closure.DELEGATE_FIRST
+
+            LimitSpec enclosedSpec = new LimitSpec(selector)
+            cloned.delegate = enclosedSpec
+            cloned()
+            node.addChild(enclosedSpec.node)
+        }
+
+        void temporary(@DelegatesTo(LimitSpec) Closure cl) {
+            executeClosure LimitMatchers.temporary(), cl
+        }
+
+        void permanent(@DelegatesTo(LimitSpec) Closure cl) {
+            executeClosure LimitMatchers.permanent(), cl
+        }
+
+        void N_situation(@DelegatesTo(LimitSpec) Closure cl) {
+            executeClosure LimitMatchers.nSituation(), cl
+        }
+
+        void any_contingency( @DelegatesTo(LimitSpec) Closure cl) {
+            executeClosure LimitMatchers.anyContingency(), cl
+        }
+
+        void contingency(String id, @DelegatesTo(LimitSpec) Closure cl) {
+            executeClosure LimitMatchers.contingency(id), cl
+        }
+
+        void contingencies(Collection<String> ids, @DelegatesTo(LimitSpec) Closure cl) {
+            executeClosure LimitMatchers.contingencies(ids), cl
+        }
+
+        void branch(String id, @DelegatesTo(LimitSpec) Closure cl) {
+            executeClosure LimitMatchers.branch(id), cl
+        }
+
+        void branches(Collection<String> ids, @DelegatesTo(LimitSpec) Closure cl) {
+            executeClosure LimitMatchers.branches(ids), cl
+        }
+    }
+
+    static LimitFactors createFactors(@DelegatesTo(LimitSpec) Closure cl) {
+        def cloned = cl.clone()
+        cloned.resolveStrategy = Closure.DELEGATE_FIRST
+
+        LimitSpec spec = new LimitSpec()
+        cloned.delegate = spec
+        cloned()
+
+        return spec.node
+    }
+
+    static void loadDsl(Binding binding, Consumer<LimitFactors> handler) {
+
+        ExpressionDslLoader.prepareClosures(binding)
+
+        binding.current_limits = { Closure cl -> handler.accept(createFactors(cl)) }
+
+    }
+
+    LimitFactors loadFactors() {
+
+        LimitFactors root = new LimitFactorsNode()
+
+        try {
+            Binding binding = new Binding()
+
+            loadDsl(binding, root.&addChild)
+
+            def shell = createShell(binding)
+
+            shell.evaluate(dslSrc)
+
+            root
+
+        } catch (CompilationFailedException e) {
+            throw new DslException(e.getMessage(), e)
+        }
+    }
+
+    LimitViolationDetector loadDetector() {
+        return new LimitViolationDetectorWithFactors(loadFactors())
+    }
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ConditionNode.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ConditionNode.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.CurrentLimits;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ *  A {@link LimitFactorsNode} which forwards requests to its children only if a condition is matched.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+class ConditionNode extends LimitFactorsNode {
+
+    private final LimitMatcher condition;
+
+    public ConditionNode(LimitMatcher condition) {
+        super();
+        this.condition = Objects.requireNonNull(condition);
+    }
+
+    @Override
+    public Optional<Float> getFactor(Contingency contingency, Branch branch, Branch.Side side, CurrentLimits.TemporaryLimit limit) {
+
+        if (condition.matches(branch, side, limit, contingency)) {
+            return super.getFactor(contingency, branch, side, limit);
+        }
+        return Optional.empty();
+    }
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ExpressionLimitMatcher.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ExpressionLimitMatcher.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.powsybl.contingency.Contingency;
+import com.powsybl.dsl.ast.ExpressionNode;
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.CurrentLimits;
+import com.powsybl.security.dsl.ast.LimitsEvaluationContext;
+import com.powsybl.security.dsl.ast.LimitsExpressionEvaluator;
+
+import java.util.Objects;
+
+/**
+ * Implementation of {@link LimitMatcher} which relies on an underlying condition
+ * described as an {@link ExpressionNode}, which may be created from a groovy DSL.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+class ExpressionLimitMatcher implements LimitMatcher {
+
+    private final ExpressionNode expression;
+
+    public ExpressionLimitMatcher(ExpressionNode expression) {
+        this.expression = Objects.requireNonNull(expression);
+    }
+
+    public boolean matches(Branch branch, Branch.Side side, CurrentLimits.TemporaryLimit limit, Contingency contingency) {
+        return LimitsExpressionEvaluator.evaluate(expression, new LimitsEvaluationContext(contingency, branch, side, limit)).equals(Boolean.TRUE);
+    }
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/FinalFactorNode.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/FinalFactorNode.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.CurrentLimits;
+
+import java.util.Optional;
+
+/**
+ * The final node of a tree of conditions, which provides an actual factor value.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+class FinalFactorNode implements LimitFactors {
+
+    private final float factor;
+
+    public FinalFactorNode(float factor) {
+        this.factor = factor;
+    }
+
+    @Override
+    public Optional<Float> getFactor(Contingency contingency, Branch branch, Branch.Side side, CurrentLimits.TemporaryLimit limit) {
+        return Optional.of(factor);
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitFactors.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitFactors.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.CurrentLimits;
+
+import java.util.Optional;
+
+/**
+ * A definition of factors to be applied to security limits.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+interface LimitFactors {
+
+    /**
+     * Get the limit factor, if defined, for the specified {@link Branch},
+     * side, current limit and contingency.
+     *
+     * @param contingency The contingency for which a factor is requested, or {@code null} for N situation.
+     * @param branch      The branch for which a factor is requested.
+     * @param side        The side for which a factor is requested.
+     * @param limit       The temporary limit for which a factor is requested, or {@code null} for permanent limit.
+     * @return            The factor to be applied to the specified limit, or empty if none matches.
+     */
+    Optional<Float> getFactor(Contingency contingency, Branch branch, Branch.Side side, CurrentLimits.TemporaryLimit limit);
+
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitFactorsNode.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitFactorsNode.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.CurrentLimits;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ *
+ * {@link LimitFactors} is implemented as a tree of conditions.
+ * This type of node request a factor to its children,
+ * and returns the first non empty factor it finds.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+class LimitFactorsNode implements LimitFactors {
+
+    private final List<LimitFactors> children;
+
+    public LimitFactorsNode() {
+        this.children = new ArrayList<>();
+    }
+
+    public void addChild(LimitFactors child) {
+        children.add(child);
+    }
+
+    protected List<LimitFactors> getChildren() {
+        return children;
+    }
+
+    @Override
+    public Optional<Float> getFactor(Contingency contingency, Branch branch, Branch.Side side, CurrentLimits.TemporaryLimit limit) {
+
+        return children.stream()
+                .map(c -> c.getFactor(contingency, branch, side, limit))
+                .filter(Optional::isPresent)
+                .findFirst()
+                .map(Optional::get);
+    }
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitMatcher.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitMatcher.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.CurrentLimits;
+
+/**
+ *
+ * A predicate for current limits selection. The current limit and the context will be described by:
+ *  - the {@link Branch} of the limit
+ *  - the {@link Branch.Side} of the limit
+ *  - the {@link CurrentLimits.TemporaryLimit} in case it is a temporary limit
+ *  - the {@link Contingency} in case we are in a post-contingency context
+ */
+interface LimitMatcher {
+
+    /**
+     * Determine if a current limit and the context match the underlying criteria
+     *
+     * @param branch        the branch of the limit
+     * @param side          the side of the limit
+     * @param limit         the temporary limit in case it is a temporary one,
+     *                      or {@code null} in case it is a permanent limit
+     * @param contingency   the contingency if we are in a post-contingency context,
+     *                      {@code null} if we are in N situation
+     *
+     * @return              true if the limit and the context match the underlying criteria
+     */
+    boolean matches(Branch branch, Branch.Side side, CurrentLimits.TemporaryLimit limit, Contingency contingency);
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitMatchers.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitMatchers.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Provides implementations of {@link LimitMatcher}.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+final class LimitMatchers {
+
+    private static final LimitMatcher TEMPORARY = (b, s, l, c) -> l != null;
+
+    private static final LimitMatcher PERMANENT = (b, s, l, c) -> l == null;
+
+    private static final LimitMatcher ANY_CONTINGENCY = (b, s, l, c) -> c != null;
+
+    private static final LimitMatcher N_SITUATION = (b, s, l, c) -> c == null;
+
+    private LimitMatchers() {
+    }
+
+    /**
+     * A {@link LimitMatcher} which matches the branch with the specified ID.
+     */
+    static LimitMatcher branch(String id) {
+        return (b, s, l, c) -> b.getId().equals(id);
+    }
+
+    /**
+     * A {@link LimitMatcher} which matches the branches with the specified IDs.
+     */
+    static LimitMatcher branches(Collection<String> ids) {
+        Set<String> set = ImmutableSet.copyOf(ids);
+        return (b, s, l, c) -> set.contains(b.getId());
+    }
+
+    /**
+     * A {@link LimitMatcher} which matches the contingency with the specified ID.
+     */
+    static LimitMatcher contingency(String id) {
+        return (b, s, l, c) -> c != null && c.getId().equals(id);
+    }
+
+    /**
+     * A {@link LimitMatcher} which matches the contingencies with the specified ID.
+     */
+    static LimitMatcher contingencies(Collection<String> ids) {
+        Set<String> set = ImmutableSet.copyOf(ids);
+        return (b, s, l, c) -> c != null && set.contains(c.getId());
+    }
+
+    /**
+     * A {@link LimitMatcher} which matches any temporary limit.
+     */
+    static LimitMatcher temporary() {
+        return TEMPORARY;
+    }
+
+    /**
+     * A {@link LimitMatcher} which matches any permanent limit.
+     */
+    static LimitMatcher permanent() {
+        return PERMANENT;
+    }
+
+    /**
+     * A {@link LimitMatcher} which matches any limit on N situation.
+     */
+    static LimitMatcher nSituation() {
+        return N_SITUATION;
+    }
+
+    /**
+     * A {@link LimitMatcher} which matches any limit on post-contingency situations.
+     */
+    static LimitMatcher anyContingency() {
+        return ANY_CONTINGENCY;
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitViolationDetectorDsl.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitViolationDetectorDsl.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.security.SecurityAnalysisInput;
+import groovy.lang.Binding;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * Enables a DSL which defines current limits factors, as described in {@link LimitFactorsLoader}.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+@AutoService(SecurityAnalysisDsl.class)
+public class LimitViolationDetectorDsl implements SecurityAnalysisDsl {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LimitViolationDetectorDsl.class);
+
+    private static void bindDetector(SecurityAnalysisInput inputs, LimitFactors factors) {
+        inputs.setDetector(new LimitViolationDetectorWithFactors(factors));
+    }
+
+    /**
+     * Enable the limit factors DSL, which will collect limit factors definition into the
+     * {@link com.powsybl.security.LimitViolationDetector LimitViolationDetector} of the specified input.
+     */
+    @Override
+    public void enable(Binding binding, SecurityAnalysisInput inputs) {
+        LOGGER.debug("Loading limits violation detector DSL.");
+        LimitFactorsLoader.loadDsl(binding, f -> bindDetector(inputs, f));
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitViolationDetectorWithFactors.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/LimitViolationDetectorWithFactors.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.CurrentLimits;
+import com.powsybl.security.DefaultLimitViolationDetector;
+import com.powsybl.security.LimitViolation;
+import com.powsybl.security.LimitViolationType;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * A {@link com.powsybl.security.LimitViolationDetector LimitViolationDetector} which detects violations based on
+ * an underlying definition of {@link LimitFactors} to be applied to current limits.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class LimitViolationDetectorWithFactors extends DefaultLimitViolationDetector {
+
+    private final LimitFactors factors;
+
+    public LimitViolationDetectorWithFactors(LimitFactors factors) {
+        this.factors = Objects.requireNonNull(factors);
+    }
+
+    @Override
+    public void checkCurrent(Contingency contingency, Branch branch, Branch.Side side, double currentValue, Consumer<LimitViolation> consumer) {
+
+        CurrentLimits limits = branch.getCurrentLimits(side);
+        if (limits == null || Double.isNaN(currentValue)) {
+            return;
+        }
+
+        //Iterate current limits with ascending duration
+        for (CurrentLimits.TemporaryLimit tl : Lists.reverse(ImmutableList.copyOf(limits.getTemporaryLimits()))) {
+            LimitViolation violation = checkTemporaryLimit(contingency, branch, side, tl, currentValue);
+            if (violation != null) {
+                consumer.accept(violation);
+                return;
+            }
+        }
+
+        if (Double.isNaN(limits.getPermanentLimit())) {
+            return;
+        }
+
+        LimitViolation violation = checkPermanentLimit(contingency, branch, side, limits, currentValue);
+        if (violation != null) {
+            consumer.accept(violation);
+        }
+    }
+
+    private LimitViolation checkTemporaryLimit(Contingency contingency, Branch branch,
+                                               Branch.Side side, CurrentLimits.TemporaryLimit tl, double currentValue) {
+
+        float factor = factors.getFactor(contingency, branch, side, tl).orElse(1f);
+
+        if (currentValue < factor * tl.getValue()) {
+            return null;
+        }
+
+        return new LimitViolation(branch.getId(),
+                LimitViolationType.CURRENT,
+                tl.getName(),
+                tl.getAcceptableDuration(),
+                tl.getValue(),
+                factor,
+                currentValue,
+                side);
+    }
+
+    private LimitViolation checkPermanentLimit(Contingency contingency, Branch branch,
+                                               Branch.Side side, CurrentLimits limits, double currentValue) {
+
+        float factor = factors.getFactor(contingency, branch, side, null).orElse(1f);
+        if (currentValue < limits.getPermanentLimit() * factor) {
+            return null;
+        }
+        return new LimitViolation(branch.getId(),
+                LimitViolationType.CURRENT,
+                null,
+                Integer.MAX_VALUE,
+                limits.getPermanentLimit(),
+                factor,
+                currentValue,
+                side);
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/SecurityAnalysisContingencyDsl.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/SecurityAnalysisContingencyDsl.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.contingency.Contingency;
+import com.powsybl.contingency.dsl.ContingencyDslLoader;
+import com.powsybl.security.SecurityAnalysisInput;
+import groovy.lang.Binding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * Enable the definition of contingencies in the same script as limit factors.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+@AutoService(SecurityAnalysisDsl.class)
+public class SecurityAnalysisContingencyDsl implements SecurityAnalysisDsl {
+
+
+    /**
+     * Enable the contingency DSL, which will collect contingencies into the {@link com.powsybl.contingency.ContingenciesProvider ContingenciesProvider}
+     * of the specified input.
+     */
+    @Override
+    public void enable(Binding binding, SecurityAnalysisInput input) {
+        List<Contingency> contingencies = new ArrayList<>();
+        input.setContingencies(network -> contingencies);
+        ContingencyDslLoader.loadDsl(binding, input.getNetworkVariant().getNetwork(), contingencies::add, null);
+    }
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/SecurityAnalysisDsl.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/SecurityAnalysisDsl.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.powsybl.dsl.GroovyDsl;
+import com.powsybl.security.SecurityAnalysisInput;
+
+/**
+ * Defines a DSL to customize {@link SecurityAnalysisInput},
+ * used by the {@link SecurityAnalysisDslPreprocessor}.
+ * You can define your own DSL by providing en implementation of that interface
+ * as a service, possibly using {@link com.google.auto.service.AutoService}.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public interface SecurityAnalysisDsl extends GroovyDsl<SecurityAnalysisInput> {
+
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/SecurityAnalysisDslPreprocessor.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/SecurityAnalysisDslPreprocessor.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.google.common.io.ByteSource;
+import com.powsybl.commons.util.ServiceLoaderCache;
+import com.powsybl.dsl.GroovyAggregateDsl;
+import com.powsybl.dsl.GroovyDsl;
+import com.powsybl.dsl.GroovyDslInterpreter;
+import com.powsybl.security.SecurityAnalysisInput;
+import com.powsybl.security.preprocessor.SecurityAnalysisPreprocessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link SecurityAnalysisPreprocessor} which reads the configuration from a DSL groovy script.
+ * The DSL may be defined by multiple services implementing {@link SecurityAnalysisDsl} service.
+ * All DSLs will be loaded before actually executing the script
+ * by calling the {@link SecurityAnalysisPreprocessor#preprocess(SecurityAnalysisInput)} method.
+ *
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class SecurityAnalysisDslPreprocessor implements SecurityAnalysisPreprocessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityAnalysisDslPreprocessor.class);
+
+    private final ByteSource configurationSource;
+
+    SecurityAnalysisDslPreprocessor(ByteSource configurationSource) {
+        this.configurationSource = Objects.requireNonNull(configurationSource);
+    }
+
+    @Override
+    public void preprocess(SecurityAnalysisInput configuration) {
+
+        LOGGER.debug("Starting configuration of security analysis inputs, based on groovy DSL.");
+
+        List<SecurityAnalysisDsl> dslParts = new ServiceLoaderCache<>(SecurityAnalysisDsl.class).getServices();
+        GroovyDsl<SecurityAnalysisInput> dsl = new GroovyAggregateDsl<>(dslParts);
+
+        GroovyDslInterpreter<SecurityAnalysisInput> interpreter = new GroovyDslInterpreter<>(dsl);
+
+        LOGGER.debug("Evaluating security analysis configuration DSL file.");
+        interpreter.interprete(configurationSource.asCharSource(StandardCharsets.UTF_8), configuration);
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/SecurityAnalysisDslPreprocessorFactory.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/SecurityAnalysisDslPreprocessorFactory.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.google.auto.service.AutoService;
+import com.google.common.io.ByteSource;
+import com.powsybl.security.preprocessor.SecurityAnalysisPreprocessor;
+import com.powsybl.security.preprocessor.SecurityAnalysisPreprocessorFactory;
+
+import java.util.Objects;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+@AutoService(SecurityAnalysisPreprocessorFactory.class)
+public class SecurityAnalysisDslPreprocessorFactory implements SecurityAnalysisPreprocessorFactory {
+
+    @Override
+    public String getName() {
+        return "groovy-dsl";
+    }
+
+    @Override
+    public SecurityAnalysisPreprocessor newPreprocessor(ByteSource configSource) {
+        Objects.requireNonNull(configSource);
+        return new SecurityAnalysisDslPreprocessor(configSource);
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/AbstractLimitsExpressionNode.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/AbstractLimitsExpressionNode.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl.ast;
+
+import com.powsybl.dsl.ast.ExpressionNode;
+import com.powsybl.dsl.ast.ExpressionVisitor;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public abstract class AbstractLimitsExpressionNode implements ExpressionNode {
+
+    @Override
+    public <R, A> R accept(ExpressionVisitor<R, A> visitor, A arg) {
+        return accept((LimitsExpressionVisitor<R, A>) visitor, arg);
+    }
+
+    abstract <R, A> R accept(LimitsExpressionVisitor<R, A> visitor, A arg);
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/LimitsEvaluationContext.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/LimitsEvaluationContext.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl.ast;
+
+import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.CurrentLimits.TemporaryLimit;
+
+import java.util.Objects;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class LimitsEvaluationContext {
+
+    private final Branch branch;
+    private final Branch.Side side;
+    private final TemporaryLimit limit;
+    private final Contingency contingency;
+
+    public LimitsEvaluationContext(Contingency contingency, Branch branch, Branch.Side side, TemporaryLimit limit) {
+        this.branch = Objects.requireNonNull(branch);
+        this.side = Objects.requireNonNull(side);
+        this.limit = limit;
+        this.contingency = contingency;
+    }
+
+    public Branch getBranch() {
+        return branch;
+    }
+
+    public Branch.Side getSide() {
+        return side;
+    }
+
+    public TemporaryLimit getLimit() {
+        return limit;
+    }
+
+    public Contingency getContingency() {
+        return contingency;
+    }
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/LimitsExpressionEvaluator.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/LimitsExpressionEvaluator.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl.ast;
+
+import com.powsybl.dsl.DslException;
+import com.powsybl.dsl.ast.ExpressionEvaluator;
+import com.powsybl.dsl.ast.ExpressionNode;
+
+import java.util.Objects;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class LimitsExpressionEvaluator extends ExpressionEvaluator implements LimitsExpressionVisitor<Object, Void> {
+
+    private final LimitsEvaluationContext context;
+
+    public LimitsExpressionEvaluator(LimitsEvaluationContext context) {
+        this.context = Objects.requireNonNull(context);
+    }
+
+    @Override
+    public Object visitVariable(LimitsVariableNode node, Void arg) {
+        switch (node.getType()) {
+            case VOLTAGE:
+                return context.getBranch().getTerminal(context.getSide()).getVoltageLevel().getNominalV();
+            case DURATION:
+                if (context.getLimit() == null) {
+                    return null;
+                }
+                return context.getLimit().getAcceptableDuration();
+            default:
+                throw new DslException("Unknown variable type: " + node.getType());
+        }
+    }
+
+    public static Object evaluate(ExpressionNode node, LimitsEvaluationContext context) {
+        return node.accept(new LimitsExpressionEvaluator(context), null);
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/LimitsExpressionVisitor.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/LimitsExpressionVisitor.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl.ast;
+
+import com.powsybl.dsl.ast.ExpressionVisitor;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public interface LimitsExpressionVisitor<R, A> extends ExpressionVisitor<R, A> {
+
+    R visitVariable(LimitsVariableNode node, A arg);
+}

--- a/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/LimitsVariableNode.java
+++ b/security-analysis/security-analysis-dsl/src/main/java/com/powsybl/security/dsl/ast/LimitsVariableNode.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl.ast;
+
+import java.util.Objects;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public final class LimitsVariableNode extends AbstractLimitsExpressionNode {
+
+    private static final LimitsVariableNode DURATION = new LimitsVariableNode(Type.DURATION);
+    private static final LimitsVariableNode VOLTAGE = new LimitsVariableNode(Type.VOLTAGE);
+
+    private final Type type;
+
+    public static LimitsVariableNode voltage() {
+        return VOLTAGE;
+    }
+
+    public static LimitsVariableNode duration() {
+        return DURATION;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public enum Type {
+        VOLTAGE,
+        DURATION
+    }
+
+    private LimitsVariableNode(Type type) {
+        this.type = Objects.requireNonNull(type);
+    }
+
+    @Override
+    <R, A> R accept(LimitsExpressionVisitor<R, A> visitor, A arg) {
+        return visitor.visitVariable(this, arg);
+    }
+}

--- a/security-analysis/security-analysis-dsl/src/test/java/com/powsybl/security/dsl/LimitFactorsTest.java
+++ b/security-analysis/security-analysis-dsl/src/test/java/com/powsybl/security/dsl/LimitFactorsTest.java
@@ -1,0 +1,269 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.dsl;
+
+import com.google.common.io.Resources;
+import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.security.LimitViolation;
+import com.powsybl.security.LimitViolationDetector;
+import com.powsybl.security.SecurityAnalysisInput;
+import com.powsybl.security.preprocessor.SecurityAnalysisPreprocessorFactory;
+import com.powsybl.security.execution.NetworkVariant;
+import groovy.lang.GroovyCodeSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class LimitFactorsTest {
+
+    private final SecurityAnalysisPreprocessorFactory factory = new SecurityAnalysisDslPreprocessorFactory();
+
+    private Network network;
+    private Line line;
+    private TwoWindingsTransformer transformer;
+    private CurrentLimits.TemporaryLimit temporaryLimit;
+
+    @Before
+    public void setUp() {
+        network = EurostagTutorialExample1Factory.create();
+
+        line = network.getLine("NHV1_NHV2_1");
+        transformer = network.getTwoWindingsTransformer("NGEN_NHV1");
+
+        line.newCurrentLimits1()
+                .setPermanentLimit(1000)
+                .beginTemporaryLimit()
+                .setName("IT20")
+                .setAcceptableDuration(1200)
+                .setValue(1500)
+                .endTemporaryLimit()
+                .beginTemporaryLimit()
+                .setName("IT10")
+                .setAcceptableDuration(600)
+                .setValue(2000)
+                .endTemporaryLimit()
+                .add();
+
+        transformer.newCurrentLimits1()
+                .setPermanentLimit(1000)
+                .beginTemporaryLimit()
+                .setName("IT20")
+                .setAcceptableDuration(1200)
+                .setValue(1500)
+                .endTemporaryLimit()
+                .beginTemporaryLimit()
+                .setName("IT10")
+                .setAcceptableDuration(600)
+                .setValue(2000)
+                .endTemporaryLimit()
+                .add();
+
+        temporaryLimit = line.getCurrentLimits1().getTemporaryLimit(1200);
+    }
+
+    @Test
+    public void test() {
+
+        LimitFactors factors = new LimitFactorsLoader(new GroovyCodeSource(getClass().getResource("/limits-dsl.groovy")))
+                .loadFactors();
+
+        assertEquals(0.95f, factors.getFactor(null, line, Branch.Side.ONE, null).orElse(1.0f), 0);
+        assertEquals(1.0f, factors.getFactor(null, line, Branch.Side.ONE, temporaryLimit).orElse(1.0f), 0);
+        assertEquals(0.99f, factors.getFactor(new Contingency("contingency1"), line, Branch.Side.TWO, null).orElse(1.0f), 0);
+        assertEquals(0.98f, factors.getFactor(new Contingency("toto"), line, Branch.Side.TWO, null).orElse(1.0f), 0);
+    }
+
+    @Test
+    public void testBranches() {
+
+        LimitFactors factors = new LimitFactorsLoader(new GroovyCodeSource(getClass().getResource("/limits-dsl-branches.groovy")))
+                .loadFactors();
+
+        Contingency c1 = new Contingency("contingency1");
+        Contingency c2 = new Contingency("contingency2");
+        assertThat(factors.getFactor(c1, line, Branch.Side.ONE, null))
+                .hasValue(0.95f);
+        assertThat(factors.getFactor(c2, line, Branch.Side.TWO, null))
+                .hasValue(0.95f);
+        assertThat(factors.getFactor(null, line, Branch.Side.ONE, null))
+                .isEmpty();
+
+        assertThat(factors.getFactor(c1, transformer, Branch.Side.ONE, null))
+                .hasValue(0.8f);
+        assertThat(factors.getFactor(c2, transformer, Branch.Side.ONE, null))
+                .isEmpty();
+        assertThat(factors.getFactor(null, transformer, Branch.Side.ONE, null))
+                .isEmpty();
+    }
+
+    private void checkDetector(LimitViolationDetector detector) {
+
+        assertThat(detector).isInstanceOf(LimitViolationDetectorWithFactors.class);
+
+        List<LimitViolation> violations = new ArrayList<>();
+        detector.checkCurrent(null, line, Branch.Side.ONE, 960, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(Integer.MAX_VALUE, v.getAcceptableDuration());
+                    assertEquals(960f, v.getValue(), 0f);
+                    assertEquals(1000f, v.getLimit(), 0f);
+                });
+
+        violations.clear();
+        detector.checkCurrent(null, line, Branch.Side.ONE, 940, violations::add);
+        assertThat(violations).isEmpty();
+
+        violations.clear();
+        detector.checkCurrent(null, line, Branch.Side.TWO, 2000, violations::add);
+        assertThat(violations).isEmpty();
+
+        violations.clear();
+        detector.checkCurrent(null, line, Branch.Side.ONE, 1499, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(Integer.MAX_VALUE, v.getAcceptableDuration());
+                    assertEquals(1499, v.getValue(), 0f);
+                    assertEquals(1000f, v.getLimit(), 0f);
+                });
+
+        violations.clear();
+        detector.checkCurrent(null, line, Branch.Side.ONE, 1501, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(1200, v.getAcceptableDuration());
+                    assertEquals(1501f, v.getValue(), 0f);
+                    assertEquals(1500f, v.getLimit(), 0f);
+                });
+
+        violations.clear();
+        detector.checkCurrent(new Contingency("toto"), line, Branch.Side.ONE, 979, violations::add);
+        assertThat(violations).isEmpty();
+
+        violations.clear();
+        detector.checkCurrent(new Contingency("toto"), line, Branch.Side.ONE, 981, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(Integer.MAX_VALUE, v.getAcceptableDuration());
+                    assertEquals(981, v.getValue(), 0f);
+                    assertEquals(1000f, v.getLimit(), 0f);
+                });
+
+        violations.clear();
+        detector.checkCurrent(new Contingency("contingency1"), line, Branch.Side.ONE, 989, violations::add);
+        assertThat(violations).isEmpty();
+
+        violations.clear();
+        detector.checkCurrent(new Contingency("contingency1"), line, Branch.Side.ONE, 991, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(Integer.MAX_VALUE, v.getAcceptableDuration());
+                    assertEquals(991, v.getValue(), 0f);
+                    assertEquals(1000f, v.getLimit(), 0f);
+                });
+    }
+
+    @Test
+    public void testDetector() {
+
+        LimitViolationDetector detector = new LimitFactorsLoader(new GroovyCodeSource(getClass().getResource("/limits-dsl.groovy")))
+                .loadDetector();
+
+        checkDetector(detector);
+    }
+
+    @Test
+    public void testPreprocessor() {
+        SecurityAnalysisInput inputs = new SecurityAnalysisInput(Mockito.mock(NetworkVariant.class));
+        factory.newPreprocessor(Resources.asByteSource(getClass().getResource("/limits-dsl.groovy")))
+                .preprocess(inputs);
+
+        checkDetector(inputs.getLimitViolationDetector());
+    }
+
+    @Test
+    public void testExpressions() {
+        SecurityAnalysisInput inputs = new SecurityAnalysisInput(Mockito.mock(NetworkVariant.class));
+        factory.newPreprocessor(Resources.asByteSource(getClass().getResource("/limits-dsl-expressions.groovy")))
+                .preprocess(inputs);
+
+        LimitViolationDetector detector = inputs.getLimitViolationDetector();
+
+        List<LimitViolation> violations = new ArrayList<>();
+
+        //Check 0.9 factor
+        detector.checkCurrent(null, line, Branch.Side.ONE, 910, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(Integer.MAX_VALUE, v.getAcceptableDuration());
+                    assertEquals(910, v.getValue(), 0f);
+                    assertEquals(1000f, v.getLimit(), 0f);
+                });
+
+        violations.clear();
+        detector.checkCurrent(null, line, Branch.Side.ONE, 890, violations::add);
+        assertThat(violations).isEmpty();
+
+        //Check 0.8 factor
+        violations.clear();
+        detector.checkCurrent(null, transformer, Branch.Side.ONE, 810, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(Integer.MAX_VALUE, v.getAcceptableDuration());
+                    assertEquals(810, v.getValue(), 0f);
+                    assertEquals(1000f, v.getLimit(), 0f);
+                });
+
+        violations.clear();
+        detector.checkCurrent(null, transformer, Branch.Side.ONE, 790, violations::add);
+        assertThat(violations).isEmpty();
+
+        //Check 0.7 factor
+        violations.clear();
+        detector.checkCurrent(null, transformer, Branch.Side.ONE, 0.7 * 1500 + 10, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(1200, v.getAcceptableDuration());
+                    assertEquals(0.7 * 1500 + 10, v.getValue(), 0f);
+                    assertEquals(1500, v.getLimit(), 0f);
+                });
+
+        violations.clear();
+        detector.checkCurrent(null, transformer, Branch.Side.ONE, 0.7 * 1500 - 10, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(Integer.MAX_VALUE, v.getAcceptableDuration());
+                });
+        //Check 0.6 factor
+        violations.clear();
+        detector.checkCurrent(null, transformer, Branch.Side.ONE, 0.6 * 2000 + 10, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(600, v.getAcceptableDuration());
+                    assertEquals(0.6 * 2000 + 10, v.getValue(), 0f);
+                    assertEquals(2000f, v.getLimit(), 0f);
+                });
+
+        violations.clear();
+        detector.checkCurrent(null, transformer, Branch.Side.ONE, 0.6 * 2000 - 10, violations::add);
+        assertThat(violations)
+                .hasOnlyOneElementSatisfying(v -> {
+                    assertEquals(1200, v.getAcceptableDuration());
+                });
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/test/java/com/powsybl/security/dsl/SecurityAnalysisDslPreprocessorTest.java
+++ b/security-analysis/security-analysis-dsl/src/test/java/com/powsybl/security/dsl/SecurityAnalysisDslPreprocessorTest.java
@@ -1,0 +1,31 @@
+package com.powsybl.security.dsl;
+
+import com.google.common.io.ByteSource;
+import com.google.common.io.Resources;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.security.SecurityAnalysisInput;
+import org.junit.Test;
+
+import static com.powsybl.iidm.network.VariantManagerConstants.INITIAL_VARIANT_ID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class SecurityAnalysisDslPreprocessorTest {
+
+    @Test
+    public void test() {
+
+        SecurityAnalysisInput input = new SecurityAnalysisInput(EurostagTutorialExample1Factory.create(), INITIAL_VARIANT_ID);
+
+        ByteSource source = Resources.asByteSource(getClass().getResource("/limits-and-contincencies-dsl.groovy"));
+        new SecurityAnalysisDslPreprocessor(source).preprocess(input);
+
+        assertEquals(1, input.getContingenciesProvider().getContingencies(null).size());
+
+        assertTrue(input.getLimitViolationDetector() instanceof LimitViolationDetectorWithFactors);
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/test/resources/limits-and-contincencies-dsl.groovy
+++ b/security-analysis/security-analysis-dsl/src/test/resources/limits-and-contincencies-dsl.groovy
@@ -1,0 +1,23 @@
+current_limits {
+
+    N_situation {
+
+        permanent {
+            factor 0.95
+        }
+
+        temporary {
+            factor 1.0
+        }
+    }
+
+    contingency('HV line 1') {
+        factor 0.99
+    }
+}
+
+contingency('HV line 1') {
+
+    equipments 'NHV1_NHV2_1'
+
+}

--- a/security-analysis/security-analysis-dsl/src/test/resources/limits-dsl-branches.groovy
+++ b/security-analysis/security-analysis-dsl/src/test/resources/limits-dsl-branches.groovy
@@ -1,0 +1,16 @@
+current_limits {
+
+
+    branch('NHV1_NHV2_1') {
+        contingencies(['contingency1', 'contingency2']) {
+            factor 0.95
+        }
+    }
+
+    branches(['NGEN_NHV1', 'NGEN_LOAD']) {
+        contingency('contingency1') {
+            factor 0.8
+        }
+    }
+
+}

--- a/security-analysis/security-analysis-dsl/src/test/resources/limits-dsl-expressions.groovy
+++ b/security-analysis/security-analysis-dsl/src/test/resources/limits-dsl-expressions.groovy
@@ -1,0 +1,25 @@
+current_limits {
+
+
+    permanent {
+        where(voltage >= 300) {
+            factor 0.9
+        }
+
+        where(voltage >= 10) {
+            factor 0.8
+        }
+    }
+
+    temporary {
+        where(duration >= 1000) {
+            factor 0.7
+        }
+
+        where(duration >= 500) {
+            factor 0.6
+        }
+    }
+
+    factor 0.5
+}

--- a/security-analysis/security-analysis-dsl/src/test/resources/limits-dsl.groovy
+++ b/security-analysis/security-analysis-dsl/src/test/resources/limits-dsl.groovy
@@ -1,0 +1,21 @@
+current_limits {
+
+    N_situation {
+
+        permanent {
+            factor 0.95
+        }
+
+        temporary {
+            factor 1.0
+        }
+    }
+
+    contingency('contingency1') {
+        factor 0.99
+    }
+
+    any_contingency {
+        factor 0.98
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

A new feature : ability to customize current limits monitored by the security analysis.

**What is the current behavior?** *(You can also link to an open issue here)*

Security analysis only reports violations according to the DefaultLimitViolationDetector logic, which uses current limits defined in the Network.

**What is the new behavior (if this is a feature change)?**

The user may define, through a DSL, factors to be applied to current limits defined in the Network for limit violation detection purpose.
Those factors may be defined separately for specified contingencies, voltage levels, durations etc.

