### PR TITLE
In loadflow results completion, check that there is a bus in the busView 

### DIFF
--- a/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/LoadFlowResultsCompletion.java
+++ b/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/LoadFlowResultsCompletion.java
@@ -84,6 +84,7 @@ public class LoadFlowResultsCompletion implements CandidateComputation {
             Terminal terminal = sh.getTerminal();
             if (terminal.isConnected()
                     && Double.isNaN(terminal.getQ())
+                    && terminal.getBusView().getBus() != null
                     && terminal.getBusView().getBus().isInMainConnectedComponent()) {
                 double v = terminal.getBusView().getBus().getV();
                 double q = -sh.getCurrentB() * v * v;
@@ -127,7 +128,7 @@ public class LoadFlowResultsCompletion implements CandidateComputation {
     }
 
     private void completeTerminalData(Terminal terminal, Side side, BranchData branchData) {
-        if (terminal.isConnected() && terminal.getBusView().getBus().isInMainConnectedComponent()) {
+        if (terminal.isConnected() && terminal.getBusView().getBus() != null && terminal.getBusView().getBus().isInMainConnectedComponent()) {
             if (Double.isNaN(terminal.getP())) {
                 LOGGER.debug("Branch {}, Side {}: setting p = {}", branchData.getId(), side, branchData.getComputedP(side));
                 terminal.setP(branchData.getComputedP(side));
@@ -140,7 +141,7 @@ public class LoadFlowResultsCompletion implements CandidateComputation {
     }
 
     private void completeTerminalData(Terminal terminal, ThreeWindingsTransformer.Side side, TwtData twtData) {
-        if (terminal.isConnected() && terminal.getBusView().getBus().isInMainConnectedComponent()) {
+        if (terminal.isConnected() && terminal.getBusView().getBus() != null && terminal.getBusView().getBus().isInMainConnectedComponent()) {
             if (Double.isNaN(terminal.getP())) {
                 LOGGER.debug("Twt {}, Side {}: setting p = {}", twtData.getId(), side, twtData.getComputedP(side));
                 terminal.setP(twtData.getComputedP(side));


### PR DESCRIPTION
Bug fix.

Before checking if it belongs to the main connected component, check that there is a bus for the terminal in the busView.

In certain topologies, there could be equipment connected to configured bus for which no corresponding bus has been created in the busView.

Observed analyzing IOP June data for REE bus-branch test case: shunt connected to a configured bus (24 kV) that contains no other equipment and is connected to a 1 kV bus through an out-of-service transformer.
