### PR TITLE
Fix maven-plugin-plugin configuration

### DIFF
--- a/itools-packager/pom.xml
+++ b/itools-packager/pom.xml
@@ -28,6 +28,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>${maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR fix a compilation issue in itools-packager module, with some environments


**What is the current behavior?** *(You can also link to an open issue here)*
Sometimes the compilation failed with the following error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-plugin-plugin:3.6.0:descriptor (default-descriptor) on project powsybl-itools-packager-maven-plugin: Error extracting plugin descriptor: 'No mojo definitions were found for plugin: com.powsybl:powsybl-itools-packager-maven-plugin.' -> [Help 1]
```
This is a [known bug](https://issues.apache.org/jira/browse/MNG-5346) that can be fixed with a correct configuration in pom.xml.



**What is the new behavior (if this is a feature change)?**
The compilation works in all environments.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
