### PR TITLE
Adding container notification implementation

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkListener.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkListener.java
@@ -22,7 +22,11 @@ public interface NetworkListener {
         // empty default implementation
     }
 
-    default void onElementAdded(Identifiable identifiable, String attribute, Object oldValue, Object newValue) {
+    default void onElementAdded(Identifiable identifiable, String attribute, Object newValue) {
+        // empty default implementation
+    }
+
+    default void onElementReplaced(Identifiable identifiable, String attribute, Object oldValue, Object newValue) {
         // empty default implementation
     }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkListener.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkListener.java
@@ -22,6 +22,14 @@ public interface NetworkListener {
         // empty default implementation
     }
 
+    default void onElementAdded(Identifiable identifiable, String attribute, Object oldValue, Object newValue) {
+        // empty default implementation
+    }
+
+    default void onElementRemoved(Identifiable identifiable, String attribute, Object oldValue) {
+        // empty default implementation
+    }
+
     default void onVariantCreated(String sourceVariantId, String targetVariantId) {
         // empty default implementation
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
@@ -70,7 +70,9 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
 
     @Override
     public String setProperty(String key, String value) {
-        return properties.put(key, value);
+        String oldValue = properties.put(key, value);
+        getNetwork().getListeners().notifyElementAdded(this, () -> "properties[" + key + "]", oldValue, value);
+        return oldValue;
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
@@ -71,7 +71,11 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
     @Override
     public String setProperty(String key, String value) {
         String oldValue = properties.put(key, value);
-        getNetwork().getListeners().notifyElementAdded(this, () -> "properties[" + key + "]", oldValue, value);
+        if (Objects.isNull(oldValue)) {
+            getNetwork().getListeners().notifyElementAdded(this, () -> "properties[" + key + "]", value);
+        } else {
+            getNetwork().getListeners().notifyElementReplaced(this, () -> "properties[" + key + "]", oldValue, value);
+        }
         return oldValue;
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
@@ -97,6 +97,32 @@ class NetworkListenerList {
         }
     }
 
+    void notifyElementAdded(Identifiable<?> identifiable, Supplier<String> attribute, Object oldValue, Object newValue) {
+        if (!listeners.isEmpty() && !Objects.equals(oldValue, newValue)) {
+            notifyElementAdded(identifiable, attribute.get(), oldValue, newValue);
+        }
+    }
+
+    void notifyElementAdded(Identifiable<?> identifiable, String attribute, Object oldValue, Object newValue) {
+        for (NetworkListener listener : listeners) {
+            try {
+                listener.onElementAdded(identifiable, attribute, oldValue, newValue);
+            } catch (Exception t) {
+                LOGGER.error(t.toString(), t);
+            }
+        }
+    }
+
+    void notifyElementRemoved(Identifiable<?> identifiable, String attribute, Object oldValue) {
+        for (NetworkListener listener : listeners) {
+            try {
+                listener.onElementRemoved(identifiable, attribute, oldValue);
+            } catch (Exception t) {
+                LOGGER.error(t.toString(), t);
+            }
+        }
+    }
+
     void notifyVariantCreated(String sourceVariantId, String targetVariantId) {
         for (NetworkListener listener : listeners) {
             try {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkListenerList.java
@@ -97,19 +97,41 @@ class NetworkListenerList {
         }
     }
 
-    void notifyElementAdded(Identifiable<?> identifiable, Supplier<String> attribute, Object oldValue, Object newValue) {
-        if (!listeners.isEmpty() && !Objects.equals(oldValue, newValue)) {
-            notifyElementAdded(identifiable, attribute.get(), oldValue, newValue);
+    void notifyElementAdded(Identifiable<?> identifiable, Supplier<String> attribute, Object newValue) {
+        if (!listeners.isEmpty()) {
+            notifyElementAdded(identifiable, attribute.get(), newValue);
         }
     }
 
-    void notifyElementAdded(Identifiable<?> identifiable, String attribute, Object oldValue, Object newValue) {
+    void notifyElementAdded(Identifiable<?> identifiable, String attribute, Object newValue) {
         for (NetworkListener listener : listeners) {
             try {
-                listener.onElementAdded(identifiable, attribute, oldValue, newValue);
+                listener.onElementAdded(identifiable, attribute, newValue);
             } catch (Exception t) {
                 LOGGER.error(t.toString(), t);
             }
+        }
+    }
+
+    void notifyElementReplaced(Identifiable<?> identifiable, Supplier<String> attribute, Object oldValue, Object newValue) {
+        if (!listeners.isEmpty() && !Objects.equals(oldValue, newValue)) {
+            notifyElementReplaced(identifiable, attribute.get(), oldValue, newValue);
+        }
+    }
+
+    void notifyElementReplaced(Identifiable<?> identifiable, String attribute, Object oldValue, Object newValue) {
+        for (NetworkListener listener : listeners) {
+            try {
+                listener.onElementReplaced(identifiable, attribute, oldValue, newValue);
+            } catch (Exception t) {
+                LOGGER.error(t.toString(), t);
+            }
+        }
+    }
+
+    void notifyElementRemoved(Identifiable<?> identifiable, Supplier<String> attribute, Object oldValue) {
+        if (!listeners.isEmpty()) {
+            notifyElementRemoved(identifiable, attribute.get(), oldValue);
         }
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubstationImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubstationImpl.java
@@ -156,7 +156,7 @@ class SubstationImpl extends AbstractIdentifiable<Substation> implements Substat
             throw new ValidationException(this, "geographical tag is null");
         }
         if (geographicalTags.add(tag)) {
-            getNetwork().getListeners().notifyElementAdded(this, "geographicalTags", null, tag);
+            getNetwork().getListeners().notifyElementAdded(this, "geographicalTags", tag);
         }
         return this;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubstationImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubstationImpl.java
@@ -155,9 +155,8 @@ class SubstationImpl extends AbstractIdentifiable<Substation> implements Substat
         if (tag == null) {
             throw new ValidationException(this, "geographical tag is null");
         }
-        Set<String> oldValue = new LinkedHashSet<>(this.geographicalTags);
         if (geographicalTags.add(tag)) {
-            getNetwork().getListeners().notifyUpdate(this, "geographicalTags", oldValue, geographicalTags);
+            getNetwork().getListeners().notifyElementAdded(this, "geographicalTags", null, tag);
         }
         return this;
     }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworkTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NetworkTest.java
@@ -15,6 +15,7 @@ import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -137,6 +138,11 @@ public class NetworkTest {
         assertSame(busCalc, generator1.getTerminal().getBusView().getBus());
         assertEquals(0, busCalc.getConnectedComponent().getNum());
 
+        // Changes listener
+        NetworkListener mockedListener = Mockito.mock(DefaultNetworkListener.class);
+        // Add observer changes to current network
+        network.addListener(mockedListener);
+
         // Identifiable properties
         String key = "keyTest";
         String value = "ValueTest";
@@ -148,6 +154,19 @@ public class NetworkTest {
         assertEquals(value, busCalc.getProperty(key));
         assertEquals("default", busCalc.getProperty("invalid", "default"));
         assertEquals(1, busCalc.getPropertyNames().size());
+
+        // Check notification done
+        Mockito.verify(mockedListener, Mockito.times(1))
+                .onElementAdded(busCalc, "properties[" + key + "]", null, value);
+        // Check no notification on same property
+        busCalc.setProperty(key, value);
+        Mockito.verifyNoMoreInteractions(mockedListener);
+        // Remove changes observer
+        network.removeListener(mockedListener);
+        // Adding same property without listener registered
+        busCalc.setProperty(key, value);
+        // Check no notification
+        Mockito.verifyNoMoreInteractions(mockedListener);
     }
 
     @Test

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/SubstationTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/SubstationTest.java
@@ -57,15 +57,21 @@ public class SubstationTest {
         substation.setTso("new tso");
         assertEquals("new tso", substation.getTso());
 
-        // Create a mocked network listener
+        // Create mocked network listeners
+        NetworkListener exceptionListener = Mockito.mock(DefaultNetworkListener.class);
+        Mockito.doThrow(new UnsupportedOperationException()).when(exceptionListener).onElementAdded(Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.any());
         NetworkListener mockedListener = Mockito.mock(DefaultNetworkListener.class);
+        // Test without listeners registered
+        substation.addGeographicalTag("no listeners");
+        Mockito.verifyNoMoreInteractions(mockedListener);
         // Add observer changes to current network
+        network.addListener(exceptionListener);
         network.addListener(mockedListener);
         // Change in order to raise update notification
         substation.addGeographicalTag("test");
         // Check notification done
         Mockito.verify(mockedListener, Mockito.times(1))
-               .onUpdate(Mockito.any(Substation.class), Mockito.anyString(), Mockito.anyCollection(), Mockito.anyCollection());
+               .onElementAdded(Mockito.any(Substation.class), Mockito.anyString(), Mockito.isNull(), Mockito.anyString());
         // Remove observer
         network.removeListener(mockedListener);
     }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/SubstationTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/SubstationTest.java
@@ -59,11 +59,12 @@ public class SubstationTest {
 
         // Create mocked network listeners
         NetworkListener exceptionListener = Mockito.mock(DefaultNetworkListener.class);
-        Mockito.doThrow(new UnsupportedOperationException()).when(exceptionListener).onElementAdded(Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.any());
+        Mockito.doThrow(new UnsupportedOperationException()).when(exceptionListener).onElementAdded(Mockito.any(), Mockito.anyString(), Mockito.any());
         NetworkListener mockedListener = Mockito.mock(DefaultNetworkListener.class);
         // Test without listeners registered
         substation.addGeographicalTag("no listeners");
         Mockito.verifyNoMoreInteractions(mockedListener);
+        Mockito.verifyNoMoreInteractions(exceptionListener);
         // Add observer changes to current network
         network.addListener(exceptionListener);
         network.addListener(mockedListener);
@@ -71,7 +72,7 @@ public class SubstationTest {
         substation.addGeographicalTag("test");
         // Check notification done
         Mockito.verify(mockedListener, Mockito.times(1))
-               .onElementAdded(Mockito.any(Substation.class), Mockito.anyString(), Mockito.isNull(), Mockito.anyString());
+               .onElementAdded(Mockito.any(Substation.class), Mockito.anyString(), Mockito.anyString());
         // Remove observer
         network.removeListener(mockedListener);
     }


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Change container changes notification


**What is the current behavior?** *(You can also link to an open issue here)*
Container notification use NetworkListener::onUpdate method with following parameters: old container content copy and new container 


**What is the new behavior (if this is a feature change)?**
Adding new notifications methods in NetworkListener:
onElementAdded
onElementRemoved


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
