### PR TITLE
distribution-core: add missing modules to dependencies to get coverage report

### DIFF
--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -159,10 +159,34 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- In test scope, so that coverage is correctly reported but the jar is not packaged for distribution -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-cgmes-conformity</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-cgmes-model</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <!-- In test scope, so that coverage is correctly reported but the jar is not packaged for distribution -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-cgmes-model-alternatives</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- In provided scope, so that coverage is correctly reported but the jar is not packaged for distribution -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-cim-anonymiser</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -372,7 +396,6 @@
             <artifactId>powsybl-ucte-network</artifactId>
             <version>${project.version}</version>
         </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
CI Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
Code Coverage isn't tracked for the following files in coveralls:
jacoco-powsybl-cgmes-conformity.exec
jacoco-powsybl-cgmes-model-alternatives.exec
jacoco-powsybl-cim-anonymiser.exec


**What is the new behavior (if this is a feature change)?**
Code coverage is tracked.

Note: the coveralls setup is as follow:
each maven module generates a .exec file with a custom name jacoco-XXX.exec (the custom name is used for other reason: to easily copy all .exec files in the same dir and merge them in a aggregate .exec file, used for sonar). jacoco:report-aggregate in distribution-core (by chance) looks for *.exec files in the target folder of dependencies (that's the reason why the modules need to be listed in the pom as dependencies) and produces jacoco-aggregate.xml. Finally the maven-coveralls-plugin is configured to have an additional jacocoReport = jacoco-aggregate.xml.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
