### PR TITLE
Fix IIDM extensions read bug in case of partial missing xml serializer

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
@@ -10,6 +10,7 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
+import java.util.Objects;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -22,20 +23,44 @@ public final class XmlUtil {
     public interface XmlEventHandler {
 
         void onStartElement() throws XMLStreamException;
+    }
 
+    /**
+     * An richer event handler which give element depth with each start event.
+     */
+    public interface XmlEventHandler2 {
+
+        void onStartElement(int elementDepth) throws XMLStreamException;
     }
 
     public static String readUntilEndElement(String endElementName, XMLStreamReader reader, XmlEventHandler eventHandler) throws XMLStreamException {
+        return readUntilEndElement(endElementName, reader, elementDepth -> {
+            if (eventHandler != null) {
+                eventHandler.onStartElement();
+            }
+        });
+    }
+
+    public static String readUntilEndElement(String endElementName, XMLStreamReader reader, XmlEventHandler2 eventHandler) throws XMLStreamException {
+        Objects.requireNonNull(endElementName);
+        Objects.requireNonNull(reader);
+
         String text = null;
         int event;
+        int depth = 0;
         while (!((event = reader.next()) == XMLStreamConstants.END_ELEMENT
                 && reader.getLocalName().equals(endElementName))) {
             text = null;
             switch (event) {
                 case XMLStreamConstants.START_ELEMENT:
                     if (eventHandler != null) {
-                        eventHandler.onStartElement();
+                        eventHandler.onStartElement(depth);
                     }
+                    depth++;
+                    break;
+
+                case XMLStreamConstants.END_ELEMENT:
+                    depth--;
                     break;
 
                 case XMLStreamConstants.CHARACTERS:

--- a/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
@@ -28,20 +28,20 @@ public final class XmlUtil {
     /**
      * An richer event handler which give element depth with each start event.
      */
-    public interface XmlEventHandler2 {
+    public interface XmlEventHandlerWithDepth {
 
         void onStartElement(int elementDepth) throws XMLStreamException;
     }
 
     public static String readUntilEndElement(String endElementName, XMLStreamReader reader, XmlEventHandler eventHandler) throws XMLStreamException {
-        return readUntilEndElement(endElementName, reader, elementDepth -> {
+        return readUntilEndElementWithDepth(endElementName, reader, elementDepth -> {
             if (eventHandler != null) {
                 eventHandler.onStartElement();
             }
         });
     }
 
-    public static String readUntilEndElement(String endElementName, XMLStreamReader reader, XmlEventHandler2 eventHandler) throws XMLStreamException {
+    public static String readUntilEndElementWithDepth(String endElementName, XMLStreamReader reader, XmlEventHandlerWithDepth eventHandler) throws XMLStreamException {
         Objects.requireNonNull(endElementName);
         Objects.requireNonNull(reader);
 

--- a/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
+++ b/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.commons.xml;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class XmlUtilTest {
+
+    @Test
+    public void readUntilEndElementTest() throws XMLStreamException {
+        String xml = String.join(System.lineSeparator(),
+                "<a>",
+                "    <b>",
+                "        <c/>",
+                "    </b>",
+                "    <d/>",
+                "</a>");
+        Map<String, Integer> depths = new HashMap<>();
+        try (StringReader reader = new StringReader(xml)) {
+            XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(reader);
+            try {
+                XmlUtil.readUntilEndElement("a", xmlReader, elementDepth -> depths.put(xmlReader.getLocalName(), elementDepth));
+            } finally {
+                xmlReader.close();
+            }
+        }
+        assertEquals(ImmutableMap.of("a", 0, "b", 1, "c", 2, "d", 1), depths);
+    }
+}

--- a/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
+++ b/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 public class XmlUtilTest {
 
     @Test
-    public void readUntilEndElementTest() throws XMLStreamException {
+    public void readUntilEndElementWithDepthTest() throws XMLStreamException {
         String xml = String.join(System.lineSeparator(),
                 "<a>",
                 "    <b>",
@@ -36,7 +36,7 @@ public class XmlUtilTest {
         try (StringReader reader = new StringReader(xml)) {
             XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(reader);
             try {
-                XmlUtil.readUntilEndElement("a", xmlReader, elementDepth -> depths.put(xmlReader.getLocalName(), elementDepth));
+                XmlUtil.readUntilEndElementWithDepth("a", xmlReader, elementDepth -> depths.put(xmlReader.getLocalName(), elementDepth));
             } finally {
                 xmlReader.close();
             }

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeAreaXmlSerializer.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeAreaXmlSerializer.java
@@ -34,7 +34,7 @@ public class EntsoeAreaXmlSerializer extends AbstractExtensionXmlSerializer<Subs
 
     @Override
     public EntsoeArea read(Substation substation, XmlReaderContext context) throws XMLStreamException {
-        EntsoeGeographicalCode code = EntsoeGeographicalCode.valueOf(XmlUtil.readUntilEndElement(getExtensionName(), context.getReader(), (XmlUtil.XmlEventHandler) null));
+        EntsoeGeographicalCode code = EntsoeGeographicalCode.valueOf(XmlUtil.readUntilEndElement(getExtensionName(), context.getReader(), null));
         return new EntsoeArea(substation, code);
     }
 }

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeAreaXmlSerializer.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeAreaXmlSerializer.java
@@ -34,7 +34,7 @@ public class EntsoeAreaXmlSerializer extends AbstractExtensionXmlSerializer<Subs
 
     @Override
     public EntsoeArea read(Substation substation, XmlReaderContext context) throws XMLStreamException {
-        EntsoeGeographicalCode code = EntsoeGeographicalCode.valueOf(XmlUtil.readUntilEndElement(getExtensionName(), context.getReader(), null));
+        EntsoeGeographicalCode code = EntsoeGeographicalCode.valueOf(XmlUtil.readUntilEndElement(getExtensionName(), context.getReader(), (XmlUtil.XmlEventHandler) null));
         return new EntsoeArea(substation, code);
     }
 }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -709,8 +709,8 @@ public final class NetworkXml {
 
         XmlUtil.readUntilEndElement(EXTENSION_ELEMENT_NAME, context.getReader(), elementDepth -> {
             // extensions root elements are nested directly in 'extension' element, so there is no need
-            // to check for an extensions to exist if depth is greater than zero. Furthermore in case of
-            // missing extension serializer, we must not check for en extension in sub elements.
+            // to check for an extension to exist if depth is greater than zero. Furthermore in case of
+            // missing extension serializer, we must not check for an extension in sub elements.
             if (elementDepth == 0) {
                 String extensionName = context.getReader().getLocalName();
                 if (!context.getOptions().withExtension(extensionName)) {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -707,7 +707,7 @@ public final class NetworkXml {
     private static void readExtensions(Identifiable identifiable, NetworkXmlReaderContext context,
                                        Set<String> extensionNamesNotFound) throws XMLStreamException {
 
-        XmlUtil.readUntilEndElement(EXTENSION_ELEMENT_NAME, context.getReader(), elementDepth -> {
+        XmlUtil.readUntilEndElementWithDepth(EXTENSION_ELEMENT_NAME, context.getReader(), elementDepth -> {
             // extensions root elements are nested directly in 'extension' element, so there is no need
             // to check for an extension to exist if depth is greater than zero. Furthermore in case of
             // missing extension serializer, we must not check for an extension in sub elements.

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -526,6 +526,8 @@ public final class NetworkXml {
                 }
             });
 
+            checkExtensionsNotFound(context, extensionNamesNotFound);
+
             if (modeWarn[0]) {
                 LOGGER.warn("Mode isn't UNIQUE_FILE and some extensions was found in the base file!, some extensions may be overwritten later when reading extensions files");
             }
@@ -534,6 +536,17 @@ public final class NetworkXml {
             return network;
         } catch (XMLStreamException e) {
             throw new UncheckedXmlStreamException(e);
+        }
+    }
+
+    private static void checkExtensionsNotFound(NetworkXmlReaderContext context, Set<String> extensionNamesNotFound) {
+        if (!extensionNamesNotFound.isEmpty()) {
+            if (context.getOptions().isThrowExceptionIfExtensionNotFound()) {
+                throw new PowsyblException("Extensions " + extensionNamesNotFound + " " +
+                        "not found !");
+            } else {
+                LOGGER.error("Extensions {} not found", extensionNamesNotFound);
+            }
         }
     }
 
@@ -682,6 +695,9 @@ public final class NetworkXml {
                     throw new PowsyblException("Unexpected element: " +  reader.getLocalName());
                 }
             });
+
+            checkExtensionsNotFound(context, extensionNamesNotFound);
+
             return network;
         } catch (XMLStreamException e) {
             throw new UncheckedXmlStreamException(e);
@@ -691,39 +707,20 @@ public final class NetworkXml {
     private static void readExtensions(Identifiable identifiable, NetworkXmlReaderContext context,
                                        Set<String> extensionNamesNotFound) throws XMLStreamException {
 
-        XmlUtil.readUntilEndElement(EXTENSION_ELEMENT_NAME, context.getReader(), new XmlUtil.XmlEventHandler() {
+        XmlUtil.readUntilEndElement(EXTENSION_ELEMENT_NAME, context.getReader(), () -> {
+            String extensionName = context.getReader().getLocalName();
+            if (!context.getOptions().withExtension(extensionName)) {
+                return;
+            }
 
-            private boolean topLevel = true;
-
-            @Override
-            public void onStartElement() throws XMLStreamException {
-                if (topLevel) {
-                    String extensionName = context.getReader().getLocalName();
-                    if (!context.getOptions().withExtension(extensionName)) {
-                        return;
-                    }
-
-                    ExtensionXmlSerializer extensionXmlSerializer = EXTENSIONS_SUPPLIER.get().findProvider(extensionName);
-                    if (extensionXmlSerializer != null) {
-                        Extension<? extends Identifiable<?>> extension = extensionXmlSerializer.read(identifiable, context);
-                        identifiable.addExtension(extensionXmlSerializer.getExtensionClass(), extension);
-                        topLevel = true;
-                    } else {
-                        extensionNamesNotFound.add(extensionName);
-                        topLevel = false;
-                    }
-                }
+            ExtensionXmlSerializer extensionXmlSerializer = EXTENSIONS_SUPPLIER.get().findProvider(extensionName);
+            if (extensionXmlSerializer != null) {
+                Extension<? extends Identifiable<?>> extension = extensionXmlSerializer.read(identifiable, context);
+                identifiable.addExtension(extensionXmlSerializer.getExtensionClass(), extension);
+            } else {
+                extensionNamesNotFound.add(extensionName);
             }
         });
-
-        if (!extensionNamesNotFound.isEmpty()) {
-            if (context.getOptions().isThrowExceptionIfExtensionNotFound()) {
-                throw new PowsyblException("Extensions " + extensionNamesNotFound + " " +
-                        "not found !");
-            } else {
-                LOGGER.error("Extensions {} not found", extensionNamesNotFound);
-            }
-        }
     }
 
     public static void update(Network network, InputStream is) {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

2 bug fixes

**What is the current behavior?** *(You can also link to an open issue here)*

In case of multiple IIDM extensions for one equipment, XML reader has an issue.
For instance with the following iidm xml sample:
```xml
    <extension id="G1">
         <foo />
         <bar />        
    </extension>
```
If xml serializer is missing (not found in the classpath) for extension foo, extension bar will never be read even if its xml  serializer is found.

There is second issue with extension not found warning which is repeated as many equipment there is in the network (this is probably a recent regression).

**What is the new behavior (if this is a feature change)?**

Extension bar is read from xml even if foo serializer has not been found. 
Warning about missing extensions is logged one time at the end of extensions read.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
