### PR TITLE
Publish CoordinatedReactiveControl extension

### DIFF
--- a/iidm/iidm-extensions/pom.xml
+++ b/iidm/iidm-extensions/pom.xml
@@ -25,6 +25,15 @@
     <dependencies>
         <!-- compile dependencies  -->
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-commons</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
             <version>${project.version}</version>

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControl.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControl.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.Generator;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class CoordinatedReactiveControl extends AbstractExtension<Generator> {
+
+    private double qPercent;
+
+    public CoordinatedReactiveControl(Generator generator, double qPercent) {
+        super(generator);
+        this.qPercent = checkQPercent(qPercent);
+    }
+
+    @Override
+    public String getName() {
+        return "coordinatedReactiveControl";
+    }
+
+    public double getQPercent() {
+        return qPercent;
+    }
+
+    public void setQPercent(double qPercent) {
+        this.qPercent = checkQPercent(qPercent);
+    }
+
+    private static double checkQPercent(double qPercent) {
+        if (Double.isNaN(qPercent)) {
+            throw new PowsyblException("Undefined value for qPercent");
+        }
+        if (qPercent < 0.0 || qPercent > 100.0) {
+            throw new PowsyblException("Unexpected value for qPercent: " + qPercent);
+        }
+        return qPercent;
+    }
+}

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlXmlSerializer.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlXmlSerializer.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionXmlSerializer;
+import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlUtil;
+import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.Generator;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.InputStream;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionXmlSerializer.class)
+public class CoordinatedReactiveControlXmlSerializer implements ExtensionXmlSerializer<Generator, CoordinatedReactiveControl> {
+
+    @Override
+    public boolean hasSubElements() {
+        return false;
+    }
+
+    @Override
+    public InputStream getXsdAsStream() {
+        return getClass().getResourceAsStream("/xsd/coordinatedReactiveControl.xsd");
+    }
+
+    @Override
+    public String getNamespaceUri() {
+        return "http://www.powsybl.org/schema/iidm/ext/coordinated_reactive_control/1_0";
+    }
+
+    @Override
+    public String getNamespacePrefix() {
+        return "crc";
+    }
+
+    @Override
+    public void write(CoordinatedReactiveControl extension, XmlWriterContext context) throws XMLStreamException {
+        context.getExtensionsWriter().writeAttribute("qPercent", Double.toString(extension.getQPercent()));
+    }
+
+    @Override
+    public CoordinatedReactiveControl read(Generator extendable, XmlReaderContext context) throws XMLStreamException {
+        double qPercent = XmlUtil.readDoubleAttribute(context.getReader(), "qPercent");
+        return new CoordinatedReactiveControl(extendable, qPercent);
+    }
+
+    @Override
+    public String getExtensionName() {
+        return "coordinatedReactiveControl";
+    }
+
+    @Override
+    public String getCategoryName() {
+        return "network";
+    }
+
+    @Override
+    public Class<? super CoordinatedReactiveControl> getExtensionClass() {
+        return CoordinatedReactiveControl.class;
+    }
+}

--- a/iidm/iidm-extensions/src/main/resources/xsd/coordinatedReactiveControl.xsd
+++ b/iidm/iidm-extensions/src/main/resources/xsd/coordinatedReactiveControl.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:crc="http://www.powsybl.org/schema/iidm/ext/coordinated_reactive_control/1_0"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/coordinated_reactive_control/1_0"
+           elementFormDefault="qualified">
+    <xs:simpleType name="percent">
+        <xs:restriction base="xs:double">
+            <xs:minInclusive value="0.0"/>
+            <xs:maxInclusive value="100.0"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="coordinatedReactiveControl">
+        <xs:complexType>
+            <xs:attribute name="qPercent" use="required" type="crc:percent"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-extensions/src/test/java/com/powsybl/iidm/network/extensions/ActivePowerControlXmlTest.java
+++ b/iidm/iidm-extensions/src/test/java/com/powsybl/iidm/network/extensions/ActivePowerControlXmlTest.java
@@ -30,13 +30,11 @@ public class ActivePowerControlXmlTest extends AbstractConverterTest {
         Battery bat = network.getBattery("BAT");
         assertNotNull(bat);
 
-        ActivePowerControl activePowerControl = new ActivePowerControl<>(bat, true, 4f);
+        ActivePowerControl<Battery> activePowerControl = new ActivePowerControl<>(bat, true, 4f);
         bat.addExtension(ActivePowerControl.class, activePowerControl);
 
         Generator generator = network.getGenerator("GEN");
         generator.addExtension(ActivePowerControl.class, new ActivePowerControl<>(generator, false, 3));
-
-        NetworkXml.write(network, System.out);
 
         Network network2 = roundTripXmlTest(network,
                 NetworkXml::writeAndValidate,
@@ -45,7 +43,7 @@ public class ActivePowerControlXmlTest extends AbstractConverterTest {
 
         Battery bat2 = network2.getBattery("BAT");
         assertNotNull(bat2);
-        ActivePowerControl activePowerControl2 = bat2.getExtension(ActivePowerControl.class);
+        ActivePowerControl<Battery> activePowerControl2 = bat2.getExtension(ActivePowerControl.class);
         assertNotNull(activePowerControl2);
 
         assertEquals(activePowerControl.isParticipate(), activePowerControl2.isParticipate());

--- a/iidm/iidm-extensions/src/test/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlTest.java
+++ b/iidm/iidm-extensions/src/test/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class CoordinatedReactiveControlTest {
+
+    private Generator generator;
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        Network network = EurostagTutorialExample1Factory.create();
+        generator = network.getGenerator("GEN");
+    }
+
+    @Test
+    public void test() {
+        CoordinatedReactiveControl control = new CoordinatedReactiveControl(generator, 100.0);
+        assertEquals(100.0, control.getQPercent(), 0.0);
+        assertEquals("GEN", control.getExtendable().getId());
+    }
+
+    @Test
+    public void testUndefined() {
+        exception.expect(PowsyblException.class);
+        exception.expectMessage("Undefined value for qPercent");
+        new CoordinatedReactiveControl(generator, Double.NaN);
+    }
+
+    @Test
+    public void testError() {
+        exception.expect(PowsyblException.class);
+        exception.expectMessage("Unexpected value for qPercent: 101.0");
+        new CoordinatedReactiveControl(generator, 101.0);
+    }
+}

--- a/iidm/iidm-extensions/src/test/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlXmlSerializerTest.java
+++ b/iidm/iidm-extensions/src/test/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlXmlSerializerTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.xml.NetworkXml;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class CoordinatedReactiveControlXmlSerializerTest extends AbstractConverterTest {
+
+    @Test
+    public void test() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.setCaseDate(DateTime.parse("2019-05-27T12:17:02.504+02:00"));
+        Generator gen = network.getGenerator("GEN");
+
+        CoordinatedReactiveControl control = new CoordinatedReactiveControl(gen, 100.0);
+        gen.addExtension(CoordinatedReactiveControl.class, control);
+
+        Network network2 = roundTripXmlTest(network,
+                NetworkXml::writeAndValidate,
+                NetworkXml::read,
+                "/coordinatedReactiveControl.xml");
+
+        CoordinatedReactiveControl controlXml = network2.getGenerator("GEN").getExtension(CoordinatedReactiveControl.class);
+        assertNotNull(controlXml);
+        assertEquals(100.0, controlXml.getQPercent(), 0.0);
+    }
+
+}

--- a/iidm/iidm-extensions/src/test/resources/coordinatedReactiveControl.xml
+++ b/iidm/iidm-extensions/src/test/resources/coordinatedReactiveControl.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" xmlns:crc="http://www.powsybl.org/schema/iidm/ext/coordinated_reactive_control/1_0" id="sim1" caseDate="2019-05-27T12:17:02.504+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:extension id="GEN">
+        <crc:coordinatedReactiveControl qPercent="100.0"/>
+    </iidm:extension>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
N/A


**What is the new behavior (if this is a feature change)?**
There is an extension to control coordinately the reactive power. This extension could be used in load-flows to find the reactive power setpoints of generators with the same regulating terminal. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:


(if any of the questions/checkboxes don't apply, please delete them entirely)
