### PR TITLE
Add targetDeadband for IIDM tap changers

### DIFF
--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
@@ -427,7 +427,8 @@ public class CgmesConformity1NetworkCatalog {
             Branch.Side side = Branch.Side.TWO;
             RatioTapChangerAdder rtca = tx.newRatioTapChanger()
                     .setLowTapPosition(low)
-                    .setTapPosition(18);
+                    .setTapPosition(18)
+                    .setTargetDeadband(0.5);
             for (int k = low; k <= high; k++) {
                 int n = k - neutral;
                 double du = voltageInc / 100;
@@ -563,7 +564,7 @@ public class CgmesConformity1NetworkCatalog {
                     xmin, xmax,
                     voltageInc, windingConnectionAngle,
                     PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL,
-                    true, -65.0);
+                    true, -65.0, 35.0);
         }
         {
             double p = -90;
@@ -788,7 +789,7 @@ public class CgmesConformity1NetworkCatalog {
                     xmin, xmax,
                     voltageInc, windingConnectionAngle,
                     PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL, false,
-                    0.0);
+                    0.0, 0.5);
         }
         txBE22.newCurrentLimits1().setPermanentLimit(1705.8)
                 .beginTemporaryLimit()
@@ -821,7 +822,7 @@ public class CgmesConformity1NetworkCatalog {
                     xmin, xmax,
                     voltageInc, windingConnectionAngle,
                     PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL, true,
-                    -65.0);
+                    -65.0, 35.0);
         }
         txBE21.newCurrentLimits1().setPermanentLimit(938.2)
                 .beginTemporaryLimit()
@@ -880,7 +881,7 @@ public class CgmesConformity1NetworkCatalog {
             double voltageInc,
             double windingConnectionAngle,
             PhaseTapChanger.RegulationMode mode, boolean regulating,
-            double regulationValue) {
+            double regulationValue, double targetDeadband) {
         LOG.debug("EXPECTED tx {}", tx.getId());
         double rho0 = tx.getRatedU2() / tx.getRatedU1();
         double rho02 = rho0 * rho0;
@@ -965,6 +966,7 @@ public class CgmesConformity1NetworkCatalog {
         ptca.setRegulating(regulating)
                 .setRegulationMode(mode)
                 .setRegulationValue(regulationValue)
+                .setTargetDeadband(targetDeadband)
                 .setRegulationTerminal(tx.getTerminal2())
                 .add();
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMapping.java
@@ -33,6 +33,7 @@ public class RegulatingControlMapping {
         private final String topologicalNode;
         private final boolean enabled;
         private final double targetValue;
+        private final double targetDeadband;
 
         private final Map<String, Boolean> idsEq = new HashMap<>();
 
@@ -42,6 +43,7 @@ public class RegulatingControlMapping {
             this.topologicalNode = p.getId("topologicalNode");
             this.enabled = p.asBoolean("enabled", true);
             this.targetValue = p.asDouble("targetValue");
+            this.targetDeadband = p.asDouble("targetDeadband", Double.NaN);
         }
     }
 
@@ -118,6 +120,7 @@ public class RegulatingControlMapping {
                     .setTargetV(Double.NaN);
         } else {
             adder.setRegulating(control.enabled || p.asBoolean("tapChangerControlEnabled", false))
+                    .setTargetDeadband(control.targetDeadband)
                     .setTargetV(control.targetValue);
         }
         setRegulatingTerminal(p, control, defaultTerminal, adder);
@@ -156,12 +159,14 @@ public class RegulatingControlMapping {
     private void addCurrentFlowRegControl(PropertyBag p, RegulatingControl control, Terminal defaultTerminal, PhaseTapChangerAdder adder, int side, TwoWindingsTransformer t2w) {
         adder.setRegulationMode(PhaseTapChanger.RegulationMode.CURRENT_LIMITER)
                 .setRegulationValue(getTargetValue(control.targetValue, control.cgmesTerminal, side, t2w))
+                .setTargetDeadband(control.targetDeadband)
                 .setRegulating(control.enabled);
         setRegulatingTerminal(p, control, defaultTerminal, adder);
     }
 
     private void addActivePowerRegControl(PropertyBag p, RegulatingControl control, Terminal defaultTerminal, PhaseTapChangerAdder adder, int side, TwoWindingsTransformer t2w) {
         adder.setRegulationMode(PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL)
+                .setTargetDeadband(control.targetDeadband)
                 .setRegulating(control.enabled)
                 .setRegulationValue(getTargetValue(-control.targetValue, control.cgmesTerminal, side, t2w));
         setRegulatingTerminal(p, control, defaultTerminal, adder);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -452,6 +452,9 @@ public class Comparison {
             compare("tapChanger.tapPosition",
                     expected.getTapPosition(),
                     actual.getTapPosition());
+            compare("tapChanger.targetDeadband",
+                    expected.getTargetDeadband(),
+                    actual.getTargetDeadband());
             compare("tapChanger.stepCount", expected.getStepCount(), actual.getStepCount());
             // Check steps
             for (int k = expected.getLowTapPosition(); k <= expected.getStepCount(); k++) {

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/PhaseTapChangerAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/PhaseTapChangerAdder.java
@@ -41,6 +41,10 @@ public interface PhaseTapChangerAdder {
 
     PhaseTapChangerAdder setRegulationTerminal(Terminal regulationTerminal);
 
+    default PhaseTapChangerAdder setTargetDeadband(double targetDeadband) {
+        throw new UnsupportedOperationException();
+    }
+
     StepAdder beginStep();
 
     PhaseTapChanger add();

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/RatioTapChangerAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/RatioTapChangerAdder.java
@@ -39,6 +39,10 @@ public interface RatioTapChangerAdder {
 
     RatioTapChangerAdder setRegulationTerminal(Terminal regulationTerminal);
 
+    default RatioTapChangerAdder setTargetDeadband(double targetDeadband) {
+        throw new UnsupportedOperationException();
+    }
+
     StepAdder beginStep();
 
     RatioTapChanger add();

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TapChanger.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TapChanger.java
@@ -89,6 +89,14 @@ public interface TapChanger<C extends TapChanger<C, S>, S extends TapChangerStep
      */
     C setRegulationTerminal(Terminal regulationTerminal);
 
+    default double getTargetDeadband() {
+        throw new UnsupportedOperationException();
+    }
+
+    default C setTargetDeadband(double targetDeadband) {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Remove the tap changer.
      */

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
@@ -128,6 +128,9 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
     }
 
     public C setTargetDeadband(double targetDeadband) {
+        if (!Double.isNaN(targetDeadband) && targetDeadband < 0) {
+            throw new ValidationException(parent, "Unexpected value for target deadband of phase tap changer: " + targetDeadband);
+        }
         this.targetDeadband.set(network.get().getVariantIndex(), targetDeadband);
         return (C) this;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.network.impl;
 import com.powsybl.commons.util.trove.TBooleanArrayList;
 import com.powsybl.iidm.network.Terminal;
 import com.powsybl.iidm.network.impl.util.Ref;
+import gnu.trove.list.array.TDoubleArrayList;
 import gnu.trove.list.array.TIntArrayList;
 
 import java.util.List;
@@ -35,9 +36,11 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
 
     protected final TBooleanArrayList regulating;
 
+    protected final TDoubleArrayList targetDeadband;
+
     protected AbstractTapChanger(Ref<? extends VariantManagerHolder> network, H parent,
                                  int lowTapPosition, List<S> steps, TerminalExt regulationTerminal,
-                                 int tapPosition, boolean regulating) {
+                                 int tapPosition, boolean regulating, double targetDeadband) {
         this.network = network;
         this.parent = parent;
         this.lowTapPosition = lowTapPosition;
@@ -46,9 +49,11 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         this.tapPosition = new TIntArrayList(variantArraySize);
         this.regulating = new TBooleanArrayList(variantArraySize);
+        this.targetDeadband = new TDoubleArrayList(variantArraySize);
         for (int i = 0; i < variantArraySize; i++) {
             this.tapPosition.add(tapPosition);
             this.regulating.add(regulating);
+            this.targetDeadband.add(targetDeadband);
         }
     }
 
@@ -118,6 +123,15 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
         return (C) this;
     }
 
+    public double getTargetDeadband() {
+        return targetDeadband.get(network.get().getVariantIndex());
+    }
+
+    public C setTargetDeadband(double targetDeadband) {
+        this.targetDeadband.set(network.get().getVariantIndex(), targetDeadband);
+        return (C) this;
+    }
+
     @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
         regulating.ensureCapacity(regulating.size() + number);
@@ -125,6 +139,7 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
         for (int i = 0; i < number; i++) {
             regulating.add(regulating.get(sourceIndex));
             tapPosition.add(tapPosition.get(sourceIndex));
+            targetDeadband.add(targetDeadband.get(sourceIndex));
         }
     }
 
@@ -132,6 +147,7 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
     public void reduceVariantArraySize(int number) {
         regulating.remove(regulating.size() - number, number);
         tapPosition.remove(tapPosition.size() - number, number);
+        targetDeadband.remove(targetDeadband.size() - number, number);
     }
 
     @Override
@@ -144,6 +160,7 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
         for (int index : indexes) {
             regulating.set(index, regulating.get(sourceIndex));
             tapPosition.set(index, tapPosition.get(sourceIndex));
+            targetDeadband.set(index, targetDeadband.get(sourceIndex));
         }
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerAdderImpl.java
@@ -32,6 +32,8 @@ class PhaseTapChangerAdderImpl implements PhaseTapChangerAdder {
 
     private boolean regulating = false;
 
+    private double targetDeadband = Double.NaN;
+
     private TerminalExt regulationTerminal;
 
     class StepAdderImpl implements StepAdder {
@@ -150,6 +152,12 @@ class PhaseTapChangerAdderImpl implements PhaseTapChangerAdder {
     }
 
     @Override
+    public PhaseTapChangerAdder setTargetDeadband(double targetDeadband) {
+        this.targetDeadband = targetDeadband;
+        return this;
+    }
+
+    @Override
     public PhaseTapChangerAdder setRegulationTerminal(Terminal regulationTerminal) {
         this.regulationTerminal = (TerminalExt) regulationTerminal;
         return this;
@@ -175,8 +183,11 @@ class PhaseTapChangerAdderImpl implements PhaseTapChangerAdder {
                     + highTapPosition + "]");
         }
         ValidationUtil.checkPhaseTapChangerRegulation(transformer, regulationMode, regulationValue, regulating, regulationTerminal, getNetwork());
+        if (!Double.isNaN(targetDeadband) && targetDeadband < 0) {
+            throw new ValidationException(transformer, "Unexpected value for target deadband of phase tap changer: " + targetDeadband);
+        }
         PhaseTapChangerImpl tapChanger
-                = new PhaseTapChangerImpl(transformer, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, regulationMode, regulationValue);
+                = new PhaseTapChangerImpl(transformer, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, regulationMode, regulationValue, targetDeadband);
         transformer.setPhaseTapChanger(tapChanger);
         return tapChanger;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerImpl.java
@@ -27,8 +27,8 @@ class PhaseTapChangerImpl extends AbstractTapChanger<TwoWindingsTransformerImpl,
 
     PhaseTapChangerImpl(TwoWindingsTransformerImpl parent, int lowTapPosition,
                         List<PhaseTapChangerStepImpl> steps, TerminalExt regulationTerminal,
-                        int tapPosition, boolean regulating, RegulationMode regulationMode, double regulationValue) {
-        super(parent.getNetwork().getRef(), parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating);
+                        int tapPosition, boolean regulating, RegulationMode regulationMode, double regulationValue, double targetDeadband) {
+        super(parent.getNetwork().getRef(), parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, targetDeadband);
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         this.regulationMode = regulationMode;
         this.regulationValue = new TDoubleArrayList(variantArraySize);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerAdderImpl.java
@@ -32,6 +32,8 @@ class RatioTapChangerAdderImpl implements RatioTapChangerAdder {
 
     private double targetV = Double.NaN;
 
+    private double targetDeadband = Double.NaN;
+
     private TerminalExt regulationTerminal;
 
     class StepAdderImpl implements StepAdder {
@@ -139,6 +141,12 @@ class RatioTapChangerAdderImpl implements RatioTapChangerAdder {
     }
 
     @Override
+    public RatioTapChangerAdder setTargetDeadband(double targetDeadband) {
+        this.targetDeadband = targetDeadband;
+        return this;
+    }
+
+    @Override
     public RatioTapChangerAdder setRegulationTerminal(Terminal regulationTerminal) {
         this.regulationTerminal = (TerminalExt) regulationTerminal;
         return this;
@@ -164,9 +172,12 @@ class RatioTapChangerAdderImpl implements RatioTapChangerAdder {
                     + highTapPosition + "]");
         }
         ValidationUtil.checkRatioTapChangerRegulation(parent, loadTapChangingCapabilities, regulating, regulationTerminal, targetV, getNetwork());
+        if (!Double.isNaN(targetDeadband) && targetDeadband < 0) {
+            throw new ValidationException(parent, "Unexpected value for target deadband of ratio tap changer: " + targetDeadband);
+        }
         RatioTapChangerImpl tapChanger
                 = new RatioTapChangerImpl(parent, lowTapPosition, steps, regulationTerminal, loadTapChangingCapabilities,
-                                          tapPosition, regulating, targetV);
+                                          tapPosition, regulating, targetV, targetDeadband);
         parent.setRatioTapChanger(tapChanger);
         return tapChanger;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerImpl.java
@@ -25,8 +25,8 @@ class RatioTapChangerImpl extends AbstractTapChanger<RatioTapChangerParent, Rati
 
     RatioTapChangerImpl(RatioTapChangerParent parent, int lowTapPosition,
                         List<RatioTapChangerStepImpl> steps, TerminalExt regulationTerminal, boolean loadTapChangingCapabilities,
-                        int tapPosition, boolean regulating, double targetV) {
-        super(parent.getNetwork().getRef(), parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating);
+                        int tapPosition, boolean regulating, double targetV, double targetDeadband) {
+        super(parent.getNetwork().getRef(), parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, targetDeadband);
         this.loadTapChangingCapabilities = loadTapChangingCapabilities;
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         this.targetV = new TDoubleArrayList(variantArraySize);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/TapChangerTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/TapChangerTest.java
@@ -57,6 +57,7 @@ public class TapChangerTest {
                                                 .setTapPosition(1)
                                                 .setLowTapPosition(0)
                                                 .setRegulating(true)
+                                                .setTargetDeadband(1.0)
                                                 .setRegulationMode(PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL)
                                                 .setRegulationValue(10.0)
                                                 .setRegulationTerminal(terminal)
@@ -81,6 +82,7 @@ public class TapChangerTest {
         assertEquals(0, phaseTapChanger.getLowTapPosition());
         assertEquals(1, phaseTapChanger.getHighTapPosition());
         assertTrue(phaseTapChanger.isRegulating());
+        assertEquals(1.0, phaseTapChanger.getTargetDeadband(), 0.0);
         assertEquals(PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL, phaseTapChanger.getRegulationMode());
         assertEquals(terminal, phaseTapChanger.getRegulationTerminal());
         assertEquals(10.0, phaseTapChanger.getRegulationValue(), 0.0);
@@ -91,6 +93,8 @@ public class TapChangerTest {
         assertSame(phaseTapChanger.getCurrentStep(), phaseTapChanger.getStep(0));
         phaseTapChanger.setRegulationValue(5.0);
         assertEquals(5.0, phaseTapChanger.getRegulationValue(), 0.0);
+        phaseTapChanger.setTargetDeadband(0.5);
+        assertEquals(0.5, phaseTapChanger.getTargetDeadband(), 0.0);
         phaseTapChanger.setRegulating(false);
         assertFalse(phaseTapChanger.isRegulating());
         phaseTapChanger.setRegulationMode(PhaseTapChanger.RegulationMode.FIXED_TAP);
@@ -303,6 +307,7 @@ public class TapChangerTest {
                                                 .setTapPosition(1)
                                                 .setLoadTapChangingCapabilities(false)
                                                 .setRegulating(true)
+                                                .setTargetDeadband(1.0)
                                                 .setTargetV(220.0)
                                                 .setRegulationTerminal(twt.getTerminal1())
                                                 .beginStep()
@@ -330,7 +335,8 @@ public class TapChangerTest {
         assertEquals(0, ratioTapChanger.getLowTapPosition());
         assertEquals(1, ratioTapChanger.getTapPosition());
         assertFalse(ratioTapChanger.hasLoadTapChangingCapabilities());
-        ratioTapChanger.setRegulating(true);
+        assertTrue(ratioTapChanger.isRegulating());
+        assertEquals(1.0, ratioTapChanger.getTargetDeadband(), 0.0);
         assertEquals(220.0, ratioTapChanger.getTargetV(), 0.0);
         assertSame(twt.getTerminal1(), ratioTapChanger.getRegulationTerminal());
         assertEquals(3, ratioTapChanger.getStepCount());
@@ -342,6 +348,8 @@ public class TapChangerTest {
         assertEquals(110.0, ratioTapChanger.getTargetV(), 0.0);
         ratioTapChanger.setRegulating(false);
         assertFalse(ratioTapChanger.isRegulating());
+        ratioTapChanger.setTargetDeadband(0.5);
+        assertEquals(0.5, ratioTapChanger.getTargetDeadband(), 0.0);
         ratioTapChanger.setRegulationTerminal(twt.getTerminal2());
         assertSame(twt.getTerminal2(), ratioTapChanger.getRegulationTerminal());
 

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/PhaseShifterTestCaseFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/PhaseShifterTestCaseFactory.java
@@ -174,4 +174,12 @@ public final class PhaseShifterTestCaseFactory {
         l2.getTerminal2().setP(-50.0).setQ(-25.0);
         return network;
     }
+
+    public static Network createWithTargetDeadband() {
+        Network network = create();
+        network.getTwoWindingsTransformer("PS1")
+                .getPhaseTapChanger()
+                .setTargetDeadband(10.0);
+        return network;
+    }
 }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
@@ -25,6 +25,7 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
     private static final String ATTR_REGULATING = "regulating";
     private static final String ELEM_TERMINAL_REF = "terminalRef";
     private static final String ELEM_STEP = "step";
+    private static final String TARGET_DEADBAND = "targetDeadband";
 
     protected static void writeTapChangerStep(TapChangerStep<?> tcs, XMLStreamWriter writer) throws XMLStreamException {
         XmlUtil.writeDouble("r", tcs.getR(), writer);
@@ -37,6 +38,7 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
     protected static void writeTapChanger(TapChanger<?, ?> tc, XMLStreamWriter writer) throws XMLStreamException {
         writer.writeAttribute(ATTR_LOW_TAP_POSITION, Integer.toString(tc.getLowTapPosition()));
         writer.writeAttribute(ATTR_TAP_POSITION, Integer.toString(tc.getTapPosition()));
+        XmlUtil.writeDouble(TARGET_DEADBAND, tc.getTargetDeadband(), writer);
     }
 
     protected static void writeRatioTapChanger(String name, RatioTapChanger rtc, NetworkXmlWriterContext context) throws XMLStreamException {
@@ -63,11 +65,13 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
     protected static void readRatioTapChanger(String elementName, RatioTapChangerAdder adder, Terminal terminal, NetworkXmlReaderContext context) throws XMLStreamException {
         int lowTapPosition = XmlUtil.readIntAttribute(context.getReader(), ATTR_LOW_TAP_POSITION);
         int tapPosition = XmlUtil.readIntAttribute(context.getReader(), ATTR_TAP_POSITION);
+        double targetDeadband = XmlUtil.readOptionalDoubleAttribute(context.getReader(), TARGET_DEADBAND);
         boolean regulating = XmlUtil.readOptionalBoolAttribute(context.getReader(), ATTR_REGULATING, false);
         boolean loadTapChangingCapabilities = XmlUtil.readBoolAttribute(context.getReader(), "loadTapChangingCapabilities");
         double targetV = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "targetV");
         adder.setLowTapPosition(lowTapPosition)
                 .setTapPosition(tapPosition)
+                .setTargetDeadband(targetDeadband)
                 .setLoadTapChangingCapabilities(loadTapChangingCapabilities)
                 .setTargetV(targetV);
         if (loadTapChangingCapabilities) {
@@ -143,12 +147,14 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
     protected static void readPhaseTapChanger(TwoWindingsTransformer twt, NetworkXmlReaderContext context) throws XMLStreamException {
         int lowTapPosition = XmlUtil.readIntAttribute(context.getReader(), ATTR_LOW_TAP_POSITION);
         int tapPosition = XmlUtil.readIntAttribute(context.getReader(), ATTR_TAP_POSITION);
+        double targetDeadband = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "targetDeadband");
         PhaseTapChanger.RegulationMode regulationMode = PhaseTapChanger.RegulationMode.valueOf(context.getReader().getAttributeValue(null, "regulationMode"));
         double regulationValue = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "regulationValue");
         boolean regulating = XmlUtil.readOptionalBoolAttribute(context.getReader(), ATTR_REGULATING, false);
         PhaseTapChangerAdder adder = twt.newPhaseTapChanger()
                 .setLowTapPosition(lowTapPosition)
                 .setTapPosition(tapPosition)
+                .setTargetDeadband(targetDeadband)
                 .setRegulationMode(regulationMode)
                 .setRegulationValue(regulationValue)
                 .setRegulating(regulating);

--- a/iidm/iidm-xml-converter/src/main/resources/xsd/iidm.xsd
+++ b/iidm/iidm-xml-converter/src/main/resources/xsd/iidm.xsd
@@ -423,6 +423,7 @@
         </xs:sequence>
         <xs:attribute name="lowTapPosition" use="required" type="xs:int"/>
         <xs:attribute name="tapPosition" use="required" type="xs:int"/>
+        <xs:attribute name="targetDeadband" use="optional" type="xs:double"/>
         <xs:attribute name="loadTapChangingCapabilities" use="required" type="xs:boolean"/>
         <xs:attribute name="regulating" use="optional" type="xs:boolean"/>
         <xs:attribute name="targetV" use="optional" type="xs:double"/>
@@ -441,6 +442,7 @@
         </xs:sequence>
         <xs:attribute name="lowTapPosition" use="required" type="xs:int"/>
         <xs:attribute name="tapPosition" use="required" type="xs:int"/>
+        <xs:attribute name="targetDeadband" use="optional" type="xs:double"/>
         <xs:attribute name="regulationMode" use="required" type="iidm:PhaseRegulationMode"/>
         <xs:attribute name="regulationValue" use="optional" type="xs:double"/>
         <xs:attribute name="regulating" use="optional" type="xs:boolean"/>

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PhaseShifterXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PhaseShifterXmlTest.java
@@ -19,7 +19,7 @@ public class PhaseShifterXmlTest extends AbstractConverterTest {
 
     @Test
     public void roundTripTest() throws IOException {
-        roundTripXmlTest(PhaseShifterTestCaseFactory.create(),
+        roundTripXmlTest(PhaseShifterTestCaseFactory.createWithTargetDeadband(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
                 "/phaseShifterRoundTripRef.xml");

--- a/iidm/iidm-xml-converter/src/test/resources/phaseShifterRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/phaseShifterRoundTripRef.xml
@@ -15,7 +15,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="PS1" r="2.0" x="100.0" g="0.0" b="0.0" ratedU1="380.0" ratedU2="380.0" bus1="B1" connectableBus1="B1" voltageLevelId1="VL1" bus2="B3" connectableBus2="B3" voltageLevelId2="VL3" p1="50.08403" q1="29.201416" p2="-50.042015" q2="-27.100708">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP" regulationValue="200.0">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" targetDeadband="10.0" regulationMode="FIXED_TAP" regulationValue="200.0">
                 <iidm:terminalRef id="PS1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-20.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
New feature: introduction of an optional attribute  `targetDeadband` for tap changers. It corresponds to the deadband used with discrete control to avoid excessive update of controls while regulating.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
The  XML schema for IIDM has been updated: ratio tap changers and phase tap changers have now an optional attribute `targetDeadband`. 
This attribute is only considered for IIDM networks and CGMES networks. AMPL and UCTE networks do not consider this `targetDeadband`.

(if any of the questions/checkboxes don't apply, please delete them entirely)
