### PR TITLE
Bug fix in getConnectableBus() in calculated BBranch topology from NB network

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -387,6 +387,9 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             // node associated to a bus
             BusExt[] connectableBus2 = new BusExt[1];
             graph.traverse(node, (v1, e, v2) -> {
+                if (connectableBus2[0] != null) {
+                    return TraverseResult.TERMINATE;
+                }
                 connectableBus2[0] = getBus(v2);
                 if (connectableBus2[0] != null) {
                     return TraverseResult.TERMINATE;
@@ -394,7 +397,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                 return TraverseResult.CONTINUE;
             });
             // if nothing found, just take the first bus
-            if (connectableBus2[0] != null) {
+            if (connectableBus2[0] == null) {
                 Iterator<CalculatedBus> it = getBuses().iterator();
                 if (!it.hasNext()) {
                     throw new AssertionError("Should not happen");

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -388,6 +388,8 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             BusExt[] connectableBus2 = new BusExt[1];
             graph.traverse(node, (v1, e, v2) -> {
                 if (connectableBus2[0] != null) {
+                    // traverse does not stop the algorithm when TERMINATE, it only stops searching in a given direction
+                    // this condition insures that while checking all the edges (in every direction) of a node, if a bus is found, it will not be lost
                     return TraverseResult.TERMINATE;
                 }
                 connectableBus2[0] = getBus(v2);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerTest.java
@@ -69,6 +69,90 @@ public class NodeBreakerTest {
         return network;
     }
 
+    private static Network createIsolatedLoadNetwork() {
+        Network network = Network.create("test", "test");
+        Substation s1 = network.newSubstation().setId("S").add();
+        VoltageLevel vl1 = s1.newVoltageLevel().setId("VL").setNominalV(1f)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+
+        vl1.getNodeBreakerView()
+                .setNodeCount(11)
+                .newBusbarSection()
+                .setId("B0")
+                .setNode(0)
+                .add();
+        vl1.getNodeBreakerView()
+                .newBusbarSection()
+                .setId("B1")
+                .setNode(1)
+                .add();
+        vl1.getNodeBreakerView()
+                .newBusbarSection()
+                .setId("B2")
+                .setNode(2)
+                .add();
+
+        vl1.newLoad()
+                .setId("L0")
+                .setNode(6)
+                .setP0(0)
+                .setQ0(0)
+                .add();
+        vl1.newLoad()
+                .setId("L1")
+                .setNode(3)
+                .setP0(0)
+                .setQ0(0)
+                .add();
+        vl1.newLoad()
+                .setId("L2")
+                .setNode(4)
+                .setP0(0)
+                .setQ0(0)
+                .add();
+        vl1.newLoad()
+                .setId("L3")
+                .setNode(5)
+                .setP0(0)
+                .setQ0(0)
+                .add();
+
+        vl1.getNodeBreakerView().newBreaker()
+                .setId("L0-node")
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(6)
+                .add();
+        vl1.getNodeBreakerView().newBreaker()
+                .setId("L1-node")
+                .setOpen(true)
+                .setNode1(4)
+                .setNode2(10)
+                .add();
+        vl1.getNodeBreakerView().newBreaker()
+                .setId("L0-B0")
+                .setOpen(false)
+                .setNode1(3)
+                .setNode2(1)
+                .add();
+        vl1.getNodeBreakerView().newBreaker()
+                .setId("B0-node")
+                .setOpen(true)
+                .setNode1(1)
+                .setNode2(10)
+                .setRetained(true)
+                .add();
+        vl1.getNodeBreakerView().newBreaker()
+                .setId("node-B1")
+                .setOpen(false)
+                .setNode1(10)
+                .setNode2(2)
+                .setRetained(true)
+                .add();
+        return network;
+    }
+
     @Test
     public void connectDisconnect() {
         Network network = createNetwork();
@@ -177,5 +261,27 @@ public class NodeBreakerTest {
         // Check thew load is connected to the correct bus bar.
         BusbarSection bb = vl.getNodeBreakerView().getBusbarSection("voltageLevel1BusbarSection1");
         assertEquals(getBus(bb), getBus(l2));
+    }
+
+    @Test
+    public void testIsolatedLoadBusBranch() {
+        Network network = createIsolatedLoadNetwork();
+        assertEquals(2, network.getBusView().getBusStream().count());
+
+        // load "L0" is connected to bus "VL_0"
+        assertNotNull(getBus(network.getLoad("L0")));
+        assertEquals("VL_0", getConnectableBus(network.getLoad("L0")).getId());
+
+        // load "L1" is connected to bus "VL_1"
+        assertNotNull(getBus(network.getLoad("L1")));
+        assertEquals("VL_1", getConnectableBus(network.getLoad("L1")).getId());
+
+        // load "L2" is not connected but is connectable to bus "VL_1"
+        assertNull(getBus(network.getLoad("L2")));
+        assertEquals("VL_1", getConnectableBus(network.getLoad("L2")).getId());
+
+        // load "L3" is not connected and has no connectable bus (the first bus is taken as connectable bus in this case)
+        assertNull(getBus(network.getLoad("L3")));
+        assertEquals("VL_0", getConnectableBus(network.getLoad("L3")).getId());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
There are several issues with calculated bus branch topology from a node breaker network:
- `connectableBus` of an injection can be `null` (which is **contrary** to specification)
- for an unconnected injection, `connectableBus` depends on the swiches' traversing order in a voltage level since it is reinitialized at each iteration in switch even if a `connectableBus` is found
- for an unconnected injection, `connectableBus` was actually always the first bus of the voltage level

**What is the new behavior (if this is a feature change)?**
- `connectableBus` is never null: if none is found, the first bus of the voltage level is returned
- for an unconnected injection, `connectableBus` is independant of the switches' order (if found, it is not reinitialized) and is not always the first bus of the voltage level


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
