### PR TITLE
fix travis build: The job exceeded the maximum log length, and has be…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ install: true
 # When travis starts using maven > 3.6.1, add -T 2.0C to hopefully speed things up.
 # With maven 3.5.2 we can't because we get the exception described in https://issues.apache.org/jira/browse/MNG-6590
 script:
-- mvn clean verify -Pjacoco coveralls:report
-- if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_JDK_VERSION" = "oraclejdk8" -a "$TRAVIS_EVENT_TYPE" = "pull_request" -a "$TRAVIS_SECURE_ENV_VARS"  = "true" ]; then mvn sonar:sonar; fi
+- mvn -B clean verify -Pjacoco coveralls:report
+- if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_JDK_VERSION" = "oraclejdk8" -a "$TRAVIS_EVENT_TYPE" = "pull_request" -a "$TRAVIS_SECURE_ENV_VARS"  = "true" ]; then mvn -B sonar:sonar; fi
 
 before_cache:
 - rm -rf $HOME/.m2/repository/com/powsybl


### PR DESCRIPTION
…en terminated.

The log is filled with "Progress (5): 1.5/2.1 MB | 0.5/1.2 MB | 96/318 kB | 40/187 kB | 0.3/2.0 MB"

This is because we turned off the default install of travis in 44a04084da7ca, which used -B (= --batch-mode) which disabled these logs

Signed-off-by: Jon Harper <jon.harper87@gmail.com>


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
All travis builds are in error


**What is the new behavior (if this is a feature change)?**
Fix travis builds


