### PR TITLE
Implementation of Identifiable::getNetwork()

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Identifiable.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Identifiable.java
@@ -21,6 +21,11 @@ import java.util.Properties;
 public interface Identifiable<I extends Identifiable<I>> extends Extendable<I> {
 
     /**
+     * Get the network associated to the object.
+     */
+    Network getNetwork();
+
+    /**
      * Get the unique identifier of the object.
      */
     String getId();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractBus.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractBus.java
@@ -43,6 +43,11 @@ abstract class AbstractBus extends AbstractIdentifiable<Bus> implements Bus {
     }
 
     @Override
+    public NetworkImpl getNetwork() {
+        return voltageLevel.getNetwork();
+    }
+
+    @Override
     public VoltageLevel getVoltageLevel() {
         return voltageLevel;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
@@ -42,7 +42,8 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         return terminals;
     }
 
-    protected NetworkImpl getNetwork() {
+    @Override
+    public NetworkImpl getNetwork() {
         if (terminals.isEmpty()) {
             throw new PowsyblException(id + " is not attached to a network");
         }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
@@ -38,6 +38,9 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
         return name != null ? name : id;
     }
 
+    @Override
+    public abstract NetworkImpl getNetwork();
+
     protected abstract String getTypeDescription();
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MergedBus.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MergedBus.java
@@ -88,6 +88,11 @@ class MergedBus extends AbstractIdentifiable<Bus> implements CalculatedBus {
     }
 
     @Override
+    public NetworkImpl getNetwork() {
+        return (NetworkImpl) getVoltageLevel().getSubstation().getNetwork();
+    }
+
+    @Override
     public VoltageLevel getVoltageLevel() {
         checkValidity();
         return buses.iterator().next().getVoltageLevel();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MergedBus.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MergedBus.java
@@ -89,7 +89,7 @@ class MergedBus extends AbstractIdentifiable<Bus> implements CalculatedBus {
 
     @Override
     public NetworkImpl getNetwork() {
-        return (NetworkImpl) getVoltageLevel().getSubstation().getNetwork();
+        return (NetworkImpl) getVoltageLevel().getNetwork();
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -175,6 +175,11 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
     }
 
     @Override
+    public NetworkImpl getNetwork() {
+        return this;
+    }
+
+    @Override
     public VariantManagerImpl getVariantManager() {
         return variantManager;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
@@ -43,6 +43,11 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
     }
 
     @Override
+    public NetworkImpl getNetwork() {
+        return voltageLevel.getNetwork();
+    }
+
+    @Override
     public VoltageLevelExt getVoltageLevel() {
         return voltageLevel;
     }
@@ -54,12 +59,12 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
 
     @Override
     public boolean isOpen() {
-        return open.get(voltageLevel.getNetwork().getVariantIndex());
+        return open.get(getNetwork().getVariantIndex());
     }
 
     @Override
     public void setOpen(boolean open) {
-        NetworkImpl network = voltageLevel.getNetwork();
+        NetworkImpl network = getNetwork();
         int index = network.getVariantIndex();
         boolean oldValue = this.open.get(index);
         if (oldValue != open) {
@@ -72,7 +77,7 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
 
     @Override
     public boolean isRetained() {
-        return retained.get(voltageLevel.getNetwork().getVariantIndex());
+        return retained.get(getNetwork().getVariantIndex());
     }
 
     @Override
@@ -80,7 +85,7 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
         if (voltageLevel.getTopologyKind() != TopologyKind.NODE_BREAKER) {
             throw new ValidationException(this, "retain status is not modifiable in a non node/breaker voltage level");
         }
-        NetworkImpl network = voltageLevel.getNetwork();
+        NetworkImpl network = getNetwork();
         int index = network.getVariantIndex();
         boolean oldValue = this.retained.get(index);
         if (oldValue != retained) {
@@ -102,7 +107,7 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
         if (oldValue != fictitious) {
             this.fictitious = fictitious;
             voltageLevel.invalidateCache();
-            NetworkImpl network = voltageLevel.getNetwork();
+            NetworkImpl network = getNetwork();
             network.getListeners().notifyUpdate(this, "fictitious", oldValue, fictitious);
         }
     }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/BusTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/BusTest.java
@@ -69,6 +69,7 @@ public class BusTest {
         vscConverterStation.getTerminal().setQ(q2);
 
         assertSame(voltageLevel, bus.getVoltageLevel());
+        assertSame(network, bus.getNetwork());
         try {
             bus.setV(-1.0);
             fail();

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/CalculatedTopologyTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/CalculatedTopologyTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -33,6 +34,7 @@ public class CalculatedTopologyTest {
         assertNotNull(ma);
         assertNotNull(mb);
         assertEquals(ma, mb);
+        assertSame(n, ma.getNetwork());
     }
 
     private Network createBusBreaker() {

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworkTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworkTest.java
@@ -41,6 +41,7 @@ public class NetworkTest {
     @Test
     public void testNetwork1() {
         Network network = NetworkTest1Factory.create();
+        assertSame(network, network.getNetwork());
         assertEquals(1, Iterables.size(network.getCountries()));
         assertEquals(1, network.getCountryCount());
         Country country1 = network.getCountries().iterator().next();

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VariantManagerImplTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VariantManagerImplTest.java
@@ -52,6 +52,11 @@ public class VariantManagerImplTest {
         }
 
         @Override
+        public Network getNetwork() {
+            return null;
+        }
+
+        @Override
         public boolean hasProperty() {
             return false;
         }


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Adding following method into Identifiable interface:
Network getNetwork()


**What is the current behavior?** *(You can also link to an open issue here)*
Identifiable interface do not offer getter on Network used


**What is the new behavior (if this is a feature change)?**
Identifiable interface offer getter on Network used


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
