### PR TITLE
Fix IIDM Groovy property access

### DIFF
--- a/iidm/iidm-api/src/main/groovy/com/powsybl/iidm/network/IdentifiableExtension.groovy
+++ b/iidm/iidm-api/src/main/groovy/com/powsybl/iidm/network/IdentifiableExtension.groovy
@@ -21,7 +21,7 @@ class IdentifiableExtension {
     }
 
     static void propertyMissing(Identifiable self, String name, Object value) {
-        self.setProperty(name, value)
+        self.setProperty(name, value != null ? value.toString() : value)
     }
 
     /**

--- a/iidm/iidm-impl/src/test/groovy/com/powsybl/iidm/network/impl/IdentifiableExtensionGroovyTest.groovy
+++ b/iidm/iidm-impl/src/test/groovy/com/powsybl/iidm/network/impl/IdentifiableExtensionGroovyTest.groovy
@@ -42,12 +42,23 @@ class IdentifiableExtensionGroovyTest {
     }
 
     @Test
-    void testProperty() {
+    void testStringProperty() {
         assertFalse(s.hasProperty())
         assertNull(s.greeting)
         s.greeting = "hello"
         assertEquals("hello", s.getProperty("greeting"))
         assertEquals("hello", s.greeting)
+    }
+
+    @Test
+    void testBooleanProperty() {
+        assertFalse(s.hasProperty())
+        assertNull(s.ok)
+        s.ok = true
+        assertEquals("true", s.getProperty("ok"))
+        assertEquals("true", s.ok)
+        s.ok = null
+        assertNull(s.ok)
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
A regression fix in PR #911


**What is the current behavior?** *(You can also link to an open issue here)*
It is not possible anymore to set a non `java.lang.String` property using Groovy syntax:
```groovy
s.ok = true
```
It only works with `java.lang.String`

**What is the new behavior (if this is a feature change)?**
It works for any Java type.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
