### PR TITLE
travis: restore sonar on push events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install: true
 # With maven 3.5.2 we can't because we get the exception described in https://issues.apache.org/jira/browse/MNG-6590
 script:
 - mvn -B clean verify -Pjacoco coveralls:report
-- if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_JDK_VERSION" = "oraclejdk8" -a "$TRAVIS_EVENT_TYPE" = "pull_request" -a "$TRAVIS_SECURE_ENV_VARS"  = "true" ]; then mvn -B sonar:sonar; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_JDK_VERSION" = "oraclejdk8" -a "$TRAVIS_SECURE_ENV_VARS"  = "true" ]; then mvn -B sonar:sonar; fi
 
 before_cache:
 - rm -rf $HOME/.m2/repository/com/powsybl


### PR DESCRIPTION
it is used:
- after a merge to master. This is what allows us to have badges (and the general state of master)
- in short lived branches. This is not used much because the PR view is nicer (it gives a 'diff'), but could be useful.

Signed-off-by: Jon Harper <jon.harper87@gmail.com>


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The badge on https://github.com/powsybl/powsybl-core is no longer updated


**What is the new behavior (if this is a feature change)?**
badge updated


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
