### PR TITLE
time-series: fix CalculatedTimeSeries::split(int newchunksize)

### DIFF
--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CalculatedTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CalculatedTimeSeries.java
@@ -248,7 +248,8 @@ public class CalculatedTimeSeries implements DoubleTimeSeries {
     }
 
     @Override
-    public List<DoubleTimeSeries> split(int chunkCount) {
+    public List<DoubleTimeSeries> split(int newChunkSize) {
+        int chunkCount = TimeSeries.computeChunkCount(index, newChunkSize);
         return Collections.nCopies(chunkCount, this);
     }
 

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeries.java
@@ -67,6 +67,10 @@ public interface TimeSeries<P extends AbstractPoint, T extends TimeSeries<P, T>>
         return createString(name, index, new String[0]);
     }
 
+    static int computeChunkCount(TimeSeriesIndex index, int newChunkSize) {
+        return (int) Math.ceil((double) index.getPointCount() / newChunkSize);
+    }
+
     static StringTimeSeries createString(String name, TimeSeriesIndex index, String... values) {
         Objects.requireNonNull(name);
         Objects.requireNonNull(index);
@@ -104,7 +108,7 @@ public interface TimeSeries<P extends AbstractPoint, T extends TimeSeries<P, T>>
             throw new IllegalArgumentException("New chunk size " + newChunkSize + " is greater than point count "
                     + index.getPointCount());
         }
-        int chunkCount = (int) Math.ceil((double) index.getPointCount() / newChunkSize);
+        int chunkCount = computeChunkCount(index, newChunkSize);
         List<List<T>> splitList = new ArrayList<>(chunkCount);
         for (int i = 0; i < chunkCount; i++) {
             splitList.add(new ArrayList<>(timeSeriesList.size()));

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/CalculatedTimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/CalculatedTimeSeriesTest.java
@@ -188,6 +188,20 @@ public class CalculatedTimeSeriesTest {
     }
 
     @Test
+    public void splitSmallChunkTest() {
+        timeSeries.synchronize(new RegularTimeSeriesIndex(0, 99, 1));
+        List<List<DoubleTimeSeries>> list = TimeSeries.split(Arrays.asList(timeSeries), 50);
+        assertEquals(2, list.size());
+    }
+
+    @Test
+    public void splitBigChunkTest() {
+        timeSeries.synchronize(new RegularTimeSeriesIndex(0, 99, 1));
+        List<List<DoubleTimeSeries>> list = TimeSeries.split(Arrays.asList(timeSeries), 2);
+        assertEquals(50, list.size());
+    }
+
+    @Test
     public void jsonTest() throws IOException {
         TimeSeriesIndex index = RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-07-20T00:00:00Z"), Duration.ofDays(200));
         DoubleTimeSeries ts = TimeSeries.createDouble("ts", index, 1d, 2d);


### PR DESCRIPTION


Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
the array access in TimeSeries::split(list<Timeseries> list, int newchunksize) throws IndexOutOfBoundsException when we use a newChunkSize that is >= to sqrt(totalsize) for CalculatedTimeSeries


**What is the new behavior (if this is a feature change)?**
fixed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO