### PR TITLE
[WIP] Ratio between tw2's rated voltages and the voltage level nominal voltage is taken into account

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TwoWindingsTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TwoWindingsTransformerConversion.java
@@ -52,12 +52,15 @@ public class TwoWindingsTransformerConversion extends AbstractConductingEquipmen
         double ratedU1 = end1.asDouble("ratedU");
         double ratedU2 = end2.asDouble("ratedU");
 
-        double rho0 = ratedU2 / ratedU1;
-        double rho0Square = rho0 * rho0;
-        double r0 = r1 * rho0Square + r2;
-        double x0 = x1 * rho0Square + x2;
-        double g0 = g1 / rho0Square + g2;
-        double b0 = b1 / rho0Square + b2;
+        double vNomi = context.network().getVoltageLevel(iidmVoltageLevelId(2)).getNominalV();
+        double rho01 = vNomi / ratedU1;
+        double rh02 = vNomi / ratedU2;
+        double rho01Square = rho01 * rho01;
+        double rh02Square = rh02 * rh02;
+        double r0 = r1 * rho01Square + r2 * rh02Square;
+        double x0 = x1 * rho01Square + x2 * rh02Square;
+        double g0 = g1 / rho01Square + g2 / rh02Square;
+        double b0 = b1 / rho01Square + b2 / rh02Square;
 
         TwoWindingsTransformerAdder adder = substation().newTwoWindingsTransformer()
                 .setR(r0)


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When r, x, g and b attributes of T2W are calculated to be on side 2 of T2W, the ratio between the TW2's rated voltage and the voltage level's nominal voltage is not taken into account when it is different from 1.


**What is the new behavior (if this is a feature change)?**
With this correction, this ratio is taken into account.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No.