### PR TITLE
Fix setProperty return type

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Identifiable.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Identifiable.java
@@ -63,7 +63,7 @@ public interface Identifiable<I extends Identifiable<I>> extends Extendable<I> {
     /**
      * Set property value associated to specified key.
      */
-    Object setProperty(String key, String value);
+    String setProperty(String key, String value);
 
     /**
      * Get properties key values.

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
@@ -66,7 +66,7 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
     }
 
     @Override
-    public Object setProperty(String key, String value) {
+    public String setProperty(String key, String value) {
         return properties.put(key, value);
     }
 

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VariantManagerImplTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VariantManagerImplTest.java
@@ -72,7 +72,7 @@ public class VariantManagerImplTest {
         }
 
         @Override
-        public Object setProperty(String key, String value) {
+        public String setProperty(String key, String value) {
             return null;
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
The setProperty method return an `Object` as `java.util.properties` did


**What is the new behavior (if this is a feature change)?**
The setProperty method now return an `String`


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [X] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
