### PR TITLE
Fix BusTerminal::BusBreakerView::setConnectableBus()

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTerminal.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTerminal.java
@@ -41,8 +41,12 @@ class BusTerminal extends AbstractTerminal {
         @Override
         public void setConnectableBus(String busId) {
             Objects.requireNonNull(busId);
-            VoltageLevelExt vl = voltageLevel;
-            voltageLevel.detach(BusTerminal.this);
+            BusBreakerVoltageLevel vl = (BusBreakerVoltageLevel) voltageLevel;
+
+            // Assert that the new bus exists
+            vl.getBus(busId, true);
+
+            vl.detach(BusTerminal.this);
             int variantIndex = network.get().getVariantIndex();
             String oldValue = BusTerminal.this.connectableBusId.set(variantIndex, busId);
             vl.attach(BusTerminal.this, false);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/BusTerminalTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/BusTerminalTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.iidm.network.impl;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ */
+public class BusTerminalTest {
+
+    @Test
+    public void testSetInvalidConnectableBus() {
+        Network network = EurostagTutorialExample1Factory.create();
+        try {
+            network.getLoad("LOAD").getTerminal().getBusBreakerView().setConnectableBus("UNKNOWN");
+        } catch (PowsyblException e) {
+            // Ignored
+        }
+        try {
+            network.getLoad("LOAD").getTerminal().getBusBreakerView().setConnectableBus("UNKNOWN");
+        } catch (NullPointerException e) {
+            Assert.fail();
+        } catch (PowsyblException e) {
+            // Ignored
+        }
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If you set the connectable bus of a terminal through its BusBreakerView to an invalid bus, the terminal is in an inconsistent state after the exception is catched. It's then impossible to put it back in a valid state because the terminal is detached. A NullPointerException is thrown because voltageLevel is null.


**What is the new behavior (if this is a feature change)?**
We check that the new bus exists in the VoltageLevel before doing anything. If an exception is thrown, the terminal remains unchanged.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
