### PR TITLE
Replace Identifiable.getProperties by getProperty & setProperty

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -182,7 +182,7 @@ public class Conversion {
 
     private void assignNetworkProperties(Context context) {
         profiling.start();
-        context.network().getProperties().put(NETWORK_PS_CGMES_MODEL_DETAIL,
+        context.network().setProperty(NETWORK_PS_CGMES_MODEL_DETAIL,
                 context.nodeBreaker()
                         ? NETWORK_PS_CGMES_MODEL_DETAIL_NODE_BREAKER
                         : NETWORK_PS_CGMES_MODEL_DETAIL_BUS_BRANCH);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TopologyTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TopologyTester.java
@@ -40,7 +40,7 @@ public class TopologyTester {
     public boolean test(boolean strict) {
         // Only makes sense if the network has been obtained
         // from CGMES node-breaker detailed data
-        if (!network.getProperties().getProperty(Conversion.NETWORK_PS_CGMES_MODEL_DETAIL)
+        if (!network.getProperty(Conversion.NETWORK_PS_CGMES_MODEL_DETAIL)
                 .equals(Conversion.NETWORK_PS_CGMES_MODEL_DETAIL_NODE_BREAKER)) {
             return true;
         }

--- a/iidm/iidm-api/src/main/groovy/com/powsybl/iidm/network/IdentifiableExtension.groovy
+++ b/iidm/iidm-api/src/main/groovy/com/powsybl/iidm/network/IdentifiableExtension.groovy
@@ -17,11 +17,11 @@ class IdentifiableExtension {
     static Object propertyMissing(Identifiable self, String name) {
         // first check if an extension exist then a property
         Extension extension = self.getExtensionByName(name)
-        extension != null ? extension : self.properties[name]
+        extension != null ? extension : self.getProperty(name)
     }
 
     static void propertyMissing(Identifiable self, String name, Object value) {
-        self.properties[name] = value
+        self.setProperty(name, value)
     }
 
     /**

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Identifiable.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Identifiable.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.iidm.network;
 
+import java.util.Set;
+
 import com.powsybl.commons.extensions.Extendable;
 
 import java.util.Properties;
@@ -35,6 +37,36 @@ public interface Identifiable<I extends Identifiable<I>> extends Extendable<I> {
 
     /**
      * Get properties associated to the object.
+     *
+     * @deprecated Use {@link #getProperty(String)} & {@link #setProperty(String, String)} instead.
      */
-    Properties getProperties();
+    @Deprecated
+    default Properties getProperties() {
+        throw new UnsupportedOperationException("Deprecated");
+    }
+
+    /**
+     * Check that this object has property with specified name.
+     */
+    boolean hasProperty(String key);
+
+    /**
+     * Get property associated to specified key.
+     */
+    String getProperty(String key);
+
+    /**
+     * Get property associated to specified key, with default value.
+     */
+    String getProperty(String key, String defaultValue);
+
+    /**
+     * Set property value associated to specified key.
+     */
+    Object setProperty(String key, String value);
+
+    /**
+     * Get properties key values.
+     */
+    Set<String> getPropertyNames();
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
@@ -21,7 +21,7 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
 
     protected String name;
 
-    protected Properties properties;
+    protected final Map<String, String> properties = new HashMap<>();
 
     AbstractIdentifiable(String id, String name) {
         this.id = id;
@@ -47,15 +47,32 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
 
     @Override
     public boolean hasProperty() {
-        return properties != null && !properties.isEmpty();
+        return !properties.isEmpty();
     }
 
     @Override
-    public Properties getProperties() {
-        if (properties == null) {
-            properties = new Properties();
-        }
-        return properties;
+    public boolean hasProperty(String key) {
+        return properties.containsKey(key);
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return properties.get(key);
+    }
+
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        return properties.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public Object setProperty(String key, String value) {
+        return properties.put(key, value);
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return properties.keySet();
     }
 
     @Override

--- a/iidm/iidm-impl/src/test/groovy/com/powsybl/iidm/network/impl/IdentifiableExtensionGroovyTest.groovy
+++ b/iidm/iidm-impl/src/test/groovy/com/powsybl/iidm/network/impl/IdentifiableExtensionGroovyTest.groovy
@@ -46,7 +46,7 @@ class IdentifiableExtensionGroovyTest {
         assertFalse(s.hasProperty())
         assertNull(s.greeting)
         s.greeting = "hello"
-        assertEquals("hello", s.getProperties().getProperty("greeting"))
+        assertEquals("hello", s.getProperty("greeting"))
         assertEquals("hello", s.greeting)
     }
 

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworkTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworkTest.java
@@ -135,6 +135,18 @@ public class NetworkTest {
         assertSame(busCalc, load1.getTerminal().getBusView().getBus());
         assertSame(busCalc, generator1.getTerminal().getBusView().getBus());
         assertEquals(0, busCalc.getConnectedComponent().getNum());
+
+        // Identifiable properties
+        String key = "keyTest";
+        String value = "ValueTest";
+        assertFalse(busCalc.hasProperty());
+        assertTrue(busCalc.getPropertyNames().isEmpty());
+        busCalc.setProperty(key, value);
+        assertTrue(busCalc.hasProperty());
+        assertTrue(busCalc.hasProperty(key));
+        assertEquals(value, busCalc.getProperty(key));
+        assertEquals("default", busCalc.getProperty("invalid", "default"));
+        assertEquals(1, busCalc.getPropertyNames().size());
     }
 
     @Test

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VariantManagerImplTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VariantManagerImplTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Properties;
 import java.util.Set;
 
 import static org.junit.Assert.*;
@@ -58,8 +57,28 @@ public class VariantManagerImplTest {
         }
 
         @Override
-        public Properties getProperties() {
+        public boolean hasProperty(String key) {
+            return false;
+        }
+
+        @Override
+        public String getProperty(String key) {
             return null;
+        }
+
+        @Override
+        public String getProperty(String key, String defaultValue) {
+            return null;
+        }
+
+        @Override
+        public Object setProperty(String key, String value) {
+            return null;
+        }
+
+        @Override
+        public Set<String> getPropertyNames() {
+            return Collections.emptySet();
         }
 
         @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/PropertiesXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/PropertiesXml.java
@@ -7,12 +7,11 @@
 
 package com.powsybl.iidm.xml;
 
-import com.powsybl.iidm.network.Identifiable;
+import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
 
 import javax.xml.stream.XMLStreamException;
-import java.util.Properties;
 
-import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
+import com.powsybl.iidm.network.Identifiable;
 
 /**
  * @author Mathieu Bague <mathieu.bague@rte-france.com>
@@ -24,11 +23,10 @@ public final class PropertiesXml {
     private static final String NAME = "name";
     private static final String VALUE = "value";
 
-    public static void write(Identifiable identifiable, NetworkXmlWriterContext context) throws XMLStreamException {
+    public static void write(Identifiable<?> identifiable, NetworkXmlWriterContext context) throws XMLStreamException {
         if (identifiable.hasProperty()) {
-            Properties props = identifiable.getProperties();
-            for (String name : props.stringPropertyNames()) {
-                String value = props.getProperty(name);
+            for (String name : identifiable.getPropertyNames()) {
+                String value = identifiable.getProperty(name);
                 context.getWriter().writeEmptyElement(IIDM_URI, PROPERTY);
                 context.getWriter().writeAttribute(NAME, name);
                 context.getWriter().writeAttribute(VALUE, value);
@@ -40,7 +38,7 @@ public final class PropertiesXml {
         assert context.getReader().getLocalName().equals(PROPERTY);
         String name = context.getReader().getAttributeValue(null, NAME);
         String value = context.getReader().getAttributeValue(null, VALUE);
-        identifiable.getProperties().put(name, value);
+        identifiable.setProperty(name, value);
     }
 
     private PropertiesXml() {

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
@@ -51,7 +51,7 @@ public class NetworkXmlTest extends AbstractConverterTest {
     @Test
     public void testValidationIssueWithProperties() throws Exception {
         Network network = createEurostagTutorialExample1();
-        network.getGenerator("GEN").getProperties().setProperty("test", "foo");
+        network.getGenerator("GEN").setProperty("test", "foo");
         Path xmlFile = tmpDir.resolve("n.xml");
         NetworkXml.writeAndValidate(network, xmlFile);
     }

--- a/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/ShuntCompensatorsValidationTest.java
+++ b/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/ShuntCompensatorsValidationTest.java
@@ -10,7 +10,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.Properties;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.output.NullWriter;
@@ -74,10 +73,7 @@ public class ShuntCompensatorsValidationTest extends AbstractValidationTest {
         Mockito.when(shunt.getCurrentSectionCount()).thenReturn(currentSectionCount);
         Mockito.when(shunt.getMaximumSectionCount()).thenReturn(maximumSectionCount);
         Mockito.when(shunt.getbPerSection()).thenReturn(bPerSection);
-
-        Properties shuntProperties = new Properties();
-        shuntProperties.put("qMax", Double.toString(qMax));
-        Mockito.when(shunt.getProperties()).thenReturn(shuntProperties);
+        Mockito.when(shunt.getProperty("qMax")).thenReturn(Double.toString(qMax));
     }
 
     @Test

--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteExporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteExporter.java
@@ -123,7 +123,7 @@ public class UcteExporter implements Exporter {
         }
 
         UcteNodeCode ucteNodeCode = context.getNamingStrategy().getUcteNodeCode(bus);
-        String geographicalName = bus.getProperties().getProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, null);
+        String geographicalName = bus.getProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, null);
 
         // FIXME(mathbagu): how to initialize active/reactive load and generation: 0 vs NaN vs DEFAULT_MAX_POWER?
         // FIXME(mathbagu): how to find the slack node?
@@ -239,7 +239,7 @@ public class UcteExporter implements Exporter {
      */
     private static void convertXNode(UcteNetwork ucteNetwork, DanglingLine danglingLine, UcteExporterContext context) {
         UcteNodeCode xnodeCode = context.getNamingStrategy().getUcteNodeCode(danglingLine);
-        String geographicalName = danglingLine.getProperties().getProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, null);
+        String geographicalName = danglingLine.getProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, null);
 
         UcteNode ucteNode = convertXNode(ucteNetwork, xnodeCode, geographicalName);
         ucteNode.setActiveLoad((float) danglingLine.getP0());
@@ -255,7 +255,7 @@ public class UcteExporter implements Exporter {
      */
     private static void convertXNode(UcteNetwork ucteNetwork, MergedXnode mergedXnode, UcteExporterContext context) {
         UcteNodeCode xnodeCode = context.getNamingStrategy().getUcteNodeCode(mergedXnode.getCode());
-        String geographicalName = mergedXnode.getExtendable().getProperties().getProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, "");
+        String geographicalName = mergedXnode.getExtendable().getProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, "");
 
         convertXNode(ucteNetwork, xnodeCode, geographicalName);
     }
@@ -269,7 +269,7 @@ public class UcteExporter implements Exporter {
      */
     private static void convertXNode(UcteNetwork ucteNetwork, TieLine tieLine, UcteExporterContext context) {
         UcteNodeCode xnodeCode = context.getNamingStrategy().getUcteNodeCode(tieLine.getUcteXnodeCode());
-        String geographicalName = tieLine.getProperties().getProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, "");
+        String geographicalName = tieLine.getProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, "");
 
         convertXNode(ucteNetwork, xnodeCode, geographicalName);
     }
@@ -323,7 +323,7 @@ public class UcteExporter implements Exporter {
 
         UcteElementId ucteElementId = context.getNamingStrategy().getUcteElementId(sw);
         UcteElementStatus status = sw.isOpen() ? BUSBAR_COUPLER_OUT_OF_OPERATION : BUSBAR_COUPLER_IN_OPERATION;
-        String elementName = sw.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY, null);
+        String elementName = sw.getProperty(ELEMENT_NAME_PROPERTY_KEY, null);
 
         UcteLine ucteLine = new UcteLine(ucteElementId, status, 0, 0, 0, null, elementName);
         ucteNetwork.addLine(ucteLine);
@@ -348,7 +348,7 @@ public class UcteExporter implements Exporter {
 
         UcteElementId lineId = context.getNamingStrategy().getUcteElementId(line);
         UcteElementStatus status = line.getTerminal1().isConnected() && line.getTerminal2().isConnected() ? REAL_ELEMENT_IN_OPERATION : REAL_ELEMENT_OUT_OF_OPERATION;
-        String elementName = line.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY, null);
+        String elementName = line.getProperty(ELEMENT_NAME_PROPERTY_KEY, null);
 
         UcteLine ucteLine = new UcteLine(
                 lineId,
@@ -399,7 +399,7 @@ public class UcteExporter implements Exporter {
 
         // Create half line 1
         UcteElementId ucteElementId1 = context.getNamingStrategy().getUcteElementId(mergedXnode.getLine1Name());
-        String elementName1 = line.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY + "_1", null);
+        String elementName1 = line.getProperty(ELEMENT_NAME_PROPERTY_KEY + "_1", null);
         UcteLine ucteLine1 = new UcteLine(
                 ucteElementId1,
                 status,
@@ -412,7 +412,7 @@ public class UcteExporter implements Exporter {
 
         // Create half line2
         UcteElementId ucteElementId2 = context.getNamingStrategy().getUcteElementId(mergedXnode.getLine2Name());
-        String elementName2 = line.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY + "_2", null);
+        String elementName2 = line.getProperty(ELEMENT_NAME_PROPERTY_KEY + "_2", null);
         UcteLine ucteLine2 = new UcteLine(
                 ucteElementId2,
                 status,
@@ -443,7 +443,7 @@ public class UcteExporter implements Exporter {
         // Create half line 1
         TieLine.HalfLine half1 = tieLine.getHalf1();
         UcteElementId ucteElementId1 = context.getNamingStrategy().getUcteElementId(half1.getId());
-        String elementName1 = tieLine.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY + "_1", null);
+        String elementName1 = tieLine.getProperty(ELEMENT_NAME_PROPERTY_KEY + "_1", null);
         UcteLine ucteLine1 = new UcteLine(
                 ucteElementId1,
                 status,
@@ -457,7 +457,7 @@ public class UcteExporter implements Exporter {
         // Create half line2
         TieLine.HalfLine half2 = tieLine.getHalf2();
         UcteElementId ucteElementId2 = context.getNamingStrategy().getUcteElementId(half2.getId());
-        String elementName2 = tieLine.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY + "_2", null);
+        String elementName2 = tieLine.getProperty(ELEMENT_NAME_PROPERTY_KEY + "_2", null);
         UcteLine ucteLine2 = new UcteLine(
                 ucteElementId2,
                 status,
@@ -484,7 +484,7 @@ public class UcteExporter implements Exporter {
 
         // Create line
         UcteElementId elementId = context.getNamingStrategy().getUcteElementId(danglingLine);
-        String elementName = danglingLine.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY, null);
+        String elementName = danglingLine.getProperty(ELEMENT_NAME_PROPERTY_KEY, null);
         double permanentLimit = danglingLine.getCurrentLimits() == null ? DEFAULT_MAX_CURRENT : danglingLine.getCurrentLimits().getPermanentLimit();
 
         UcteElementStatus status = danglingLine.getTerminal().isConnected() ? EQUIVALENT_ELEMENT_IN_OPERATION : EQUIVALENT_ELEMENT_OUT_OF_OPERATION;
@@ -512,9 +512,9 @@ public class UcteExporter implements Exporter {
     private static void convertTwoWindingsTransformer(UcteNetwork ucteNetwork, TwoWindingsTransformer twoWindingsTransformer, UcteExporterContext context) {
         UcteElementId elementId = context.getNamingStrategy().getUcteElementId(twoWindingsTransformer);
         UcteElementStatus status = twoWindingsTransformer.getTerminal1().isConnected() && twoWindingsTransformer.getTerminal2().isConnected() ? REAL_ELEMENT_IN_OPERATION : REAL_ELEMENT_OUT_OF_OPERATION;
-        String elementName = twoWindingsTransformer.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY, null);
+        String elementName = twoWindingsTransformer.getProperty(ELEMENT_NAME_PROPERTY_KEY, null);
         double currentLimits = getPermanentLimit(twoWindingsTransformer);
-        float nominalPower = Float.parseFloat(twoWindingsTransformer.getProperties().getProperty(NOMINAL_POWER_KEY, null));
+        float nominalPower = Float.parseFloat(twoWindingsTransformer.getProperty(NOMINAL_POWER_KEY, null));
 
         UcteTransformer ucteTransformer = new UcteTransformer(
                 elementId,
@@ -640,9 +640,9 @@ public class UcteExporter implements Exporter {
     }
 
     private static void setSwitchCurrentLimit(UcteLine ucteLine, Switch sw) {
-        if (sw.getProperties().containsKey(CURRENT_LIMIT_PROPERTY_KEY)) {
+        if (sw.hasProperty(CURRENT_LIMIT_PROPERTY_KEY)) {
             try {
-                ucteLine.setCurrentLimit(Integer.parseInt(sw.getProperties().getProperty(CURRENT_LIMIT_PROPERTY_KEY)));
+                ucteLine.setCurrentLimit(Integer.parseInt(sw.getProperty(CURRENT_LIMIT_PROPERTY_KEY)));
             } catch (NumberFormatException exception) {
                 ucteLine.setCurrentLimit((int) DEFAULT_MAX_CURRENT);
                 LOGGER.warn("Switch {}: No current limit, set value to {}", sw.getId(), DEFAULT_MAX_CURRENT);

--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -771,30 +771,30 @@ public class UcteImporter implements Importer {
     }
 
     private static void addElementNameProperty(TieLine tieLine, DanglingLine dl1, DanglingLine dl2) {
-        if (dl1.getProperties().containsKey(ELEMENT_NAME_PROPERTY_KEY)) {
-            tieLine.getProperties().setProperty(ELEMENT_NAME_PROPERTY_KEY + "_1", dl1.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY));
+        if (dl1.hasProperty(ELEMENT_NAME_PROPERTY_KEY)) {
+            tieLine.setProperty(ELEMENT_NAME_PROPERTY_KEY + "_1", dl1.getProperty(ELEMENT_NAME_PROPERTY_KEY));
         }
 
-        if (dl2.getProperties().containsKey(ELEMENT_NAME_PROPERTY_KEY)) {
-            tieLine.getProperties().setProperty(ELEMENT_NAME_PROPERTY_KEY + "_2", dl2.getProperties().getProperty(ELEMENT_NAME_PROPERTY_KEY));
+        if (dl2.hasProperty(ELEMENT_NAME_PROPERTY_KEY)) {
+            tieLine.setProperty(ELEMENT_NAME_PROPERTY_KEY + "_2", dl2.getProperty(ELEMENT_NAME_PROPERTY_KEY));
         }
     }
 
     private static void addElementNameProperty(UcteElement ucteElement, Identifiable identifiable) {
         if (ucteElement.getElementName() != null) {
-            identifiable.getProperties().setProperty(ELEMENT_NAME_PROPERTY_KEY, ucteElement.getElementName());
+            identifiable.setProperty(ELEMENT_NAME_PROPERTY_KEY, ucteElement.getElementName());
         }
     }
 
     private static void addCurrentLimitProperty(UcteLine ucteLine, Switch aSwitch) {
         if (ucteLine.getCurrentLimit() != null) {
-            aSwitch.getProperties().setProperty(CURRENT_LIMIT_PROPERTY_KEY, String.valueOf(ucteLine.getCurrentLimit()));
+            aSwitch.setProperty(CURRENT_LIMIT_PROPERTY_KEY, String.valueOf(ucteLine.getCurrentLimit()));
         }
     }
 
     private static void addGeographicalNameProperty(UcteNode ucteNode, Identifiable identifiable) {
         if (ucteNode.getGeographicalName() != null) {
-            identifiable.getProperties().setProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, ucteNode.getGeographicalName());
+            identifiable.setProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, ucteNode.getGeographicalName());
         }
     }
 
@@ -803,7 +803,7 @@ public class UcteImporter implements Importer {
 
         if (optUcteNodeCode.isPresent()) {
             UcteNode ucteNode = ucteNetwork.getNode(optUcteNodeCode.get());
-            tieLine.getProperties().setProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, ucteNode.getGeographicalName());
+            tieLine.setProperty(GEOGRAPHICAL_NAME_PROPERTY_KEY, ucteNode.getGeographicalName());
         } else {
             throw new UcteException(NOT_POSSIBLE_TO_IMPORT);
         }
@@ -811,11 +811,11 @@ public class UcteImporter implements Importer {
 
     private static void addOrderCodeProperty(UcteLine ucteLine, Switch sw) {
         String ucteLineId = ucteLine.getId().toString();
-        sw.getProperties().setProperty(ORDER_CODE, String.valueOf(ucteLineId.charAt(ucteLineId.length() - 1)));
+        sw.setProperty(ORDER_CODE, String.valueOf(ucteLineId.charAt(ucteLineId.length() - 1)));
     }
 
     private static void addNominalPowerProperty(UcteTransformer transformer, TwoWindingsTransformer twoWindingsTransformer) {
-        twoWindingsTransformer.getProperties().setProperty(NOMINAL_POWER_KEY, String.valueOf(transformer.getNominalPower()));
+        twoWindingsTransformer.setProperty(NOMINAL_POWER_KEY, String.valueOf(transformer.getNominalPower()));
     }
 
     @Override

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
@@ -77,14 +77,14 @@ public class UcteImporterTest {
 
         Network network = new UcteImporter().importData(dataSource, null);
         // Test Element name Line
-        assertEquals("Test Line", network.getLine("F_SU1_12 F_SU2_11 1").getProperties().getProperty("elementName"));
+        assertEquals("Test Line", network.getLine("F_SU1_12 F_SU2_11 1").getProperty("elementName"));
         // Test Dangling Line element name
-        assertEquals("Test DL", network.getDanglingLine("XG__F_21 F_SU1_21 1").getProperties().getProperty("elementName"));
+        assertEquals("Test DL", network.getDanglingLine("XG__F_21 F_SU1_21 1").getProperty("elementName"));
         // Test Switch element name
-        assertEquals("Test Coupler", network.getSwitch("F_SU1_12 F_SU1_11 1").getProperties().getProperty("elementName"));
+        assertEquals("Test Coupler", network.getSwitch("F_SU1_12 F_SU1_11 1").getProperty("elementName"));
         // Test 2WT element name
-        assertEquals("Test 2WT 1", network.getBranch("F_SU1_11 F_SU1_21 1").getProperties().getProperty("elementName"));
-        assertEquals("Test 2WT 2", network.getBranch("B_SU1_11 B_SU1_21 1").getProperties().getProperty("elementName"));
+        assertEquals("Test 2WT 1", network.getBranch("F_SU1_11 F_SU1_21 1").getProperty("elementName"));
+        assertEquals("Test 2WT 2", network.getBranch("B_SU1_11 B_SU1_21 1").getProperty("elementName"));
         // Test tie line
         // cannot refer to side of tieline directly cause order of half lines may change
         // at import : due to HashSet iterator on dangling lines ?
@@ -95,8 +95,8 @@ public class UcteImporterTest {
                 }).findAny().get();
         String expectedElementName1 = tieLine1.getHalf1().getId().equals("XB__F_11 B_SU1_11 1") ? "Test TL 1/2" : "Test TL 1/1";
         String expectedElementName2 = tieLine1.getHalf2().getId().equals("XB__F_11 B_SU1_11 1") ? "Test TL 1/2" : "Test TL 1/1";
-        assertEquals(expectedElementName1, tieLine1.getProperties().getProperty("elementName_1"));
-        assertEquals(expectedElementName2, tieLine1.getProperties().getProperty("elementName_2"));
+        assertEquals(expectedElementName1, tieLine1.getProperty("elementName_1"));
+        assertEquals(expectedElementName2, tieLine1.getProperty("elementName_2"));
 
         TieLine tieLine2 = (TieLine) network.getLineStream().filter(Line::isTieLine)
                 .filter(line -> {
@@ -105,8 +105,8 @@ public class UcteImporterTest {
                 }).findAny().get();
         expectedElementName1 = tieLine2.getHalf1().getId().equals("XB__F_21 B_SU1_21 1") ? "Test TL 2/2" : "Test TL 2/1";
         expectedElementName2 = tieLine2.getHalf2().getId().equals("XB__F_21 B_SU1_21 1") ? "Test TL 2/2" : "Test TL 2/1";
-        assertEquals(expectedElementName1, tieLine2.getProperties().getProperty("elementName_1"));
-        assertEquals(expectedElementName2, tieLine2.getProperties().getProperty("elementName_2"));
+        assertEquals(expectedElementName1, tieLine2.getProperty("elementName_1"));
+        assertEquals(expectedElementName2, tieLine2.getProperty("elementName_2"));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Change access to properties fields of Identifiable class


**What is the current behavior?** *(You can also link to an open issue here)*
Identifiable.getProperties is used to set new properties


**What is the new behavior (if this is a feature change)?**
Identifiable.getProperties method is no longer accessible, replaced by getProperty & setProperty

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
