### PR TITLE
Add regulation in shunt (IIDM/XIIDM)

### DIFF
--- a/action/action-dsl/src/test/java/com/powsybl/action/dsl/ActionDslLoaderTest.java
+++ b/action/action-dsl/src/test/java/com/powsybl/action/dsl/ActionDslLoaderTest.java
@@ -193,6 +193,7 @@ public class ActionDslLoaderTest {
                 .setRegulationMode(PhaseTapChanger.RegulationMode.CURRENT_LIMITER)
                 .setRegulationTerminal(network.getTwoWindingsTransformer("NGEN_NHV1").getTerminal2())
                 .setRegulationValue(1.0)
+                .setTargetDeadband(0)
                 .beginStep()
                     .setR(1.0)
                     .setX(2.0)

--- a/cgmes/cgmes-conversion/src/test/resources/cim14/ieee14.xiidm
+++ b/cgmes/cgmes-conversion/src/test/resources/cim14/ieee14.xiidm
@@ -78,7 +78,7 @@
                 <iidm:bus id="_BUS____9_TN" v="14.596500396728516" angle="-14.953522682189941"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD___9_EC" name="LOAD   9" loadType="UNDEFINED" p0="29.5" q0="16.600000381469727" bus="_BUS____9_TN" connectableBus="_BUS____9_TN" p="29.5" q="16.600000381469727"/>
-            <iidm:shunt id="_BANK___9_SC" name="BANK   9" bPerSection="0.09976900368928909" maximumSectionCount="1" currentSectionCount="1" bus="_BUS____9_TN" connectableBus="_BUS____9_TN"/>
+            <iidm:shunt id="_BANK___9_SC" name="BANK   9" bPerSection="0.09976900368928909" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_BUS____9_TN" connectableBus="_BUS____9_TN"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_BUS____7_VL" name="BUS    7_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>

--- a/cgmes/cgmes-conversion/src/test/resources/cim14/nordic32.xiidm
+++ b/cgmes/cgmes-conversion/src/test/resources/cim14/nordic32.xiidm
@@ -50,7 +50,7 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="_N4012____TN" v="389.052001953125" angle="-3.1062989234924316"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="_N4012____SC" name="N4012   " bPerSection="-6.249999860301614E-4" maximumSectionCount="1" currentSectionCount="1" bus="_N4012____TN" connectableBus="_N4012____TN"/>
+            <iidm:shunt id="_N4012____SC" name="N4012   " bPerSection="-6.249999860301614E-4" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N4012____TN" connectableBus="_N4012____TN"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1012____VL" name="N1012   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -90,7 +90,7 @@
                 <iidm:bus id="_N1022____TN" v="110.60600280761719" angle="-17.621028900146484"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1022____EC" name="N1022   " loadType="UNDEFINED" p0="280.0" q0="95.0" bus="_N1022____TN" connectableBus="_N1022____TN" p="280.0" q="95.0"/>
-            <iidm:shunt id="_N1022____SC" name="N1022   " bPerSection="0.002958579920232296" maximumSectionCount="1" currentSectionCount="1" bus="_N1022____TN" connectableBus="_N1022____TN"/>
+            <iidm:shunt id="_N1022____SC" name="N1022   " bPerSection="0.002958579920232296" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N1022____TN" connectableBus="_N1022____TN"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_NG5_____-N1022___-1_PT" name="NG5     -N1022   -1" r="0.0" x="10.140029907226562" g="0.0" b="0.0" ratedU1="15.0" ratedU2="123.81199645996094" bus1="_NG5______TN" connectableBus1="_NG5______TN" voltageLevelId1="_NG5______VL" bus2="_N1022____TN" connectableBus2="_N1022____TN" voltageLevelId2="_N1022____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
@@ -107,7 +107,7 @@
                 <iidm:bus id="_N1041____TN" v="110.677001953125" angle="-94.36389923095703"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1041____EC" name="N1041   " loadType="UNDEFINED" p0="400.0" q0="180.0" bus="_N1041____TN" connectableBus="_N1041____TN" p="400.0" q="180.0"/>
-            <iidm:shunt id="_N1041____SC" name="N1041   " bPerSection="0.011834300123155117" maximumSectionCount="1" currentSectionCount="1" bus="_N1041____TN" connectableBus="_N1041____TN"/>
+            <iidm:shunt id="_N1041____SC" name="N1041   " bPerSection="0.011834300123155117" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N1041____TN" connectableBus="_N1041____TN"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="_N1044____SS" name="N1044   _SS" country="NO" geographicalTags="_SGR_13">
@@ -121,7 +121,7 @@
                 <iidm:bus id="_N1044____TN" v="112.66100311279297" angle="-80.51592254638672"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1044____EC" name="N1044   " loadType="UNDEFINED" p0="840.0" q0="300.0" bus="_N1044____TN" connectableBus="_N1044____TN" p="840.0" q="300.0"/>
-            <iidm:shunt id="_N1044____SC" name="N1044   " bPerSection="0.011834300123155117" maximumSectionCount="1" currentSectionCount="1" bus="_N1044____TN" connectableBus="_N1044____TN"/>
+            <iidm:shunt id="_N1044____SC" name="N1044   " bPerSection="0.011834300123155117" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N1044____TN" connectableBus="_N1044____TN"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_N1044___-N4044___-1_PT" name="N1044   -N4044   -1" r="0.0" x="15.999960899353027" g="0.0" b="0.0" ratedU1="130.0" ratedU2="388.3599853515625" bus1="_N1044____TN" connectableBus1="_N1044____TN" voltageLevelId1="_N1044____VL" bus2="_N4044____TN" connectableBus2="_N4044____TN" voltageLevelId2="_N4044____VL">
             <iidm:currentLimits1 permanentLimit="4441.16015625"/>
@@ -143,7 +143,7 @@
                 <iidm:bus id="_N1045____TN" v="115.51200103759766" angle="-85.65843200683594"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1045____EC" name="N1045   " loadType="UNDEFINED" p0="720.0" q0="230.0" bus="_N1045____TN" connectableBus="_N1045____TN" p="720.0" q="230.0"/>
-            <iidm:shunt id="_N1045____SC" name="N1045   " bPerSection="0.011834300123155117" maximumSectionCount="1" currentSectionCount="1" bus="_N1045____TN" connectableBus="_N1045____TN"/>
+            <iidm:shunt id="_N1045____SC" name="N1045   " bPerSection="0.011834300123155117" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N1045____TN" connectableBus="_N1045____TN"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_N1045___-N4045___-1_PT" name="N1045   -N4045   -1" r="0.0" x="15.999998092651367" g="0.0" b="0.0" ratedU1="130.0" ratedU2="384.6000061035156" bus1="_N1045____TN" connectableBus1="_N1045____TN" voltageLevelId1="_N1045____VL" bus2="_N4045____TN" connectableBus2="_N4045____TN" voltageLevelId2="_N4045____VL">
             <iidm:currentLimits1 permanentLimit="4441.16015625"/>
@@ -196,7 +196,7 @@
                 <iidm:bus id="_N4043____TN" v="343.68499755859375" angle="-75.2749252319336"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4043____EC" name="N4043   " loadType="UNDEFINED" p0="900.0" q0="303.20001220703125" bus="_N4043____TN" connectableBus="_N4043____TN" p="900.0" q="303.20001220703125"/>
-            <iidm:shunt id="_N4043____SC" name="N4043   " bPerSection="0.0012499999720603228" maximumSectionCount="1" currentSectionCount="1" bus="_N4043____TN" connectableBus="_N4043____TN"/>
+            <iidm:shunt id="_N4043____SC" name="N4043   " bPerSection="0.0012499999720603228" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N4043____TN" connectableBus="_N4043____TN"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="_N4046____SS" name="N4046   _SS" country="DK" geographicalTags="_SGR_40">
@@ -205,7 +205,7 @@
                 <iidm:bus id="_N4046____TN" v="346.0889892578125" angle="-76.19192504882812"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4046____EC" name="N4046   " loadType="UNDEFINED" p0="700.0" q0="250.0" bus="_N4046____TN" connectableBus="_N4046____TN" p="700.0" q="250.0"/>
-            <iidm:shunt id="_N4046____SC" name="N4046   " bPerSection="6.249999860301614E-4" maximumSectionCount="1" currentSectionCount="1" bus="_N4046____TN" connectableBus="_N4046____TN"/>
+            <iidm:shunt id="_N4046____SC" name="N4046   " bPerSection="6.249999860301614E-4" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N4046____TN" connectableBus="_N4046____TN"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="_N4061____SS" name="N4061   _SS" country="DK" geographicalTags="_SGR_40">
@@ -249,7 +249,7 @@
                 <iidm:bus id="_N4041____TN" v="353.125" angle="-62.66741180419922"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4041____EC" name="N4041   " loadType="UNDEFINED" p0="540.0" q0="160.0" bus="_N4041____TN" connectableBus="_N4041____TN" p="540.0" q="160.0"/>
-            <iidm:shunt id="_N4041____SC" name="N4041   " bPerSection="0.0012499999720603228" maximumSectionCount="1" currentSectionCount="1" bus="_N4041____TN" connectableBus="_N4041____TN"/>
+            <iidm:shunt id="_N4041____SC" name="N4041   " bPerSection="0.0012499999720603228" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N4041____TN" connectableBus="_N4041____TN"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_NG13____-N4041___-1_PT" name="NG13    -N4041   -1" r="0.0" x="53.327980041503906" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG13_____TN" connectableBus1="_NG13_____TN" voltageLevelId1="_NG13_____VL" bus2="_N4041____TN" connectableBus2="_N4041____TN" voltageLevelId2="_N4041____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
@@ -310,7 +310,7 @@
                 <iidm:bus id="_N4051____TN" v="363.5039978027344" angle="-85.46057891845703"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4051____EC" name="N4051   " loadType="UNDEFINED" p0="800.0" q0="302.3999938964844" bus="_N4051____TN" connectableBus="_N4051____TN" p="800.0" q="302.3999938964844"/>
-            <iidm:shunt id="_N4051____SC" name="N4051   " bPerSection="6.249999860301614E-4" maximumSectionCount="1" currentSectionCount="1" bus="_N4051____TN" connectableBus="_N4051____TN"/>
+            <iidm:shunt id="_N4051____SC" name="N4051   " bPerSection="6.249999860301614E-4" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N4051____TN" connectableBus="_N4051____TN"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_NG16____-N4051___-1_PT" name="NG16    -N4051   -1" r="0.0" x="34.288021087646484" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG16_____TN" connectableBus1="_NG16_____TN" voltageLevelId1="_NG16_____VL" bus2="_N4051____TN" connectableBus2="_N4051____TN" voltageLevelId2="_N4051____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
@@ -371,7 +371,7 @@
                 <iidm:bus id="_N4071____TN" v="384.0769958496094" angle="-2.306674003601074"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4071____EC" name="N4071   " loadType="UNDEFINED" p0="300.0" q0="100.0" bus="_N4071____TN" connectableBus="_N4071____TN" p="300.0" q="100.0"/>
-            <iidm:shunt id="_N4071____SC" name="N4071   " bPerSection="-0.0024999999441206455" maximumSectionCount="1" currentSectionCount="1" bus="_N4071____TN" connectableBus="_N4071____TN"/>
+            <iidm:shunt id="_N4071____SC" name="N4071   " bPerSection="-0.0024999999441206455" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N4071____TN" connectableBus="_N4071____TN"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_NG19____-N4071___-1_PT" name="NG19    -N4071   -1" r="0.0" x="48.00001907348633" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG19_____TN" connectableBus1="_NG19_____TN" voltageLevelId1="_NG19_____VL" bus2="_N4071____TN" connectableBus2="_N4071____TN" voltageLevelId2="_N4071____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>
@@ -490,7 +490,7 @@
                 <iidm:bus id="_N1043____TN" v="113.4800033569336" angle="-89.6317367553711"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1043____EC" name="N1043   " loadType="UNDEFINED" p0="260.0" q0="100.0" bus="_N1043____TN" connectableBus="_N1043____TN" p="260.0" q="100.0"/>
-            <iidm:shunt id="_N1043____SC" name="N1043   " bPerSection="0.008875739760696888" maximumSectionCount="1" currentSectionCount="1" bus="_N1043____TN" connectableBus="_N1043____TN"/>
+            <iidm:shunt id="_N1043____SC" name="N1043   " bPerSection="0.008875739760696888" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="_N1043____TN" connectableBus="_N1043____TN"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_NG7_____-N1043___-1_PT" name="NG7     -N1043   -1" r="0.0" x="12.674969673156738" g="0.0" b="0.0" ratedU1="15.0" ratedU2="123.81199645996094" bus1="_NG7______TN" connectableBus1="_NG7______TN" voltageLevelId1="_NG7______VL" bus2="_N1043____TN" connectableBus2="_N1043____TN" voltageLevelId2="_N1043____VL">
             <iidm:currentLimits1 permanentLimit="38490.0"/>

--- a/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
+++ b/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
@@ -428,6 +428,7 @@ public class IeeeCdfImporter implements Importer {
                 .setRegulating(regulating)
                 .setRegulationTerminal(regulatingTerminal)
                 .setTargetV(targetV)
+                .setTargetDeadband(regulating ? 0.0 : Double.NaN)
                 .setTapPosition(0);
         for (double rho : rhos) {
             ratioTapChangerAdder.beginStep()

--- a/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee118cdf.xiidm
+++ b/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee118cdf.xiidm
@@ -43,7 +43,7 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="B5" name="Olive     V2" v="1.002" angle="15.73"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="B5-SH" bPerSection="-40.0" maximumSectionCount="1" currentSectionCount="1" bus="B5" connectableBus="B5"/>
+            <iidm:shunt id="B5-SH" bPerSection="-40.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B5" connectableBus="B5"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL8" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -308,7 +308,7 @@
                 <iidm:minMaxReactiveLimits minQ="-8.0" maxQ="24.0"/>
             </iidm:generator>
             <iidm:load id="B34-L" loadType="UNDEFINED" p0="59.0" q0="26.0" bus="B34" connectableBus="B34"/>
-            <iidm:shunt id="B34-SH" bPerSection="14.000000000000002" maximumSectionCount="1" currentSectionCount="1" bus="B34" connectableBus="B34"/>
+            <iidm:shunt id="B34-SH" bPerSection="14.000000000000002" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B34" connectableBus="B34"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S86">
@@ -335,7 +335,7 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="B37" name="EastLima  V2" v="0.992" angle="11.77"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="B37-SH" bPerSection="-25.0" maximumSectionCount="1" currentSectionCount="1" bus="B37" connectableBus="B37"/>
+            <iidm:shunt id="B37-SH" bPerSection="-25.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B37" connectableBus="B37"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL38" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -396,7 +396,7 @@
                 <iidm:bus id="B44" name="WMVernon  V2" v="0.985" angle="13.82"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B44-L" loadType="UNDEFINED" p0="16.0" q0="8.0" bus="B44" connectableBus="B44"/>
-            <iidm:shunt id="B44-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" bus="B44" connectableBus="B44"/>
+            <iidm:shunt id="B44-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B44" connectableBus="B44"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S80">
@@ -405,7 +405,7 @@
                 <iidm:bus id="B45" name="N.Newark  V2" v="0.987" angle="15.67"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B45-L" loadType="UNDEFINED" p0="53.0" q0="22.0" bus="B45" connectableBus="B45"/>
-            <iidm:shunt id="B45-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" bus="B45" connectableBus="B45"/>
+            <iidm:shunt id="B45-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B45" connectableBus="B45"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S71">
@@ -417,7 +417,7 @@
                 <iidm:minMaxReactiveLimits minQ="-100.0" maxQ="100.0"/>
             </iidm:generator>
             <iidm:load id="B46-L" loadType="UNDEFINED" p0="28.0" q0="10.0" bus="B46" connectableBus="B46"/>
-            <iidm:shunt id="B46-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" bus="B46" connectableBus="B46"/>
+            <iidm:shunt id="B46-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B46" connectableBus="B46"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S72">
@@ -434,7 +434,7 @@
                 <iidm:bus id="B48" name="Zanesvll  V2" v="1.021" angle="19.93"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B48-L" loadType="UNDEFINED" p0="20.0" q0="11.0" bus="B48" connectableBus="B48"/>
-            <iidm:shunt id="B48-SH" bPerSection="15.0" maximumSectionCount="1" currentSectionCount="1" bus="B48" connectableBus="B48"/>
+            <iidm:shunt id="B48-SH" bPerSection="15.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B48" connectableBus="B48"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S74">
@@ -672,7 +672,7 @@
                 <iidm:minMaxReactiveLimits minQ="-6.0" maxQ="9.0"/>
             </iidm:generator>
             <iidm:load id="B74-L" loadType="UNDEFINED" p0="68.0" q0="27.0" bus="B74" connectableBus="B74"/>
-            <iidm:shunt id="B74-SH" bPerSection="12.0" maximumSectionCount="1" currentSectionCount="1" bus="B74" connectableBus="B74"/>
+            <iidm:shunt id="B74-SH" bPerSection="12.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B74" connectableBus="B74"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S18">
@@ -719,7 +719,7 @@
                 <iidm:bus id="B79" name="CapitlHl  V2" v="1.009" angle="26.72"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B79-L" loadType="UNDEFINED" p0="39.0" q0="32.0" bus="B79" connectableBus="B79"/>
-            <iidm:shunt id="B79-SH" bPerSection="20.0" maximumSectionCount="1" currentSectionCount="1" bus="B79" connectableBus="B79"/>
+            <iidm:shunt id="B79-SH" bPerSection="20.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B79" connectableBus="B79"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S1">
@@ -745,7 +745,7 @@
                 <iidm:bus id="B82" name="Logan     V2" v="0.989" angle="27.24"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B82-L" loadType="UNDEFINED" p0="54.0" q0="27.0" bus="B82" connectableBus="B82"/>
-            <iidm:shunt id="B82-SH" bPerSection="20.0" maximumSectionCount="1" currentSectionCount="1" bus="B82" connectableBus="B82"/>
+            <iidm:shunt id="B82-SH" bPerSection="20.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B82" connectableBus="B82"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S3">
@@ -754,7 +754,7 @@
                 <iidm:bus id="B83" name="Sprigg    V2" v="0.985" angle="28.42"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B83-L" loadType="UNDEFINED" p0="20.0" q0="10.0" bus="B83" connectableBus="B83"/>
-            <iidm:shunt id="B83-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" bus="B83" connectableBus="B83"/>
+            <iidm:shunt id="B83-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B83" connectableBus="B83"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S4">
@@ -960,7 +960,7 @@
                 <iidm:minMaxReactiveLimits minQ="-8.0" maxQ="23.0"/>
             </iidm:generator>
             <iidm:load id="B105-L" loadType="UNDEFINED" p0="31.0" q0="26.0" bus="B105" connectableBus="B105"/>
-            <iidm:shunt id="B105-SH" bPerSection="20.0" maximumSectionCount="1" currentSectionCount="1" bus="B105" connectableBus="B105"/>
+            <iidm:shunt id="B105-SH" bPerSection="20.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B105" connectableBus="B105"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S45">
@@ -980,7 +980,7 @@
                 <iidm:minMaxReactiveLimits minQ="-200.0" maxQ="200.0"/>
             </iidm:generator>
             <iidm:load id="B107-L" loadType="UNDEFINED" p0="28.0" q0="12.0" bus="B107" connectableBus="B107"/>
-            <iidm:shunt id="B107-SH" bPerSection="6.0" maximumSectionCount="1" currentSectionCount="1" bus="B107" connectableBus="B107"/>
+            <iidm:shunt id="B107-SH" bPerSection="6.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B107" connectableBus="B107"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S41">
@@ -1008,7 +1008,7 @@
                 <iidm:minMaxReactiveLimits minQ="-8.0" maxQ="23.0"/>
             </iidm:generator>
             <iidm:load id="B110-L" loadType="UNDEFINED" p0="39.0" q0="30.0" bus="B110" connectableBus="B110"/>
-            <iidm:shunt id="B110-SH" bPerSection="6.0" maximumSectionCount="1" currentSectionCount="1" bus="B110" connectableBus="B110"/>
+            <iidm:shunt id="B110-SH" bPerSection="6.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B110" connectableBus="B110"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S32">

--- a/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee14cdf-solved.xiidm
+++ b/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee14cdf-solved.xiidm
@@ -49,7 +49,7 @@
                 <iidm:bus id="B9" name="Bus 9     LV" v="1.056" angle="-14.94"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B9-L" loadType="UNDEFINED" p0="29.5" q0="16.6" bus="B9" connectableBus="B9" p="29.5" q="16.6"/>
-            <iidm:shunt id="B9-SH" bPerSection="19.0" maximumSectionCount="1" currentSectionCount="1" bus="B9" connectableBus="B9" q="-21.187584"/>
+            <iidm:shunt id="B9-SH" bPerSection="19.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B9" connectableBus="B9" q="-21.187584"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T4-7-1" r="0.0" x="0.0020912" g="0.0" b="0.0" ratedU1="0.978" ratedU2="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B7" connectableBus2="B7" voltageLevelId2="VL7" p1="28.12612787731891" q1="-9.753887720619232" p2="-28.126127877318922" q2="11.464367695376083"/>
         <iidm:twoWindingsTransformer id="T4-9-1" r="0.0" x="0.0055618" g="0.0" b="0.0" ratedU1="0.969" ratedU2="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B9" connectableBus2="B9" voltageLevelId2="VL9" p1="16.10119634666402" q1="-0.37521312955084385" p2="-16.101196346664025" q2="1.6823451017767743"/>

--- a/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee14cdf.xiidm
+++ b/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee14cdf.xiidm
@@ -49,7 +49,7 @@
                 <iidm:bus id="B9" name="Bus 9     LV" v="1.056" angle="-14.94"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B9-L" loadType="UNDEFINED" p0="29.5" q0="16.6" bus="B9" connectableBus="B9"/>
-            <iidm:shunt id="B9-SH" bPerSection="19.0" maximumSectionCount="1" currentSectionCount="1" bus="B9" connectableBus="B9"/>
+            <iidm:shunt id="B9-SH" bPerSection="19.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B9" connectableBus="B9"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T4-7-1" r="0.0" x="0.0020912" g="0.0" b="0.0" ratedU1="0.978" ratedU2="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B7" connectableBus2="B7" voltageLevelId2="VL7"/>
         <iidm:twoWindingsTransformer id="T4-9-1" r="0.0" x="0.0055618" g="0.0" b="0.0" ratedU1="0.969" ratedU2="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B9" connectableBus2="B9" voltageLevelId2="VL9"/>

--- a/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee300cdf.xiidm
+++ b/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee300cdf.xiidm
@@ -49,21 +49,21 @@
             </iidm:generator>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T3-1-1" r="0.0" x="5.2E-4" g="0.0" b="0.0" ratedU1="0.947" ratedU2="1.0" bus1="B3" connectableBus1="B3" voltageLevelId1="VL3" bus2="B1" connectableBus2="B1" voltageLevelId2="VL1">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0284">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0284">
                 <iidm:terminalRef id="T3-1-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T7001-1-1" r="0.0" x="1.953E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B7001" connectableBus1="B7001" voltageLevelId1="VL7001" bus2="B1" connectableBus2="B1" voltageLevelId2="VL1"/>
         <iidm:twoWindingsTransformer id="T3-2-1" r="0.0" x="5.2E-4" g="0.0" b="0.0" ratedU1="0.956" ratedU2="1.0" bus1="B3" connectableBus1="B3" voltageLevelId1="VL3" bus2="B2" connectableBus2="B2" voltageLevelId2="VL2">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0354">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0354">
                 <iidm:terminalRef id="T3-2-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T7002-2-1" r="1.0E-5" x="1.46E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B7002" connectableBus1="B7002" voltageLevelId1="VL7002" bus2="B2" connectableBus2="B2" voltageLevelId2="VL2"/>
         <iidm:twoWindingsTransformer id="T3-4-1" r="0.0" x="5.0E-5" g="0.0" b="0.0" ratedU1="0.971" ratedU2="1.0" bus1="B3" connectableBus1="B3" voltageLevelId1="VL3" bus2="B4" connectableBus2="B4" voltageLevelId2="VL4">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0308">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0308">
                 <iidm:terminalRef id="T3-4-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -89,13 +89,13 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T7-5-1" r="0.0" x="3.9E-4" g="0.0" b="0.0" ratedU1="0.948" ratedU2="1.0" bus1="B7" connectableBus1="B7" voltageLevelId1="VL7" bus2="B5" connectableBus2="B5" voltageLevelId2="VL5">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0191">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0191">
                 <iidm:terminalRef id="T7-5-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T7-6-1" r="0.0" x="3.9E-4" g="0.0" b="0.0" ratedU1="0.959" ratedU2="1.0" bus1="B7" connectableBus1="B7" voltageLevelId1="VL7" bus2="B6" connectableBus2="B6" voltageLevelId2="VL6">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0312">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0312">
                 <iidm:terminalRef id="T7-6-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -158,7 +158,7 @@
             </iidm:generator>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T10-11-1" r="0.0" x="8.9E-4" g="0.0" b="0.0" ratedU1="1.046" ratedU2="1.0" bus1="B10" connectableBus1="B10" voltageLevelId1="VL10" bus2="B11" connectableBus2="B11" voltageLevelId2="VL11">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0057">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0057">
                 <iidm:terminalRef id="T10-11-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -210,13 +210,13 @@
             </iidm:generator>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T15-17-1" r="1.94E-4" x="3.11E-4" g="0.0" b="0.0" ratedU1="0.9561" ratedU2="1.0" bus1="B15" connectableBus1="B15" voltageLevelId1="VL15" bus2="B17" connectableBus2="B17" voltageLevelId2="VL17">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0649">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0649">
                 <iidm:terminalRef id="T15-17-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T16-15-1" r="1.0E-5" x="3.8E-4" g="0.0" b="0.0" ratedU1="0.971" ratedU2="1.0" bus1="B16" connectableBus1="B16" voltageLevelId1="VL16" bus2="B15" connectableBus2="B15" voltageLevelId2="VL15">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0343">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0343">
                 <iidm:terminalRef id="T16-15-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -285,7 +285,7 @@
             </iidm:generator>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T24-23-1" r="0.0" x="6.4E-4" g="0.0" b="0.0" ratedU1="0.943" ratedU2="1.0" bus1="B24" connectableBus1="B24" voltageLevelId1="VL24" bus2="B23" connectableBus2="B23" voltageLevelId2="VL23">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0501">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0501">
                 <iidm:terminalRef id="T24-23-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -344,7 +344,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T36-35-1" r="0.0" x="4.7E-4" g="0.0" b="0.0" ratedU1="1.01" ratedU2="1.0" bus1="B36" connectableBus1="B36" voltageLevelId1="VL36" bus2="B35" connectableBus2="B35" voltageLevelId2="VL35">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9757">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9757">
                 <iidm:terminalRef id="T36-35-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -378,13 +378,13 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T9001-9006-1" r="2.439E-4" x="0.0043682" g="0.0" b="0.0" ratedU1="0.9668" ratedU2="1.0" bus1="B9001" connectableBus1="B9001" voltageLevelId1="VL9001" bus2="B9006" connectableBus2="B9006" voltageLevelId2="VL9006">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0029">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0029">
                 <iidm:terminalRef id="T9001-9006-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T9001-9012-1" r="3.624E-4" x="0.0064898" g="0.0" b="0.0" ratedU1="0.9796" ratedU2="1.0" bus1="B9001" connectableBus1="B9001" voltageLevelId1="VL9001" bus2="B9012" connectableBus2="B9012" voltageLevelId2="VL9012">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0023">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0023">
                 <iidm:terminalRef id="T9001-9012-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -471,14 +471,14 @@
             </iidm:generator>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T45-44-1" r="0.0" x="2.0E-4" g="0.0" b="0.0" ratedU1="1.008" ratedU2="1.0" bus1="B45" connectableBus1="B45" voltageLevelId1="VL45" bus2="B44" connectableBus2="B44" voltageLevelId2="VL44">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0086">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0086">
                 <iidm:terminalRef id="T45-44-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T7044-44-1" r="0.0" x="0.0018181" g="0.0" b="0.0" ratedU1="0.942" ratedU2="1.0" bus1="B7044" connectableBus1="B7044" voltageLevelId1="VL7044" bus2="B44" connectableBus2="B44" voltageLevelId2="VL44"/>
         <iidm:twoWindingsTransformer id="T45-46-1" r="0.0" x="2.1E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B45" connectableBus1="B45" voltageLevelId1="VL45" bus2="B46" connectableBus2="B46" voltageLevelId2="VL46">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0344">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0344">
                 <iidm:terminalRef id="T45-46-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -635,7 +635,7 @@
             </iidm:generator>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T62-61-1" r="0.0" x="5.9E-4" g="0.0" b="0.0" ratedU1="0.975" ratedU2="1.0" bus1="B62" connectableBus1="B62" voltageLevelId1="VL62" bus2="B61" connectableBus2="B61" voltageLevelId2="VL61">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9906">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9906">
                 <iidm:terminalRef id="T62-61-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -659,7 +659,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T63-64-1" r="0.0" x="3.8E-4" g="0.0" b="0.0" ratedU1="1.017" ratedU2="1.0" bus1="B63" connectableBus1="B63" voltageLevelId1="VL63" bus2="B64" connectableBus2="B64" voltageLevelId2="VL64">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.948">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.948">
                 <iidm:terminalRef id="T63-64-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -678,7 +678,7 @@
             <iidm:load id="B201-L" loadType="UNDEFINED" p0="41.0" q0="14.0" bus="B201" connectableBus="B201"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T201-69-2" r="0.0" x="9.8E-4" g="0.0" b="0.0" ratedU1="1.03" ratedU2="1.0" bus1="B201" connectableBus1="B201" voltageLevelId1="VL201" bus2="B69" connectableBus2="B69" voltageLevelId2="VL69">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.963">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.963">
                 <iidm:terminalRef id="T201-69-2" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -730,7 +730,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T73-74-1" r="0.0" x="2.4400000000000002E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B73" connectableBus1="B73" voltageLevelId1="VL73" bus2="B74" connectableBus2="B74" voltageLevelId2="VL74">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9964">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9964">
                 <iidm:terminalRef id="T73-74-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -790,7 +790,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T81-88-1" r="0.0" x="2.0E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B81" connectableBus1="B81" voltageLevelId1="VL81" bus2="B88" connectableBus2="B88" voltageLevelId2="VL88">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0151">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0151">
                 <iidm:terminalRef id="T81-88-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -820,7 +820,7 @@
             <iidm:load id="B99-L" loadType="UNDEFINED" p0="83.5" q0="0.0" bus="B99" connectableBus="B99"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T85-99-1" r="0.0" x="4.8E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B85" connectableBus1="B85" voltageLevelId1="VL85" bus2="B99" connectableBus2="B99" voltageLevelId2="VL99">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9894">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9894">
                 <iidm:terminalRef id="T85-99-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -839,7 +839,7 @@
             <iidm:load id="B102-L" loadType="UNDEFINED" p0="77.8" q0="0.0" bus="B102" connectableBus="B102"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T86-102-1" r="0.0" x="4.8E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B86" connectableBus1="B86" voltageLevelId1="VL86" bus2="B102" connectableBus2="B102" voltageLevelId2="VL102">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0008">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0008">
                 <iidm:terminalRef id="T86-102-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -858,7 +858,7 @@
             <iidm:load id="B94-L" loadType="UNDEFINED" p0="60.3" q0="0.0" bus="B94" connectableBus="B94"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T87-94-1" r="0.0" x="4.6E-4" g="0.0" b="0.0" ratedU1="1.015" ratedU2="1.0" bus1="B87" connectableBus1="B87" voltageLevelId1="VL87" bus2="B94" connectableBus2="B94" voltageLevelId2="VL94">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.993">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.993">
                 <iidm:terminalRef id="T87-94-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1017,7 +1017,7 @@
             <iidm:load id="B207-L" loadType="UNDEFINED" p0="-21.0" q0="-14.2" bus="B207" connectableBus="B207"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T114-207-1" r="0.0" x="0.00149" g="0.0" b="0.0" ratedU1="0.967" ratedU2="1.0" bus1="B114" connectableBus1="B114" voltageLevelId1="VL114" bus2="B207" connectableBus2="B207" voltageLevelId2="VL207">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0137">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0137">
                 <iidm:terminalRef id="T114-207-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1036,7 +1036,7 @@
             <iidm:load id="B121-L" loadType="UNDEFINED" p0="535.0" q0="55.0" bus="B121" connectableBus="B121"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T121-115-1" r="0.0" x="2.8000000000000003E-4" g="0.0" b="0.0" ratedU1="1.05" ratedU2="1.0" bus1="B121" connectableBus1="B121" voltageLevelId1="VL121" bus2="B115" connectableBus2="B115" voltageLevelId2="VL115">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9603">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9603">
                 <iidm:terminalRef id="T121-115-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1070,7 +1070,7 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="B117" name="2" v="0.9348" angle="-4.72"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="B117-SH" bPerSection="325.0" maximumSectionCount="1" currentSectionCount="1" bus="B117" connectableBus="B117"/>
+            <iidm:shunt id="B117-SH" bPerSection="325.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B117" connectableBus="B117"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL159" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -1079,7 +1079,7 @@
             <iidm:load id="B159-L" loadType="UNDEFINED" p0="33.0" q0="16.5" bus="B159" connectableBus="B159"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T159-117-1" r="0.0" x="1.6E-4" g="0.0" b="0.0" ratedU1="1.0506" ratedU2="1.0" bus1="B159" connectableBus1="B159" voltageLevelId1="VL159" bus2="B117" connectableBus2="B117" voltageLevelId2="VL117">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9348">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9348">
                 <iidm:terminalRef id="T159-117-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1109,7 +1109,7 @@
             <iidm:load id="B1190-L" loadType="UNDEFINED" p0="100.31" q0="29.17" bus="B1190" connectableBus="B1190"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T119-1190-1" r="1.0E-5" x="2.3E-4" g="0.0" b="0.0" ratedU1="1.0223" ratedU2="1.0" bus1="B119" connectableBus1="B119" voltageLevelId1="VL119" bus2="B1190" connectableBus2="B1190" voltageLevelId2="VL1190">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0128">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0128">
                 <iidm:terminalRef id="T119-1190-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1121,7 +1121,7 @@
                 <iidm:bus id="B120" name="2" v="0.9584" angle="-8.77"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B120-L" loadType="UNDEFINED" p0="777.0" q0="215.0" bus="B120" connectableBus="B120"/>
-            <iidm:shunt id="B120-SH" bPerSection="55.0" maximumSectionCount="1" currentSectionCount="1" bus="B120" connectableBus="B120"/>
+            <iidm:shunt id="B120-SH" bPerSection="55.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B120" connectableBus="B120"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL1200" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -1130,7 +1130,7 @@
             <iidm:load id="B1200-L" loadType="UNDEFINED" p0="-100.0" q0="34.17" bus="B1200" connectableBus="B1200"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T120-1200-1" r="0.0" x="2.3E-4" g="0.0" b="0.0" ratedU1="0.9284" ratedU2="1.0" bus1="B120" connectableBus1="B120" voltageLevelId1="VL120" bus2="B1200" connectableBus2="B1200" voltageLevelId2="VL1200">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0244">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0244">
                 <iidm:terminalRef id="T120-1200-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1150,7 +1150,7 @@
             <iidm:load id="B157-L" loadType="UNDEFINED" p0="123.5" q0="-24.3" bus="B157" connectableBus="B157"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T122-157-1" r="5.0E-6" x="1.95E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B122" connectableBus1="B122" voltageLevelId1="VL122" bus2="B157" connectableBus2="B157" voltageLevelId2="VL157">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9845">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9845">
                 <iidm:terminalRef id="T122-157-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1230,13 +1230,13 @@
             </iidm:generator>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T130-131-1" r="0.0" x="1.7999999999999998E-4" g="0.0" b="0.0" ratedU1="1.0522" ratedU2="1.0" bus1="B130" connectableBus1="B130" voltageLevelId1="VL130" bus2="B131" connectableBus2="B131" voltageLevelId2="VL131">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9861">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9861">
                 <iidm:terminalRef id="T130-131-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T130-150-1" r="0.0" x="1.4000000000000001E-4" g="0.0" b="0.0" ratedU1="1.0522" ratedU2="1.0" bus1="B130" connectableBus1="B130" voltageLevelId1="VL130" bus2="B150" connectableBus2="B150" voltageLevelId2="VL150">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9869">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9869">
                 <iidm:terminalRef id="T130-150-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1310,7 +1310,7 @@
             <iidm:load id="B163-L" loadType="UNDEFINED" p0="0.0" q0="0.4" bus="B163" connectableBus="B163"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T163-137-1" r="1.3E-5" x="3.8399999999999996E-4" g="0.0" b="-5.7" ratedU1="0.98" ratedU2="1.0" bus1="B163" connectableBus1="B163" voltageLevelId1="VL163" bus2="B137" connectableBus2="B137" voltageLevelId2="VL137">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0471">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0471">
                 <iidm:terminalRef id="T163-137-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1349,7 +1349,7 @@
             </iidm:generator>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T182-139-1" r="2.9999999999999997E-6" x="1.31E-4" g="0.0" b="0.0" ratedU1="1.05" ratedU2="1.0" bus1="B182" connectableBus1="B182" voltageLevelId1="VL182" bus2="B139" connectableBus2="B139" voltageLevelId2="VL139">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0117">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0117">
                 <iidm:terminalRef id="T182-139-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1380,7 +1380,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T141-174-1" r="2.3999999999999997E-5" x="6.03E-4" g="0.0" b="0.0" ratedU1="0.975" ratedU2="1.0" bus1="B141" connectableBus1="B141" voltageLevelId1="VL141" bus2="B174" connectableBus2="B174" voltageLevelId2="VL174">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0622">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0622">
                 <iidm:terminalRef id="T141-174-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1400,7 +1400,7 @@
             <iidm:load id="B175-L" loadType="UNDEFINED" p0="176.0" q0="83.0" bus="B175" connectableBus="B175"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T142-175-1" r="2.3999999999999997E-5" x="4.98E-4" g="0.0" b="-8.7" ratedU1="1.0" ratedU2="1.0" bus1="B142" connectableBus1="B142" voltageLevelId1="VL142" bus2="B175" connectableBus2="B175" voltageLevelId2="VL175">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.973">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.973">
                 <iidm:terminalRef id="T142-175-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1428,13 +1428,13 @@
             <iidm:load id="B148-L" loadType="UNDEFINED" p0="63.0" q0="25.0" bus="B148" connectableBus="B148"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T143-144-1" r="0.0" x="8.33E-4" g="0.0" b="0.0" ratedU1="1.035" ratedU2="1.0" bus1="B143" connectableBus1="B143" voltageLevelId1="VL143" bus2="B144" connectableBus2="B144" voltageLevelId2="VL144">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.016">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.016">
                 <iidm:terminalRef id="T143-144-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T143-148-1" r="1.3E-5" x="3.71E-4" g="0.0" b="0.0" ratedU1="0.9565" ratedU2="1.0" bus1="B143" connectableBus1="B143" voltageLevelId1="VL143" bus2="B148" connectableBus2="B148" voltageLevelId2="VL148">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0577">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0577">
                 <iidm:terminalRef id="T143-148-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1454,7 +1454,7 @@
             <iidm:load id="B180-L" loadType="UNDEFINED" p0="69.5" q0="49.3" bus="B180" connectableBus="B180"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T145-180-1" r="5.0E-6" x="1.82E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B145" connectableBus1="B145" voltageLevelId1="VL145" bus2="B180" connectableBus2="B180" voltageLevelId2="VL180">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9793">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9793">
                 <iidm:terminalRef id="T145-180-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1517,7 +1517,7 @@
             <iidm:load id="B183-L" loadType="UNDEFINED" p0="40.0" q0="4.0" bus="B183" connectableBus="B183"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T153-183-1" r="2.7000000000000002E-5" x="6.39E-4" g="0.0" b="0.0" ratedU1="1.073" ratedU2="1.0" bus1="B153" connectableBus1="B153" voltageLevelId1="VL153" bus2="B183" connectableBus2="B183" voltageLevelId2="VL183">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9717">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9717">
                 <iidm:terminalRef id="T153-183-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1529,7 +1529,7 @@
                 <iidm:bus id="B154" name="2" v="0.9663" angle="-1.8"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B154-L" loadType="UNDEFINED" p0="70.0" q0="5.0" bus="B154" connectableBus="B154"/>
-            <iidm:shunt id="B154-SH" bPerSection="34.5" maximumSectionCount="1" currentSectionCount="1" bus="B154" connectableBus="B154"/>
+            <iidm:shunt id="B154-SH" bPerSection="34.5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B154" connectableBus="B154"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S75">
@@ -1552,11 +1552,11 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="B164" name="2" v="0.9839" angle="9.66"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="B164-SH" bPerSection="-212.0" maximumSectionCount="1" currentSectionCount="1" bus="B164" connectableBus="B164"/>
+            <iidm:shunt id="B164-SH" bPerSection="-212.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B164" connectableBus="B164"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T155-156-1" r="8.000000000000001E-6" x="2.5600000000000004E-4" g="0.0" b="0.0" ratedU1="1.05" ratedU2="1.0" bus1="B155" connectableBus1="B155" voltageLevelId1="VL155" bus2="B156" connectableBus2="B156" voltageLevelId2="VL156"/>
         <iidm:twoWindingsTransformer id="T164-155-1" r="9.0E-6" x="2.31E-4" g="0.0" b="-3.3000000000000003" ratedU1="0.956" ratedU2="1.0" bus1="B164" connectableBus1="B164" voltageLevelId1="VL164" bus2="B155" connectableBus2="B155" voltageLevelId2="VL155">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0177">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0177">
                 <iidm:terminalRef id="T164-155-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1597,7 +1597,7 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="B166" name="2" v="0.9973" angle="30.22"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="B166-SH" bPerSection="-103.0" maximumSectionCount="1" currentSectionCount="1" bus="B166" connectableBus="B166"/>
+            <iidm:shunt id="B166-SH" bPerSection="-103.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B166" connectableBus="B166"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL7166" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -1656,7 +1656,7 @@
                 <iidm:bus id="B173" name="2" v="0.9837" angle="-12.75"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B173-L" loadType="UNDEFINED" p0="163.5" q0="43.0" bus="B173" connectableBus="B173"/>
-            <iidm:shunt id="B173-SH" bPerSection="53.0" maximumSectionCount="1" currentSectionCount="1" bus="B173" connectableBus="B173"/>
+            <iidm:shunt id="B173-SH" bPerSection="53.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B173" connectableBus="B173"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S51">
@@ -1695,7 +1695,7 @@
                 <iidm:bus id="B179" name="2" v="0.9699" angle="-9.37"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B179-L" loadType="UNDEFINED" p0="74.0" q0="29.0" bus="B179" connectableBus="B179"/>
-            <iidm:shunt id="B179-SH" bPerSection="45.0" maximumSectionCount="1" currentSectionCount="1" bus="B179" connectableBus="B179"/>
+            <iidm:shunt id="B179-SH" bPerSection="45.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B179" connectableBus="B179"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S70">
@@ -1767,7 +1767,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T189-210-1" r="0.0" x="0.00252" g="0.0" b="0.0" ratedU1="1.03" ratedU2="1.0" bus1="B189" connectableBus1="B189" voltageLevelId1="VL189" bus2="B210" connectableBus2="B210" voltageLevelId2="VL210">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9788">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9788">
                 <iidm:terminalRef id="T189-210-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1781,7 +1781,7 @@
             <iidm:generator id="B190-G" energySource="OTHER" minP="-1.7976931348623157E308" maxP="1.7976931348623157E308" voltageRegulatorOn="true" targetP="475.0" targetV="1.0551" targetQ="0.0" bus="B190" connectableBus="B190">
                 <iidm:minMaxReactiveLimits minQ="-300.0" maxQ="300.0"/>
             </iidm:generator>
-            <iidm:shunt id="B190-SH" bPerSection="-150.0" maximumSectionCount="1" currentSectionCount="1" bus="B190" connectableBus="B190"/>
+            <iidm:shunt id="B190-SH" bPerSection="-150.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B190" connectableBus="B190"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S41">
@@ -1827,7 +1827,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T193-196-1" r="0.0" x="0.00237" g="0.0" b="0.0" ratedU1="1.03" ratedU2="1.0" bus1="B193" connectableBus1="B193" voltageLevelId1="VL193" bus2="B196" connectableBus2="B196" voltageLevelId2="VL196">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9695">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9695">
                 <iidm:terminalRef id="T193-196-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1874,19 +1874,19 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T195-212-1" r="8.000000000000001E-6" x="3.66E-4" g="0.0" b="0.0" ratedU1="0.985" ratedU2="1.0" bus1="B195" connectableBus1="B195" voltageLevelId1="VL195" bus2="B212" connectableBus2="B212" voltageLevelId2="VL212">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0132">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0132">
                 <iidm:terminalRef id="T195-212-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T202-211-1" r="0.0" x="0.00128" g="0.0" b="0.0" ratedU1="1.01" ratedU2="1.0" bus1="B202" connectableBus1="B202" voltageLevelId1="VL202" bus2="B211" connectableBus2="B211" voltageLevelId2="VL211">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0017">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0017">
                 <iidm:terminalRef id="T202-211-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T211-212-1" r="3.0E-5" x="1.2200000000000001E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B211" connectableBus1="B211" voltageLevelId1="VL211" bus2="B212" connectableBus2="B212" voltageLevelId2="VL212">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0132">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0132">
                 <iidm:terminalRef id="T211-212-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -1938,10 +1938,10 @@
                 <iidm:bus id="B248" name="3" v="0.976" angle="-25.23"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B248-L" loadType="UNDEFINED" p0="29.0" q0="14.0" bus="B248" connectableBus="B248"/>
-            <iidm:shunt id="B248-SH" bPerSection="45.6" maximumSectionCount="1" currentSectionCount="1" bus="B248" connectableBus="B248"/>
+            <iidm:shunt id="B248-SH" bPerSection="45.6" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B248" connectableBus="B248"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T200-248-1" r="0.0" x="0.0022" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B200" connectableBus1="B200" voltageLevelId1="VL200" bus2="B248" connectableBus2="B248" voltageLevelId2="VL248">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.976">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.976">
                 <iidm:terminalRef id="T200-248-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -2033,7 +2033,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T218-219-1" r="1.0E-5" x="3.5400000000000004E-4" g="0.0" b="-1.0" ratedU1="0.97" ratedU2="1.0" bus1="B218" connectableBus1="B218" voltageLevelId1="VL218" bus2="B219" connectableBus2="B219" voltageLevelId2="VL219">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0554">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0554">
                 <iidm:terminalRef id="T218-219-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -2101,7 +2101,7 @@
             <iidm:load id="B224-L" loadType="UNDEFINED" p0="173.0" q0="99.0" bus="B224" connectableBus="B224"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T223-224-1" r="1.1999999999999999E-5" x="1.95E-4" g="0.0" b="-36.4" ratedU1="1.0" ratedU2="1.0" bus1="B223" connectableBus1="B223" voltageLevelId1="VL223" bus2="B224" connectableBus2="B224" voltageLevelId2="VL224">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0002">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="1.0002">
                 <iidm:terminalRef id="T223-224-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
@@ -2137,7 +2137,7 @@
                 <iidm:bus id="B231" name="3" v="1.0535" angle="-21.22"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B231-L" loadType="UNDEFINED" p0="159.0" q0="107.0" bus="B231" connectableBus="B231"/>
-            <iidm:shunt id="B231-SH" bPerSection="-300.0" maximumSectionCount="1" currentSectionCount="1" bus="B231" connectableBus="B231"/>
+            <iidm:shunt id="B231-SH" bPerSection="-300.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B231" connectableBus="B231"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T227-231-1" r="9.0E-6" x="4.72E-4" g="0.0" b="18.599999999999998" ratedU1="1.0" ratedU2="1.0" bus1="B227" connectableBus1="B227" voltageLevelId1="VL227" bus2="B231" connectableBus2="B231" voltageLevelId2="VL231"/>
     </iidm:substation>
@@ -2219,7 +2219,7 @@
                 <iidm:minMaxReactiveLimits minQ="-200.0" maxQ="200.0"/>
             </iidm:generator>
             <iidm:load id="B238-L" loadType="UNDEFINED" p0="255.0" q0="149.0" bus="B238" connectableBus="B238"/>
-            <iidm:shunt id="B238-SH" bPerSection="-150.0" maximumSectionCount="1" currentSectionCount="1" bus="B238" connectableBus="B238"/>
+            <iidm:shunt id="B238-SH" bPerSection="-150.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B238" connectableBus="B238"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL239" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -2236,7 +2236,7 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="B240" name="3" v="1.0237" angle="-20.14"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="B240-SH" bPerSection="-140.0" maximumSectionCount="1" currentSectionCount="1" bus="B240" connectableBus="B240"/>
+            <iidm:shunt id="B240-SH" bPerSection="-140.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B240" connectableBus="B240"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S136">
@@ -2441,7 +2441,7 @@
                 <iidm:bus id="B9003" name="1" v="0.9833" angle="-19.68"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B9003-L" loadType="UNDEFINED" p0="2.71" q0="0.94" bus="B9003" connectableBus="B9003"/>
-            <iidm:shunt id="B9003-SH" bPerSection="2.4" maximumSectionCount="1" currentSectionCount="1" bus="B9003" connectableBus="B9003"/>
+            <iidm:shunt id="B9003-SH" bPerSection="2.4" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B9003" connectableBus="B9003"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL9031" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -2466,7 +2466,7 @@
                 <iidm:bus id="B9034" name="1" v="0.9973" angle="-21.1"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B9034-L" loadType="UNDEFINED" p0="1.55" q0="0.54" bus="B9034" connectableBus="B9034"/>
-            <iidm:shunt id="B9034-SH" bPerSection="1.72" maximumSectionCount="1" currentSectionCount="1" bus="B9034" connectableBus="B9034"/>
+            <iidm:shunt id="B9034-SH" bPerSection="1.72" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B9034" connectableBus="B9034"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL9035" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -2582,7 +2582,7 @@
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T9005-9051-1" r="1.578E-4" x="0.0037486000000000004" g="0.0" b="0.0" ratedU1="1.0435" ratedU2="1.0" bus1="B9005" connectableBus1="B9005" voltageLevelId1="VL9005" bus2="B9051" connectableBus2="B9051" voltageLevelId2="VL9051"/>
         <iidm:twoWindingsTransformer id="T9005-9052-1" r="1.578E-4" x="0.0037486000000000004" g="0.0" b="0.0" ratedU1="0.9391" ratedU2="1.0" bus1="B9005" connectableBus1="B9005" voltageLevelId1="VL9005" bus2="B9052" connectableBus2="B9052" voltageLevelId2="VL9052">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9786">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="0.9786">
                 <iidm:terminalRef id="T9005-9052-1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>

--- a/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee30cdf.xiidm
+++ b/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee30cdf.xiidm
@@ -71,7 +71,7 @@
                 <iidm:bus id="B10" name="Roanoke   33" v="1.045" angle="-15.97"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B10-L" loadType="UNDEFINED" p0="5.8" q0="2.0" bus="B10" connectableBus="B10"/>
-            <iidm:shunt id="B10-SH" bPerSection="19.0" maximumSectionCount="1" currentSectionCount="1" bus="B10" connectableBus="B10"/>
+            <iidm:shunt id="B10-SH" bPerSection="19.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B10" connectableBus="B10"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T6-9-1" r="0.0" x="0.00208" g="0.0" b="0.0" ratedU1="0.978" ratedU2="1.0" bus1="B6" connectableBus1="B6" voltageLevelId1="VL6" bus2="B9" connectableBus2="B9" voltageLevelId2="VL9"/>
         <iidm:twoWindingsTransformer id="T6-10-1" r="0.0" x="0.005560000000000001" g="0.0" b="0.0" ratedU1="0.969" ratedU2="1.0" bus1="B6" connectableBus1="B6" voltageLevelId1="VL6" bus2="B10" connectableBus2="B10" voltageLevelId2="VL10"/>
@@ -200,7 +200,7 @@
                 <iidm:bus id="B24" name="Bus 24    33" v="1.021" angle="-16.78"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B24-L" loadType="UNDEFINED" p0="8.7" q0="6.7" bus="B24" connectableBus="B24"/>
-            <iidm:shunt id="B24-SH" bPerSection="4.3" maximumSectionCount="1" currentSectionCount="1" bus="B24" connectableBus="B24"/>
+            <iidm:shunt id="B24-SH" bPerSection="4.3" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B24" connectableBus="B24"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S5">

--- a/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee57cdf.xiidm
+++ b/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee57cdf.xiidm
@@ -44,7 +44,7 @@
                 <iidm:bus id="B18" name="Sprigg    V2" v="1.001" angle="-11.71"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B18-L" loadType="UNDEFINED" p0="27.2" q0="9.8" bus="B18" connectableBus="B18"/>
-            <iidm:shunt id="B18-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" bus="B18" connectableBus="B18"/>
+            <iidm:shunt id="B18-SH" bPerSection="10.0" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B18" connectableBus="B18"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T4-18-1" r="0.0" x="0.00555" g="0.0" b="0.0" ratedU1="0.97" ratedU2="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B18" connectableBus2="B18" voltageLevelId2="VL18"/>
         <iidm:twoWindingsTransformer id="T4-18-2" r="0.0" x="0.0043" g="0.0" b="0.0" ratedU1="0.978" ratedU2="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B18" connectableBus2="B18" voltageLevelId2="VL18"/>
@@ -265,7 +265,7 @@
                 <iidm:bus id="B25" name="Bus 25    V4" v="0.982" angle="-18.13"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B25-L" loadType="UNDEFINED" p0="6.3" q0="3.2" bus="B25" connectableBus="B25"/>
-            <iidm:shunt id="B25-SH" bPerSection="5.8999999999999995" maximumSectionCount="1" currentSectionCount="1" bus="B25" connectableBus="B25"/>
+            <iidm:shunt id="B25-SH" bPerSection="5.8999999999999995" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B25" connectableBus="B25"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL26" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -441,7 +441,7 @@
                 <iidm:bus id="B53" name="Bus 53    V5" v="0.971" angle="-12.23"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B53-L" loadType="UNDEFINED" p0="20.0" q0="10.0" bus="B53" connectableBus="B53"/>
-            <iidm:shunt id="B53-SH" bPerSection="6.3" maximumSectionCount="1" currentSectionCount="1" bus="B53" connectableBus="B53"/>
+            <iidm:shunt id="B53-SH" bPerSection="6.3" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B53" connectableBus="B53"/>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S41">

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ShuntCompensator.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ShuntCompensator.java
@@ -83,4 +83,80 @@ public interface ShuntCompensator extends Injection<ShuntCompensator> {
      */
     double getCurrentB();
 
+    /**
+     * Get the terminal used for regulation.
+     */
+    default Terminal getRegulatingTerminal() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Set the terminal used for regulation.
+     * If null is passed as regulating terminal, the regulation is considered local.
+     */
+    default ShuntCompensator setRegulatingTerminal(Terminal regulatingTerminal) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Get the shunt compensator's regulating status.
+     * <p>
+     * Depends on the working variant.
+     * @see VariantManager
+     */
+    default boolean isVoltageRegulatorOn() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Set the shunt compensator's regulating status.
+     * <p>
+     * Depends on the working variant.
+     * @see VariantManager
+     */
+    default ShuntCompensator setVoltageRegulatorOn(boolean voltageRegulatorOn) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Get the shunt compensator's voltage target in kV if it exists. Else return NaN.
+     * <p>
+     * Depends on the working variant.
+     * @see VariantManager
+     */
+    default double getTargetV() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Set the shunt compensator's voltage target in kV.
+     * <p>
+     * Depends on the working variant.
+     * @see VariantManager
+     */
+    default ShuntCompensator setTargetV(double targetV) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Get the shunt compensator's deadband (in kV) used to avoid excessive update of discrete control while regulating.
+     * This attribute is necessary only if the shunt compensator is regulating.
+     * <p>
+     * Depends on the working variant.
+     * @see VariantManager
+     */
+    default double getTargetDeadband() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Set the shunt compensator's deadband (in kV) used to avoid excessive update of discrete control while regulating.
+     * This attribute is necessary only if the shunt compensator is regulating. It must be positive.
+     * <p>
+     * Depends on the working variant.
+     * @see VariantManager
+     */
+    default ShuntCompensator setTargetDeadband(double targetDeadband) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ShuntCompensatorAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ShuntCompensatorAdder.java
@@ -32,6 +32,22 @@ public interface ShuntCompensatorAdder extends InjectionAdder<ShuntCompensatorAd
 
     ShuntCompensatorAdder setCurrentSectionCount(int currentSectionCount);
 
+    default ShuntCompensatorAdder setRegulatingTerminal(Terminal regulatingTerminal) {
+        throw new UnsupportedOperationException();
+    }
+
+    default ShuntCompensatorAdder setVoltageRegulatorOn(boolean voltageRegulatorOn) {
+        throw new UnsupportedOperationException();
+    }
+
+    default ShuntCompensatorAdder setTargetV(double targetV) {
+        throw new UnsupportedOperationException();
+    }
+
+    default ShuntCompensatorAdder setTargetDeadband(double targetDeadband) {
+        throw new UnsupportedOperationException();
+    }
+
     ShuntCompensator add();
 
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TapChanger.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TapChanger.java
@@ -94,10 +94,24 @@ public interface TapChanger<C extends TapChanger<C, S>, S extends TapChangerStep
      */
     C setRegulationTerminal(Terminal regulationTerminal);
 
+    /**
+     * Get the tap changer's deadband (in kV) used to avoid excessive update of discrete control while regulating.
+     * This attribute is necessary only if the tap changer is regulating.
+     * <p>
+     * Depends on the working variant.
+     * @see VariantManager
+     */
     default double getTargetDeadband() {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Set the tap changer's deadband (in kV) used to avoid excessive update of discrete control while regulating.
+     * This attribute is necessary only if the tap changer is regulating. It must be positive.
+     * <p>
+     * Depends on the working variant.
+     * @see VariantManager
+     */
     default C setTargetDeadband(double targetDeadband) {
         throw new UnsupportedOperationException();
     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -50,7 +50,16 @@ public final class ValidationUtil {
         }
     }
 
-    public static void checkVoltageControl(Validable validable, Boolean voltageRegulatorOn, double voltageSetpoint, double reactivePowerSetpoint) {
+    public static void checkTargetDeadband(Validable validable, String validableType, boolean regulating, double targetDeadband) {
+        if (regulating && Double.isNaN(targetDeadband)) {
+            throw new ValidationException(validable, "Undefined value for target deadband of regulating " + validableType);
+        }
+        if (targetDeadband < 0) {
+            throw new ValidationException(validable, "Unexpected value for target deadband of " + validableType + ": " + targetDeadband + " < 0");
+        }
+    }
+
+    public static boolean checkVoltageControl(Validable validable, Boolean voltageRegulatorOn, double voltageSetpoint) {
         if (voltageRegulatorOn == null) {
             throw new ValidationException(validable, "voltage regulator status is not set");
         }
@@ -59,10 +68,14 @@ public final class ValidationUtil {
             if (Double.isNaN(voltageSetpoint) || voltageSetpoint <= 0) {
                 throw createInvalidValueException(validable, voltageSetpoint, "voltage setpoint", "voltage regulator is on");
             }
-        } else {
-            if (Double.isNaN(reactivePowerSetpoint)) {
-                throw createInvalidValueException(validable, reactivePowerSetpoint, "reactive power setpoint", "voltage regulator is off");
-            }
+            return false;
+        }
+        return true;
+    }
+
+    public static void checkVoltageControl(Validable validable, Boolean voltageRegulatorOn, double voltageSetpoint, double reactivePowerSetpoint) {
+        if (checkVoltageControl(validable, voltageRegulatorOn, voltageSetpoint) && Double.isNaN(reactivePowerSetpoint)) {
+            throw createInvalidValueException(validable, reactivePowerSetpoint, "reactive power setpoint", "voltage regulator is off");
         }
     }
 

--- a/iidm/iidm-extensions/src/test/resources/coordinatedReactiveControl.xml
+++ b/iidm/iidm-extensions/src/test/resources/coordinatedReactiveControl.xml
@@ -29,7 +29,7 @@
             <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>

--- a/iidm/iidm-extensions/src/test/resources/threeWindingsTransformerPhaseAngleClock.xml
+++ b/iidm/iidm-extensions/src/test/resources/threeWindingsTransformerPhaseAngleClock.xml
@@ -22,7 +22,7 @@
             <iidm:load id="LOAD_11" loadType="UNDEFINED" p0="0.0" q0="-10.6" bus="BUS_11" connectableBus="BUS_11" p="0.0" q="-10.6"/>
         </iidm:voltageLevel>
         <iidm:threeWindingsTransformer id="3WT" r1="17.424" x1="1.7424" g1="0.00573921028466483" b1="5.73921028466483E-4" ratedU1="132.0" r2="1.089" x2="0.1089" g2="0.0" b2="0.0" ratedU2="33.0" r3="0.121" x3="0.0121" g3="0.0" b3="0.0" ratedU3="11.0" ratedU0="132.0" bus1="BUS_132" connectableBus1="BUS_132" voltageLevelId1="VL_132" bus2="BUS_33" connectableBus2="BUS_33" voltageLevelId2="VL_33" bus3="BUS_11" connectableBus3="BUS_11" voltageLevelId3="VL_11">
-            <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulating="true" targetV="33.0">
+            <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulating="true" targetV="33.0" targetDeadband="0.0">
                 <iidm:terminalRef id="LOAD_33"/>
                 <iidm:step r="0.9801" x="0.09801" g="0.08264462809917356" b="0.008264462809917356" rho="0.9"/>
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>

--- a/iidm/iidm-extensions/src/test/resources/twoWindingsTransformerPhaseAngleClock.xml
+++ b/iidm/iidm-extensions/src/test/resources/twoWindingsTransformerPhaseAngleClock.xml
@@ -29,7 +29,7 @@
             <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GeneratorImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GeneratorImpl.java
@@ -140,7 +140,7 @@ class GeneratorImpl extends AbstractConnectable<Generator> implements Generator,
 
     @Override
     public GeneratorImpl setRegulatingTerminal(Terminal regulatingTerminal) {
-        ValidationUtil.checkRegulatingTerminal(this, (TerminalExt) regulatingTerminal, getNetwork());
+        ValidationUtil.checkRegulatingTerminal(this, regulatingTerminal, getNetwork());
         Terminal oldValue = this.regulatingTerminal;
         this.regulatingTerminal = regulatingTerminal != null ? (TerminalExt) regulatingTerminal : getTerminal();
         notifyUpdate("regulatingTerminal", oldValue, regulatingTerminal);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerAdderImpl.java
@@ -194,9 +194,7 @@ class PhaseTapChangerAdderImpl implements PhaseTapChangerAdder {
                     + highTapPosition + "]");
         }
         ValidationUtil.checkPhaseTapChangerRegulation(parent, regulationMode, regulationValue, regulating, regulationTerminal, getNetwork());
-        if (!Double.isNaN(targetDeadband) && targetDeadband < 0) {
-            throw new ValidationException(parent, "Unexpected value for target deadband of phase tap changer: " + targetDeadband);
-        }
+        ValidationUtil.checkTargetDeadband(parent, "phase tap changer", regulating, targetDeadband);
         PhaseTapChangerImpl tapChanger
                 = new PhaseTapChangerImpl(parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, regulationMode, regulationValue, targetDeadband);
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerImpl.java
@@ -33,7 +33,7 @@ class PhaseTapChangerImpl extends AbstractTapChanger<PhaseTapChangerParent, Phas
     PhaseTapChangerImpl(PhaseTapChangerParent parent, int lowTapPosition,
                         List<PhaseTapChangerStepImpl> steps, TerminalExt regulationTerminal,
                         int tapPosition, boolean regulating, RegulationMode regulationMode, double regulationValue, double targetDeadband) {
-        super(parent.getNetwork().getRef(), parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, targetDeadband);
+        super(parent.getNetwork().getRef(), parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, targetDeadband, "phase tap changer");
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         this.regulationMode = regulationMode;
         this.regulationValue = new TDoubleArrayList(variantArraySize);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerAdderImpl.java
@@ -183,9 +183,7 @@ class RatioTapChangerAdderImpl implements RatioTapChangerAdder {
                     + highTapPosition + "]");
         }
         ValidationUtil.checkRatioTapChangerRegulation(parent, regulating, regulationTerminal, targetV, getNetwork());
-        if (!Double.isNaN(targetDeadband) && targetDeadband < 0) {
-            throw new ValidationException(parent, "Unexpected value for target deadband of ratio tap changer: " + targetDeadband);
-        }
+        ValidationUtil.checkTargetDeadband(parent, "ratio tap changer", regulating, targetDeadband);
         RatioTapChangerImpl tapChanger
                 = new RatioTapChangerImpl(parent, lowTapPosition, steps, regulationTerminal, loadTapChangingCapabilities,
                                           tapPosition, regulating, targetV, targetDeadband);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerImpl.java
@@ -32,7 +32,7 @@ class RatioTapChangerImpl extends AbstractTapChanger<RatioTapChangerParent, Rati
     RatioTapChangerImpl(RatioTapChangerParent parent, int lowTapPosition,
                         List<RatioTapChangerStepImpl> steps, TerminalExt regulationTerminal, boolean loadTapChangingCapabilities,
                         int tapPosition, boolean regulating, double targetV, double targetDeadband) {
-        super(parent.getNetwork().getRef(), parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, targetDeadband);
+        super(parent.getNetwork().getRef(), parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, targetDeadband, "ratio tap changer");
         this.loadTapChangingCapabilities = loadTapChangingCapabilities;
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         this.targetV = new TDoubleArrayList(variantArraySize);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorAdderImpl.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.iidm.network.ShuntCompensatorAdder;
 import com.powsybl.iidm.network.ValidationUtil;
+import com.powsybl.iidm.network.Terminal;
 
 /**
  *
@@ -22,6 +23,14 @@ class ShuntCompensatorAdderImpl extends AbstractInjectionAdder<ShuntCompensatorA
     private int maximumSectionCount;
 
     private int currentSectionCount;
+
+    private double targetV = Double.NaN;
+
+    private double targetDeadband = Double.NaN;
+
+    private TerminalExt regulatingTerminal;
+
+    private boolean voltageRegulatorOn = false;
 
     ShuntCompensatorAdderImpl(VoltageLevelExt voltageLevel) {
         this.voltageLevel = voltageLevel;
@@ -56,15 +65,43 @@ class ShuntCompensatorAdderImpl extends AbstractInjectionAdder<ShuntCompensatorA
     }
 
     @Override
+    public ShuntCompensatorAdder setRegulatingTerminal(Terminal regulatingTerminal) {
+        this.regulatingTerminal = (TerminalExt) regulatingTerminal;
+        return this;
+    }
+
+    @Override
+    public ShuntCompensatorAdder setVoltageRegulatorOn(boolean voltageRegulatorOn) {
+        this.voltageRegulatorOn = voltageRegulatorOn;
+        return this;
+    }
+
+    @Override
+    public ShuntCompensatorAdder setTargetV(double targetV) {
+        this.targetV = targetV;
+        return this;
+    }
+
+    @Override
+    public ShuntCompensatorAdder setTargetDeadband(double targetDeadband) {
+        this.targetDeadband = targetDeadband;
+        return this;
+    }
+
+    @Override
     public ShuntCompensatorImpl add() {
         String id = checkAndGetUniqueId();
         TerminalExt terminal = checkAndGetTerminal();
         ValidationUtil.checkbPerSection(this, bPerSection);
         ValidationUtil.checkSections(this, currentSectionCount, maximumSectionCount);
+        ValidationUtil.checkRegulatingTerminal(this, regulatingTerminal, getNetwork());
+        ValidationUtil.checkVoltageControl(this, voltageRegulatorOn, targetV);
+        ValidationUtil.checkTargetDeadband(this, "shunt compensator", voltageRegulatorOn, targetDeadband);
         ShuntCompensatorImpl shunt
                 = new ShuntCompensatorImpl(getNetwork().getRef(),
-                                           id, getName(), bPerSection, maximumSectionCount,
-                                           currentSectionCount);
+                id, getName(), bPerSection, maximumSectionCount,
+                currentSectionCount, regulatingTerminal == null ? terminal : regulatingTerminal,
+                voltageRegulatorOn, targetV, targetDeadband);
         shunt.addTerminal(terminal);
         voltageLevel.attach(terminal, false);
         getNetwork().getIndex().checkAndAdd(shunt);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorImpl.java
@@ -6,10 +6,13 @@
  */
 package com.powsybl.iidm.network.impl;
 
+import com.powsybl.commons.util.trove.TBooleanArrayList;
 import com.powsybl.iidm.network.ConnectableType;
 import com.powsybl.iidm.network.ShuntCompensator;
 import com.powsybl.iidm.network.ValidationUtil;
+import com.powsybl.iidm.network.Terminal;
 import com.powsybl.iidm.network.impl.util.Ref;
+import gnu.trove.list.array.TDoubleArrayList;
 import gnu.trove.list.array.TIntArrayList;
 
 /**
@@ -26,22 +29,42 @@ class ShuntCompensatorImpl extends AbstractConnectable<ShuntCompensator> impleme
     /* the maximum number of section */
     private int maximumSectionCount;
 
+    /* the regulating terminal */
+    private TerminalExt regulatingTerminal;
+
     // attributes depending on the variant
 
     /* the current number of section switched on */
     private final TIntArrayList currentSectionCount;
 
+    /* the regulating status */
+    private final TBooleanArrayList voltageRegulatorOn;
+
+    /* the target voltage value */
+    private final TDoubleArrayList targetV;
+
+    /* the target deadband */
+    private final TDoubleArrayList targetDeadband;
+
     ShuntCompensatorImpl(Ref<? extends VariantManagerHolder> network,
                          String id, String name, double bPerSection, int maximumSectionCount,
-                         int currentSectionCount) {
+                         int currentSectionCount, TerminalExt regulatingTerminal, boolean voltageRegulatorOn,
+                         double targetV, double targetDeadband) {
         super(id, name);
         this.network = network;
         this.bPerSection = bPerSection;
         this.maximumSectionCount = maximumSectionCount;
+        this.regulatingTerminal = regulatingTerminal;
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         this.currentSectionCount = new TIntArrayList(variantArraySize);
+        this.voltageRegulatorOn = new TBooleanArrayList(variantArraySize);
+        this.targetV = new TDoubleArrayList(variantArraySize);
+        this.targetDeadband = new TDoubleArrayList(variantArraySize);
         for (int i = 0; i < variantArraySize; i++) {
             this.currentSectionCount.add(currentSectionCount);
+            this.voltageRegulatorOn.add(voltageRegulatorOn);
+            this.targetV.add(targetV);
+            this.targetDeadband.add(targetDeadband);
         }
     }
 
@@ -104,11 +127,76 @@ class ShuntCompensatorImpl extends AbstractConnectable<ShuntCompensator> impleme
     }
 
     @Override
+    public TerminalExt getRegulatingTerminal() {
+        return regulatingTerminal;
+    }
+
+    @Override
+    public ShuntCompensatorImpl setRegulatingTerminal(Terminal regulatingTerminal) {
+        ValidationUtil.checkRegulatingTerminal(this, regulatingTerminal, getNetwork());
+        Terminal oldValue = this.regulatingTerminal;
+        this.regulatingTerminal = regulatingTerminal != null ? (TerminalExt) regulatingTerminal : getTerminal();
+        notifyUpdate("regulatingTerminal", oldValue, this.regulatingTerminal);
+        return this;
+    }
+
+    @Override
+    public boolean isVoltageRegulatorOn() {
+        return voltageRegulatorOn.get(network.get().getVariantIndex());
+    }
+
+    @Override
+    public ShuntCompensatorImpl setVoltageRegulatorOn(boolean voltageRegulatorOn) {
+        int variantIndex = network.get().getVariantIndex();
+        ValidationUtil.checkVoltageControl(this, voltageRegulatorOn, targetV.get(variantIndex));
+        boolean oldValue = this.voltageRegulatorOn.set(variantIndex, voltageRegulatorOn);
+        String variantId = network.get().getVariantManager().getVariantId(variantIndex);
+        notifyUpdate("voltageRegulatorOn", variantId, oldValue, voltageRegulatorOn);
+        return this;
+    }
+
+    @Override
+    public double getTargetV() {
+        return targetV.get(network.get().getVariantIndex());
+    }
+
+    @Override
+    public ShuntCompensatorImpl setTargetV(double targetV) {
+        int variantIndex = network.get().getVariantIndex();
+        ValidationUtil.checkVoltageControl(this, voltageRegulatorOn.get(variantIndex), targetV);
+        double oldValue = this.targetV.set(variantIndex, targetV);
+        String variantId = network.get().getVariantManager().getVariantId(variantIndex);
+        notifyUpdate("targetV", variantId, oldValue, targetV);
+        return this;
+    }
+
+    @Override
+    public double getTargetDeadband() {
+        return targetDeadband.get(network.get().getVariantIndex());
+    }
+
+    @Override
+    public ShuntCompensatorImpl setTargetDeadband(double targetDeadband) {
+        int variantIndex = network.get().getVariantIndex();
+        ValidationUtil.checkTargetDeadband(this, "shunt compensator", this.voltageRegulatorOn.get(variantIndex), targetDeadband);
+        double oldValue = this.targetDeadband.set(variantIndex, targetDeadband);
+        String variantId = network.get().getVariantManager().getVariantId(variantIndex);
+        notifyUpdate("targetDeadband", variantId, oldValue, targetDeadband);
+        return this;
+    }
+
+    @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
         super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
         currentSectionCount.ensureCapacity(currentSectionCount.size() + number);
+        voltageRegulatorOn.ensureCapacity(voltageRegulatorOn.size() + number);
+        targetV.ensureCapacity(targetV.size() + number);
+        targetDeadband.ensureCapacity(targetDeadband.size() + number);
         for (int i = 0; i < number; i++) {
             currentSectionCount.add(currentSectionCount.get(sourceIndex));
+            voltageRegulatorOn.add(voltageRegulatorOn.get(sourceIndex));
+            targetV.add(targetV.get(sourceIndex));
+            targetDeadband.add(targetDeadband.get(sourceIndex));
         }
     }
 
@@ -116,6 +204,9 @@ class ShuntCompensatorImpl extends AbstractConnectable<ShuntCompensator> impleme
     public void reduceVariantArraySize(int number) {
         super.reduceVariantArraySize(number);
         currentSectionCount.remove(currentSectionCount.size() - number, number);
+        voltageRegulatorOn.remove(voltageRegulatorOn.size() - number, number);
+        targetV.remove(targetV.size() - number, number);
+        targetDeadband.remove(targetDeadband.size() - number, number);
     }
 
     @Override
@@ -129,6 +220,9 @@ class ShuntCompensatorImpl extends AbstractConnectable<ShuntCompensator> impleme
         super.allocateVariantArrayElement(indexes, sourceIndex);
         for (int index : indexes) {
             currentSectionCount.set(index, currentSectionCount.get(sourceIndex));
+            voltageRegulatorOn.set(index, voltageRegulatorOn.get(sourceIndex));
+            targetV.set(index, targetV.get(sourceIndex));
+            targetDeadband.set(index, targetDeadband.get(sourceIndex));
         }
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractShuntCompensatorTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractShuntCompensatorTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.network.tck;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.NoEquipmentNetworkFactory;
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,31 +32,47 @@ public abstract class AbstractShuntCompensatorTest {
 
     private Network network;
     private VoltageLevel voltageLevel;
+    private Terminal terminal;
 
     @Before
     public void setUp() {
         network = NoEquipmentNetworkFactory.create();
+        network.getVoltageLevel("vl2").newLoad()
+                .setId("load")
+                .setBus("busB")
+                .setConnectableBus("busB")
+                .setP0(0)
+                .setQ0(0)
+                .add();
+        terminal = network.getLoad("load").getTerminal();
         voltageLevel = network.getVoltageLevel("vl1");
     }
 
     @Test
     public void baseTest() {
         // adder
-        ShuntCompensator shuntCompensator = voltageLevel
-                                        .newShuntCompensator()
-                                            .setId(SHUNT)
-                                            .setName("shuntName")
-                                            .setConnectableBus("busA")
-                                            .setbPerSection(5.0)
-                                            .setCurrentSectionCount(6)
-                                            .setMaximumSectionCount(10)
-                                        .add();
+        ShuntCompensator shuntCompensator = voltageLevel.newShuntCompensator()
+                .setId(SHUNT)
+                .setName("shuntName")
+                .setConnectableBus("busA")
+                .setbPerSection(5.0)
+                .setCurrentSectionCount(6)
+                .setMaximumSectionCount(10)
+                .setRegulatingTerminal(terminal)
+                .setVoltageRegulatorOn(true)
+                .setTargetV(200)
+                .setTargetDeadband(10)
+                .add();
         assertEquals(ConnectableType.SHUNT_COMPENSATOR, shuntCompensator.getType());
         assertEquals("shuntName", shuntCompensator.getName());
         assertEquals(SHUNT, shuntCompensator.getId());
         assertEquals(5.0, shuntCompensator.getbPerSection(), 0.0);
         assertEquals(6, shuntCompensator.getCurrentSectionCount());
         assertEquals(10, shuntCompensator.getMaximumSectionCount());
+        assertSame(terminal, shuntCompensator.getRegulatingTerminal());
+        assertTrue(shuntCompensator.isVoltageRegulatorOn());
+        assertEquals(200, shuntCompensator.getTargetV(), 0.0);
+        assertEquals(10, shuntCompensator.getTargetDeadband(), 0.0);
 
         // setter getter
         try {
@@ -92,6 +109,45 @@ public abstract class AbstractShuntCompensatorTest {
         shuntCompensator.setMaximumSectionCount(20);
         assertEquals(20, shuntCompensator.getMaximumSectionCount());
 
+        try {
+            Network tmp = EurostagTutorialExample1Factory.create();
+            Terminal tmpTerminal = tmp.getGenerator("GEN").getTerminal();
+            shuntCompensator.setRegulatingTerminal(tmpTerminal);
+            fail();
+        } catch (ValidationException ignored) {
+            // ignore
+        }
+        shuntCompensator.setRegulatingTerminal(null);
+        assertSame(shuntCompensator.getTerminal(), shuntCompensator.getRegulatingTerminal());
+
+        try {
+            shuntCompensator.setTargetV(Double.NaN);
+            fail();
+        } catch (ValidationException ignored) {
+            // ignore
+        }
+        try {
+            shuntCompensator.setVoltageRegulatorOn(false);
+            shuntCompensator.setTargetV(Double.NaN);
+            shuntCompensator.setVoltageRegulatorOn(true);
+            fail();
+        } catch (ValidationException ignored) {
+            // ignore
+        }
+        shuntCompensator.setVoltageRegulatorOn(false);
+        shuntCompensator.setTargetV(400);
+        assertFalse(shuntCompensator.isVoltageRegulatorOn());
+        assertEquals(400, shuntCompensator.getTargetV(), 0.0);
+
+        try {
+            shuntCompensator.setTargetDeadband(-1.0);
+            fail();
+        } catch (ValidationException ignored) {
+            // ignore
+        }
+        shuntCompensator.setTargetDeadband(5.0);
+        assertEquals(5.0, shuntCompensator.getTargetDeadband(), 0.0);
+
         // remove
         int count = network.getShuntCompensatorCount();
         shuntCompensator.remove();
@@ -104,27 +160,50 @@ public abstract class AbstractShuntCompensatorTest {
     public void invalidbPerSection() {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("susceptance per section is invalid");
-        createShunt(INVALID, INVALID, Double.NaN, 5, 10);
+        createShunt(INVALID, INVALID, Double.NaN, 5, 10, null, false, Double.NaN, Double.NaN);
     }
 
     @Test
     public void invalidZerobPerSection() {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("susceptance per section is equal to zero");
-        createShunt(INVALID, INVALID, 0.0, 5, 10);
+        createShunt(INVALID, INVALID, 0.0, 5, 10, null, false, Double.NaN, Double.NaN);
     }
 
     @Test
     public void invalidNegativeMaxPerSection() {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("should be greater than 0");
-        createShunt(INVALID, INVALID, 2.0, 0, -1);
+        createShunt(INVALID, INVALID, 2.0, 0, -1, null, false, Double.NaN, Double.NaN);
+    }
+
+    @Test
+    public void invalidRegulatingTerminal() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("regulating terminal is not part of the network");
+        Network tmp = EurostagTutorialExample1Factory.create();
+        Terminal tmpTerminal = tmp.getGenerator("GEN").getTerminal();
+        createShunt(INVALID, INVALID, 2.0, 0, 10, tmpTerminal, false, Double.NaN, Double.NaN);
+    }
+
+    @Test
+    public void invalidTargetV() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("invalid value (-10.0) for voltage setpoint");
+        createShunt(INVALID, INVALID, 2.0, 0, 10, null, true, -10, Double.NaN);
+    }
+
+    @Test
+    public void invalidTargetDeadband() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("Unexpected value for target deadband of shunt compensator: -10.0");
+        createShunt(INVALID, INVALID, 2.0, 0, 10, null, false, Double.NaN, -10);
     }
 
     @Test
     public void testSetterGetterInMultiVariants() {
         VariantManager variantManager = network.getVariantManager();
-        createShunt(TEST_MULTI_VARIANT, TEST_MULTI_VARIANT, 2.0, 5, 10);
+        createShunt(TEST_MULTI_VARIANT, TEST_MULTI_VARIANT, 2.0, 5, 10, terminal, true, 200, 10);
         ShuntCompensator shunt = network.getShuntCompensator(TEST_MULTI_VARIANT);
         List<String> variantsToAdd = Arrays.asList("s1", "s2", "s3", "s4");
         variantManager.cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, variantsToAdd);
@@ -134,7 +213,10 @@ public abstract class AbstractShuntCompensatorTest {
         assertEquals(5, shunt.getCurrentSectionCount());
         assertEquals(10.0, shunt.getCurrentB(), 0.0); // 2*5
         // change values in s4
-        shunt.setCurrentSectionCount(4);
+        shunt.setCurrentSectionCount(4)
+                .setVoltageRegulatorOn(false)
+                .setTargetV(220)
+                .setTargetDeadband(5.0);
 
         // remove s2
         variantManager.removeVariant("s2");
@@ -144,11 +226,17 @@ public abstract class AbstractShuntCompensatorTest {
         // check values cloned by allocate
         assertEquals(4, shunt.getCurrentSectionCount());
         assertEquals(8.0, shunt.getCurrentB(), 0.0); // 2*4
+        assertFalse(shunt.isVoltageRegulatorOn());
+        assertEquals(220, shunt.getTargetV(), 0.0);
+        assertEquals(5.0, shunt.getTargetDeadband(), 0.0);
 
         // recheck initial variant value
         variantManager.setWorkingVariant(VariantManagerConstants.INITIAL_VARIANT_ID);
         assertEquals(5, shunt.getCurrentSectionCount());
         assertEquals(10.0, shunt.getCurrentB(), 0.0); // 2*5
+        assertTrue(shunt.isVoltageRegulatorOn());
+        assertEquals(200, shunt.getTargetV(), 0.0);
+        assertEquals(10, shunt.getTargetDeadband(), 0.0);
 
         // remove working variant s4
         variantManager.setWorkingVariant("s4");
@@ -159,16 +247,38 @@ public abstract class AbstractShuntCompensatorTest {
         } catch (Exception ignored) {
             // ignore
         }
+        try {
+            shunt.isVoltageRegulatorOn();
+            fail();
+        } catch (Exception ignored) {
+            // ignore
+        }
+        try {
+            shunt.getTargetV();
+            fail();
+        } catch (Exception ignored) {
+            // ignore
+        }
+        try {
+            shunt.getTargetDeadband();
+            fail();
+        } catch (Exception ignored) {
+            // ignore
+        }
     }
 
-    private void createShunt(String id, String name, double bPerSection, int currentSectionCount, int maxSectionCount) {
+    private void createShunt(String id, String name, double bPerSection, int currentSectionCount, int maxSectionCount, Terminal regulatingTerminal, boolean voltageRegulatorOn, double targetV, double targetDeadband) {
         voltageLevel.newShuntCompensator()
-                    .setId(id)
-                    .setName(name)
-                    .setConnectableBus("busA")
-                    .setbPerSection(bPerSection)
-                    .setCurrentSectionCount(currentSectionCount)
-                    .setMaximumSectionCount(maxSectionCount)
+                .setId(id)
+                .setName(name)
+                .setConnectableBus("busA")
+                .setbPerSection(bPerSection)
+                .setCurrentSectionCount(currentSectionCount)
+                .setMaximumSectionCount(maxSectionCount)
+                .setRegulatingTerminal(regulatingTerminal)
+                .setVoltageRegulatorOn(voltageRegulatorOn)
+                .setTargetV(targetV)
+                .setTargetDeadband(targetDeadband)
                 .add();
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTapChangerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTapChangerTest.java
@@ -546,6 +546,7 @@ public abstract class AbstractTapChangerTest {
         ThreeWindingsTransformer.Leg leg3 = threeWindingsTransformer.getLeg3();
         leg2.newRatioTapChanger()
                 .setTargetV(10.0)
+                .setTargetDeadband(0)
                 .setLoadTapChangingCapabilities(false)
                 .setLowTapPosition(0)
                 .setTapPosition(1)

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
@@ -160,6 +160,7 @@ public final class EurostagTutorialExample1Factory {
                 .setLoadTapChangingCapabilities(true)
                 .setRegulating(true)
                 .setTargetV(158.0)
+                .setTargetDeadband(0)
                 .setRegulationTerminal(nhv2Nload.getTerminal2())
             .add();
         vlload.newLoad()

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/ShuntTestCaseFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/ShuntTestCaseFactory.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.test;
+
+import com.powsybl.iidm.network.*;
+import org.joda.time.DateTime;
+
+import java.util.Objects;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public final class ShuntTestCaseFactory {
+
+    private ShuntTestCaseFactory() {
+    }
+
+    public static Network create() {
+        return create(NetworkFactory.findDefault());
+    }
+
+    public static Network create(NetworkFactory networkFactory) {
+        Objects.requireNonNull(networkFactory);
+
+        Network network = networkFactory.createNetwork("shuntTestCase", "test")
+                .setCaseDate(DateTime.parse("2019-09-30T16:29:18.263+02:00"));
+
+        Substation s1 = network.newSubstation()
+                .setId("S1")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("VL1")
+                .setNominalV(380)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("B1")
+                .add();
+
+        Substation s2 = network.newSubstation()
+                .setId("S2")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("VL2")
+                .setNominalV(220)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("B2")
+                .add();
+
+        Load load = vl2.newLoad()
+                .setId("LOAD")
+                .setConnectableBus("B2")
+                .setBus("B2")
+                .setP0(100.0)
+                .setQ0(50.0)
+                .add();
+
+        vl1.newShuntCompensator()
+                .setId("SHUNT")
+                .setBus("B1")
+                .setConnectableBus("B1")
+                .setMaximumSectionCount(1)
+                .setCurrentSectionCount(1)
+                .setbPerSection(1e-5)
+                .setVoltageRegulatorOn(true)
+                .setRegulatingTerminal(load.getTerminal())
+                .setTargetV(200)
+                .setTargetDeadband(5.0)
+                .add();
+
+        return network;
+    }
+}

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/ThreeWindingsTransformerNetworkFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/ThreeWindingsTransformerNetworkFactory.java
@@ -150,6 +150,7 @@ public final class ThreeWindingsTransformerNetworkFactory {
                 .setLoadTapChangingCapabilities(true)
                 .setRegulating(true)
                 .setTargetV(33.0)
+                .setTargetDeadband(0)
                 .setRegulationTerminal(load33.getTerminal())
                 .add();
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
@@ -6,8 +6,10 @@
  */
 package com.powsybl.iidm.xml;
 
+import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.xml.util.IidmXmlUtil;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -40,15 +42,50 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
         XmlUtil.writeDouble("rho", tcs.getRho(), writer);
     }
 
-    protected static void writeTapChanger(TapChanger<?, ?> tc, XMLStreamWriter writer) throws XMLStreamException {
-        writer.writeAttribute(ATTR_LOW_TAP_POSITION, Integer.toString(tc.getLowTapPosition()));
-        writer.writeAttribute(ATTR_TAP_POSITION, Integer.toString(tc.getTapPosition()));
-        XmlUtil.writeDouble(TARGET_DEADBAND, tc.getTargetDeadband(), writer);
+    private static void writeTargetDeadband(double targetDeadband, NetworkXmlWriterContext context) {
+        IidmXmlUtil.runUntilMaximumVersion(IidmXmlVersion.V_1_1, context, () -> {
+            try {
+                // in IIDM-XML version 1.0, 0 as targetDeadband is ignored for backwards compatibility
+                // (i.e. ensuring round trips in IIDM-XML version 1.0)
+                XmlUtil.writeOptionalDouble(TARGET_DEADBAND, targetDeadband, 0, context.getWriter());
+            } catch (XMLStreamException e) {
+                throw new UncheckedXmlStreamException(e);
+            }
+        });
+        IidmXmlUtil.runFromMinimumVersion(IidmXmlVersion.V_1_2, context, () -> {
+            try {
+                XmlUtil.writeDouble(TARGET_DEADBAND, targetDeadband, context.getWriter());
+            } catch (XMLStreamException e) {
+                throw new UncheckedXmlStreamException(e);
+            }
+        });
+    }
+
+    private static double readTargetDeadband(boolean regulating, NetworkXmlReaderContext context) {
+        double[] targetDeadband = new double[1];
+        IidmXmlUtil.runUntilMaximumVersion(IidmXmlVersion.V_1_1, context, () -> {
+            targetDeadband[0] = XmlUtil.readOptionalDoubleAttribute(context.getReader(), TARGET_DEADBAND);
+            // in IIDM-XML version 1.0, NaN as targetDeadband when regulating is allowed.
+            // in IIDM-XML version 1.1 and more recent, it is forbidden and throws an exception
+            // to prevent issues, targetDeadband is set to 0 in this case
+            if (regulating && Double.isNaN(targetDeadband[0])) {
+                targetDeadband[0] = 0;
+            }
+        });
+        IidmXmlUtil.runFromMinimumVersion(IidmXmlVersion.V_1_2,
+                context, () -> targetDeadband[0] = XmlUtil.readOptionalDoubleAttribute(context.getReader(), TARGET_DEADBAND));
+        return targetDeadband[0];
+    }
+
+    private static void writeTapChanger(TapChanger<?, ?> tc, NetworkXmlWriterContext context) throws XMLStreamException {
+        context.getWriter().writeAttribute(ATTR_LOW_TAP_POSITION, Integer.toString(tc.getLowTapPosition()));
+        context.getWriter().writeAttribute(ATTR_TAP_POSITION, Integer.toString(tc.getTapPosition()));
+        writeTargetDeadband(tc.getTargetDeadband(), context);
     }
 
     protected static void writeRatioTapChanger(String name, RatioTapChanger rtc, NetworkXmlWriterContext context) throws XMLStreamException {
         context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), name);
-        writeTapChanger(rtc, context.getWriter());
+        writeTapChanger(rtc, context);
         context.getWriter().writeAttribute("loadTapChangingCapabilities", Boolean.toString(rtc.hasLoadTapChangingCapabilities()));
         if (rtc.hasLoadTapChangingCapabilities() || rtc.isRegulating()) {
             context.getWriter().writeAttribute(ATTR_REGULATING, Boolean.toString(rtc.isRegulating()));
@@ -70,8 +107,8 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
     protected static void readRatioTapChanger(String elementName, RatioTapChangerAdder adder, Terminal terminal, NetworkXmlReaderContext context) throws XMLStreamException {
         int lowTapPosition = XmlUtil.readIntAttribute(context.getReader(), ATTR_LOW_TAP_POSITION);
         int tapPosition = XmlUtil.readIntAttribute(context.getReader(), ATTR_TAP_POSITION);
-        double targetDeadband = XmlUtil.readOptionalDoubleAttribute(context.getReader(), TARGET_DEADBAND);
         boolean regulating = XmlUtil.readOptionalBoolAttribute(context.getReader(), ATTR_REGULATING, false);
+        double targetDeadband = readTargetDeadband(regulating, context);
         boolean loadTapChangingCapabilities = XmlUtil.readBoolAttribute(context.getReader(), "loadTapChangingCapabilities");
         double targetV = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "targetV");
         adder.setLowTapPosition(lowTapPosition)
@@ -121,7 +158,7 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
 
     protected static void writePhaseTapChanger(String name, PhaseTapChanger ptc, NetworkXmlWriterContext context) throws XMLStreamException {
         context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), name);
-        writeTapChanger(ptc, context.getWriter());
+        writeTapChanger(ptc, context);
         context.getWriter().writeAttribute("regulationMode", ptc.getRegulationMode().name());
         if (ptc.getRegulationMode() != PhaseTapChanger.RegulationMode.FIXED_TAP || !Double.isNaN(ptc.getRegulationValue())) {
             XmlUtil.writeDouble("regulationValue", ptc.getRegulationValue(), context.getWriter());
@@ -144,10 +181,10 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
     protected static void readPhaseTapChanger(String name, PhaseTapChangerAdder adder, Terminal terminal, NetworkXmlReaderContext context) throws XMLStreamException {
         int lowTapPosition = XmlUtil.readIntAttribute(context.getReader(), ATTR_LOW_TAP_POSITION);
         int tapPosition = XmlUtil.readIntAttribute(context.getReader(), ATTR_TAP_POSITION);
-        double targetDeadband = XmlUtil.readOptionalDoubleAttribute(context.getReader(), TARGET_DEADBAND);
+        boolean regulating = XmlUtil.readOptionalBoolAttribute(context.getReader(), ATTR_REGULATING, false);
+        double targetDeadband = readTargetDeadband(regulating, context);
         PhaseTapChanger.RegulationMode regulationMode = PhaseTapChanger.RegulationMode.valueOf(context.getReader().getAttributeValue(null, "regulationMode"));
         double regulationValue = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "regulationValue");
-        boolean regulating = XmlUtil.readOptionalBoolAttribute(context.getReader(), ATTR_REGULATING, false);
         adder
                 .setLowTapPosition(lowTapPosition)
                 .setTapPosition(tapPosition)

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ShuntXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ShuntXml.java
@@ -10,11 +10,11 @@ import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.network.ShuntCompensator;
 import com.powsybl.iidm.network.ShuntCompensatorAdder;
 import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.xml.util.IidmXmlUtil;
 
 import javax.xml.stream.XMLStreamException;
 
 /**
- *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 class ShuntXml extends AbstractConnectableXml<ShuntCompensator, ShuntCompensatorAdder, VoltageLevel> {
@@ -23,6 +23,8 @@ class ShuntXml extends AbstractConnectableXml<ShuntCompensator, ShuntCompensator
 
     static final String ROOT_ELEMENT_NAME = "shunt";
 
+    private static final String REGULATING_TERMINAL = "regulatingTerminal";
+
     @Override
     protected String getRootElementName() {
         return ROOT_ELEMENT_NAME;
@@ -30,7 +32,7 @@ class ShuntXml extends AbstractConnectableXml<ShuntCompensator, ShuntCompensator
 
     @Override
     protected boolean hasSubElements(ShuntCompensator sc) {
-        return false;
+        return sc != sc.getRegulatingTerminal().getConnectable();
     }
 
     @Override
@@ -38,8 +40,22 @@ class ShuntXml extends AbstractConnectableXml<ShuntCompensator, ShuntCompensator
         XmlUtil.writeDouble("bPerSection", sc.getbPerSection(), context.getWriter());
         context.getWriter().writeAttribute("maximumSectionCount", Integer.toString(sc.getMaximumSectionCount()));
         context.getWriter().writeAttribute("currentSectionCount", Integer.toString(sc.getCurrentSectionCount()));
+        IidmXmlUtil.writeBooleanAttributeFromMinimumVersion(ROOT_ELEMENT_NAME, "voltageRegulatorOn", sc.isVoltageRegulatorOn(), false,
+                IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion.V_1_2, context);
+        IidmXmlUtil.writeDoubleAttributeFromMinimumVersion(ROOT_ELEMENT_NAME, "targetV", sc.getTargetV(),
+                IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion.V_1_2, context);
+        IidmXmlUtil.writeDoubleAttributeFromMinimumVersion(ROOT_ELEMENT_NAME, "targetDeadband",
+                sc.getTargetDeadband(), IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion.V_1_2, context);
         writeNodeOrBus(null, sc.getTerminal(), context);
         writePQ(null, sc.getTerminal(), context.getWriter());
+    }
+
+    @Override
+    protected void writeSubElements(ShuntCompensator sc, VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
+        if (sc != sc.getRegulatingTerminal().getConnectable()) {
+            IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, REGULATING_TERMINAL, IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_2, context);
+            TerminalRefXml.writeTerminalRef(sc.getRegulatingTerminal(), context, REGULATING_TERMINAL);
+        }
     }
 
     @Override
@@ -52,6 +68,14 @@ class ShuntXml extends AbstractConnectableXml<ShuntCompensator, ShuntCompensator
         double bPerSection = XmlUtil.readDoubleAttribute(context.getReader(), "bPerSection");
         int maximumSectionCount = XmlUtil.readIntAttribute(context.getReader(), "maximumSectionCount");
         int currentSectionCount = XmlUtil.readIntAttribute(context.getReader(), "currentSectionCount");
+        IidmXmlUtil.runFromMinimumVersion(IidmXmlVersion.V_1_2, context, () -> {
+            boolean voltageRegulatorOn = XmlUtil.readBoolAttribute(context.getReader(), "voltageRegulatorOn");
+            double targetV = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "targetV");
+            double targetDeadband = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "targetDeadband");
+            adder.setVoltageRegulatorOn(voltageRegulatorOn)
+                    .setTargetV(targetV)
+                    .setTargetDeadband(targetDeadband);
+        });
         adder.setbPerSection(bPerSection)
                 .setMaximumSectionCount(maximumSectionCount)
                 .setCurrentSectionCount(currentSectionCount);
@@ -63,6 +87,15 @@ class ShuntXml extends AbstractConnectableXml<ShuntCompensator, ShuntCompensator
 
     @Override
     protected void readSubElements(ShuntCompensator sc, NetworkXmlReaderContext context) throws XMLStreamException {
-        readUntilEndRootElement(context.getReader(), () -> ShuntXml.super.readSubElements(sc, context));
+        readUntilEndRootElement(context.getReader(), () -> {
+            if (context.getReader().getLocalName().equals(REGULATING_TERMINAL)) {
+                IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, REGULATING_TERMINAL, IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_2, context);
+                String id = context.getAnonymizer().deanonymizeString(context.getReader().getAttributeValue(null, "id"));
+                String side = context.getReader().getAttributeValue(null, "side");
+                context.getEndTasks().add(() -> sc.setRegulatingTerminal(TerminalRefXml.readTerminalRef(sc.getTerminal().getVoltageLevel().getSubstation().getNetwork(), id, side)));
+            } else {
+                super.readSubElements(sc, context);
+            }
+        });
     }
 }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml.util;
 
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.xml.AbstractNetworkXmlContext;
 import com.powsybl.iidm.xml.IidmXmlVersion;
@@ -102,6 +103,7 @@ public final class IidmXmlUtil {
         if (context.getVersion().compareTo(minVersion) >= 0) {
             runnable.run();
         }
+
     }
 
     /**
@@ -114,16 +116,54 @@ public final class IidmXmlUtil {
     }
 
     /**
-     * Write a <b>mandatory</b> double attribute from a given minimum IIDM-XML version.<br>
+     * Write a <b>mandatory</b> boolean attribute from a given minimum IIDM-XML version.<br>
+     * If the context's IIDM-XML version is strictly older than the given minimum IIDM-XML version, the attribute's value <b>should be default</b>
+     * (else an exception is thrown).
+     */
+    public static void writeBooleanAttributeFromMinimumVersion(String rootElementName, String attributeName, boolean value, boolean defaultValue,
+                                                               ErrorMessage type, IidmXmlVersion minVersion, NetworkXmlWriterContext context) {
+        writeAttributeFromMinimumVersion(rootElementName, attributeName, value != defaultValue, type, minVersion, context, () -> {
+            try {
+                context.getWriter().writeAttribute(attributeName, Boolean.toString(value));
+            } catch (XMLStreamException e) {
+                throw new UncheckedXmlStreamException(e);
+            }
+        });
+    }
+
+    /**
+     * Write a double attribute from a given minimum IIDM-XML version if its value is defined.<br>
+     * If the context's IIDM-XML version is strictly older than the given minimum IIDM-XML version, the attribute's value <b>should be undefined i.e. NaN</b>
+     * (else an exception is thrown).
+     */
+    public static void writeDoubleAttributeFromMinimumVersion(String rootElementName, String attributeName, double value,
+                                                              ErrorMessage type, IidmXmlVersion minVersion, NetworkXmlWriterContext context) {
+        writeDoubleAttributeFromMinimumVersion(rootElementName, attributeName, value, Double.NaN, type, minVersion, context);
+    }
+
+    /**
+     * Write a double attribute from a given minimum IIDM-XML version if its value is defined.<br>
      * If the context's IIDM-XML version is strictly older than the given minimum IIDM-XML version, the attribute's value <b>should be default</b>
      * (else an exception is thrown).
      */
     public static void writeDoubleAttributeFromMinimumVersion(String rootElementName, String attributeName, double value, double defaultValue,
-                                                              ErrorMessage type, IidmXmlVersion minVersion, NetworkXmlWriterContext context) throws XMLStreamException {
+                                                              ErrorMessage type, IidmXmlVersion minVersion, NetworkXmlWriterContext context) {
+        writeAttributeFromMinimumVersion(rootElementName, attributeName, !Objects.equals(value, defaultValue), type, minVersion, context, () -> {
+            try {
+                XmlUtil.writeDouble(attributeName, value, context.getWriter());
+            } catch (XMLStreamException e) {
+                throw new UncheckedXmlStreamException(e);
+            }
+        });
+    }
+
+    private static void writeAttributeFromMinimumVersion(String rootElementName, String attributeName, boolean isNotDefaultValue,
+                                                         ErrorMessage type, IidmXmlVersion minVersion, NetworkXmlWriterContext context,
+                                                         Runnable write) {
         if (context.getVersion().compareTo(minVersion) >= 0) {
-            XmlUtil.writeDouble(attributeName, value, context.getWriter());
+            write.run();
         } else {
-            assertMinimumVersionIfNotDefault(!Objects.equals(value, defaultValue), rootElementName, attributeName, type, minVersion, context);
+            assertMinimumVersionIfNotDefault(isNotDefaultValue, rootElementName, attributeName, type, minVersion, context);
         }
     }
 

--- a/iidm/iidm-xml-converter/src/main/resources/xsd/iidm_V1_2.xsd
+++ b/iidm/iidm-xml-converter/src/main/resources/xsd/iidm_V1_2.xsd
@@ -264,9 +264,15 @@
     <xs:complexType name="ShuntCompensator">
         <xs:complexContent>
             <xs:extension base="iidm:Injection">
+                <xs:sequence>
+                    <xs:element name="regulatingTerminal" minOccurs="0" type="iidm:TerminalRef"/>
+                </xs:sequence>
                 <xs:attribute name="bPerSection" use="required" type="xs:double"/>
                 <xs:attribute name="maximumSectionCount" use="required" type="xs:int"/>
                 <xs:attribute name="currentSectionCount" use="required" type="xs:int"/>
+                <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+                <xs:attribute name="targetV" use="optional" type="xs:double"/>
+                <xs:attribute name="targetDeadband" use="optional" type="xs:double"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ShuntCompensatorXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ShuntCompensatorXmlTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.xml;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.export.ExportOptions;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.ShuntCompensator;
+import com.powsybl.iidm.network.test.ShuntTestCaseFactory;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class ShuntCompensatorXmlTest extends AbstractXmlConverterTest {
+
+    @Test
+    public void test() throws IOException {
+        Network network = ShuntTestCaseFactory.create();
+        ShuntCompensator sc = network.getShuntCompensator("SHUNT");
+        sc.setProperty("test", "test");
+        roundTripXmlTest(network,
+                NetworkXml::writeAndValidate,
+                NetworkXml::read,
+                getVersionedNetworkPath("shuntRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
+
+        // backward compatibility
+        roundTripVersionedXmlFromMinToCurrentVersionTest("shuntRoundTripRef.xml", IidmXmlVersion.V_1_2);
+    }
+
+    @Test
+    public void unsupportedReadTest() {
+        testForAllPreviousVersions(IidmXmlVersion.V_1_2, v -> assertTrue(read(v)));
+    }
+
+    @Test
+    public void unsupportedWriteTest() {
+        Network network = ShuntTestCaseFactory.create();
+        testForAllPreviousVersions(IidmXmlVersion.V_1_2, v -> assertTrue(write(network, v.toString("."))));
+    }
+
+    private boolean read(IidmXmlVersion version) {
+        boolean exceptionThrown = false;
+        try {
+            NetworkXml.read(getVersionedNetworkAsStream("faultyShunt.xml", version));
+        } catch (PowsyblException e) {
+            exceptionThrown = true;
+            assertEquals("shunt.regulatingTerminal is not supported for IIDM-XML version " +
+                            version.toString(".") + ". IIDM-XML version should be >= 1.2",
+                    e.getMessage());
+        }
+        return exceptionThrown;
+    }
+
+    private boolean write(Network network, String version) {
+        boolean exceptionThrown = false;
+        try {
+            ExportOptions options = new ExportOptions().setVersion(version);
+            NetworkXml.write(network, options, tmpDir.resolve("/fail.xml"));
+        } catch (PowsyblException e) {
+            exceptionThrown = true;
+            assertEquals("shunt.voltageRegulatorOn is not defined as default and not supported for IIDM-XML version " +
+                            version + ". IIDM-XML version should be >= 1.2",
+                    e.getMessage());
+        }
+        return exceptionThrown;
+    }
+}

--- a/iidm/iidm-xml-converter/src/test/resources/V1_0/faultyShunt.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_0/faultyShunt.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="shuntTestCase" caseDate="2019-09-30T16:29:18.263+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="S1" country="FR">
+        <iidm:voltageLevel id="VL1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B1"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="SHUNT" bPerSection="1.0E-5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="true" targetV="200.0" targetDeadband="5.0" bus="B1" connectableBus="B1">
+                <iidm:property name="test" value="test"/>
+                <iidm:regulatingTerminal id="LOAD"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S2" country="FR">
+        <iidm:voltageLevel id="VL2" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B2"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="100.0" q0="50.0" bus="B2" connectableBus="B2"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_1/LccRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_1/LccRoundTripRef.xml
@@ -21,7 +21,7 @@
                 <iidm:switch id="DISC_BBS1_BK3" name="Disconnector" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="5"/>
                 <iidm:switch id="BK3" name="Breaker" kind="BREAKER" retained="true" open="false" node1="5" node2="6"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="C2_Filter1" name="Filter 3"  bPerSection="3.0E-5" maximumSectionCount="1" currentSectionCount="1" node="4" q="12.5"/>
+            <iidm:shunt id="C2_Filter1" name="Filter 3" bPerSection="3.0E-5" maximumSectionCount="1" currentSectionCount="1" node="4" q="12.5"/>
             <iidm:shunt id="C2_Filter2" name="Filter 4" bPerSection="4.0E-5" maximumSectionCount="1" currentSectionCount="1" node="6" q="12.5"/>
             <iidm:lccConverterStation id="C2" name="Converter2" lossFactor="0.011" powerFactor="0.6" node="2" p="75.0" q="25.0"/>
         </iidm:voltageLevel>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_1/LccRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_1/LccRoundTripRef.xml
@@ -21,7 +21,7 @@
                 <iidm:switch id="DISC_BBS1_BK3" name="Disconnector" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="5"/>
                 <iidm:switch id="BK3" name="Breaker" kind="BREAKER" retained="true" open="false" node1="5" node2="6"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="C2_Filter1" name="Filter 3" bPerSection="3.0E-5" maximumSectionCount="1" currentSectionCount="1" node="4" q="12.5"/>
+            <iidm:shunt id="C2_Filter1" name="Filter 3"  bPerSection="3.0E-5" maximumSectionCount="1" currentSectionCount="1" node="4" q="12.5"/>
             <iidm:shunt id="C2_Filter2" name="Filter 4" bPerSection="4.0E-5" maximumSectionCount="1" currentSectionCount="1" node="6" q="12.5"/>
             <iidm:lccConverterStation id="C2" name="Converter2" lossFactor="0.011" powerFactor="0.6" node="2" p="75.0" q="25.0"/>
         </iidm:voltageLevel>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_1/faultyShunt.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_1/faultyShunt.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_1" id="shuntTestCase" caseDate="2019-09-30T16:29:18.263+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="S1" country="FR">
+        <iidm:voltageLevel id="VL1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B1"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="SHUNT" bPerSection="1.0E-5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="true" targetV="200.0" targetDeadband="5.0" bus="B1" connectableBus="B1">
+                <iidm:property name="test" value="test"/>
+                <iidm:regulatingTerminal id="LOAD"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S2" country="FR">
+        <iidm:voltageLevel id="VL2" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B2"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="100.0" q0="50.0" bus="B2" connectableBus="B2"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/LccRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/LccRoundTripRef.xml
@@ -5,8 +5,8 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="B1"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="C1_Filter1" name="Filter 1" bPerSection="1.0E-5" maximumSectionCount="1" currentSectionCount="1" bus="B1" connectableBus="B1" q="25.0"/>
-            <iidm:shunt id="C1_Filter2" name="Filter 2" bPerSection="2.0E-5" maximumSectionCount="1" currentSectionCount="0" connectableBus="B1" q="25.0"/>
+            <iidm:shunt id="C1_Filter1" name="Filter 1" bPerSection="1.0E-5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B1" connectableBus="B1" q="25.0"/>
+            <iidm:shunt id="C1_Filter2" name="Filter 2" bPerSection="2.0E-5" maximumSectionCount="1" currentSectionCount="0" voltageRegulatorOn="false" connectableBus="B1" q="25.0"/>
             <iidm:lccConverterStation id="C1" name="Converter1" lossFactor="0.011" powerFactor="0.5" bus="B1" connectableBus="B1" p="100.0" q="50.0"/>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -21,8 +21,8 @@
                 <iidm:switch id="DISC_BBS1_BK3" name="Disconnector" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="5"/>
                 <iidm:switch id="BK3" name="Breaker" kind="BREAKER" retained="true" open="false" node1="5" node2="6"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="C2_Filter1" name="Filter 3" bPerSection="3.0E-5" maximumSectionCount="1" currentSectionCount="1" node="4" q="12.5"/>
-            <iidm:shunt id="C2_Filter2" name="Filter 4" bPerSection="4.0E-5" maximumSectionCount="1" currentSectionCount="1" node="6" q="12.5"/>
+            <iidm:shunt id="C2_Filter1" name="Filter 3"  bPerSection="3.0E-5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" node="4" q="12.5"/>
+            <iidm:shunt id="C2_Filter2" name="Filter 4" bPerSection="4.0E-5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" node="6" q="12.5"/>
             <iidm:lccConverterStation id="C2" name="Converter2" lossFactor="0.011" powerFactor="0.6" node="2" p="75.0" q="25.0"/>
         </iidm:voltageLevel>
     </iidm:substation>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/LccRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/LccRoundTripRef.xml
@@ -21,7 +21,7 @@
                 <iidm:switch id="DISC_BBS1_BK3" name="Disconnector" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="5"/>
                 <iidm:switch id="BK3" name="Breaker" kind="BREAKER" retained="true" open="false" node1="5" node2="6"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="C2_Filter1" name="Filter 3"  bPerSection="3.0E-5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" node="4" q="12.5"/>
+            <iidm:shunt id="C2_Filter1" name="Filter 3" bPerSection="3.0E-5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" node="4" q="12.5"/>
             <iidm:shunt id="C2_Filter2" name="Filter 4" bPerSection="4.0E-5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" node="6" q="12.5"/>
             <iidm:lccConverterStation id="C2" name="Converter2" lossFactor="0.011" powerFactor="0.6" node="2" p="75.0" q="25.0"/>
         </iidm:voltageLevel>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/completeThreeWindingsTransformerRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/completeThreeWindingsTransformerRoundTripRef.xml
@@ -29,7 +29,7 @@
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger1>
-            <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulating="true" targetV="33.0">
+            <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulating="true" targetV="33.0" targetDeadband="0.0">
                 <iidm:terminalRef id="LOAD_33"/>
                 <iidm:step r="0.9801" x="0.09801" g="0.08264462809917356" b="0.008264462809917356" rho="0.9"/>
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/danglingLine.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/danglingLine.xml
@@ -15,7 +15,7 @@
             <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial-example1-anonymized.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial-example1-anonymized.xml
@@ -29,7 +29,7 @@
             <iidm:load id="P" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="O" connectableBus="O"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="Q" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="M" connectableBus1="M" voltageLevelId1="L" bus2="O" connectableBus2="O" voltageLevelId2="N">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
                 <iidm:terminalRef id="Q" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial-example1-properties.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial-example1-properties.xml
@@ -32,7 +32,7 @@
             <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial-example1-with-terminalMock-ext.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial-example1-with-terminalMock-ext.xml
@@ -29,7 +29,7 @@
             <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial-example1.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial-example1.xml
@@ -29,7 +29,7 @@
             <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" regulating="true" loadTapChangingCapabilities="true" targetV="158.0" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial1-lf.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/eurostag-tutorial1-lf.xml
@@ -29,7 +29,7 @@
             <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/shuntRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/shuntRoundTripRef.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="shuntTestCase" caseDate="2019-09-30T16:29:18.263+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="S1" country="FR">
+        <iidm:voltageLevel id="VL1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B1"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="SHUNT" bPerSection="1.0E-5" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="true" targetV="200.0" targetDeadband="5.0" bus="B1" connectableBus="B1">
+                <iidm:property name="test" value="test"/>
+                <iidm:regulatingTerminal id="LOAD"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S2" country="FR">
+        <iidm:voltageLevel id="VL2" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B2"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="100.0" q0="50.0" bus="B2" connectableBus="B2"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/terminalRef.xiidm
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/terminalRef.xiidm
@@ -5,9 +5,9 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="VL41" v="91.1261139" angle="-11.1787205"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="SHUNT_VL4.11" bPerSection="0.0035802468191832304" maximumSectionCount="1" currentSectionCount="1" connectableBus="VL41" q="9999.0"/>
-            <iidm:shunt id="SHUNT_VL4.21" bPerSection="0.003703703638166189" maximumSectionCount="1" currentSectionCount="1" connectableBus="VL41" q="9999.0"/>
-            <iidm:shunt id="SHUNT_VL4.31" bPerSection="0.003703703638166189" maximumSectionCount="1" currentSectionCount="1" connectableBus="VL41" q="9999.0"/>
+            <iidm:shunt id="SHUNT_VL4.11" bPerSection="0.0035802468191832304" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" connectableBus="VL41" q="9999.0"/>
+            <iidm:shunt id="SHUNT_VL4.21" bPerSection="0.003703703638166189" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" connectableBus="VL41" q="9999.0"/>
+            <iidm:shunt id="SHUNT_VL4.31" bPerSection="0.003703703638166189" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" connectableBus="VL41" q="9999.0"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL6" nominalV="225.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/threeWindingsTransformerRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/threeWindingsTransformerRoundTripRef.xml
@@ -22,7 +22,7 @@
             <iidm:load id="LOAD_11" loadType="UNDEFINED" p0="0.0" q0="-10.6" bus="BUS_11" connectableBus="BUS_11" p="0.0" q="-10.6"/>
         </iidm:voltageLevel>
         <iidm:threeWindingsTransformer id="3WT" r1="17.424" x1="1.7424" g1="0.00573921028466483" b1="5.73921028466483E-4" ratedU1="132.0" r2="1.089" x2="0.1089" g2="0.0" b2="0.0" ratedU2="33.0" r3="0.121" x3="0.0121" g3="0.0" b3="0.0" ratedU3="11.0" ratedU0="132.0" bus1="BUS_132" connectableBus1="BUS_132" voltageLevelId1="VL_132" bus2="BUS_33" connectableBus2="BUS_33" voltageLevelId2="VL_33" bus3="BUS_11" connectableBus3="BUS_11" voltageLevelId3="VL_11">
-            <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulating="true" targetV="33.0">
+            <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulating="true" targetV="33.0" targetDeadband="0.0">
                 <iidm:terminalRef id="LOAD_33"/>
                 <iidm:step r="0.9801" x="0.09801" g="0.08264462809917356" b="0.008264462809917356" rho="0.9"/>
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/tieline.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/tieline.xml
@@ -29,7 +29,7 @@
             <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>

--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -429,6 +429,7 @@ public class UcteImporter implements Importer {
             rtca.setLoadTapChangingCapabilities(true)
                     .setRegulating(true)
                     .setTargetV(uctePhaseRegulation.getU())
+                    .setTargetDeadband(0.0)
                     .setRegulationTerminal(transformer.getTerminal1());
         }
         for (int i = -uctePhaseRegulation.getN(); i <= uctePhaseRegulation.getN(); i++) {


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
#900 : add regulation for shunts

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
New features:
- regulation of shunt is added (cf. http://www.powsybl.org/docs/iidm/model/shuntCompensator.html)
- for homogenization purposes, `RatioTapChanger.targetDeadband` and `PhaseTapChanger.targetDeadband` are now mandatory when the tap changer is regulating (same behavior than shunts)
- XIIDM serialization/deserialization of these evolutions
- implement new utility methods in `IidmXmlUtil`
- implement new utility test methods in `AbstractXmlConverterTest`

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)
