### PR TITLE
Import qPercent (coordinated reactive control) for synchronous machines

### DIFF
--- a/cgmes/cgmes-conversion/pom.xml
+++ b/cgmes/cgmes-conversion/pom.xml
@@ -63,6 +63,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-extensions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.gdata</artifactId>
         </dependency>

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SynchronousMachineConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SynchronousMachineConversion.java
@@ -12,6 +12,7 @@ import com.powsybl.cgmes.model.PowerFlow;
 import com.powsybl.iidm.network.EnergySource;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.GeneratorAdder;
+import com.powsybl.iidm.network.extensions.CoordinatedReactiveControl;
 import com.powsybl.triplestore.api.PropertyBag;
 
 /**
@@ -52,6 +53,10 @@ public class SynchronousMachineConversion extends AbstractReactiveLimitsOwnerCon
         identify(adder);
         connect(adder);
         Generator g = adder.add();
+        if (p.containsKey("qPercent") && !Double.isNaN(p.asDouble("qPercent"))) {
+            CoordinatedReactiveControl coordinatedReactiveControl = new CoordinatedReactiveControl(g, p.asDouble("qPercent"));
+            g.addExtension(CoordinatedReactiveControl.class, coordinatedReactiveControl);
+        }
         convertedTerminals(g.getTerminal());
         convertReactiveLimits(g);
     }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -37,6 +37,7 @@ import com.powsybl.iidm.network.TapChanger;
 import com.powsybl.iidm.network.TapChangerStep;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.extensions.CoordinatedReactiveControl;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -261,6 +262,22 @@ public class Comparison {
         compare("ratedS", expected.getRatedS(), actual.getRatedS());
         compare("terminalP", expected.getTerminal().getP(), actual.getTerminal().getP());
         compare("terminalQ", expected.getTerminal().getQ(), actual.getTerminal().getQ());
+        compareQPercents(expected.getExtension(CoordinatedReactiveControl.class), actual.getExtension(CoordinatedReactiveControl.class));
+    }
+
+    private void compareQPercents(CoordinatedReactiveControl expected, CoordinatedReactiveControl actual) {
+        if (expected == null) {
+            if (actual != null) {
+                diff.unexpected("qPercent");
+                return;
+            }
+            return;
+        }
+        if (actual == null) {
+            diff.unexpected("qPercent");
+            return;
+        }
+        diff.compare("qPercent", expected.getQPercent(), actual.getQPercent());
     }
 
     private void compareGeneratorReactiveLimits(ReactiveLimits expected, ReactiveLimits actual) {

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -657,6 +657,7 @@ WHERE {
     OPTIONAL { ?SynchronousMachine cim:SynchronousMachine.maxQ ?maxQ }
     OPTIONAL { ?SynchronousMachine cim:SynchronousMachine.InitialReactiveCapabilityCurve ?ReactiveCapabilityCurve }
     OPTIONAL { ?SynchronousMachine cim:RegulatingCondEq.RegulatingControl ?RegulatingControl }
+    OPTIONAL { ?SynchronousMachine cim:SynchronousMachine.qPercent ?qPercent }
     OPTIONAL { GRAPH ?graphSSH3 {
     	?SynchronousMachine 
     		cim:RotatingMachine.p ?p ;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
CGMES `qPercent` attribute for synchronous machines is not taken into account during import.


**What is the new behavior (if this is a feature change)?**
It is taken into account


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

