### PR TITLE
Add a parameter to handle remote voltage or not

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -46,6 +46,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
     public static final boolean DEFAULT_NO_GENERATOR_REACTIVE_LIMITS = false;
     public static final boolean DEFAULT_PHASE_SHIFTER_REGULATION_ON = false;
     public static final boolean DEFAULT_SPECIFIC_COMPATIBILITY = false;
+    public static final boolean DEFAULT_WITH_REMOTE_VOLTAGE_GENERATORS = false;
 
     private static final Supplier<ExtensionProviders<ConfigLoader>> SUPPLIER =
             Suppliers.memoize(() -> ExtensionProviders.createProvider(ConfigLoader.class, "loadflow-parameters"));
@@ -84,6 +85,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
                     parameters.setNoGeneratorReactiveLimits(config.getBooleanProperty("noGeneratorReactiveLimits", DEFAULT_NO_GENERATOR_REACTIVE_LIMITS));
                     parameters.setPhaseShifterRegulationOn(config.getBooleanProperty("phaseShifterRegulationOn", DEFAULT_PHASE_SHIFTER_REGULATION_ON));
                     parameters.setSpecificCompatibility(config.getBooleanProperty("specificCompatibility", DEFAULT_SPECIFIC_COMPATIBILITY));
+                    parameters.setWithRemoteVoltageGenerators(config.getBooleanProperty("withRemoteVoltageGenerators", DEFAULT_WITH_REMOTE_VOLTAGE_GENERATORS));
                 });
     }
 
@@ -97,13 +99,22 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
 
     private boolean specificCompatibility;
 
+    private boolean withRemoteVoltageGenerators;
+
     public LoadFlowParameters(VoltageInitMode voltageInitMode, boolean transformerVoltageControlOn,
-                              boolean noGeneratorReactiveLimits, boolean phaseShifterRegulationOn, boolean specificCompatibility) {
+                              boolean noGeneratorReactiveLimits, boolean phaseShifterRegulationOn, boolean specificCompatibility,
+                              boolean withRemoteVoltageGenerators) {
         this.voltageInitMode = voltageInitMode;
         this.transformerVoltageControlOn = transformerVoltageControlOn;
         this.noGeneratorReactiveLimits = noGeneratorReactiveLimits;
         this.phaseShifterRegulationOn = phaseShifterRegulationOn;
         this.specificCompatibility = specificCompatibility;
+        this.withRemoteVoltageGenerators = withRemoteVoltageGenerators;
+    }
+
+    public LoadFlowParameters(VoltageInitMode voltageInitMode, boolean transformerVoltageControlOn,
+                              boolean noGeneratorReactiveLimits, boolean phaseShifterRegulationOn, boolean specificCompatibility) {
+        this(voltageInitMode, transformerVoltageControlOn, noGeneratorReactiveLimits, phaseShifterRegulationOn, specificCompatibility, DEFAULT_WITH_REMOTE_VOLTAGE_GENERATORS);
     }
 
     public LoadFlowParameters(VoltageInitMode voltageInitMode, boolean transformerVoltageControlOn) {
@@ -125,6 +136,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
         noGeneratorReactiveLimits = other.noGeneratorReactiveLimits;
         phaseShifterRegulationOn = other.phaseShifterRegulationOn;
         specificCompatibility = other.specificCompatibility;
+        withRemoteVoltageGenerators = other.withRemoteVoltageGenerators;
     }
 
     public VoltageInitMode getVoltageInitMode() {
@@ -172,12 +184,25 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
         return this;
     }
 
+    public boolean isWithRemoteVoltageGenerators() {
+        return withRemoteVoltageGenerators;
+    }
+
+    public LoadFlowParameters setWithRemoteVoltageGenerators(boolean withRemoteVoltageGenerators) {
+        this.withRemoteVoltageGenerators = withRemoteVoltageGenerators;
+        return this;
+    }
+
     protected Map<String, Object> toMap() {
-        return ImmutableMap.of("voltageInitMode", voltageInitMode,
-                "transformerVoltageControlOn", transformerVoltageControlOn,
-                "noGeneratorReactiveLimits", noGeneratorReactiveLimits,
-                "phaseShifterRegulationOn", phaseShifterRegulationOn,
-                "specificCompatibility", specificCompatibility);
+        ImmutableMap.Builder<String, Object> immutableMapBuilder = ImmutableMap.builder();
+        immutableMapBuilder
+                .put("voltageInitMode", voltageInitMode)
+                .put("transformerVoltageControlOn", transformerVoltageControlOn)
+                .put("noGeneratorReactiveLimits", noGeneratorReactiveLimits)
+                .put("phaseShifterRegulationOn", phaseShifterRegulationOn)
+                .put("specificCompatibility", specificCompatibility)
+                .put("withRemoteVoltageGenerators", withRemoteVoltageGenerators);
+        return immutableMapBuilder.build();
     }
 
     public LoadFlowParameters copy() {

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
@@ -26,8 +26,8 @@ import static org.junit.Assert.*;
  */
 public class LoadFlowParametersTest {
 
-    InMemoryPlatformConfig platformConfig;
-    FileSystem fileSystem;
+    private InMemoryPlatformConfig platformConfig;
+    private FileSystem fileSystem;
 
     @Before
     public void setUp() {
@@ -42,12 +42,13 @@ public class LoadFlowParametersTest {
 
     private void checkValues(LoadFlowParameters parameters, LoadFlowParameters.VoltageInitMode voltageInitMode,
                              boolean transformerVoltageControlOn, boolean noGeneratorReactiveLimits,
-                             boolean phaseShifterRegulationOn, boolean specificCompatibility) {
+                             boolean phaseShifterRegulationOn, boolean specificCompatibility, boolean withRemoteVoltageGenerators) {
         assertEquals(parameters.getVoltageInitMode(), voltageInitMode);
         assertEquals(parameters.isTransformerVoltageControlOn(), transformerVoltageControlOn);
         assertEquals(parameters.isPhaseShifterRegulationOn(), phaseShifterRegulationOn);
         assertEquals(parameters.isNoGeneratorReactiveLimits(), noGeneratorReactiveLimits);
         assertEquals(parameters.isSpecificCompatibility(), specificCompatibility);
+        assertEquals(parameters.isWithRemoteVoltageGenerators(), withRemoteVoltageGenerators);
     }
 
     @Test
@@ -58,15 +59,17 @@ public class LoadFlowParametersTest {
                 LoadFlowParameters.DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON,
                 LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
                 LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON,
-                LoadFlowParameters.DEFAULT_SPECIFIC_COMPATIBILITY);
+                LoadFlowParameters.DEFAULT_SPECIFIC_COMPATIBILITY,
+                LoadFlowParameters.DEFAULT_WITH_REMOTE_VOLTAGE_GENERATORS);
     }
 
     @Test
-    public void checkConfig() throws Exception {
+    public void checkConfig() {
         boolean transformerVoltageControlOn = true;
         boolean noGeneratorReactiveLimits = true;
         boolean phaseShifterRegulationOn = true;
         boolean specificCompatibility = true;
+        boolean withRemoteVoltageGenerators = true;
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.UNIFORM_VALUES;
 
         MapModuleConfig moduleConfig = platformConfig.createModuleConfig("load-flow-default-parameters");
@@ -75,14 +78,15 @@ public class LoadFlowParametersTest {
         moduleConfig.setStringProperty("noGeneratorReactiveLimits", Boolean.toString(noGeneratorReactiveLimits));
         moduleConfig.setStringProperty("phaseShifterRegulationOn", Boolean.toString(phaseShifterRegulationOn));
         moduleConfig.setStringProperty("specificCompatibility", Boolean.toString(specificCompatibility));
+        moduleConfig.setStringProperty("withRemoteVoltageGenerators", Boolean.toString(specificCompatibility));
         LoadFlowParameters parameters = new LoadFlowParameters();
         LoadFlowParameters.load(parameters, platformConfig);
         checkValues(parameters, voltageInitMode, transformerVoltageControlOn,
-                noGeneratorReactiveLimits, phaseShifterRegulationOn, specificCompatibility);
+                noGeneratorReactiveLimits, phaseShifterRegulationOn, specificCompatibility, withRemoteVoltageGenerators);
     }
 
     @Test
-    public void checkIncompleteConfig() throws Exception {
+    public void checkIncompleteConfig() {
         boolean transformerVoltageControlOn = true;
         MapModuleConfig moduleConfig = platformConfig.createModuleConfig("load-flow-default-parameters");
         moduleConfig.setStringProperty("transformerVoltageControlOn", Boolean.toString(transformerVoltageControlOn));
@@ -90,50 +94,56 @@ public class LoadFlowParametersTest {
         LoadFlowParameters.load(parameters, platformConfig);
         checkValues(parameters, LoadFlowParameters.DEFAULT_VOLTAGE_INIT_MODE,
                 transformerVoltageControlOn, LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
-                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_SPECIFIC_COMPATIBILITY);
+                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_SPECIFIC_COMPATIBILITY,
+                LoadFlowParameters.DEFAULT_WITH_REMOTE_VOLTAGE_GENERATORS);
     }
 
     @Test
-    public void checkConstructorByVoltageInitMode() throws Exception {
+    public void checkConstructorByVoltageInitMode() {
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.DC_VALUES;
         LoadFlowParameters parameters = new LoadFlowParameters(voltageInitMode);
         checkValues(parameters, voltageInitMode, LoadFlowParameters.DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON,
                 LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
-                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_SPECIFIC_COMPATIBILITY);
+                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_SPECIFIC_COMPATIBILITY,
+                LoadFlowParameters.DEFAULT_WITH_REMOTE_VOLTAGE_GENERATORS);
     }
 
     @Test
-    public void checkSetters() throws Exception {
+    public void checkSetters() {
         boolean transformerVoltageControlOn = true;
         boolean noGeneratorReactiveLimits = true;
         boolean phaseShifterRegulationOn = true;
         boolean specificCompatibility = true;
+        boolean withRemoteVoltageGenerators = true;
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.DC_VALUES;
 
         LoadFlowParameters parameters = new LoadFlowParameters();
         LoadFlowParameters.load(parameters, platformConfig);
-        parameters.setNoGeneratorReactiveLimits(noGeneratorReactiveLimits);
-        parameters.setPhaseShifterRegulationOn(phaseShifterRegulationOn);
-        parameters.setTransformerVoltageControlOn(transformerVoltageControlOn);
-        parameters.setVoltageInitMode(voltageInitMode);
-        parameters.setSpecificCompatibility(specificCompatibility);
+        parameters.setNoGeneratorReactiveLimits(noGeneratorReactiveLimits)
+                .setPhaseShifterRegulationOn(phaseShifterRegulationOn)
+                .setTransformerVoltageControlOn(transformerVoltageControlOn)
+                .setVoltageInitMode(voltageInitMode)
+                .setSpecificCompatibility(specificCompatibility)
+                .setWithRemoteVoltageGenerators(withRemoteVoltageGenerators);
 
         checkValues(parameters, voltageInitMode, transformerVoltageControlOn, noGeneratorReactiveLimits,
-                phaseShifterRegulationOn, specificCompatibility);
+                phaseShifterRegulationOn, specificCompatibility, withRemoteVoltageGenerators);
     }
 
     @Test
-    public void checkClone() throws Exception {
+    public void checkClone() {
         boolean transformerVoltageControlOn = true;
         boolean noGeneratorReactiveLimits = true;
         boolean phaseShifterRegulationOn = true;
         boolean specificCompatibility = true;
+        boolean withRemoteVoltageGenerators = true;
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.UNIFORM_VALUES;
         LoadFlowParameters parameters = new LoadFlowParameters(voltageInitMode, transformerVoltageControlOn,
-                noGeneratorReactiveLimits, phaseShifterRegulationOn, specificCompatibility);
+                noGeneratorReactiveLimits, phaseShifterRegulationOn, specificCompatibility, withRemoteVoltageGenerators);
         LoadFlowParameters parametersCloned = parameters.copy();
         checkValues(parametersCloned, parameters.getVoltageInitMode(), parameters.isTransformerVoltageControlOn(),
-                parameters.isNoGeneratorReactiveLimits(), parameters.isPhaseShifterRegulationOn(), parameters.isSpecificCompatibility());
+                parameters.isNoGeneratorReactiveLimits(), parameters.isPhaseShifterRegulationOn(), parameters.isSpecificCompatibility(),
+                parameters.isWithRemoteVoltageGenerators());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Remote voltage control for generator is always taken into account during loadflow.


**What is the new behavior (if this is a feature change)?**
Users can decide to use remote voltage control for generators or not, using `withRemoteVoltageGenerators` attribute of `LoadflowParameters`.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:
The documentation will be done once this PR is merged.
