### PR TITLE
Remove deprecated sonar conf. Try to use the default conf.

### DIFF
--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -463,26 +463,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <version>${maven.antrun.version}</version>
-                        <executions>
-                            <execution>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target name="copy jacoco reports">
-                                        <copy todir="${project.build.directory}/jacoco" flatten="true">
-                                            <fileset dir=".." includes="**/jacoco*.exec" />
-                                        </copy>
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <executions>
@@ -494,21 +474,6 @@
                                 </goals>
                                 <configuration>
                                     <title>${project.parent.name}</title>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>merge</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>merge</goal>
-                                </goals>
-                                <configuration>
-                                    <destFile>${project.parent.build.directory}/jacoco-merge.exec</destFile>
-                                    <fileSets>
-                                        <fileSet>
-                                            <directory>${project.build.directory}/jacoco</directory>
-                                        </fileSet>
-                                    </fileSets>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
         <!-- javac's source and target arguments accept both 1.8 and 8, but release accepts only 8 -->
         <java.version>8</java.version>
 
-        <maven.antrun.version>1.8</maven.antrun.version>
         <maven.assembly.version>3.1.0</maven.assembly.version>
         <maven.build-helper.version>3.0.0</maven.build-helper.version>
         <maven.buildnumber.version>1.4</maven.buildnumber.version>
@@ -109,11 +108,12 @@
         <maven.templating.version>1.0.0</maven.templating.version>
         <maven.versions.version>2.7</maven.versions.version>
 
-        <sonar.jacoco.reportPaths>
-            ../target/jacoco-merge.exec,
-            ../../target/jacoco-merge.exec,
-            ../../../target/jacoco-merge.exec
-        </sonar.jacoco.reportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ../distribution-core/target/site/jacoco-aggregate/jacoco.xml,
+            ../../distribution-core/target/site/jacoco-aggregate/jacoco.xml,
+            ../../../distribution-core/target/site/jacoco-aggregate/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
+
         <sonar.exclusions>
             **/generated/**/*
         </sonar.exclusions>
@@ -414,18 +414,12 @@
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
-                                <configuration>
-                                    <destFile>${project.build.directory}/jacoco-${project.artifactId}.exec</destFile>
-                                </configuration>
                             </execution>
                             <execution>
                                 <id>report</id>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>
-                                <configuration>
-                                    <dataFile>${project.build.directory}/jacoco-${project.artifactId}.exec</dataFile>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix coverage report on sonarcloud
- sonar.jacoco.reportPath (merged exec) was deprecated and replaced with sonar.jacoco.reportPaths (multiple execs)
- sonar.jacoco.reportPaths (multiple execs) is deprecated and replaced with sonar.coverage.jacoco.xmlReportPaths (xml reports)


**What is the current behavior?** *(You can also link to an open issue here)*
The coverage report dropped 10% after https://github.com/powsybl/powsybl-core/pull/893 .
This may be because we use a doubly deprecated jacoco-merge.exec system.


**What is the new behavior (if this is a feature change)?**
Try to use the xml reports:
https://sonarcloud.io/documentation/analysis/coverage/

> sonar.jacoco.reportPaths    Deprecated. Use sonar.coverage.jacoco.xmlReportsPath. Path to JaCoCo reports in binary format. Supported only for Java

>  sonar.coverage.jacoco.xmlReportPaths | Comma-delimited list of paths to JaCoCo XML coverage reports.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

