### PR TITLE
Fix traverser in CalculatedBusImpl to handle properly internal connections

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
@@ -52,7 +52,7 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
 
         // Traverse the graph until a valid NodeTerminal is found
         VoltageLevel.NodeBreakerView.Traverser traverser = (node1, sw, node2) -> {
-            if (sw.isOpen()) {
+            if (sw != null && sw.isOpen()) {
                 return false;
             }
             terminal[0] = (NodeTerminal) voltageLevel.getNodeBreakerView().getTerminal(node2);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/EmptyCalculatedBusBugTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/EmptyCalculatedBusBugTest.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.*;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * ArrayIndexOutOfBoundsException fix test
@@ -47,5 +48,28 @@ public class EmptyCalculatedBusBugTest {
 
         network = createNetwork(true);
         assertEquals(2, network.getVoltageLevel("VL").getBusBreakerView().getBusStream().count());
+    }
+
+    @Test
+    public void testNullPointer() {
+        Network network = createNetwork(true);
+
+        VoltageLevel vl = network.getVoltageLevel("VL");
+        vl.getNodeBreakerView()
+                .setNodeCount(3)
+                .newInternalConnection()
+                .setId("IC")
+                .setNode1(1)
+                .setNode2(2)
+                .add();
+
+        Load l1 = vl.newLoad()
+                .setId("L1")
+                .setNode(0)
+                .setP0(100.0)
+                .setQ0(50.0)
+                .add();
+
+        assertNotNull(l1.getTerminal().getBusBreakerView().getBus());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If a Node/Breaker voltage level contains internal connections, a NullPointerException can be thrown when we try to get a Bus. The bug appears only if the CalculatedBusImpl doesn't contain a NodeTerminal.


**What is the new behavior (if this is a feature change)?**
The bug is fixed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
