### PR TITLE
cgmes: make public some conversion tester tools

### DIFF
--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
@@ -213,7 +213,7 @@ public class ConversionTester {
         new Comparison(expected, actual, config).compare();
     }
 
-    private void validateBusBalances(Network network) throws IOException {
+    public static void validateBusBalances(Network network) throws IOException {
         // Precision required on bus balances (MVA)
         double threshold = 0.01;
         try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
@@ -226,7 +226,7 @@ public class ConversionTester {
         }
     }
 
-    private ValidationConfig loadFlowValidationConfig(FileSystem fs, double threshold) {
+    private static ValidationConfig loadFlowValidationConfig(FileSystem fs, double threshold) {
         InMemoryPlatformConfig pconfig = new InMemoryPlatformConfig(fs);
         pconfig
                 .createModuleConfig("componentDefaultConfig")
@@ -240,7 +240,7 @@ public class ConversionTester {
         return config;
     }
 
-    private void computeMissingFlows(Network network, LoadFlowParameters lfparams) {
+    public static void computeMissingFlows(Network network, LoadFlowParameters lfparams) {
         LoadFlowResultsCompletionParameters p = new LoadFlowResultsCompletionParameters(
                 LoadFlowResultsCompletionParameters.EPSILON_X_DEFAULT,
                 LoadFlowResultsCompletionParameters.APPLY_REACTANCE_CORRECTION_DEFAULT,


### PR DESCRIPTION
Signed-off-by: Luma Zamarreño <zamarrenolm@aia.es>

Methods for completing results (flows) in a network and validating bus balances defined in the CGMES conversion tester are made public