### PR TITLE
Add methods to retrieve the HVDCLine from the converter stations

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/HvdcConverterStation.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/HvdcConverterStation.java
@@ -24,6 +24,14 @@ public interface HvdcConverterStation<T extends HvdcConverterStation<T>> extends
     }
 
     /**
+     * Return the HVDC line attached to this station.
+     * @return the HVDC line attached to this station or null.
+     */
+    default HvdcLine getHvdcLine() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Get HVDC type.
      * @return HVDC type
      */

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/HvdcLine.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/HvdcLine.java
@@ -100,6 +100,14 @@ public interface HvdcLine extends Identifiable<HvdcLine> {
     HvdcLine setMaxP(double maxP);
 
     /**
+     * Get the HVDC converter station connected to a side
+     * @return the HVDC converter station connected to the side
+     */
+    default HvdcConverterStation<?> getConverterStation(Side side) {
+        return (side == Side.ONE) ? getConverterStation1() : getConverterStation2();
+    }
+
+    /**
      * Get the HVDC converter station connected on side 1.
      * @return the HVDC converter station connected on side 1
      */

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/HvdcLine.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/HvdcLine.java
@@ -15,6 +15,11 @@ package com.powsybl.iidm.network;
  */
 public interface HvdcLine extends Identifiable<HvdcLine> {
 
+    enum Side {
+        ONE,
+        TWO
+    }
+
     /**
      * Converters mode used to known the sign of the active power of the HVDC line.
      */

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractHvdcConverterStation.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractHvdcConverterStation.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.iidm.network.ConnectableType;
 import com.powsybl.iidm.network.HvdcConverterStation;
+import com.powsybl.iidm.network.HvdcLine;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -15,11 +16,24 @@ import com.powsybl.iidm.network.HvdcConverterStation;
  */
 abstract class AbstractHvdcConverterStation<T extends HvdcConverterStation<T>> extends AbstractConnectable<T> implements HvdcConverterStation<T> {
 
+    private HvdcLine hvdcLine;
+
     private float lossFactor = Float.NaN;
 
     AbstractHvdcConverterStation(String id, String name, float lossFactor) {
         super(id, name);
+        this.hvdcLine = null;
         this.lossFactor = lossFactor;
+    }
+
+    @Override
+    public HvdcLine getHvdcLine() {
+        return hvdcLine;
+    }
+
+    T setHvdcLine(HvdcLine hvdcLine) {
+        this.hvdcLine = hvdcLine;
+        return (T) this;
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractHvdcConverterStation.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractHvdcConverterStation.java
@@ -60,4 +60,12 @@ abstract class AbstractHvdcConverterStation<T extends HvdcConverterStation<T>> e
         return (T) this;
     }
 
+    @Override
+    public void remove() {
+        if (hvdcLine != null) {
+            throw new ValidationException(this, "Impossible to remove this converter station (still attached to '" + hvdcLine.getId() + "')");
+        }
+        super.remove();
+    }
+
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
@@ -53,9 +53,18 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
         this.convertersMode.fill(0, variantArraySize, convertersMode == ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER);
         this.activePowerSetpoint = new TDoubleArrayList(variantArraySize);
         this.activePowerSetpoint.fill(0, variantArraySize, activePowerSetpoint);
-        this.converterStation1 = converterStation1;
-        this.converterStation2 = converterStation2;
+        this.converterStation1 = attach(converterStation1);
+        this.converterStation2 = attach(converterStation2);
         this.networkRef = networkRef;
+    }
+
+    private AbstractHvdcConverterStation<?> attach(AbstractHvdcConverterStation<?> converterStation) {
+        converterStation.setHvdcLine(this);
+        return converterStation;
+    }
+
+    private void detach(AbstractHvdcConverterStation<?> converterStation) {
+        converterStation.setHvdcLine(null);
     }
 
     protected void notifyUpdate(String attribute, Object oldValue, Object newValue) {
@@ -191,6 +200,9 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
 
     @Override
     public void remove() {
+        detach(converterStation1);
+        detach(converterStation2);
+
         NetworkImpl network = getNetwork();
         network.getIndex().remove(this);
         network.getListeners().notifyRemoval(this);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
@@ -35,11 +35,11 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
 
     //
 
-    private final AbstractHvdcConverterStation<?> converterStation1;
-
-    private final AbstractHvdcConverterStation<?> converterStation2;
-
     private final Ref<NetworkImpl> networkRef;
+
+    private AbstractHvdcConverterStation<?> converterStation1;
+
+    private AbstractHvdcConverterStation<?> converterStation2;
 
     HvdcLineImpl(String id, String name, double r, double nominalV, double maxP, ConvertersMode convertersMode, double activePowerSetpoint,
                  AbstractHvdcConverterStation<?> converterStation1, AbstractHvdcConverterStation<?> converterStation2,
@@ -162,6 +162,11 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
     }
 
     @Override
+    public AbstractHvdcConverterStation<?> getConverterStation(Side side) {
+        return (side == Side.ONE) ? getConverterStation1() : getConverterStation2();
+    }
+
+    @Override
     public AbstractHvdcConverterStation<?> getConverterStation1() {
         return converterStation1;
     }
@@ -200,8 +205,11 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
 
     @Override
     public void remove() {
-        detach(converterStation1);
-        detach(converterStation2);
+        // Detach converter stations
+        converterStation1.setHvdcLine(null);
+        converterStation2.setHvdcLine(null);
+        converterStation1 = null;
+        converterStation2 = null;
 
         NetworkImpl network = getNetwork();
         network.getIndex().remove(this);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
@@ -63,10 +63,6 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
         return converterStation;
     }
 
-    private void detach(AbstractHvdcConverterStation<?> converterStation) {
-        converterStation.setHvdcLine(null);
-    }
-
     protected void notifyUpdate(String attribute, Object oldValue, Object newValue) {
         getNetwork().getListeners().notifyUpdate(this, attribute, oldValue, newValue);
     }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
@@ -73,13 +73,6 @@ public class LccTest {
         assertSame(hvdcLine, cs2.getHvdcLine());
         assertSame(cs1, hvdcLine.getConverterStation1());
         assertSame(cs2, hvdcLine.getConverterStation2());
-
-        // remove
-        int count = network.getLccConverterStationCount();
-        cs1.remove();
-        assertNotNull(cs1);
-        assertNull(network.getLccConverterStation("C1"));
-        assertEquals(count - 1, network.getLccConverterStationCount());
     }
 
     @Test
@@ -88,7 +81,16 @@ public class LccTest {
         assertEquals(0, network.getHvdcLineCount());
 
         assertNull(cs1.getHvdcLine());
+        assertNull(hvdcLine.getConverterStation1());
         assertNull(cs2.getHvdcLine());
+        assertNull(hvdcLine.getConverterStation2());
+
+        // remove
+        int count = network.getLccConverterStationCount();
+        cs1.remove();
+        assertNotNull(cs1);
+        assertNull(network.getLccConverterStation("C1"));
+        assertEquals(count - 1, network.getLccConverterStationCount());
     }
 
     @Test

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
@@ -79,6 +79,13 @@ public class LccTest {
 
     @Test
     public void testHvdcLineRemove() {
+        try {
+            cs1.remove();
+            fail();
+        } catch (ValidationException e) {
+            // Ignored
+        }
+
         network.getHvdcLine("L").remove();
         assertEquals(0, network.getHvdcLineCount());
 

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
@@ -72,7 +72,9 @@ public class LccTest {
         assertSame(hvdcLine, cs1.getHvdcLine());
         assertSame(hvdcLine, cs2.getHvdcLine());
         assertSame(cs1, hvdcLine.getConverterStation1());
+        assertSame(cs1, hvdcLine.getConverterStation(HvdcLine.Side.ONE));
         assertSame(cs2, hvdcLine.getConverterStation2());
+        assertSame(cs2, hvdcLine.getConverterStation(HvdcLine.Side.TWO));
     }
 
     @Test

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
@@ -27,12 +27,14 @@ public class LccTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private Network network;
+    private HvdcLine hvdcLine;
     private LccConverterStation cs1;
     private LccConverterStation cs2;
 
     @Before
     public void setUp() {
         network = HvdcTestNetwork.createLcc();
+        hvdcLine = network.getHvdcLine("L");
         cs1 = network.getLccConverterStation("C1");
         cs2 = network.getLccConverterStation("C2");
     }
@@ -67,6 +69,11 @@ public class LccTest {
         assertEquals(cs1, l.getConverterStation1());
         assertEquals(cs2, l.getConverterStation2());
 
+        assertSame(hvdcLine, cs1.getHvdcLine());
+        assertSame(hvdcLine, cs2.getHvdcLine());
+        assertSame(cs1, hvdcLine.getConverterStation1());
+        assertSame(cs2, hvdcLine.getConverterStation2());
+
         // remove
         int count = network.getLccConverterStationCount();
         cs1.remove();
@@ -79,6 +86,9 @@ public class LccTest {
     public void testHvdcLineRemove() {
         network.getHvdcLine("L").remove();
         assertEquals(0, network.getHvdcLineCount());
+
+        assertNull(cs1.getHvdcLine());
+        assertNull(cs2.getHvdcLine());
     }
 
     @Test

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VscTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VscTest.java
@@ -77,13 +77,6 @@ public class VscTest {
         assertSame(hvdcLine, cs2.getHvdcLine());
         assertSame(cs1, hvdcLine.getConverterStation1());
         assertSame(cs2, hvdcLine.getConverterStation2());
-
-        // remove
-        int count = network.getVscConverterStationCount();
-        cs1.remove();
-        assertNull(network.getVscConverterStation("C1"));
-        assertNotNull(cs1);
-        assertEquals(count - 1, network.getVscConverterStationCount());
     }
 
     @Test
@@ -93,6 +86,13 @@ public class VscTest {
 
         assertNull(cs1.getHvdcLine());
         assertNull(cs2.getHvdcLine());
+
+        // remove
+        int count = network.getVscConverterStationCount();
+        cs1.remove();
+        assertNotNull(cs1);
+        assertNull(network.getVscConverterStation("C1"));
+        assertEquals(count - 1, network.getVscConverterStationCount());
     }
 
     @Test

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VscTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VscTest.java
@@ -83,6 +83,13 @@ public class VscTest {
 
     @Test
     public void testRemove() {
+        try {
+            cs1.remove();
+            fail();
+        } catch (ValidationException e) {
+            // Ignored
+        }
+
         network.getHvdcLine("L").remove();
         assertEquals(0, network.getHvdcLineCount());
 

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VscTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VscTest.java
@@ -23,12 +23,14 @@ import static org.junit.Assert.*;
 public class VscTest {
 
     private Network network;
+    private HvdcLine hvdcLine;
     private VscConverterStation cs1;
     private VscConverterStation cs2;
 
     @Before
     public void setUp() {
         network = HvdcTestNetwork.createVsc();
+        hvdcLine = network.getHvdcLine("L");
         cs1 = network.getVscConverterStation("C1");
         cs2 = network.getVscConverterStation("C2");
     }
@@ -71,6 +73,11 @@ public class VscTest {
         assertNotEquals(l.getConverterStation1().getTerminal().getBusView().getBus().getSynchronousComponent().getNum(),
                         l.getConverterStation2().getTerminal().getBusView().getBus().getSynchronousComponent().getNum());
 
+        assertSame(hvdcLine, cs1.getHvdcLine());
+        assertSame(hvdcLine, cs2.getHvdcLine());
+        assertSame(cs1, hvdcLine.getConverterStation1());
+        assertSame(cs2, hvdcLine.getConverterStation2());
+
         // remove
         int count = network.getVscConverterStationCount();
         cs1.remove();
@@ -83,6 +90,9 @@ public class VscTest {
     public void testRemove() {
         network.getHvdcLine("L").remove();
         assertEquals(0, network.getHvdcLineCount());
+
+        assertNull(cs1.getHvdcLine());
+        assertNull(cs2.getHvdcLine());
     }
 
     @Test

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VscTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VscTest.java
@@ -76,7 +76,9 @@ public class VscTest {
         assertSame(hvdcLine, cs1.getHvdcLine());
         assertSame(hvdcLine, cs2.getHvdcLine());
         assertSame(cs1, hvdcLine.getConverterStation1());
+        assertSame(cs1, hvdcLine.getConverterStation(HvdcLine.Side.ONE));
         assertSame(cs2, hvdcLine.getConverterStation2());
+        assertSame(cs2, hvdcLine.getConverterStation(HvdcLine.Side.TWO));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
It's impossible to easily retrieve the HVDC line from the converter station


**What is the new behavior (if this is a feature change)?**
It's now possible thanks to a new getter.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
