### PR TITLE
Export Network properties in XML

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
@@ -13,9 +13,9 @@ import com.powsybl.iidm.network.IdentifiableAdder;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import java.util.Properties;
 
 import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
+
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -43,15 +43,9 @@ abstract class AbstractIdentifiableXml<T extends Identifiable, A extends Identif
             context.getWriter().writeAttribute("name", context.getAnonymizer().anonymizeString(identifiable.getName()));
         }
         writeRootElementAttributes(identifiable, parent, context);
-        if (identifiable.hasProperty()) {
-            Properties props = identifiable.getProperties();
-            for (String name : props.stringPropertyNames()) {
-                String value = props.getProperty(name);
-                context.getWriter().writeEmptyElement(IIDM_URI, "property");
-                context.getWriter().writeAttribute("name", name);
-                context.getWriter().writeAttribute("value", value);
-            }
-        }
+
+        PropertiesXml.write(identifiable, context);
+
         writeSubElements(identifiable, parent, context);
         if (hasSubElements || identifiable.hasProperty()) {
             context.getWriter().writeEndElement();
@@ -70,9 +64,7 @@ abstract class AbstractIdentifiableXml<T extends Identifiable, A extends Identif
 
     protected void readSubElements(T identifiable, NetworkXmlReaderContext context) throws XMLStreamException {
         if (context.getReader().getLocalName().equals("property")) {
-            String name = context.getReader().getAttributeValue(null, "name");
-            String value = context.getReader().getAttributeValue(null, "value");
-            identifiable.getProperties().put(name, value);
+            PropertiesXml.read(identifiable, context);
         } else {
             throw new PowsyblException("Unknown element name <" + context.getReader().getLocalName() + "> in <" + identifiable.getId() + ">");
         }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -329,6 +329,8 @@ public final class NetworkXml {
         // Consider the network has been exported so its extensions will be written also
         context.addExportedEquipment(n);
 
+        PropertiesXml.write(n, context);
+
         for (Substation s : n.getSubstations()) {
             SubstationXml.INSTANCE.write(s, null, context);
         }
@@ -487,6 +489,10 @@ public final class NetworkXml {
 
             XmlUtil.readUntilEndElement(NETWORK_ROOT_ELEMENT_NAME, reader, () -> {
                 switch (reader.getLocalName()) {
+                    case PropertiesXml.PROPERTY:
+                        PropertiesXml.read(network, context);
+                        break;
+
                     case SubstationXml.ROOT_ELEMENT_NAME:
                         SubstationXml.INSTANCE.read(network, context);
                         break;

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/PropertiesXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/PropertiesXml.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.iidm.xml;
+
+import com.powsybl.iidm.network.Identifiable;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.Properties;
+
+import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
+
+/**
+ * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ */
+public final class PropertiesXml {
+
+    static final String PROPERTY = "property";
+
+    private static final String NAME = "name";
+    private static final String VALUE = "value";
+
+    public static void write(Identifiable identifiable, NetworkXmlWriterContext context) throws XMLStreamException {
+        if (identifiable.hasProperty()) {
+            Properties props = identifiable.getProperties();
+            for (String name : props.stringPropertyNames()) {
+                String value = props.getProperty(name);
+                context.getWriter().writeEmptyElement(IIDM_URI, PROPERTY);
+                context.getWriter().writeAttribute(NAME, name);
+                context.getWriter().writeAttribute(VALUE, value);
+            }
+        }
+    }
+
+    public static void read(Identifiable identifiable, NetworkXmlReaderContext context) {
+        assert context.getReader().getLocalName().equals(PROPERTY);
+        String name = context.getReader().getAttributeValue(null, NAME);
+        String value = context.getReader().getAttributeValue(null, VALUE);
+        identifiable.getProperties().put(name, value);
+    }
+
+    private PropertiesXml() {
+    }
+}

--- a/iidm/iidm-xml-converter/src/main/resources/xsd/iidm.xsd
+++ b/iidm/iidm-xml-converter/src/main/resources/xsd/iidm.xsd
@@ -20,6 +20,7 @@
     <xs:element name="network">
         <xs:complexType>
              <xs:sequence>
+                 <xs:element name="property" type="iidm:Property" minOccurs="0" maxOccurs="unbounded" />
                  <xs:element name="substation" type="iidm:Substation" minOccurs="0" maxOccurs="unbounded"/>
                  <xs:choice minOccurs="0" maxOccurs="unbounded">
                      <xs:element name="line" type="iidm:Line"/>

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PropertiesXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PropertiesXmlTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.iidm.xml;
+
+import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.iidm.network.Network;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ */
+public class PropertiesXmlTest extends AbstractConverterTest {
+
+    private Network createNetwork() {
+        return NetworkXml.read(getClass().getResourceAsStream("/eurostag-tutorial-example1-properties.xml"));
+    }
+
+    @Test
+    public void roundTripTest() throws IOException {
+        roundTripXmlTest(createNetwork(),
+                NetworkXml::writeAndValidate,
+                NetworkXml::read,
+                "/eurostag-tutorial-example1-properties.xml");
+    }
+}

--- a/iidm/iidm-xml-converter/src/test/resources/eurostag-tutorial-example1-properties.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/eurostag-tutorial-example1-properties.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:property name="prop1" value="value1"/>
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:property name="prop2" value="value2"/>
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:property name="prop3" value="value3"/>
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2">
+        <iidm:property name="prop4" value="value4"/>
+    </iidm:line>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
This PR is link to this [topic](https://spectrum.chat/powsybl/issues/properties-to-a-network~f964caca-2a63-457d-9798-66f16c4c341a)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix?


**What is the current behavior?** *(You can also link to an open issue here)*
If a network has properties, when exporting to XML, these properties are lost.


**What is the new behavior (if this is a feature change)?**
The properties are read/write by the XML formatter.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
