### PR TITLE
ClassicPlatformConfigProvider: use user.home when powsybl-config-dir is the empty string. 

### DIFF
--- a/config-classic/src/main/java/com/powsybl/config/classic/ClassicPlatformConfigProvider.java
+++ b/config-classic/src/main/java/com/powsybl/config/classic/ClassicPlatformConfigProvider.java
@@ -55,7 +55,7 @@ public class ClassicPlatformConfigProvider implements PlatformConfigProvider {
         Objects.requireNonNull(fileSystem);
         Objects.requireNonNull(userHome);
         Path[] configDirs = null;
-        if (directories != null) {
+        if (directories != null && !directories.isEmpty()) {
             configDirs = Arrays.stream(directories.split(":"))
                     .map(PlatformEnv::substitute)
                     .map(fileSystem::getPath)

--- a/config-classic/src/test/java/com/powsybl/config/classic/ClassicPlatformConfigProviderTest.java
+++ b/config-classic/src/test/java/com/powsybl/config/classic/ClassicPlatformConfigProviderTest.java
@@ -44,7 +44,8 @@ public class ClassicPlatformConfigProviderTest {
 
     private List<String> getAbsolutePaths(String configDirs) {
         Path[] paths = ClassicPlatformConfigProvider.getDefaultConfigDirs(fileSystem, configDirs, "/");
-        return Arrays.stream(paths).map(Path::toAbsolutePath).map(Path::toString).collect(Collectors.toList());
+        return Arrays.stream(paths).map(Path::toAbsolutePath).map(Path::normalize).map(Path::toString)
+                .collect(Collectors.toList());
     }
 
     @Test
@@ -53,11 +54,18 @@ public class ClassicPlatformConfigProviderTest {
     }
 
     @Test
+    public void testEdgeCaseEmptyAfterSplit() {
+        assertEquals(Arrays.asList("/.itools"), getAbsolutePaths(":"));
+    }
+
+    @Test
+    public void workDir() {
+        assertEquals(Arrays.asList("/work"), getAbsolutePaths("."));
+    }
+
+    @Test
     public void testEmptyConfigDirs() {
-        // "FIXME: should return the same as with null but currently returns the working
-        // dir")
-        // assertEquals(Arrays.asList("/.itools"), getAbsolutePaths(""));
-        assertEquals(Arrays.asList("/work"), getAbsolutePaths(""));
+        assertEquals(Arrays.asList("/.itools"), getAbsolutePaths(""));
     }
 
     @Test


### PR DESCRIPTION
Add tests for other edge cases

The empty string used to mean the current working directory. It is error prone for 2 reasons:
- if you decide to add another config dir before the working directory, your string becomes "other:" but this is parsed as just other.
Note that ":other" would have parsed as current directory and then other.
- some users might want to remove a property by setting it to the empty string, expecting the default to be used

To use the current working directory, you now have to use "." which removes all the surprising cases described before

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature/BugFix


**What is the current behavior?** *(You can also link to an open issue here)*
specifying -Dpowsybl.config-dirs="" means the current working directory


**What is the new behavior (if this is a feature change)?**
specifying -Dpowsybl.config-dirs="" means the same as not specifying -Dpowsybl.config-dirs (default user.home)


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO. Not many people use the current working directory, and hopefully if they did, they used the more sensible alternative "."
