### PR TITLE
Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 /commons/target/
 /computation-local/target/
 /computation/target/
+/config-classic/target/
 /config-test/target/
 /contingency/target/
 /contingency/contingency-api/target/

--- a/action/action-simulator/pom.xml
+++ b/action/action-simulator/pom.xml
@@ -121,6 +121,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-tools</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/afs/afs-ws/afs-ws-server/pom.xml
+++ b/afs/afs-ws/afs-ws-server/pom.xml
@@ -105,6 +105,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/afs/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/AppStorageServerTest.java
+++ b/afs/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/AppStorageServerTest.java
@@ -55,6 +55,7 @@ public class AppStorageServerTest extends AbstractAppStorageTest {
                                .loadPomFromFile("pom.xml")
                                .importRuntimeDependencies()
                                .resolve("org.mockito:mockito-all",
+                                        "com.powsybl:powsybl-config-test",
                                         "com.powsybl:powsybl-afs-mapdb")
                                .withTransitivity()
                                .asFile();

--- a/config-classic/pom.xml
+++ b/config-classic/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.powsybl</groupId>
+        <artifactId>powsybl-core</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>powsybl-config-classic</artifactId>
+    <name>Config Classic</name>
+    <description>Classic Config Provider</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.powsybl.config.classic</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Compilation dependencies -->
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-commons</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/config-classic/src/main/java/com/powsybl/config/classic/ClassicPlatformConfigProvider.java
+++ b/config-classic/src/main/java/com/powsybl/config/classic/ClassicPlatformConfigProvider.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.commons.config;
+package com.powsybl.config.classic;
 
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -14,6 +14,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import com.powsybl.commons.config.ModuleConfigRepository;
+import com.powsybl.commons.config.PlatformConfig;
+import com.powsybl.commons.config.PlatformConfigProvider;
+import com.powsybl.commons.config.PlatformEnv;
+import com.powsybl.commons.config.EnvironmentModuleConfigRepository;
+import com.powsybl.commons.config.StackedModuleConfigRepository;
 
 import com.google.auto.service.AutoService;
 

--- a/config-classic/src/test/java/com/powsybl/config/classic/ClassicPlatformConfigProviderTest.java
+++ b/config-classic/src/test/java/com/powsybl/config/classic/ClassicPlatformConfigProviderTest.java
@@ -4,12 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.commons.config;
+package com.powsybl.config.classic;
 
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.config.ModuleConfigRepository;
 
 import org.junit.After;
 import org.junit.Before;

--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -207,6 +207,13 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-classic</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- In provided scope, so that coverage is correctly reported but the jar is not packaged for distribution -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/loadflow/loadflow-api/pom.xml
+++ b/loadflow/loadflow-api/pom.xml
@@ -99,6 +99,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-scripting</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/loadflow/loadflow-validation/pom.xml
+++ b/loadflow/loadflow-validation/pom.xml
@@ -64,6 +64,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,15 @@
                     <generateBackupPoms>false</generateBackupPoms>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                  <systemPropertyVariables>
+                    <powsybl.config.provider>test</powsybl.config.provider>
+                  </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <module>commons</module>
         <module>computation</module>
         <module>computation-local</module>
+        <module>config-classic</module>
         <module>config-test</module>
         <module>contingency</module>
         <module>distribution-core</module>
@@ -220,15 +221,6 @@
                 <version>${maven.versions.version}</version>
                 <configuration>
                     <generateBackupPoms>false</generateBackupPoms>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                  <systemPropertyVariables>
-                    <powsybl.config.provider>test</powsybl.config.provider>
-                  </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/security-analysis/security-analysis-api/pom.xml
+++ b/security-analysis/security-analysis-api/pom.xml
@@ -117,6 +117,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/sensitivity-api/pom.xml
+++ b/sensitivity-api/pom.xml
@@ -76,6 +76,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-tools</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>


### PR DESCRIPTION
**Other information**:
Needs discussion: maven cli tests now behave differently from IDE tests...





**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature

**What is the current behavior?** *(You can also link to an open issue here)*
The PlatformConfig from defaultConfig() has the hardcoded behavior of looking into powsybl.config.dirs (or ~/.itools if not defined) and looking into the environnement


**What is the new behavior (if this is a feature change)?**
Allow to choose a PlatformConfigProvider using system variables (-Dpowsybl.config.provider). It should implement a getConfig method that is called (once, it is cached) when using defaultConfig(). By default it keeps the old behavior.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO

