### PR TITLE
Fix XmlUtil.readUntilElementElementWithDepth in case of handler consu…

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
@@ -54,7 +54,12 @@ public final class XmlUtil {
             switch (event) {
                 case XMLStreamConstants.START_ELEMENT:
                     if (eventHandler != null) {
+                        String startLocalName = reader.getLocalName();
                         eventHandler.onStartElement(depth);
+                        // if handler has already consumed end element we must decrease the depth
+                        if (reader.getEventType() == XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals(startLocalName)) {
+                            depth--;
+                        }
                     }
                     depth++;
                     break;

--- a/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
+++ b/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
@@ -57,7 +57,8 @@ public class XmlUtilTest {
                     // consume b and c
                     if (xmlReader.getLocalName().equals("b")) {
                         try {
-                            XmlUtil.readUntilEndElement("b", xmlReader, () -> {});
+                            XmlUtil.readUntilEndElement("b", xmlReader, () -> {
+                            });
                         } catch (XMLStreamException e) {
                             throw new UncheckedXmlStreamException(e);
                         }

--- a/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
+++ b/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.commons.xml;
 
 import com.google.common.collect.ImmutableMap;
+import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import org.junit.Test;
 
 import javax.xml.stream.XMLInputFactory;
@@ -23,17 +24,18 @@ import static org.junit.Assert.assertEquals;
  */
 public class XmlUtilTest {
 
+    private static final String XML = String.join(System.lineSeparator(),
+            "<a>",
+            "    <b>",
+            "        <c/>",
+            "    </b>",
+            "    <d/>",
+            "</a>");
+
     @Test
     public void readUntilEndElementWithDepthTest() throws XMLStreamException {
-        String xml = String.join(System.lineSeparator(),
-                "<a>",
-                "    <b>",
-                "        <c/>",
-                "    </b>",
-                "    <d/>",
-                "</a>");
         Map<String, Integer> depths = new HashMap<>();
-        try (StringReader reader = new StringReader(xml)) {
+        try (StringReader reader = new StringReader(XML)) {
             XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(reader);
             try {
                 XmlUtil.readUntilEndElementWithDepth("a", xmlReader, elementDepth -> depths.put(xmlReader.getLocalName(), elementDepth));
@@ -43,4 +45,29 @@ public class XmlUtilTest {
         }
         assertEquals(ImmutableMap.of("a", 0, "b", 1, "c", 2, "d", 1), depths);
     }
+
+    @Test
+    public void nestedReadUntilEndElementWithDepthTest() throws XMLStreamException {
+        Map<String, Integer> depths = new HashMap<>();
+        try (StringReader reader = new StringReader(XML)) {
+            XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(reader);
+            try {
+                XmlUtil.readUntilEndElementWithDepth("a", xmlReader, elementDepth -> {
+                    depths.put(xmlReader.getLocalName(), elementDepth);
+                    // consume b and c
+                    if (xmlReader.getLocalName().equals("b")) {
+                        try {
+                            XmlUtil.readUntilEndElement("b", xmlReader, () -> {});
+                        } catch (XMLStreamException e) {
+                            throw new UncheckedXmlStreamException(e);
+                        }
+                    }
+                });
+            } finally {
+                xmlReader.close();
+            }
+        }
+        assertEquals(ImmutableMap.of("a", 0, "b", 1, "d", 1), depths);
+    }
+
 }


### PR DESCRIPTION
…ming xml

Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When using XmlUtil.readUntilEndElementWithDepth, if the handler call the xml stream reader and consume all elements, the depth is wrong.


**What is the new behavior (if this is a feature change)?**
The depth is correctly decreased.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
