### PR TITLE
Change the visibility of ActivePowerControl constructor to solve ambiguity

### DIFF
--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ActivePowerControl.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ActivePowerControl.java
@@ -28,7 +28,7 @@ public class ActivePowerControl<T extends Injection> extends AbstractExtension<T
         this((T) battery, participate, droop);
     }
 
-    protected ActivePowerControl(T component, boolean participate, float droop) {
+    ActivePowerControl(T component, boolean participate, float droop) {
         super(component);
         this.participate = participate;
         this.droop = droop;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Arguable


**What is the current behavior?** *(You can also link to an open issue here)*
When inheriting the `ActivePowerControl` class, when calling `super()`, compilation fails because there is an ambiguity between two constructors:
```
public ActivePowerControl(Generator, boolean, float);
protected ActivePowerControl(Injection, boolean, float);
```
In the derived class, we need to explicitly cast the injection instance to a `Generator` or an `Injection` to solve the ambiguity.


**What is the new behavior (if this is a feature change)?**
Changing the visibility of the protected constructor, also solve the ambiguity. I choose to change to private package, because the constructor is used in the serializer. 

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
