### PR TITLE
Add automatic module name in iidm-extensions

### DIFF
--- a/iidm/iidm-extensions/pom.xml
+++ b/iidm/iidm-extensions/pom.xml
@@ -22,6 +22,22 @@
     <name>IIDM common extensions</name>
     <description>A set of IIDM common extensions</description>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.powsybl.iidm.extensions</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- compile dependencies  -->
         <dependency>


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix an oversight: automatic module name of iidm-extensions is added


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
