### PR TITLE
Regression fix : long task computation manager is used for security analysis sub-tasks

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/tools/SecurityAnalysisTool.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/tools/SecurityAnalysisTool.java
@@ -303,8 +303,8 @@ public class SecurityAnalysisTool implements Tool {
 
         SecurityAnalysisExecution execution = buildExecution(options, executionBuilder);
 
-        ComputationManager computationManager = options.hasOption(TASK) ? context.getLongTimeExecutionComputationManager() :
-                context.getShortTimeExecutionComputationManager();
+        ComputationManager computationManager = options.hasOption(TASK) ? context.getShortTimeExecutionComputationManager() :
+                context.getLongTimeExecutionComputationManager();
 
         SecurityAnalysisResult result = options.getPath(OUTPUT_LOG_OPTION)
                 .map(logPath -> runSecurityAnalysisWithLog(computationManager, execution, executionInput, logPath))


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix.

**What is the current behavior?** *(You can also link to an open issue here)*

Security analysis uses short time computation manager, while sub-tasks use the long time computation manager. This is a regression introduced with security analysis preprocessors feature.

**What is the new behavior (if this is a feature change)?**

The tool now uses the correct computation manager again.
