### PR TITLE
pom.xml: restore checks on java11 normal maven executions

### DIFF
--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -437,7 +437,10 @@
         <profile>
             <id>checks</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>powsyblchecks</name>
+                    <value>!false</value>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,10 @@
         <profile>
             <id>checks</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>powsyblchecks</name>
+                    <value>!false</value>
+                </property>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
 #940

Here's how it behaves:
$ mvn package # runs the checks like before
$ mvn package -P'!checks' # doesn't run the checks like before
$ mvn package -Dpowsyblchecks=false # doesn't run the checks
$ mvn package -Dpowsyblchecks=AnythingForExampleTrue # runs the checks

We don't have to use the 2 new forms using -Dpowsyblchecks. Using properties instead of specifying the profiles directly generally allows more flexibility (like activate a profile if A and B, or allow to use multiple -D to activate multiple profiles instead of requiring the whole list in one -P'x,y,!z' but we are not forced to use it.

I used a prefixed property name "powsyblchecks" because contrary to profiles that can only activate things in the poms of the reactor, the properties affect the behavior of things declared outside of our project.
ps: profiles are somewhat global too, so the "checks" name could hurt use because you can define activeProfiles in your settings.xml. but we don't use that and no one has standardized the profile names

