### PR TITLE
[WIP] Cgmes import of rxgb attributes corrected to enter IIDM current convention

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TwoWindingsTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TwoWindingsTransformerConversion.java
@@ -52,12 +52,18 @@ public class TwoWindingsTransformerConversion extends AbstractConductingEquipmen
         double ratedU1 = end1.asDouble("ratedU");
         double ratedU2 = end2.asDouble("ratedU");
 
-        double rho0 = ratedU2 / ratedU1;
+        double rho0 = ratedU2 / ratedU1; // ratio to move r, x, g and b to the side 2
+        double rfix = voltageLevel(2).getNominalV() / ratedU2; // ratio to express r, x, g and b relatively to voltage level's nominal voltages rather than ratedU
+        double rfixSquare = rfix * rfix;
         double rho0Square = rho0 * rho0;
         double r0 = r1 * rho0Square + r2;
+        r0 *= rfixSquare;
         double x0 = x1 * rho0Square + x2;
+        x0 *= rfixSquare;
         double g0 = g1 / rho0Square + g2;
+        g0 /= rfixSquare;
         double b0 = b1 / rho0Square + b2;
+        b0 /= rfixSquare;
 
         TwoWindingsTransformerAdder adder = substation().newTwoWindingsTransformer()
                 .setR(r0)

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TwoWindingsTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TwoWindingsTransformerConversion.java
@@ -53,17 +53,17 @@ public class TwoWindingsTransformerConversion extends AbstractConductingEquipmen
         double ratedU2 = end2.asDouble("ratedU");
 
         double rho0 = ratedU2 / ratedU1; // ratio to move r, x, g and b to the side 2
-        double rfix = voltageLevel(2).getNominalV() / ratedU2; // ratio to express r, x, g and b relatively to voltage level's nominal voltages rather than ratedU
-        double rfixSquare = rfix * rfix;
+        double endVoltageRatio = voltageLevel(2).getNominalV() / ratedU2; // ratio to express r, x, g and b relatively to voltage level's nominal voltages rather than ratedU
+        double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
         double rho0Square = rho0 * rho0;
         double r0 = r1 * rho0Square + r2;
-        r0 *= rfixSquare;
+        r0 *= endVoltageRatioSquare;
         double x0 = x1 * rho0Square + x2;
-        x0 *= rfixSquare;
+        x0 *= endVoltageRatioSquare;
         double g0 = g1 / rho0Square + g2;
-        g0 /= rfixSquare;
+        g0 /= endVoltageRatioSquare;
         double b0 = b1 / rho0Square + b2;
-        b0 /= rfixSquare;
+        b0 /= endVoltageRatioSquare;
 
         TwoWindingsTransformerAdder adder = substation().newTwoWindingsTransformer()
                 .setR(r0)

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/cim14/Cim14SmallCasesNetworkCatalog.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/cim14/Cim14SmallCasesNetworkCatalog.java
@@ -131,6 +131,8 @@ public class Cim14SmallCasesNetworkCatalog {
             double u1 = 21.0;
             double rho = u2 / u1;
             double rho2 = rho * rho;
+            double rfix = vlGrid.getNominalV() / u2;
+            double rfix2 = rfix * rfix;
             double r1 = 0.001323;
             double x1 = 0.141114;
             double g1 = 0.0;
@@ -140,9 +142,13 @@ public class Cim14SmallCasesNetworkCatalog {
             double g2 = 0.0;
             double b2 = 0.0;
             double r = r1 * rho2 + r2;
+            r *= rfix2;
             double x = x1 * rho2 + x2;
+            x *= rfix2;
             double g = g1 / rho2 + g2;
+            g /= rfix2;
             double b = b1 / rho2 + b2;
+            b /= rfix2;
             TwoWindingsTransformer tx = sGen.newTwoWindingsTransformer()
                 .setId("_GEN_____-GRID____-1_PT")
                 .setName("GEN     -GRID    -1")

--- a/cgmes/cgmes-conversion/src/test/resources/cim14/nordic32.xiidm
+++ b/cgmes/cgmes-conversion/src/test/resources/cim14/nordic32.xiidm
@@ -20,11 +20,11 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_N1011____EC" name="N1011   " loadType="UNDEFINED" p0="200.0" q0="80.0" bus="_N1011____TN" connectableBus="_N1011____TN" p="200.0" q="80.0"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG9_____-N4011___-1_PT" name="NG9     -N4011   -1" r="0.0" x="24.000009536743164" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG9______TN" connectableBus1="_NG9______TN" voltageLevelId1="_NG9______VL" bus2="_N4011____TN" connectableBus2="_N4011____TN" voltageLevelId2="_N4011____VL">
+        <iidm:twoWindingsTransformer id="_NG9_____-N4011___-1_PT" name="NG9     -N4011   -1" r="0.0" x="26.45895111111111" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG9______TN" connectableBus1="_NG9______TN" voltageLevelId1="_NG9______VL" bus2="_N4011____TN" connectableBus2="_N4011____TN" voltageLevelId2="_N4011____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_N1011___-N4011___-1_PT" name="N1011   -N4011   -1" r="0.0" x="12.799967765808105" g="0.0" b="0.0" ratedU1="130.0" ratedU2="421.0400085449219" bus1="_N1011____TN" connectableBus1="_N1011____TN" voltageLevelId1="_N1011____VL" bus2="_N4011____TN" connectableBus2="_N4011____TN" voltageLevelId2="_N4011____VL">
+        <iidm:twoWindingsTransformer id="_N1011___-N4011___-1_PT" name="N1011   -N4011   -1" r="0.0" x="11.55266272189349" g="0.0" b="0.0" ratedU1="130.0" ratedU2="421.0400085449219" bus1="_N1011____TN" connectableBus1="_N1011____TN" voltageLevelId1="_N1011____VL" bus2="_N4011____TN" connectableBus2="_N4011____TN" voltageLevelId2="_N4011____VL">
             <iidm:currentLimits1 permanentLimit="4441.16015625"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -62,11 +62,11 @@
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="4441.16015625"/>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_NG10____-N4012___-1_PT" name="NG10    -N4012   -1" r="0.0" x="30.00002670288086" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG10_____TN" connectableBus1="_NG10_____TN" voltageLevelId1="_NG10_____VL" bus2="_N4012____TN" connectableBus2="_N4012____TN" voltageLevelId2="_N4012____VL">
+        <iidm:twoWindingsTransformer id="_NG10____-N4012___-1_PT" name="NG10    -N4012   -1" r="0.0" x="33.07370666666666" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG10_____TN" connectableBus1="_NG10_____TN" voltageLevelId1="_NG10_____VL" bus2="_N4012____TN" connectableBus2="_N4012____TN" voltageLevelId2="_N4012____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_N1012___-N4012___-1_PT" name="N1012   -N4012   -1" r="0.0" x="12.799967765808105" g="0.0" b="0.0" ratedU1="130.0" ratedU2="421.0400085449219" bus1="_N1012____TN" connectableBus1="_N1012____TN" voltageLevelId1="_N1012____VL" bus2="_N4012____TN" connectableBus2="_N4012____TN" voltageLevelId2="_N4012____VL">
+        <iidm:twoWindingsTransformer id="_N1012___-N4012___-1_PT" name="N1012   -N4012   -1" r="0.0" x="11.55266272189349" g="0.0" b="0.0" ratedU1="130.0" ratedU2="421.0400085449219" bus1="_N1012____TN" connectableBus1="_N1012____TN" voltageLevelId1="_N1012____VL" bus2="_N4012____TN" connectableBus2="_N4012____TN" voltageLevelId2="_N4012____VL">
             <iidm:currentLimits1 permanentLimit="4441.16015625"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -92,11 +92,11 @@
             <iidm:load id="_N1022____EC" name="N1022   " loadType="UNDEFINED" p0="280.0" q0="95.0" bus="_N1022____TN" connectableBus="_N1022____TN" p="280.0" q="95.0"/>
             <iidm:shunt id="_N1022____SC" name="N1022   " bPerSection="0.002958579920232296" maximumSectionCount="1" currentSectionCount="1" bus="_N1022____TN" connectableBus="_N1022____TN"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG5_____-N1022___-1_PT" name="NG5     -N1022   -1" r="0.0" x="10.140029907226562" g="0.0" b="0.0" ratedU1="15.0" ratedU2="123.81199645996094" bus1="_NG5______TN" connectableBus1="_NG5______TN" voltageLevelId1="_NG5______VL" bus2="_N1022____TN" connectableBus2="_N1022____TN" voltageLevelId2="_N1022____VL">
+        <iidm:twoWindingsTransformer id="_NG5_____-N1022___-1_PT" name="NG5     -N1022   -1" r="0.0" x="11.17893688888889" g="0.0" b="0.0" ratedU1="15.0" ratedU2="123.81199645996094" bus1="_NG5______TN" connectableBus1="_NG5______TN" voltageLevelId1="_NG5______VL" bus2="_N1022____TN" connectableBus2="_N1022____TN" voltageLevelId2="_N1022____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="4441.16015625"/>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_N1022___-N4022___-1_PT" name="N1022   -N4022   -1" r="0.0" x="19.200050354003906" g="0.0" b="0.0" ratedU1="130.0" ratedU2="430.1199951171875" bus1="_N1022____TN" connectableBus1="_N1022____TN" voltageLevelId1="_N1022____VL" bus2="_N4022____TN" connectableBus2="_N4022____TN" voltageLevelId2="_N4022____VL">
+        <iidm:twoWindingsTransformer id="_N1022___-N4022___-1_PT" name="N1022   -N4022   -1" r="0.0" x="16.605159763313612" g="0.0" b="0.0" ratedU1="130.0" ratedU2="430.1199951171875" bus1="_N1022____TN" connectableBus1="_N1022____TN" voltageLevelId1="_N1022____VL" bus2="_N4022____TN" connectableBus2="_N4022____TN" voltageLevelId2="_N4022____VL">
             <iidm:currentLimits1 permanentLimit="4441.16015625"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -123,11 +123,11 @@
             <iidm:load id="_N1044____EC" name="N1044   " loadType="UNDEFINED" p0="840.0" q0="300.0" bus="_N1044____TN" connectableBus="_N1044____TN" p="840.0" q="300.0"/>
             <iidm:shunt id="_N1044____SC" name="N1044   " bPerSection="0.011834300123155117" maximumSectionCount="1" currentSectionCount="1" bus="_N1044____TN" connectableBus="_N1044____TN"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_N1044___-N4044___-1_PT" name="N1044   -N4044   -1" r="0.0" x="15.999960899353027" g="0.0" b="0.0" ratedU1="130.0" ratedU2="388.3599853515625" bus1="_N1044____TN" connectableBus1="_N1044____TN" voltageLevelId1="_N1044____VL" bus2="_N4044____TN" connectableBus2="_N4044____TN" voltageLevelId2="_N4044____VL">
+        <iidm:twoWindingsTransformer id="_N1044___-N4044___-1_PT" name="N1044   -N4044   -1" r="0.0" x="16.973443786982244" g="0.0" b="0.0" ratedU1="130.0" ratedU2="388.3599853515625" bus1="_N1044____TN" connectableBus1="_N1044____TN" voltageLevelId1="_N1044____VL" bus2="_N4044____TN" connectableBus2="_N4044____TN" voltageLevelId2="_N4044____VL">
             <iidm:currentLimits1 permanentLimit="4441.16015625"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_N1044___-N4044___-2_PT" name="N1044   -N4044   -2" r="0.0" x="15.999960899353027" g="0.0" b="0.0" ratedU1="130.0" ratedU2="388.3599853515625" bus1="_N1044____TN" connectableBus1="_N1044____TN" voltageLevelId1="_N1044____VL" bus2="_N4044____TN" connectableBus2="_N4044____TN" voltageLevelId2="_N4044____VL">
+        <iidm:twoWindingsTransformer id="_N1044___-N4044___-2_PT" name="N1044   -N4044   -2" r="0.0" x="16.973443786982244" g="0.0" b="0.0" ratedU1="130.0" ratedU2="388.3599853515625" bus1="_N1044____TN" connectableBus1="_N1044____TN" voltageLevelId1="_N1044____VL" bus2="_N4044____TN" connectableBus2="_N4044____TN" voltageLevelId2="_N4044____VL">
             <iidm:currentLimits1 permanentLimit="4441.16015625"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -145,11 +145,11 @@
             <iidm:load id="_N1045____EC" name="N1045   " loadType="UNDEFINED" p0="720.0" q0="230.0" bus="_N1045____TN" connectableBus="_N1045____TN" p="720.0" q="230.0"/>
             <iidm:shunt id="_N1045____SC" name="N1045   " bPerSection="0.011834300123155117" maximumSectionCount="1" currentSectionCount="1" bus="_N1045____TN" connectableBus="_N1045____TN"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_N1045___-N4045___-1_PT" name="N1045   -N4045   -1" r="0.0" x="15.999998092651367" g="0.0" b="0.0" ratedU1="130.0" ratedU2="384.6000061035156" bus1="_N1045____TN" connectableBus1="_N1045____TN" voltageLevelId1="_N1045____VL" bus2="_N4045____TN" connectableBus2="_N4045____TN" voltageLevelId2="_N4045____VL">
+        <iidm:twoWindingsTransformer id="_N1045___-N4045___-1_PT" name="N1045   -N4045   -1" r="0.0" x="17.30698224852071" g="0.0" b="0.0" ratedU1="130.0" ratedU2="384.6000061035156" bus1="_N1045____TN" connectableBus1="_N1045____TN" voltageLevelId1="_N1045____VL" bus2="_N4045____TN" connectableBus2="_N4045____TN" voltageLevelId2="_N4045____VL">
             <iidm:currentLimits1 permanentLimit="4441.16015625"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_N1045___-N4045___-2_PT" name="N1045   -N4045   -2" r="0.0" x="15.999998092651367" g="0.0" b="0.0" ratedU1="130.0" ratedU2="384.6000061035156" bus1="_N1045____TN" connectableBus1="_N1045____TN" voltageLevelId1="_N1045____VL" bus2="_N4045____TN" connectableBus2="_N4045____TN" voltageLevelId2="_N4045____VL">
+        <iidm:twoWindingsTransformer id="_N1045___-N4045___-2_PT" name="N1045   -N4045   -2" r="0.0" x="17.30698224852071" g="0.0" b="0.0" ratedU1="130.0" ratedU2="384.6000061035156" bus1="_N1045____TN" connectableBus1="_N1045____TN" voltageLevelId1="_N1045____VL" bus2="_N4045____TN" connectableBus2="_N4045____TN" voltageLevelId2="_N4045____VL">
             <iidm:currentLimits1 permanentLimit="4441.16015625"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -174,7 +174,7 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_N2031____EC" name="N2031   " loadType="UNDEFINED" p0="100.0" q0="30.0" bus="_N2031____TN" connectableBus="_N2031____TN" p="100.0" q="30.0"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG12____-N4031___-1_PT" name="NG12    -N4031   -1" r="0.0" x="68.5757827758789" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG12_____TN" connectableBus1="_NG12_____TN" voltageLevelId1="_NG12_____VL" bus2="_N4031____TN" connectableBus2="_N4031____TN" voltageLevelId2="_N4031____VL">
+        <iidm:twoWindingsTransformer id="_NG12____-N4031___-1_PT" name="NG12    -N4031   -1" r="0.0" x="75.60177777777777" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG12_____TN" connectableBus1="_NG12_____TN" voltageLevelId1="_NG12_____VL" bus2="_N4031____TN" connectableBus2="_N4031____TN" voltageLevelId2="_N4031____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -230,7 +230,7 @@
                 <iidm:bus id="_N4021____TN" v="359.85101318359375" angle="-38.514652252197266"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG11____-N4021___-1_PT" name="NG11    -N4021   -1" r="0.0" x="79.99981689453125" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG11_____TN" connectableBus1="_NG11_____TN" voltageLevelId1="_NG11_____VL" bus2="_N4021____TN" connectableBus2="_N4021____TN" voltageLevelId2="_N4021____VL">
+        <iidm:twoWindingsTransformer id="_NG11____-N4021___-1_PT" name="NG11    -N4021   -1" r="0.0" x="88.19626666666666" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG11_____TN" connectableBus1="_NG11_____TN" voltageLevelId1="_NG11_____VL" bus2="_N4021____TN" connectableBus2="_N4021____TN" voltageLevelId2="_N4021____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -251,7 +251,7 @@
             <iidm:load id="_N4041____EC" name="N4041   " loadType="UNDEFINED" p0="540.0" q0="160.0" bus="_N4041____TN" connectableBus="_N4041____TN" p="540.0" q="160.0"/>
             <iidm:shunt id="_N4041____SC" name="N4041   " bPerSection="0.0012499999720603228" maximumSectionCount="1" currentSectionCount="1" bus="_N4041____TN" connectableBus="_N4041____TN"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG13____-N4041___-1_PT" name="NG13    -N4041   -1" r="0.0" x="53.327980041503906" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG13_____TN" connectableBus1="_NG13_____TN" voltageLevelId1="_NG13_____VL" bus2="_N4041____TN" connectableBus2="_N4041____TN" voltageLevelId2="_N4041____VL">
+        <iidm:twoWindingsTransformer id="_NG13____-N4041___-1_PT" name="NG13    -N4041   -1" r="0.0" x="58.791751111111104" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG13_____TN" connectableBus1="_NG13_____TN" voltageLevelId1="_NG13_____VL" bus2="_N4041____TN" connectableBus2="_N4041____TN" voltageLevelId2="_N4041____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -271,7 +271,7 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_N4042____EC" name="N4042   " loadType="UNDEFINED" p0="400.0" q0="149.39999389648438" bus="_N4042____TN" connectableBus="_N4042____TN" p="400.0" q="149.39999389648438"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG14____-N4042___-1_PT" name="NG14    -N4042   -1" r="0.0" x="34.288021087646484" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG14_____TN" connectableBus1="_NG14_____TN" voltageLevelId1="_NG14_____VL" bus2="_N4042____TN" connectableBus2="_N4042____TN" voltageLevelId2="_N4042____VL">
+        <iidm:twoWindingsTransformer id="_NG14____-N4042___-1_PT" name="NG14    -N4042   -1" r="0.0" x="37.80103111111111" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG14_____TN" connectableBus1="_NG14_____TN" voltageLevelId1="_NG14_____VL" bus2="_N4042____TN" connectableBus2="_N4042____TN" voltageLevelId2="_N4042____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -291,7 +291,7 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_N4047____EC" name="N4047   " loadType="UNDEFINED" p0="100.0" q0="50.0" bus="_N4047____TN" connectableBus="_N4047____TN" p="100.0" q="50.0"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG15____-N4047___-1_PT" name="NG15    -N4047   -1" r="0.0" x="20.000019073486328" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG15_____TN" connectableBus1="_NG15_____TN" voltageLevelId1="_NG15_____VL" bus2="_N4047____TN" connectableBus2="_N4047____TN" voltageLevelId2="_N4047____VL">
+        <iidm:twoWindingsTransformer id="_NG15____-N4047___-1_PT" name="NG15    -N4047   -1" r="0.0" x="22.049137777777773" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG15_____TN" connectableBus1="_NG15_____TN" voltageLevelId1="_NG15_____VL" bus2="_N4047____TN" connectableBus2="_N4047____TN" voltageLevelId2="_N4047____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -312,7 +312,7 @@
             <iidm:load id="_N4051____EC" name="N4051   " loadType="UNDEFINED" p0="800.0" q0="302.3999938964844" bus="_N4051____TN" connectableBus="_N4051____TN" p="800.0" q="302.3999938964844"/>
             <iidm:shunt id="_N4051____SC" name="N4051   " bPerSection="6.249999860301614E-4" maximumSectionCount="1" currentSectionCount="1" bus="_N4051____TN" connectableBus="_N4051____TN"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG16____-N4051___-1_PT" name="NG16    -N4051   -1" r="0.0" x="34.288021087646484" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG16_____TN" connectableBus1="_NG16_____TN" voltageLevelId1="_NG16_____VL" bus2="_N4051____TN" connectableBus2="_N4051____TN" voltageLevelId2="_N4051____VL">
+        <iidm:twoWindingsTransformer id="_NG16____-N4051___-1_PT" name="NG16    -N4051   -1" r="0.0" x="37.80103111111111" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG16_____TN" connectableBus1="_NG16_____TN" voltageLevelId1="_NG16_____VL" bus2="_N4051____TN" connectableBus2="_N4051____TN" voltageLevelId2="_N4051____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -332,7 +332,7 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_N4062____EC" name="N4062   " loadType="UNDEFINED" p0="300.0" q0="100.0" bus="_N4062____TN" connectableBus="_N4062____TN" p="300.0" q="100.0"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG17____-N4062___-1_PT" name="NG17    -N4062   -1" r="0.0" x="39.99997329711914" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG17_____TN" connectableBus1="_NG17_____TN" voltageLevelId1="_NG17_____VL" bus2="_N4062____TN" connectableBus2="_N4062____TN" voltageLevelId2="_N4062____VL">
+        <iidm:twoWindingsTransformer id="_NG17____-N4062___-1_PT" name="NG17    -N4062   -1" r="0.0" x="44.09820444444444" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG17_____TN" connectableBus1="_NG17_____TN" voltageLevelId1="_NG17_____VL" bus2="_N4062____TN" connectableBus2="_N4062____TN" voltageLevelId2="_N4062____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -352,7 +352,7 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_N4063____EC" name="N4063   " loadType="UNDEFINED" p0="590.0" q0="300.0" bus="_N4063____TN" connectableBus="_N4063____TN" p="590.0" q="300.0"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG18____-N4063___-1_PT" name="NG18    -N4063   -1" r="0.0" x="20.000019073486328" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG18_____TN" connectableBus1="_NG18_____TN" voltageLevelId1="_NG18_____VL" bus2="_N4063____TN" connectableBus2="_N4063____TN" voltageLevelId2="_N4063____VL">
+        <iidm:twoWindingsTransformer id="_NG18____-N4063___-1_PT" name="NG18    -N4063   -1" r="0.0" x="22.049137777777773" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG18_____TN" connectableBus1="_NG18_____TN" voltageLevelId1="_NG18_____VL" bus2="_N4063____TN" connectableBus2="_N4063____TN" voltageLevelId2="_N4063____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -373,7 +373,7 @@
             <iidm:load id="_N4071____EC" name="N4071   " loadType="UNDEFINED" p0="300.0" q0="100.0" bus="_N4071____TN" connectableBus="_N4071____TN" p="300.0" q="100.0"/>
             <iidm:shunt id="_N4071____SC" name="N4071   " bPerSection="-0.0024999999441206455" maximumSectionCount="1" currentSectionCount="1" bus="_N4071____TN" connectableBus="_N4071____TN"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG19____-N4071___-1_PT" name="NG19    -N4071   -1" r="0.0" x="48.00001907348633" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG19_____TN" connectableBus1="_NG19_____TN" voltageLevelId1="_NG19_____VL" bus2="_N4071____TN" connectableBus2="_N4071____TN" voltageLevelId2="_N4071____VL">
+        <iidm:twoWindingsTransformer id="_NG19____-N4071___-1_PT" name="NG19    -N4071   -1" r="0.0" x="52.91790222222222" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG19_____TN" connectableBus1="_NG19_____TN" voltageLevelId1="_NG19_____VL" bus2="_N4071____TN" connectableBus2="_N4071____TN" voltageLevelId2="_N4071____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -393,7 +393,7 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_N4072____EC" name="N4072   " loadType="UNDEFINED" p0="2000.0" q0="500.0" bus="_N4072____TN" connectableBus="_N4072____TN" p="2000.0" q="500.0"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG20____-N4072___-1_PT" name="NG20    -N4072   -1" r="0.0" x="5.327999591827393" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG20_____TN" connectableBus1="_NG20_____TN" voltageLevelId1="_NG20_____VL" bus2="_N4072____TN" connectableBus2="_N4072____TN" voltageLevelId2="_N4072____VL">
+        <iidm:twoWindingsTransformer id="_NG20____-N4072___-1_PT" name="NG20    -N4072   -1" r="0.0" x="5.873884444444444" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG20_____TN" connectableBus1="_NG20_____TN" voltageLevelId1="_NG20_____VL" bus2="_N4072____TN" connectableBus2="_N4072____TN" voltageLevelId2="_N4072____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="1443.3800048828125"/>
         </iidm:twoWindingsTransformer>
@@ -471,7 +471,7 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_N1042____EC" name="N1042   " loadType="UNDEFINED" p0="330.0" q0="90.0" bus="_N1042____TN" connectableBus="_N1042____TN" p="330.0" q="90.0"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG6_____-N1042___-1_PT" name="NG6     -N1042   -1" r="0.0" x="6.337498664855957" g="0.0" b="0.0" ratedU1="15.0" ratedU2="123.81199645996094" bus1="_NG6______TN" connectableBus1="_NG6______TN" voltageLevelId1="_NG6______VL" bus2="_N1042____TN" connectableBus2="_N1042____TN" voltageLevelId2="_N1042____VL">
+        <iidm:twoWindingsTransformer id="_NG6_____-N1042___-1_PT" name="NG6     -N1042   -1" r="0.0" x="6.986813022222223" g="0.0" b="0.0" ratedU1="15.0" ratedU2="123.81199645996094" bus1="_NG6______TN" connectableBus1="_NG6______TN" voltageLevelId1="_NG6______VL" bus2="_N1042____TN" connectableBus2="_N1042____TN" voltageLevelId2="_N1042____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="4441.16015625"/>
         </iidm:twoWindingsTransformer>
@@ -492,7 +492,7 @@
             <iidm:load id="_N1043____EC" name="N1043   " loadType="UNDEFINED" p0="260.0" q0="100.0" bus="_N1043____TN" connectableBus="_N1043____TN" p="260.0" q="100.0"/>
             <iidm:shunt id="_N1043____SC" name="N1043   " bPerSection="0.008875739760696888" maximumSectionCount="1" currentSectionCount="1" bus="_N1043____TN" connectableBus="_N1043____TN"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG7_____-N1043___-1_PT" name="NG7     -N1043   -1" r="0.0" x="12.674969673156738" g="0.0" b="0.0" ratedU1="15.0" ratedU2="123.81199645996094" bus1="_NG7______TN" connectableBus1="_NG7______TN" voltageLevelId1="_NG7______VL" bus2="_N1043____TN" connectableBus2="_N1043____TN" voltageLevelId2="_N1043____VL">
+        <iidm:twoWindingsTransformer id="_NG7_____-N1043___-1_PT" name="NG7     -N1043   -1" r="0.0" x="13.973596000000002" g="0.0" b="0.0" ratedU1="15.0" ratedU2="123.81199645996094" bus1="_NG7______TN" connectableBus1="_NG7______TN" voltageLevelId1="_NG7______VL" bus2="_N1043____TN" connectableBus2="_N1043____TN" voltageLevelId2="_N1043____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="4441.16015625"/>
         </iidm:twoWindingsTransformer>
@@ -512,7 +512,7 @@
             </iidm:busBreakerTopology>
             <iidm:load id="_N2032____EC" name="N2032   " loadType="UNDEFINED" p0="200.0" q0="50.0" bus="_N2032____TN" connectableBus="_N2032____TN" p="200.0" q="50.0"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_NG8_____-N2032___-1_PT" name="NG8     -N2032   -1" r="0.0" x="8.542604446411133" g="0.0" b="0.0" ratedU1="15.0" ratedU2="209.5279998779297" bus1="_NG8______TN" connectableBus1="_NG8______TN" voltageLevelId1="_NG8______VL" bus2="_N2032____TN" connectableBus2="_N2032____TN" voltageLevelId2="_N2032____VL">
+        <iidm:twoWindingsTransformer id="_NG8_____-N2032___-1_PT" name="NG8     -N2032   -1" r="0.0" x="9.41784408888889" g="0.0" b="0.0" ratedU1="15.0" ratedU2="209.5279998779297" bus1="_NG8______TN" connectableBus1="_NG8______TN" voltageLevelId1="_NG8______VL" bus2="_N2032____TN" connectableBus2="_N2032____TN" voltageLevelId2="_N2032____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
             <iidm:currentLimits2 permanentLimit="2624.320068359375"/>
         </iidm:twoWindingsTransformer>

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
@@ -203,25 +203,23 @@ public class BranchData {
     private double getR(TwoWindingsTransformer twt) {
         double endVoltageRatio = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
         double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
-        return getValue(twt.getR(),
+        return getValue(twt.getR() / endVoltageRatioSquare,
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getR() : 0,
-                        twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getR() : 0) /
-                endVoltageRatioSquare;
+                        twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getR() : 0);
     }
 
     private double getX(TwoWindingsTransformer twt) {
         double endVoltageRatio = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
         double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
-        return getValue(twt.getX(),
+        return getValue(twt.getX() / endVoltageRatioSquare,
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getX() : 0,
-                        twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getX() : 0) /
-                endVoltageRatioSquare;
+                        twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getX() : 0);
     }
 
     private double getG1(TwoWindingsTransformer twt, boolean specificCompatibility) {
         double endVoltageRatio = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
         double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
-        return endVoltageRatioSquare * getValue(specificCompatibility ? twt.getG() / 2 : twt.getG(),
+        return getValue(specificCompatibility ? endVoltageRatioSquare * twt.getG() / 2 : twt.getG(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getG() : 0,
                         twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getG() : 0);
     }
@@ -229,7 +227,7 @@ public class BranchData {
     private double getB1(TwoWindingsTransformer twt, boolean specificCompatibility) {
         double endVoltageRatio = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
         double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
-        return endVoltageRatioSquare * getValue(specificCompatibility ? twt.getB() / 2 : twt.getB(),
+        return getValue(specificCompatibility ? endVoltageRatioSquare * twt.getB() / 2 : twt.getB(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getB() : 0,
                         twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getB() : 0);
     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
@@ -151,6 +151,9 @@ public class BranchData {
 
         id = twt.getId();
 
+        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double rfixSquare = rfix * rfix;
+
         Bus bus1 = twt.getTerminal1().getBusView().getBus();
         Bus bus2 = twt.getTerminal2().getBusView().getBus();
         Bus connectableBus1 = twt.getTerminal1().getBusView().getConnectableBus();
@@ -163,7 +166,7 @@ public class BranchData {
         y = 1 / z;
         ksi = Math.atan2(r, fixedX);
         rho1 = getRho1(twt);
-        rho2 = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        rho2 = 1f;
         u1 = bus1 != null ? bus1.getV() : Double.NaN;
         u2 = bus2 != null ? bus2.getV() : Double.NaN;
         theta1 = bus1 != null ? Math.toRadians(bus1.getAngle()) : Double.NaN;
@@ -171,9 +174,9 @@ public class BranchData {
         alpha1 = twt.getPhaseTapChanger() != null ? Math.toRadians(twt.getPhaseTapChanger().getCurrentStep().getAlpha()) : 0f;
         alpha2 = 0f;
         g1 = getG1(twt, specificCompatibility);
-        g2 = specificCompatibility ? twt.getG() / 2 : 0f;
+        g2 = specificCompatibility ? (twt.getG() / 2) * rfixSquare : 0f;
         b1 = getB1(twt, specificCompatibility);
-        b2 = specificCompatibility ? twt.getB() / 2 : 0f;
+        b2 = specificCompatibility ? (twt.getB() / 2) * rfixSquare : 0f;
         p1 = twt.getTerminal1().getP();
         q1 = twt.getTerminal1().getQ();
         p2 = twt.getTerminal2().getP();
@@ -198,31 +201,41 @@ public class BranchData {
     }
 
     private double getR(TwoWindingsTransformer twt) {
+        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double rfixSquare = rfix * rfix;
         return getValue(twt.getR(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getR() : 0,
-                        twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getR() : 0);
+                        twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getR() : 0) /
+                rfixSquare;
     }
 
     private double getX(TwoWindingsTransformer twt) {
+        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double rfixSquare = rfix * rfix;
         return getValue(twt.getX(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getX() : 0,
-                        twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getX() : 0);
+                        twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getX() : 0) /
+                rfixSquare;
     }
 
     private double getG1(TwoWindingsTransformer twt, boolean specificCompatibility) {
-        return getValue(specificCompatibility ? twt.getG() / 2 : twt.getG(),
+        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double rfixSquare = rfix * rfix;
+        return rfixSquare * getValue(specificCompatibility ? twt.getG() / 2 : twt.getG(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getG() : 0,
                         twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getG() : 0);
     }
 
     private double getB1(TwoWindingsTransformer twt, boolean specificCompatibility) {
-        return getValue(specificCompatibility ? twt.getB() / 2 : twt.getB(),
+        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double rfixSquare = rfix * rfix;
+        return rfixSquare * getValue(specificCompatibility ? twt.getB() / 2 : twt.getB(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getB() : 0,
                         twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getB() : 0);
     }
 
     private double getRho1(TwoWindingsTransformer twt) {
-        double rho = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU1();
+        double rho = twt.getRatedU2() / twt.getRatedU1();
         if (twt.getRatioTapChanger() != null) {
             rho *= twt.getRatioTapChanger().getCurrentStep().getRho();
         }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
@@ -151,8 +151,8 @@ public class BranchData {
 
         id = twt.getId();
 
-        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
-        double rfixSquare = rfix * rfix;
+        double endVoltageRatio = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
 
         Bus bus1 = twt.getTerminal1().getBusView().getBus();
         Bus bus2 = twt.getTerminal2().getBusView().getBus();
@@ -174,9 +174,9 @@ public class BranchData {
         alpha1 = twt.getPhaseTapChanger() != null ? Math.toRadians(twt.getPhaseTapChanger().getCurrentStep().getAlpha()) : 0f;
         alpha2 = 0f;
         g1 = getG1(twt, specificCompatibility);
-        g2 = specificCompatibility ? (twt.getG() / 2) * rfixSquare : 0f;
+        g2 = specificCompatibility ? (twt.getG() / 2) * endVoltageRatioSquare : 0f;
         b1 = getB1(twt, specificCompatibility);
-        b2 = specificCompatibility ? (twt.getB() / 2) * rfixSquare : 0f;
+        b2 = specificCompatibility ? (twt.getB() / 2) * endVoltageRatioSquare : 0f;
         p1 = twt.getTerminal1().getP();
         q1 = twt.getTerminal1().getQ();
         p2 = twt.getTerminal2().getP();
@@ -201,35 +201,35 @@ public class BranchData {
     }
 
     private double getR(TwoWindingsTransformer twt) {
-        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
-        double rfixSquare = rfix * rfix;
+        double endVoltageRatio = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
         return getValue(twt.getR(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getR() : 0,
                         twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getR() : 0) /
-                rfixSquare;
+                endVoltageRatioSquare;
     }
 
     private double getX(TwoWindingsTransformer twt) {
-        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
-        double rfixSquare = rfix * rfix;
+        double endVoltageRatio = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
         return getValue(twt.getX(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getX() : 0,
                         twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getX() : 0) /
-                rfixSquare;
+                endVoltageRatioSquare;
     }
 
     private double getG1(TwoWindingsTransformer twt, boolean specificCompatibility) {
-        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
-        double rfixSquare = rfix * rfix;
-        return rfixSquare * getValue(specificCompatibility ? twt.getG() / 2 : twt.getG(),
+        double endVoltageRatio = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
+        return endVoltageRatioSquare * getValue(specificCompatibility ? twt.getG() / 2 : twt.getG(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getG() : 0,
                         twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getG() : 0);
     }
 
     private double getB1(TwoWindingsTransformer twt, boolean specificCompatibility) {
-        double rfix = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
-        double rfixSquare = rfix * rfix;
-        return rfixSquare * getValue(specificCompatibility ? twt.getB() / 2 : twt.getB(),
+        double endVoltageRatio = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
+        double endVoltageRatioSquare = endVoltageRatio * endVoltageRatio;
+        return endVoltageRatioSquare * getValue(specificCompatibility ? twt.getB() / 2 : twt.getB(),
                         twt.getRatioTapChanger() != null ? twt.getRatioTapChanger().getCurrentStep().getB() : 0,
                         twt.getPhaseTapChanger() != null ? twt.getPhaseTapChanger().getCurrentStep().getB() : 0);
     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/BranchData.java
@@ -163,7 +163,7 @@ public class BranchData {
         y = 1 / z;
         ksi = Math.atan2(r, fixedX);
         rho1 = getRho1(twt);
-        rho2 = 1f;
+        rho2 = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU2();
         u1 = bus1 != null ? bus1.getV() : Double.NaN;
         u2 = bus2 != null ? bus2.getV() : Double.NaN;
         theta1 = bus1 != null ? Math.toRadians(bus1.getAngle()) : Double.NaN;
@@ -222,7 +222,7 @@ public class BranchData {
     }
 
     private double getRho1(TwoWindingsTransformer twt) {
-        double rho = twt.getRatedU2() / twt.getRatedU1();
+        double rho = twt.getTerminal2().getVoltageLevel().getNominalV() / twt.getRatedU1();
         if (twt.getRatioTapChanger() != null) {
             rho *= twt.getRatioTapChanger().getCurrentStep().getRho();
         }

--- a/loadflow/loadflow-results-completion/src/test/java/com/powsybl/loadflow/resultscompletion/AbstractLoadFlowResultsCompletionTest.java
+++ b/loadflow/loadflow-results-completion/src/test/java/com/powsybl/loadflow/resultscompletion/AbstractLoadFlowResultsCompletionTest.java
@@ -138,6 +138,9 @@ public abstract class AbstractLoadFlowResultsCompletionTest {
         Mockito.when(twtBusView2.getBus()).thenReturn(twtBus2);
         Mockito.when(twtBus2.getLineStream()).thenAnswer(dummy -> Stream.empty());
 
+        VoltageLevel vl2 = Mockito.mock(VoltageLevel.class);
+        Mockito.when(vl2.getNominalV()).thenReturn(380.0);
+
         twtTerminal1 = Mockito.mock(Terminal.class);
         Mockito.when(twtTerminal1.isConnected()).thenReturn(true);
         Mockito.when(twtTerminal1.getP()).thenReturn(twtP1);
@@ -149,6 +152,7 @@ public abstract class AbstractLoadFlowResultsCompletionTest {
         Mockito.when(twtTerminal2.getP()).thenReturn(twtP2);
         Mockito.when(twtTerminal2.getQ()).thenReturn(twtQ2);
         Mockito.when(twtTerminal2.getBusView()).thenReturn(twtBusView2);
+        Mockito.when(twtTerminal2.getVoltageLevel()).thenReturn(vl2);
 
         RatioTapChangerStep step = Mockito.mock(RatioTapChangerStep.class);
         Mockito.when(step.getR()).thenReturn(0.0);

--- a/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/FlowsValidationTest.java
+++ b/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/FlowsValidationTest.java
@@ -85,6 +85,9 @@ public class FlowsValidationTest extends AbstractValidationTest {
         BusView busView2 = Mockito.mock(BusView.class);
         Mockito.when(busView2.getBus()).thenReturn(bus2);
 
+        VoltageLevel vl2 = Mockito.mock(VoltageLevel.class);
+        Mockito.when(vl2.getNominalV()).thenReturn(20.0);
+
         terminal1 = Mockito.mock(Terminal.class);
         Mockito.when(terminal1.getP()).thenReturn(p1);
         Mockito.when(terminal1.getQ()).thenReturn(q1);
@@ -94,6 +97,7 @@ public class FlowsValidationTest extends AbstractValidationTest {
         Mockito.when(terminal2.getP()).thenReturn(p2);
         Mockito.when(terminal2.getQ()).thenReturn(q2);
         Mockito.when(terminal2.getBusView()).thenReturn(busView2);
+        Mockito.when(terminal2.getVoltageLevel()).thenReturn(vl2);
 
         line1 = Mockito.mock(Line.class);
         Mockito.when(line1.getId()).thenReturn("line1");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)**
CGMES import considers that IIDM convention for r, x, b and g is that these attributes are manufacturer data. 

**What is the new behavior (if this is a feature change)?**
CGMES import considers that IIDM convention for r, x, b and g is that these attributes are relative to ratio between the transformer's ends' voltage levels' nominal voltages and rated voltages of the transformer.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:
This IIDM convention may change in the future.
(if any of the questions/checkboxes don't apply, please delete them entirely)
