### PR TITLE
Fix HVDC line XML export anonymization bug

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/HvdcLineXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/HvdcLineXml.java
@@ -40,8 +40,8 @@ class HvdcLineXml extends AbstractIdentifiableXml<HvdcLine, HvdcLineAdder, Netwo
         context.getWriter().writeAttribute("convertersMode", l.getConvertersMode().name());
         XmlUtil.writeDouble("activePowerSetpoint", l.getActivePowerSetpoint(), context.getWriter());
         XmlUtil.writeDouble("maxP", l.getMaxP(), context.getWriter());
-        context.getWriter().writeAttribute("converterStation1", l.getConverterStation1().getId());
-        context.getWriter().writeAttribute("converterStation2", l.getConverterStation2().getId());
+        context.getWriter().writeAttribute("converterStation1", context.getAnonymizer().anonymizeString(l.getConverterStation1().getId()));
+        context.getWriter().writeAttribute("converterStation2", context.getAnonymizer().anonymizeString(l.getConverterStation2().getId()));
     }
 
     @Override
@@ -56,8 +56,8 @@ class HvdcLineXml extends AbstractIdentifiableXml<HvdcLine, HvdcLineAdder, Netwo
         HvdcLine.ConvertersMode convertersMode = HvdcLine.ConvertersMode.valueOf(context.getReader().getAttributeValue(null, "convertersMode"));
         double activePowerSetpoint = XmlUtil.readDoubleAttribute(context.getReader(), "activePowerSetpoint");
         double maxP = XmlUtil.readDoubleAttribute(context.getReader(), "maxP");
-        String converterStation1 = context.getReader().getAttributeValue(null, "converterStation1");
-        String converterStation2 = context.getReader().getAttributeValue(null, "converterStation2");
+        String converterStation1 = context.getAnonymizer().deanonymizeString(context.getReader().getAttributeValue(null, "converterStation1"));
+        String converterStation2 = context.getAnonymizer().deanonymizeString(context.getReader().getAttributeValue(null, "converterStation2"));
         return adder.setR(r)
                 .setNominalV(nominalV)
                 .setConvertersMode(convertersMode)


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR fix an anonymization bug when IIDM network contains an HVDC line


**What is the current behavior?** *(You can also link to an open issue here)*
Converter stations on side 1 and 2 of HVDC lines are not anonymized. So network is not consistent anymore because converter stations have been anonymized but not link to converter station in HVDC line. 


**What is the new behavior (if this is a feature change)?**
Converter stations on side 1 and 2 of HVDC lines are now correctly anonymized.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
