### PR TITLE
Update powsybl-math-native version to 1.0.1 (MacOS support)

### DIFF
--- a/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
+++ b/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -31,18 +30,6 @@ public class SparseMatrixTest extends AbstractMatrixTest {
     @Override
     public MatrixFactory getOtherMatrixFactory() {
         return otherMatrixFactory;
-    }
-
-    @Override
-    public void testMultiplication() {
-        assumeTrue(SparseMatrix.NATIVE_INIT);
-        super.testMultiplication();
-    }
-
-    @Override
-    public void testDecompose() throws Exception {
-        assumeTrue(SparseMatrix.NATIVE_INIT);
-        super.testDecompose();
     }
 
     @Test
@@ -86,8 +73,6 @@ public class SparseMatrixTest extends AbstractMatrixTest {
 
     @Test
     public void testRedecompose() {
-        assumeTrue(SparseMatrix.NATIVE_INIT);
-
         Matrix matrix = getMatrixFactory().create(2, 2, 2);
         matrix.set(0, 0, 3);
         matrix.set(1, 0, 4);
@@ -114,10 +99,5 @@ public class SparseMatrixTest extends AbstractMatrixTest {
             fail();
         } catch (PowsyblException ignored) {
         }
-    }
-
-    @Test
-    public void loadLibraryTest() {
-        assertFalse(SparseMatrix.loadLibrary("foo"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <wildflyarquilliancontainerembedded.version>2.1.0.Final</wildflyarquilliancontainerembedded.version>
         <xmlunit.version>2.3.0</xmlunit.version>
 
-        <powsyblmathnative.version>1.0.0</powsyblmathnative.version>
+        <powsyblmathnative.version>1.0.1</powsyblmathnative.version>
     </properties>
 
     <build>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
MacOS is not supported by powsybl-math (SparseMatrix)


**What is the new behavior (if this is a feature change)?**
MacOS is now supported by powsybl-math (SparseMatrix) and it still work on Linux and Windows


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
