### PR TITLE
Add bytes into ComputationException

### DIFF
--- a/computation/src/main/java/com/powsybl/computation/ComputationExceptionBuilder.java
+++ b/computation/src/main/java/com/powsybl/computation/ComputationExceptionBuilder.java
@@ -91,6 +91,19 @@ public class ComputationExceptionBuilder {
     }
 
     /**
+     * Add bytes.
+     * @param key The name of bytes.
+     * @param bytes Bytes.
+     * @return
+     */
+    public ComputationExceptionBuilder addBytes(String key, byte[] bytes) {
+        Objects.requireNonNull(bytes);
+        Objects.requireNonNull(key);
+        bytesByFileName.put(key, bytes);
+        return this;
+    }
+
+    /**
      * If the exception is {@literal Null}, do nothing. Otherwise, this exception is logged in a {@literal List}
      * @param exception
      * @return

--- a/computation/src/test/java/com/powsybl/computation/ComputationExceptionBuilderTest.java
+++ b/computation/src/test/java/com/powsybl/computation/ComputationExceptionBuilderTest.java
@@ -86,6 +86,17 @@ public class ComputationExceptionBuilderTest {
         assertEquals("errLog", IOUtils.toString(Objects.requireNonNull(strZipFile.getInputStream("err")), StandardCharsets.UTF_8));
         assertEquals("foo", IOUtils.toString(Objects.requireNonNull(strZipFile.getInputStream("f1.out")), StandardCharsets.UTF_8));
 
+        ComputationExceptionBuilder ceb3 = new ComputationExceptionBuilder(runtimeException);
+        String key = "bytesKey";
+        ceb3.addBytes(key, "someBytes".getBytes());
+        ComputationException computationException3 = ceb3.build();
+        byte[] bytes1 = computationException3.getFileBytes().get(key);
+        assertEquals("someBytes", new String(bytes1));
+
+        // test after serialized
+        IOUtils.copy(new ByteArrayInputStream(computationException3.toZipBytes()), Files.newOutputStream(workingDir.resolve("test3.zip")));
+        ZipFile test3 = new ZipFile(workingDir.resolve("test3.zip"));
+        assertEquals("someBytes", IOUtils.toString(test3.getInputStream(key), StandardCharsets.UTF_8));
     }
 
     @After


### PR DESCRIPTION
Signed-off-by: yichen88 <tang.yichenyves@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
Only `Path` could be added into `ComputationException`


**What is the new behavior (if this is a feature change)?**
`Byte[]` could be also added into ComputationException.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
