### PR TITLE
Correct SVC import from CGMES

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
@@ -30,8 +30,8 @@ public class StaticVarCompensatorConversion extends AbstractConductingEquipmentC
         double inductiveRating = p.asDouble("inductiveRating", 0.0);
 
         StaticVarCompensatorAdder adder = voltageLevel().newStaticVarCompensator()
-                .setBmin(-1 / capacitiveRating)
-                .setBmax(-1 / inductiveRating);
+                .setBmin(1 / inductiveRating)
+                .setBmax(1 / capacitiveRating);
         context.regulatingControlMapping().setRegulatingControl(iidmId(), p, adder);
         identify(adder);
         connect(adder);


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
There is an error in conversion (formulas) of inductive and capacitive ratings of a SVC in CGMES into bMin and bMax in IIDM.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
