### PR TITLE
Add change notification for variant on LoadImpl

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DefaultNetworkListener.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DefaultNetworkListener.java
@@ -24,4 +24,10 @@ public class DefaultNetworkListener implements NetworkListener {
     public void onUpdate(Identifiable identifiable, String attribute, Object oldValue, Object newValue) {
         // empty default implementation
     }
+
+    @Override
+    public void onUpdate(Identifiable identifiable, String attribute, int variantIndex, Object oldValue,
+            Object newValue) {
+        // empty default implementation
+    }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DefaultNetworkListener.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DefaultNetworkListener.java
@@ -24,10 +24,4 @@ public class DefaultNetworkListener implements NetworkListener {
     public void onUpdate(Identifiable identifiable, String attribute, Object oldValue, Object newValue) {
         // empty default implementation
     }
-
-    @Override
-    public void onUpdate(Identifiable identifiable, String attribute, int variantIndex, Object oldValue,
-            Object newValue) {
-        // empty default implementation
-    }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkListener.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkListener.java
@@ -17,7 +17,7 @@ public interface NetworkListener {
 
     void onUpdate(Identifiable identifiable, String attribute, Object oldValue, Object newValue);
 
-    default void onUpdate(Identifiable identifiable, String attribute, int variantIndex, Object oldValue,
+    default void onUpdate(Identifiable identifiable, String attribute, String variantId, Object oldValue,
             Object newValue) {
         // empty default implementation
     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkListener.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkListener.java
@@ -17,4 +17,8 @@ public interface NetworkListener {
 
     void onUpdate(Identifiable identifiable, String attribute, Object oldValue, Object newValue);
 
+    default void onUpdate(Identifiable identifiable, String attribute, int variantIndex, Object oldValue,
+            Object newValue) {
+        // empty default implementation
+    }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
@@ -56,6 +56,10 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         getNetwork().getListeners().notifyUpdate(this, attribute, oldValue, newValue);
     }
 
+    protected void notifyUpdate(String attribute, int variantIndex, Object oldValue, Object newValue) {
+        getNetwork().getListeners().notifyUpdate(this, attribute, variantIndex, oldValue, newValue);
+    }
+
     @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
         super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
@@ -56,8 +56,8 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         getNetwork().getListeners().notifyUpdate(this, attribute, oldValue, newValue);
     }
 
-    protected void notifyUpdate(String attribute, int variantIndex, Object oldValue, Object newValue) {
-        getNetwork().getListeners().notifyUpdate(this, attribute, variantIndex, oldValue, newValue);
+    protected void notifyUpdate(String attribute, String variantId, Object oldValue, Object newValue) {
+        getNetwork().getListeners().notifyUpdate(this, attribute, variantId, oldValue, newValue);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LoadImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LoadImpl.java
@@ -10,7 +10,6 @@ import com.powsybl.iidm.network.ConnectableType;
 import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.LoadType;
 import com.powsybl.iidm.network.impl.util.Ref;
-
 import gnu.trove.list.array.TDoubleArrayList;
 
 /**

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LoadImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LoadImpl.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.ConnectableType;
 import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.LoadType;
 import com.powsybl.iidm.network.impl.util.Ref;
+
 import gnu.trove.list.array.TDoubleArrayList;
 
 /**
@@ -79,8 +80,9 @@ class LoadImpl extends AbstractConnectable<Load> implements Load {
     @Override
     public LoadImpl setP0(double p0) {
         ValidationUtil.checkP0(this, p0);
-        double oldValue = this.p0.set(network.get().getVariantIndex(), p0);
-        notifyUpdate("p0", oldValue, p0);
+        int variantIndex = network.get().getVariantIndex();
+        double oldValue = this.p0.set(variantIndex, p0);
+        notifyUpdate("p0", variantIndex, oldValue, p0);
         return this;
     }
 
@@ -92,8 +94,9 @@ class LoadImpl extends AbstractConnectable<Load> implements Load {
     @Override
     public LoadImpl setQ0(double q0) {
         ValidationUtil.checkQ0(this, q0);
-        double oldValue = this.q0.set(network.get().getVariantIndex(), q0);
-        notifyUpdate("q0", oldValue, q0);
+        int variantIndex = network.get().getVariantIndex();
+        double oldValue = this.q0.set(variantIndex, q0);
+        notifyUpdate("q0", variantIndex, oldValue, q0);
         return this;
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LoadImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LoadImpl.java
@@ -81,7 +81,8 @@ class LoadImpl extends AbstractConnectable<Load> implements Load {
         ValidationUtil.checkP0(this, p0);
         int variantIndex = network.get().getVariantIndex();
         double oldValue = this.p0.set(variantIndex, p0);
-        notifyUpdate("p0", variantIndex, oldValue, p0);
+        String variantId = network.get().getVariantManager().getVariantId(variantIndex);
+        notifyUpdate("p0", variantId, oldValue, p0);
         return this;
     }
 
@@ -95,7 +96,8 @@ class LoadImpl extends AbstractConnectable<Load> implements Load {
         ValidationUtil.checkQ0(this, q0);
         int variantIndex = network.get().getVariantIndex();
         double oldValue = this.q0.set(variantIndex, q0);
-        notifyUpdate("q0", variantIndex, oldValue, q0);
+        String variantId = network.get().getVariantManager().getVariantId(variantIndex);
+        notifyUpdate("q0", variantId, oldValue, q0);
         return this;
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
@@ -44,11 +44,11 @@ class NetworkListenerList {
         }
     }
 
-    void notifyUpdate(Identifiable identifiable, String attribute, int variantIndex, Object oldValue, Object newValue) {
+    void notifyUpdate(Identifiable identifiable, String attribute, String variantId, Object oldValue, Object newValue) {
         if (!listeners.isEmpty() && !Objects.equals(oldValue, newValue)) {
             for (NetworkListener listener : listeners) {
                 try {
-                    listener.onUpdate(identifiable, attribute, variantIndex, oldValue, newValue);
+                    listener.onUpdate(identifiable, attribute, variantId, oldValue, newValue);
                 } catch (Exception t) {
                     LOGGER.error(t.toString(), t);
                 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
@@ -49,7 +49,7 @@ class NetworkListenerList {
             for (NetworkListener listener : listeners) {
                 try {
                     listener.onUpdate(identifiable, attribute, variantIndex, oldValue, newValue);
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     LOGGER.error(t.toString(), t);
                 }
             }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
@@ -6,7 +6,8 @@
  */
 package com.powsybl.iidm.network.impl;
 
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.NetworkListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,18 @@ class NetworkListenerList {
             for (NetworkListener listener : listeners) {
                 try {
                     listener.onUpdate(identifiable, attribute, oldValue, newValue);
+                } catch (Throwable t) {
+                    LOGGER.error(t.toString(), t);
+                }
+            }
+        }
+    }
+
+    void notifyUpdate(Identifiable identifiable, String attribute, int variantIndex, Object oldValue, Object newValue) {
+        if (!listeners.isEmpty() && !Objects.equals(oldValue, newValue)) {
+            for (NetworkListener listener : listeners) {
+                try {
+                    listener.onUpdate(identifiable, attribute, variantIndex, oldValue, newValue);
                 } catch (Throwable t) {
                     LOGGER.error(t.toString(), t);
                 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VariantManagerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VariantManagerImpl.java
@@ -81,10 +81,14 @@ public class VariantManagerImpl implements VariantManager {
         return index;
     }
 
+    public String getVariantId(int variantIndex) {
+        return id2index.inverse().get(variantIndex);
+    }
+
     @Override
     public String getWorkingVariantId() {
         int index = variantContext.getVariantIndex();
-        return id2index.inverse().get(index);
+        return getVariantId(index);
     }
 
     @Override
@@ -239,5 +243,4 @@ public class VariantManagerImpl implements VariantManager {
             variantContext.setVariantIndex(currentVariantIndex);
         }
     }
-
 }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LoadTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LoadTest.java
@@ -80,14 +80,17 @@ public class LoadTest {
         load.setQ0(-2.0);
 
         // Check update notification
-        Mockito.verify(mockedListener, Mockito.times(1)).onUpdate(load, "p0", 0, p0OldValue, -1.0);
-        Mockito.verify(mockedListener, Mockito.times(1)).onUpdate(load, "q0", 0, q0OldValue, -2.0);
+        Mockito.verify(mockedListener, Mockito.times(1))
+               .onUpdate(load, "p0", VariantManagerConstants.INITIAL_VARIANT_ID, p0OldValue, -1.0);
+        Mockito.verify(mockedListener, Mockito.times(1))
+               .onUpdate(load, "q0", VariantManagerConstants.INITIAL_VARIANT_ID, q0OldValue, -2.0);
 
         // At this point
         // no more changes is taking into account
 
         // Simulate exception for onUpdate calls
-        Mockito.doThrow(new PowsyblException()).when(mockedListener).onUpdate(load, "p0", 0, p0OldValue, -1.0);
+        Mockito.doThrow(new PowsyblException()).when(mockedListener)
+               .onUpdate(load, "p0", VariantManagerConstants.INITIAL_VARIANT_ID, p0OldValue, -1.0);
 
         // Case when same values P0 & Q0 are set
         load.setP0(-1.0);
@@ -171,8 +174,8 @@ public class LoadTest {
         load.setP0(3.0);
         load.setQ0(2.0);
         // Check P0 & Q0 update notification
-        Mockito.verify(mockedListener, Mockito.times(1)).onUpdate(load, "p0", 4, 0.6d, 3.0);
-        Mockito.verify(mockedListener, Mockito.times(1)).onUpdate(load, "q0", 4, 0.7d, 2.0);
+        Mockito.verify(mockedListener, Mockito.times(1)).onUpdate(load, "p0", "s4", 0.6d, 3.0);
+        Mockito.verify(mockedListener, Mockito.times(1)).onUpdate(load, "q0", "s4", 0.7d, 2.0);
 
         // remove s2
         variantManager.removeVariant("s2");

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LoadTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LoadTest.java
@@ -118,8 +118,12 @@ public class LoadTest {
         // Simulate exception for onUpdate calls
         Mockito.doThrow(new PowsyblException()).when(mockedListener).onUpdate(load, "p0", 0, p0OldValue, -1.0);
 
-        // Change values P0, in order to call NetworkListener::onUpdate
-        load.setP0(-1.0);
+        try {
+            // Change values P0, in order to call NetworkListener::onUpdate
+            load.setP0(-1.0);
+        } catch (PowsyblException e) {
+            fail("Exception must be catch by NetworkListenerList");
+        }
 
         // Remove observer changes
         network.removeListener(mockedListener);
@@ -128,11 +132,11 @@ public class LoadTest {
     @Test
     public void duplicateEquipment() {
         voltageLevel.newLoad()
-                        .setId("duplicate")
-                        .setP0(2.0)
-                        .setQ0(1.0)
-                        .setNode(1)
-                    .add();
+                .setId("duplicate")
+                .setP0(2.0)
+                .setQ0(1.0)
+                .setNode(1)
+                .add();
         thrown.expect(PowsyblException.class);
         thrown.expectMessage("with the id 'duplicate'");
         createLoad("duplicate", 2.0, 1.0);
@@ -149,12 +153,12 @@ public class LoadTest {
     @Test
     public void testAdder() {
         Load load = voltageLevel.newLoad()
-                        .setId("testAdder")
-                        .setP0(2.0)
-                        .setQ0(1.0)
-                        .setLoadType(LoadType.AUXILIARY)
-                        .setNode(1)
-                    .add();
+                .setId("testAdder")
+                .setP0(2.0)
+                .setQ0(1.0)
+                .setLoadType(LoadType.AUXILIARY)
+                .setNode(1)
+                .add();
         assertEquals(2.0, load.getP0(), 0.0);
         assertEquals(1.0, load.getQ0(), 0.0);
         assertEquals("testAdder", load.getId());
@@ -226,11 +230,11 @@ public class LoadTest {
 
     private void createLoad(String id, double p0, double q0) {
         voltageLevel.newLoad()
-                        .setId(id)
-                        .setP0(p0)
-                        .setQ0(q0)
-                        .setNode(1)
-                    .add();
+                .setId(id)
+                .setP0(p0)
+                .setQ0(q0)
+                .setNode(1)
+                .add();
     }
 
 }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LoadTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LoadTest.java
@@ -9,7 +9,6 @@ package com.powsybl.iidm.network.impl;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,19 +37,14 @@ public class LoadTest {
     @Test
     public void testSetterGetter() {
         Load load = network.getLoad("CE");
-
         load.setP0(-1.0);
         assertEquals(-1.0, load.getP0(), 0.0);
-
         load.setQ0(-2.0);
         assertEquals(-2.0, load.getQ0(), 0.0);
-
         load.setP0(1.0);
         assertEquals(1.0, load.getP0(), 0.0);
-
         load.setQ0(0.0);
         assertEquals(0.0, load.getQ0(), 0.0);
-
         load.setLoadType(LoadType.AUXILIARY);
         assertEquals(LoadType.AUXILIARY, load.getLoadType());
     }
@@ -90,7 +84,10 @@ public class LoadTest {
         Mockito.verify(mockedListener, Mockito.times(1)).onUpdate(load, "q0", 0, q0OldValue, -2.0);
 
         // At this point
-        // no more changes is taking account
+        // no more changes is taking into account
+
+        // Simulate exception for onUpdate calls
+        Mockito.doThrow(new PowsyblException()).when(mockedListener).onUpdate(load, "p0", 0, p0OldValue, -1.0);
 
         // Case when same values P0 & Q0 are set
         load.setP0(-1.0);
@@ -105,38 +102,13 @@ public class LoadTest {
     }
 
     @Test
-    public void testThrowableChangesNotification() {
-        // Changes listener
-        NetworkListener mockedListener = Mockito.mock(DefaultNetworkListener.class);
-        // Set observer changes
-        network.addListener(mockedListener);
-
-        // Tested instance
-        Load load = network.getLoad("CE");
-        // Get initial values
-        double p0OldValue = load.getP0();
-        // Simulate exception for onUpdate calls
-        Mockito.doThrow(new PowsyblException()).when(mockedListener).onUpdate(load, "p0", 0, p0OldValue, -1.0);
-
-        try {
-            // Change values P0, in order to call NetworkListener::onUpdate
-            load.setP0(-1.0);
-        } catch (PowsyblException e) {
-            fail("Exception must be catch by NetworkListenerList");
-        }
-
-        // Remove observer changes
-        network.removeListener(mockedListener);
-    }
-
-    @Test
     public void duplicateEquipment() {
         voltageLevel.newLoad()
-                .setId("duplicate")
-                .setP0(2.0)
-                .setQ0(1.0)
-                .setNode(1)
-                .add();
+                        .setId("duplicate")
+                        .setP0(2.0)
+                        .setQ0(1.0)
+                        .setNode(1)
+                    .add();
         thrown.expect(PowsyblException.class);
         thrown.expectMessage("with the id 'duplicate'");
         createLoad("duplicate", 2.0, 1.0);
@@ -153,12 +125,12 @@ public class LoadTest {
     @Test
     public void testAdder() {
         Load load = voltageLevel.newLoad()
-                .setId("testAdder")
-                .setP0(2.0)
-                .setQ0(1.0)
-                .setLoadType(LoadType.AUXILIARY)
-                .setNode(1)
-                .add();
+                        .setId("testAdder")
+                        .setP0(2.0)
+                        .setQ0(1.0)
+                        .setLoadType(LoadType.AUXILIARY)
+                        .setNode(1)
+                    .add();
         assertEquals(2.0, load.getP0(), 0.0);
         assertEquals(1.0, load.getQ0(), 0.0);
         assertEquals("testAdder", load.getId());
@@ -190,8 +162,8 @@ public class LoadTest {
         Load load = network.getLoad("testMultiVariant");
         List<String> variantsToAdd = Arrays.asList("s1", "s2", "s3", "s4");
         variantManager.cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, variantsToAdd);
-        variantManager.setWorkingVariant("s4");
 
+        variantManager.setWorkingVariant("s4");
         // check values cloned by extend
         assertEquals(0.6d, load.getP0(), 0.0);
         assertEquals(0.7d, load.getQ0(), 0.0);
@@ -230,11 +202,11 @@ public class LoadTest {
 
     private void createLoad(String id, double p0, double q0) {
         voltageLevel.newLoad()
-                .setId(id)
-                .setP0(p0)
-                .setQ0(q0)
-                .setNode(1)
-                .add();
+                        .setId(id)
+                        .setP0(p0)
+                        .setQ0(q0)
+                        .setNode(1)
+                    .add();
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
New feature added into NetworkListener to notify changes with variant index


**What is the current behavior?** *(You can also link to an open issue here)*
The feature does not exist


**What is the new behavior (if this is a feature change)?**
A new method is available into NetworkListener in order to notify variant changes.
Only applied on file LoadImpl.java

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
