### PR TITLE
Fix non reproducible tests: use jimfs in unix mode like everywhere else

### DIFF
--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
@@ -130,7 +130,7 @@ public class ConversionTester {
         // This is to be able to easily compare the topology computed
         // by powsybl against the topology present in the CGMES model
         iparams.put("createBusbarSectionForEveryConnectivityNode", "true");
-        try (FileSystem fs = Jimfs.newFileSystem()) {
+        try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
             PlatformConfig platformConfig = new InMemoryPlatformConfig(fs);
             CgmesImport i = new CgmesImport(platformConfig);
             ReadOnlyDataSource ds = gm.dataSource();
@@ -163,7 +163,7 @@ public class ConversionTester {
 
     private void testConversionOnlyReport(TestGridModel gm) throws IOException {
         String impl = TripleStoreFactory.defaultImplementation();
-        try (FileSystem fs = Jimfs.newFileSystem()) {
+        try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
             PlatformConfig platformConfig = new InMemoryPlatformConfig(fs);
             CgmesImport i = new CgmesImport(platformConfig);
             Properties params = new Properties();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ImportExportPerformanceTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ImportExportPerformanceTest.java
@@ -7,6 +7,7 @@
 
 package com.powsybl.cgmes.conversion.test;
 
+import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.cgmes.conversion.CgmesExport;
 import com.powsybl.cgmes.conversion.CgmesImport;
@@ -50,7 +51,7 @@ public class ImportExportPerformanceTest {
     }
 
     private void importExport(List<String> tsImpls, TestGridModel gm) throws IOException {
-        try (FileSystem fs = Jimfs.newFileSystem()) {
+        try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
             ReadOnlyDataSource ds = gm.dataSource();
 
             int size = tsImpls.size();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.cgmes.conversion.test.conformity;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.cgmes.conformity.test.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.test.CgmesConformity1NetworkCatalog;
@@ -49,7 +50,7 @@ public class CgmesConformity1ConversionTest {
 
     @Before
     public void setUp() {
-        fileSystem = Jimfs.newFileSystem();
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
         platformConfig = new InMemoryPlatformConfig(fileSystem);
     }
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/modified/CgmesConformity1ModifiedConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/modified/CgmesConformity1ModifiedConversionTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.cgmes.conversion.test.conformity.modified;
 
+import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.cgmes.conformity.test.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.test.CgmesConformity1ModifiedCatalog;
@@ -37,7 +38,7 @@ public class CgmesConformity1ModifiedConversionTest {
 
     @Before
     public void setUp() {
-        fileSystem = Jimfs.newFileSystem();
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
         platformConfig = new InMemoryPlatformConfig(fileSystem);
     }
 


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
5 tests use Jimfs.newFileSystem(). This returns a FS dependent on the host OS and makes the tests non reproducible (54 uses of Jimfs.newFileSystem(Configuration.unix()))


**What is the new behavior (if this is a feature change)?**
Use Jimfs.newFileSystem(Configuration.unix())


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO

**Other information**:
