### PR TITLE
time-series-api: implement nonrecursive ast visitors

### DIFF
--- a/time-series/time-series-api/pom.xml
+++ b/time-series/time-series-api/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
         </dependency>

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BigDecimalNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BigDecimalNodeCalc.java
@@ -13,6 +13,8 @@ import com.powsybl.timeseries.TimeSeriesException;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -34,8 +36,13 @@ public class BigDecimalNodeCalc implements LiteralNodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
         return visitor.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Collections.emptyList();
     }
 
     public BigDecimal getValue() {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BinaryOperation.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BinaryOperation.java
@@ -11,7 +11,11 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.powsybl.timeseries.TimeSeriesException;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -118,8 +122,14 @@ public class BinaryOperation implements NodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
-        return visitor.visit(this, arg);
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
+        return visitor.visit(this, arg, children.get(0), children.get(1));
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        Pair<NodeCalc, NodeCalc> p = visitor.iterate(this, arg);
+        return Arrays.asList(p.getLeft(), p.getRight());
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DefaultNodeCalcVisitor.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DefaultNodeCalcVisitor.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.timeseries.ast;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -31,34 +33,53 @@ public class DefaultNodeCalcVisitor<R, A> implements NodeCalcVisitor<R, A> {
     }
 
     @Override
-    public R visit(BinaryOperation nodeCalc, A arg) {
-        nodeCalc.getLeft().accept(this, arg);
-        nodeCalc.getRight().accept(this, arg);
+    public R visit(BinaryOperation nodeCalc, A arg, R left, R right) {
         return null;
     }
 
     @Override
-    public R visit(UnaryOperation nodeCalc, A arg) {
-        nodeCalc.getChild().accept(this, arg);
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryOperation nodeCalc, A arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
+
+    @Override
+    public R visit(UnaryOperation nodeCalc, A arg, R child) {
         return null;
     }
 
     @Override
-    public R visit(MinNodeCalc nodeCalc, A arg) {
-        nodeCalc.getChild().accept(this, arg);
+    public NodeCalc iterate(UnaryOperation nodeCalc, A arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public R visit(MinNodeCalc nodeCalc, A arg, R child) {
         return null;
     }
 
     @Override
-    public R visit(MaxNodeCalc nodeCalc, A arg) {
-        nodeCalc.getChild().accept(this, arg);
+    public NodeCalc iterate(MinNodeCalc nodeCalc, A arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public R visit(MaxNodeCalc nodeCalc, A arg, R child) {
         return null;
     }
 
     @Override
-    public R visit(TimeNodeCalc nodeCalc, A arg) {
-        nodeCalc.getChild().accept(this, arg);
+    public NodeCalc iterate(MaxNodeCalc nodeCalc, A arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public R visit(TimeNodeCalc nodeCalc, A arg, R child) {
         return null;
+    }
+
+    @Override
+    public NodeCalc iterate(TimeNodeCalc nodeCalc, A arg) {
+        return nodeCalc.getChild();
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DoubleNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DoubleNodeCalc.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.powsybl.timeseries.TimeSeriesException;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -35,8 +37,13 @@ public class DoubleNodeCalc implements LiteralNodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
         return visitor.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Collections.emptyList();
     }
 
     public double getValue() {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/FloatNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/FloatNodeCalc.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.powsybl.timeseries.TimeSeriesException;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -33,8 +35,13 @@ public class FloatNodeCalc implements LiteralNodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
         return visitor.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Collections.emptyList();
     }
 
     public float getValue() {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/IntegerNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/IntegerNodeCalc.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.powsybl.timeseries.TimeSeriesException;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -33,8 +35,13 @@ public class IntegerNodeCalc implements LiteralNodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
         return visitor.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Collections.emptyList();
     }
 
     public int getValue() {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/MaxNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/MaxNodeCalc.java
@@ -9,6 +9,8 @@ package com.powsybl.timeseries.ast;
 import com.fasterxml.jackson.core.JsonParser;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -27,8 +29,13 @@ public class MaxNodeCalc extends AbstractMinMaxNodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
-        return visitor.visit(this, arg);
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
+        return visitor.visit(this, arg, children.get(0));
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Arrays.asList(visitor.iterate(this, arg));
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/MinNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/MinNodeCalc.java
@@ -9,6 +9,8 @@ package com.powsybl.timeseries.ast;
 import com.fasterxml.jackson.core.JsonParser;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -27,8 +29,13 @@ public class MinNodeCalc extends AbstractMinMaxNodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
-        return visitor.visit(this, arg);
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
+        return visitor.visit(this, arg, children.get(0));
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Arrays.asList(visitor.iterate(this, arg));
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
@@ -14,6 +14,7 @@ import com.powsybl.timeseries.TimeSeriesException;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -21,7 +22,9 @@ import java.util.Objects;
  */
 public interface NodeCalc {
 
-    <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg);
+    <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg);
+
+    <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children);
 
     void writeJson(JsonGenerator generator) throws IOException;
 

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcCloner.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcCloner.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.timeseries.ast;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -31,30 +33,53 @@ public class NodeCalcCloner<A> implements NodeCalcVisitor<NodeCalc, A> {
     }
 
     @Override
-    public NodeCalc visit(BinaryOperation nodeCalc, A arg) {
-        return new BinaryOperation(nodeCalc.getLeft().accept(this, arg),
-                                   nodeCalc.getRight().accept(this, arg),
-                                   nodeCalc.getOperator());
+    public NodeCalc visit(BinaryOperation nodeCalc, A arg, NodeCalc left, NodeCalc right) {
+        return new BinaryOperation(left, right, nodeCalc.getOperator());
     }
 
     @Override
-    public NodeCalc visit(UnaryOperation nodeCalc, A arg) {
-        return new UnaryOperation(nodeCalc.getChild().accept(this, arg), nodeCalc.getOperator());
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryOperation nodeCalc, A arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
     }
 
     @Override
-    public NodeCalc visit(MinNodeCalc nodeCalc, A arg) {
-        return new MinNodeCalc(nodeCalc.getChild().accept(this, arg), nodeCalc.getMin());
+    public NodeCalc visit(UnaryOperation nodeCalc, A arg, NodeCalc child) {
+        return new UnaryOperation(child, nodeCalc.getOperator());
     }
 
     @Override
-    public NodeCalc visit(MaxNodeCalc nodeCalc, A arg) {
-        return new MaxNodeCalc(nodeCalc.getChild().accept(this, arg), nodeCalc.getMax());
+    public NodeCalc iterate(UnaryOperation nodeCalc, A arg) {
+        return nodeCalc.getChild();
     }
 
     @Override
-    public NodeCalc visit(TimeNodeCalc nodeCalc, A arg) {
-        return new TimeNodeCalc(nodeCalc.getChild().accept(this, arg));
+    public NodeCalc visit(MinNodeCalc nodeCalc, A arg, NodeCalc child) {
+        return new MinNodeCalc(child, nodeCalc.getMin());
+    }
+
+    @Override
+    public NodeCalc iterate(MinNodeCalc nodeCalc, A arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public NodeCalc visit(MaxNodeCalc nodeCalc, A arg, NodeCalc child) {
+        return new MaxNodeCalc(child, nodeCalc.getMax());
+    }
+
+    @Override
+    public NodeCalc iterate(MaxNodeCalc nodeCalc, A arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public NodeCalc visit(TimeNodeCalc nodeCalc, A arg, NodeCalc child) {
+        return new TimeNodeCalc(child);
+    }
+
+    @Override
+    public NodeCalc iterate(TimeNodeCalc nodeCalc, A arg) {
+        return nodeCalc.getChild();
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcModifier.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcModifier.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.timeseries.ast;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -31,12 +33,12 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
     }
 
     @Override
-    public NodeCalc visit(BinaryOperation nodeCalc, A arg) {
-        NodeCalc newLeft = nodeCalc.getLeft().accept(this, arg);
+    public NodeCalc visit(BinaryOperation nodeCalc, A arg, NodeCalc left, NodeCalc right) {
+        NodeCalc newLeft = left;
         if (newLeft != null) {
             nodeCalc.setLeft(newLeft);
         }
-        NodeCalc newRight = nodeCalc.getRight().accept(this, arg);
+        NodeCalc newRight = right;
         if (newRight != null) {
             nodeCalc.setRight(newRight);
         }
@@ -44,8 +46,13 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
     }
 
     @Override
-    public NodeCalc visit(UnaryOperation nodeCalc, A arg) {
-        NodeCalc newChild = nodeCalc.getChild().accept(this, arg);
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryOperation nodeCalc, A arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
+
+    @Override
+    public NodeCalc visit(UnaryOperation nodeCalc, A arg, NodeCalc child) {
+        NodeCalc newChild = child;
         if (newChild != null) {
             nodeCalc.setChild(newChild);
         }
@@ -53,8 +60,13 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
     }
 
     @Override
-    public NodeCalc visit(MinNodeCalc nodeCalc, A arg) {
-        NodeCalc newChild = nodeCalc.getChild().accept(this, arg);
+    public NodeCalc iterate(UnaryOperation nodeCalc, A arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public NodeCalc visit(MinNodeCalc nodeCalc, A arg, NodeCalc child) {
+        NodeCalc newChild = child;
         if (newChild != null) {
             nodeCalc.setChild(newChild);
         }
@@ -62,8 +74,13 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
     }
 
     @Override
-    public NodeCalc visit(MaxNodeCalc nodeCalc, A arg) {
-        NodeCalc newChild = nodeCalc.getChild().accept(this, arg);
+    public NodeCalc iterate(MinNodeCalc nodeCalc, A arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public NodeCalc visit(MaxNodeCalc nodeCalc, A arg, NodeCalc child) {
+        NodeCalc newChild = child;
         if (newChild != null) {
             nodeCalc.setChild(newChild);
         }
@@ -71,12 +88,22 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
     }
 
     @Override
-    public NodeCalc visit(TimeNodeCalc nodeCalc, A arg) {
-        NodeCalc newChild = nodeCalc.getChild().accept(this, arg);
+    public NodeCalc iterate(MaxNodeCalc nodeCalc, A arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public NodeCalc visit(TimeNodeCalc nodeCalc, A arg, NodeCalc child) {
+        NodeCalc newChild = child;
         if (newChild != null) {
             nodeCalc.setChild(newChild);
         }
         return null;
+    }
+
+    @Override
+    public NodeCalc iterate(TimeNodeCalc nodeCalc, A arg) {
+        return nodeCalc.getChild();
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcPrinter.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcPrinter.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.timeseries.ast;
 
-import java.util.Objects;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -14,8 +14,7 @@ import java.util.Objects;
 public class NodeCalcPrinter implements NodeCalcVisitor<String, Void> {
 
     public static String print(NodeCalc nodeCalc) {
-        Objects.requireNonNull(nodeCalc);
-        return nodeCalc.accept(new NodeCalcPrinter(), null);
+        return NodeCalcVisitors.visit(nodeCalc, null, new NodeCalcPrinter());
     }
 
     @Override
@@ -39,29 +38,28 @@ public class NodeCalcPrinter implements NodeCalcVisitor<String, Void> {
     }
 
     @Override
-    public String visit(BinaryOperation nodeCalc, Void arg) {
-        return "(" + nodeCalc.getLeft().accept(this, arg) + " " + nodeCalc.getOperator() +
-                " " + nodeCalc.getRight().accept(this, arg) + ")";
+    public String visit(BinaryOperation nodeCalc, Void arg, String left, String right) {
+        return "(" + left + " " + nodeCalc.getOperator() + " " + right + ")";
     }
 
     @Override
-    public String visit(UnaryOperation nodeCalc, Void arg) {
-        return "(" + nodeCalc.getChild().accept(this, arg) + ")." + nodeCalc.getOperator() + "()";
+    public String visit(UnaryOperation nodeCalc, Void arg, String child) {
+        return "(" + child + ")." + nodeCalc.getOperator() + "()";
     }
 
     @Override
-    public String visit(MinNodeCalc nodeCalc, Void arg) {
-        return nodeCalc.getChild().accept(this, arg) + ".min(" + nodeCalc.getMin() + ")";
+    public String visit(MinNodeCalc nodeCalc, Void arg, String child) {
+        return child + ".min(" + nodeCalc.getMin() + ")";
     }
 
     @Override
-    public String visit(MaxNodeCalc nodeCalc, Void arg) {
-        return nodeCalc.getChild().accept(this, arg) + ".max(" + nodeCalc.getMax() + ")";
+    public String visit(MaxNodeCalc nodeCalc, Void arg, String child) {
+        return child + ".max(" + nodeCalc.getMax() + ")";
     }
 
     @Override
-    public String visit(TimeNodeCalc nodeCalc, Void arg) {
-        return "(" + nodeCalc.getChild().accept(this, arg) + ").time()";
+    public String visit(TimeNodeCalc nodeCalc, Void arg, String child) {
+        return "(" + child + ").time()";
     }
 
     @Override
@@ -73,4 +71,30 @@ public class NodeCalcPrinter implements NodeCalcVisitor<String, Void> {
     public String visit(TimeSeriesNumNodeCalc nodeCalc, Void arg) {
         return "timeSeries[" + nodeCalc.getTimeSeriesNum() + "]";
     }
+
+    @Override
+    public NodeCalc iterate(TimeNodeCalc nodeCalc, Void arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryOperation nodeCalc, Void arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
+
+    @Override
+    public NodeCalc iterate(UnaryOperation nodeCalc, Void arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public NodeCalc iterate(MinNodeCalc nodeCalc, Void arg) {
+        return nodeCalc.getChild();
+    }
+
+    @Override
+    public NodeCalc iterate(MaxNodeCalc nodeCalc, Void arg) {
+        return nodeCalc.getChild();
+    }
+
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcResolver.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcResolver.java
@@ -22,7 +22,7 @@ public class NodeCalcResolver extends NodeCalcCloner<Void> {
 
     public static NodeCalc resolve(NodeCalc nodeCalc, Map<String, Integer> timeSeriesNums) {
         Objects.requireNonNull(nodeCalc);
-        return nodeCalc.accept(new NodeCalcResolver(timeSeriesNums), null);
+        return NodeCalcVisitors.visit(nodeCalc, null, new NodeCalcResolver(timeSeriesNums));
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcSimplifier.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcSimplifier.java
@@ -15,7 +15,7 @@ public class NodeCalcSimplifier extends NodeCalcModifier<Void> {
 
     public static NodeCalc simplify(NodeCalc nodeCalc) {
         Objects.requireNonNull(nodeCalc);
-        NodeCalc simplifiedNodeCalc =  nodeCalc.accept(new NodeCalcSimplifier(), null);
+        NodeCalc simplifiedNodeCalc =  NodeCalcVisitors.visit(nodeCalc, null, new NodeCalcSimplifier());
         return simplifiedNodeCalc != null ? simplifiedNodeCalc : nodeCalc;
     }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcVisitor.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcVisitor.java
@@ -6,8 +6,17 @@
  */
 package com.powsybl.timeseries.ast;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Jon Harper <jon.harper at rte-france.com>
+ *
+ *         The iterate methods allow the visitor to describe which children are
+ *         traversed and their order. The visit methods compute results for
+ *         nodes from the node and all the results of the children.
+ *
+ * @see NodeCalcVisitors
  */
 public interface NodeCalcVisitor<R, A> {
 
@@ -19,15 +28,25 @@ public interface NodeCalcVisitor<R, A> {
 
     R visit(BigDecimalNodeCalc nodeCalc, A arg);
 
-    R visit(TimeNodeCalc nodeCalc, A arg);
+    R visit(TimeNodeCalc nodeCalc, A arg, R child);
 
-    R visit(BinaryOperation nodeCalc, A arg);
+    NodeCalc iterate(TimeNodeCalc nodeCalc, A arg);
 
-    R visit(UnaryOperation nodeCalc, A arg);
+    R visit(BinaryOperation nodeCalc, A arg, R left, R right);
 
-    R visit(MinNodeCalc nodeCalc, A arg);
+    Pair<NodeCalc, NodeCalc> iterate(BinaryOperation nodeCalc, A arg);
 
-    R visit(MaxNodeCalc nodeCalc, A arg);
+    R visit(UnaryOperation nodeCalc, A arg, R child);
+
+    NodeCalc iterate(UnaryOperation nodeCalc, A arg);
+
+    R visit(MinNodeCalc nodeCalc, A arg, R child);
+
+    NodeCalc iterate(MinNodeCalc nodeCalc, A arg);
+
+    R visit(MaxNodeCalc nodeCalc, A arg, R child);
+
+    NodeCalc iterate(MaxNodeCalc nodeCalc, A arg);
 
     R visit(TimeSeriesNameNodeCalc nodeCalc, A arg);
 

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcVisitors.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcVisitors.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.timeseries.ast;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ *
+ *         This utility class implements the core iterative algorithm to perform
+ *         a post-order {@link NodeCalc} tree traversal using a
+ *         {@link NodeCalcVisitor}.
+ */
+public final class NodeCalcVisitors {
+
+    private NodeCalcVisitors() {
+    }
+
+    /**
+     * Perform the post-order tree traversal of {@code root} using {@code visitor}.
+     * The argument {@code arg} is supplied to the visitors at each visit of a node.
+     * <p>
+     * For each node, the iterate method is first called to traverse the tree. Then,
+     * after all the children have been visited, the visit method is called with the
+     * result of visiting all the children.
+     *
+     * @param root    The NodeCalc tree
+     * @param arg     an optional argument
+     * @param visitor The NodeCalcVisitor
+     * @return network factory with the given name
+     */
+    public static <R, A> R visit(NodeCalc root, A arg, NodeCalcVisitor<R, A> visitor) {
+        Objects.requireNonNull(root);
+        Objects.requireNonNull(visitor);
+        // We will traverse the tree and put the nodes in the visitQueue stack. We will
+        // compute results for the nodes and put them in the childrenQueue stack.
+        // The first time that we handle a node in the stack, we don't pop it and we
+        // only push its children to the visitQueue stack.
+        // The second time that we handle a node in the visitQueue stack, we pop it,
+        // we pop the results of the children from the childrenQueue stack, we compute
+        // the result and push it to the childrenQueue stack.
+        ArrayDeque<NodeWrapper> visitQueue = new ArrayDeque<>();
+        ArrayDeque<Optional<R>> childrenQueue = new ArrayDeque<>();
+        visitQueue.push(new NodeWrapper(root, true));
+        while (!visitQueue.isEmpty()) {
+            NodeWrapper nodeWrapper = visitQueue.peek();
+            if (nodeWrapper.beforechildren) {
+                nodeWrapper.beforechildren = false;
+                iterate(arg, visitor, visitQueue, nodeWrapper);
+            } else {
+                visitQueue.pop();
+                visit(arg, visitor, childrenQueue, nodeWrapper);
+            }
+        }
+        return childrenQueue.pop().orElse(null);
+    }
+
+    private static <A, R> void iterate(A arg, NodeCalcVisitor<R, A> visitor, ArrayDeque<NodeWrapper> visitQueue,
+            NodeWrapper nodeWrapper) {
+        if (nodeWrapper.node != null) {
+            List<NodeCalc> children = nodeWrapper.node.acceptIterate(visitor, arg);
+            Collections.reverse(children);
+            for (NodeCalc child : children) {
+                visitQueue.push(new NodeWrapper(child, true));
+            }
+            nodeWrapper.childcount = children.size();
+        } else {
+            nodeWrapper.childcount = 0;
+        }
+    }
+
+    private static <R, A> void visit(A arg, NodeCalcVisitor<R, A> visitor, ArrayDeque<Optional<R>> childrenQueue,
+            NodeWrapper nodeWrapper) {
+        List<R> results;
+        if (nodeWrapper.childcount > 0) {
+            results = new ArrayList<>();
+            for (int i = 0; i < nodeWrapper.childcount; i++) {
+                results.add(childrenQueue.pop().orElse(null));
+            }
+            Collections.reverse(results);
+        } else {
+            results = Collections.emptyList();
+        }
+        R result = nodeWrapper.node != null ? nodeWrapper.node.acceptVisit(visitor, arg, results) : null;
+        childrenQueue.push(Optional.ofNullable(result));
+    }
+
+    private static class NodeWrapper {
+
+        private NodeCalc node;
+        private boolean beforechildren;
+        private int childcount = -1;
+
+        public NodeWrapper(NodeCalc node, boolean beforechildren) {
+            this.node = node;
+            this.beforechildren = beforechildren;
+        }
+    }
+}

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeNodeCalc.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.powsybl.timeseries.TimeSeriesException;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -25,8 +27,13 @@ public class TimeNodeCalc extends AbstractSingleChildNodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
-        return visitor.visit(this, arg);
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
+        return visitor.visit(this, arg, children.get(0));
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Arrays.asList(visitor.iterate(this, arg));
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeSeriesNameNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeSeriesNameNodeCalc.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.powsybl.timeseries.TimeSeriesException;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -32,8 +34,13 @@ public class TimeSeriesNameNodeCalc implements NodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
         return visitor.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Collections.emptyList();
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeSeriesNames.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeSeriesNames.java
@@ -18,7 +18,7 @@ public class TimeSeriesNames extends DefaultNodeCalcVisitor<Void, Set<String>> {
     public static Set<String> list(NodeCalc nodeCalc) {
         Objects.requireNonNull(nodeCalc);
         Set<String> timeSeriesNames = new TreeSet<>();
-        nodeCalc.accept(new TimeSeriesNames(), timeSeriesNames);
+        NodeCalcVisitors.visit(nodeCalc, timeSeriesNames, new TimeSeriesNames());
         return timeSeriesNames;
     }
 

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeSeriesNumNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeSeriesNumNodeCalc.java
@@ -6,6 +6,9 @@
  */
 package com.powsybl.timeseries.ast;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.powsybl.timeseries.TimeSeriesException;
 
@@ -28,8 +31,13 @@ public class TimeSeriesNumNodeCalc implements NodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
         return visitor.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Collections.emptyList();
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/UnaryOperation.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/UnaryOperation.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.powsybl.timeseries.TimeSeriesException;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -62,8 +64,13 @@ public class UnaryOperation extends AbstractSingleChildNodeCalc {
     }
 
     @Override
-    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg) {
-        return visitor.visit(this, arg);
+    public <R, A> R acceptVisit(NodeCalcVisitor<R, A> visitor, A arg, List<R> children) {
+        return visitor.visit(this, arg, children.get(0));
+    }
+
+    @Override
+    public <R, A> List<NodeCalc> acceptIterate(NodeCalcVisitor<R, A> visitor, A arg) {
+        return Arrays.asList(visitor.iterate(this, arg));
     }
 
     @Override

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/NodeCalcTooManyRecursionExceptionTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/NodeCalcTooManyRecursionExceptionTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.timeseries;
+
+import com.powsybl.timeseries.ast.*;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class NodeCalcTooManyRecursionExceptionTest {
+
+    private void runAllVisitors(NodeCalc root) {
+        //Should not throw
+        NodeCalcEvaluator.eval(root, null);
+        NodeCalcPrinter.print(root);
+        TimeSeriesNames.list(root);
+        NodeCalcResolver.resolve(root, new HashMap<>());
+        NodeCalcSimplifier.simplify(root);
+    }
+
+    @Test
+    public void testLeft() {
+        NodeCalc node = new IntegerNodeCalc(0);
+        for (int i = 0; i < 10000; i++) {
+            node = BinaryOperation.plus(node, new IntegerNodeCalc(0));
+        }
+        runAllVisitors(node);
+    }
+
+    @Test
+    public void testRight() {
+        NodeCalc node = new IntegerNodeCalc(0);
+        for (int i = 0; i < 10000; i++) {
+            node = BinaryOperation.plus(new IntegerNodeCalc(0), node);
+        }
+        runAllVisitors(node);
+    }
+}


### PR DESCRIPTION
**Other information**:
This is a proof of concept PR. Let's discuss. Is it the good direction ? This change is quite verbose because the visitor pattern is verbose. It adds a new method "iterate" for each NodeCalc in the visitor interface, and it adds the corresponding accept method in all the nodecalc classes (double dispatch).
Things I don't like:
- evaluated children in the visit method are given in a list that has the corresponding values as the list return by iterate. But ideally visit(BinaryOperation, ...) should receive left and right as direct arguments, and visit(UnaryOperation) should receive child as a direct argument, instead of lists of size 2 and 1 respectively. Not sure if it's doable.

Things that can be improved if this is the good direction:
- The previous implementation gave visitors full control of how to traverse the tree (all visitors call getLeft and getRight in this order for binary ops for example). I have kept this possibility with the iterate method, but if we always traverse in the same order, we can remove iterate.

What do you think ?

ps: next things to do: NodeCalc::Equals and NodeCalc::hashCode are currently recursive and fail for deep trees. hashcode is simple to implement with a visitor but equals is not (it should traverse 2 trees at the same time, it should short-circuit). Should we implement these as well ?

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#629



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
StackOverflowError when dealing with deep NodeCalc trees


**What is the new behavior (if this is a feature change)?**
No Execption


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
