### PR TITLE
RTC always at side one in three windings transformers

### DIFF
--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
@@ -606,6 +606,82 @@ public class CgmesConformity1NetworkCatalog {
             genBrussels10.getTerminal().setQ(q);
         }
 
+        ThreeWindingsTransformer txBETR3;
+        {
+            double ratedU1 = 400.0;
+            double ratedU2 = 220.0;
+            double ratedU3 = 21.0;
+            double ratedU0 = ratedU1;
+            double r1 = 0.898462;
+            double x1 = 17.204128;
+            double g1 = 0.0;
+            double b1 = 0.0000024375;
+            double r2 = 0.323908;
+            double x2 = 5.949086;
+            double g2 = 0.0;
+            double b2 = 0.0;
+            double r3 = 0.013332;
+            double x3 = 0.059978;
+            double g3 = 0.0;
+            double b3 = 0.0;
+            txBETR3 = sBrussels.newThreeWindingsTransformer()
+                .setId("_84ed55f4-61f5-4d9d-8755-bba7b877a246")
+                .setName("BE-TR3_1")
+                .newLeg1()
+                    .setRatedU(ratedU1)
+                    .setR(r1)
+                    .setX(x1)
+                    .setG(g1)
+                    .setB(b1)
+                    .setConnectableBus(busBrussels380.getId())
+                    .setBus(busBrussels380.getId())
+                    .setVoltageLevel(vlBrussels380.getId())
+                .add()
+                .newLeg2()
+                    .setRatedU(ratedU2)
+                    .setR(r2 * (ratedU0 / ratedU2) * (ratedU0 / ratedU2))
+                    .setX(x2 * (ratedU0 / ratedU2) * (ratedU0 / ratedU2))
+                    .setConnectableBus(busBrussels225.getId())
+                    .setBus(busBrussels225.getId())
+                    .setVoltageLevel(vlBrussels225.getId())
+                .add()
+                .newLeg3()
+                    .setRatedU(ratedU3)
+                    .setR(r3 * (ratedU0 / ratedU3) * (ratedU0 / ratedU3))
+                    .setX(x3 * (ratedU0 / ratedU3) * (ratedU0 / ratedU3))
+                    .setConnectableBus(busBrussels21.getId())
+                    .setBus(busBrussels21.getId())
+                    .setVoltageLevel(vlBrussels21.getId())
+                .add()
+            .add();
+
+            int low = 1;
+            int high = 33;
+            int neutral = 17;
+            int position = 17;
+            double voltageInc = 0.625;
+            RatioTapChangerAdder rtca = txBETR3.getLeg2().newRatioTapChanger()
+                .setLowTapPosition(low)
+                .setTapPosition(position);
+            for (int k = low; k <= high; k++) {
+                int n = k - neutral;
+                double du = voltageInc / 100;
+                double rhok = 1 / (1 + n * du);
+                double dz = 0;
+                double dy = 0;
+                rtca.beginStep()
+                    .setRho(rhok)
+                    .setR(dz)
+                    .setX(dz)
+                    .setG(dy)
+                    .setB(dy)
+                    .endStep();
+            }
+            rtca.setLoadTapChangingCapabilities(true)
+                .setRegulating(false)
+                .setTargetV(Float.NaN);
+            rtca.add();
+        }
         return network;
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/RatioTapChangerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/RatioTapChangerConversion.java
@@ -196,8 +196,8 @@ public class RatioTapChangerConversion extends AbstractIdentifiedObjectConversio
             double dy = 0;
             if (!rtcAtSide1) {
                 double rho2 = rho * rho;
-                dz = (rho2 - 1) * 100;
-                dy = (1 / rho2 - 1) * 100;
+                dz = (rho2 - 1) * 100;     // Use the initial ratio before moving it
+                dy = (1 / rho2 - 1) * 100; // Use the initial ratio before moving it
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(String.format("RTC2to1 corrections  %4d  %12.8f  %12.8f  %12.8f",
                         step, n * du, dz, dy));
@@ -216,9 +216,11 @@ public class RatioTapChangerConversion extends AbstractIdentifiedObjectConversio
     private boolean rtcAtSide1() {
         // From CIM1 converter:
         // For 2 winding transformers, rho is 1/(1 + n*du) if rtc is at side 1
-        // For 3 winding transformers rho is always 1 + n*du
+        // For 3 winding transformers rho is always considered at side 1 (network side)
         if (tx2 != null) {
             return context.tapChangerTransformers().whichSide(id) == 1;
+        } else if (tx3 != null) {
+            return true;
         }
         return false;
     }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -103,6 +103,10 @@ public class Comparison {
                 actual.getTwoWindingsTransformerStream(),
                 this::compareTwoWindingTransformers);
         compare(
+                expected.getThreeWindingsTransformerStream(),
+                actual.getThreeWindingsTransformerStream(),
+                this::compareThreeWindingsTransformers);
+        compare(
                 expected.getDanglingLineStream(),
                 actual.getDanglingLineStream(),
                 this::compareDanglingLines);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -35,6 +35,7 @@ import com.powsybl.iidm.network.Substation;
 import com.powsybl.iidm.network.Switch;
 import com.powsybl.iidm.network.TapChanger;
 import com.powsybl.iidm.network.TapChangerStep;
+import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.extensions.CoordinatedReactiveControl;
@@ -418,6 +419,33 @@ public class Comparison {
         comparePhaseTapChanger(expected.getPhaseTapChanger(), actual.getPhaseTapChanger());
     }
 
+    private void compareThreeWindingsTransformers(ThreeWindingsTransformer expected,
+        ThreeWindingsTransformer actual) {
+        compareLeg(expected.getLeg1(), actual.getLeg1(), expected, actual);
+        compareLeg(expected.getLeg2(), actual.getLeg2(), expected, actual);
+        compareLeg(expected.getLeg3(), actual.getLeg3(), expected, actual);
+    }
+
+    private void compareLeg(ThreeWindingsTransformer.LegBase expected, ThreeWindingsTransformer.LegBase actual,
+        ThreeWindingsTransformer expectedt, ThreeWindingsTransformer actualt) {
+        equivalent("VoltageLevel",
+            expected.getTerminal().getVoltageLevel(),
+            actual.getTerminal().getVoltageLevel());
+        compare("r", expected.getR(), actual.getR());
+        compare("x", expected.getX(), actual.getX());
+        if (actual instanceof ThreeWindingsTransformer.Leg1) {
+            compare("g", ((ThreeWindingsTransformer.Leg1) expected).getG(), ((ThreeWindingsTransformer.Leg1) actual).getG());
+            compare("b", ((ThreeWindingsTransformer.Leg1) expected).getB(), ((ThreeWindingsTransformer.Leg1) actual).getB());
+        }
+        compare("ratedU", expected.getRatedU(), actual.getRatedU());
+        compareCurrentLimits(expectedt, actualt,
+            expected.getCurrentLimits(),
+            actual.getCurrentLimits());
+        if (actual instanceof ThreeWindingsTransformer.Leg2or3) {
+            compareRatioTapChanger(((ThreeWindingsTransformer.Leg2or3) expected).getRatioTapChanger(), ((ThreeWindingsTransformer.Leg2or3) actual).getRatioTapChanger());
+        }
+    }
+
     private void compareRatioTapChanger(
             RatioTapChanger expected,
             RatioTapChanger actual) {
@@ -474,7 +502,7 @@ public class Comparison {
                     actual.getTargetDeadband());
             compare("tapChanger.stepCount", expected.getStepCount(), actual.getStepCount());
             // Check steps
-            for (int k = expected.getLowTapPosition(); k <= expected.getStepCount(); k++) {
+            for (int k = expected.getLowTapPosition(); k <= expected.getHighTapPosition(); k++) {
                 TCS stepExpected = expected.getStep(k);
                 TCS stepActual = actual.getStep(k);
                 compareTapChangerStep(stepExpected, stepActual, testTapChangerStep1);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
RTC in three windings transformers is considered at side two of the leg (star bus side)



**What is the new behavior (if this is a feature change)?**
RTC in three windings transformers is considered at side one of the leg (network bus side)


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
