### PR TITLE
CGMES remote regulating terminal is connected if a connected terminal exists on the topological node

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/TerminalMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/TerminalMapping.java
@@ -54,14 +54,23 @@ public class TerminalMapping {
     }
 
     public Terminal findFromTopologicalNode(String topologicalNode) {
+        Terminal disconnectedTerminal = null;
         if (topologicalNodesMapping.containsKey(topologicalNode)) {
             for (String cgmesTerminalId : topologicalNodesMapping.get(topologicalNode)) {
-                if (find(cgmesTerminalId) != null) {
-                    return find(cgmesTerminalId);
+                Terminal terminal = find(cgmesTerminalId);
+                if (terminal != null) {
+                    if (terminal.isConnected()) { // returns the first connected terminal associated with the given topological node
+                        return terminal;
+                    } else if (disconnectedTerminal == null) {
+                        disconnectedTerminal = terminal;
+                    }
                 }
             }
         }
-        return null;
+        // if no connected terminal is found associated with the given topological node
+        // returns a disconnected terminal associated with the given topological node
+        // if no terminal found, returns null
+        return disconnectedTerminal; 
     }
 
     public String findCgmesTerminalFromTopologicalNode(String topologicalNode) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/TerminalMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/TerminalMapping.java
@@ -70,7 +70,7 @@ public class TerminalMapping {
         // if no connected terminal is found associated with the given topological node
         // returns a disconnected terminal associated with the given topological node
         // if no terminal found, returns null
-        return disconnectedTerminal; 
+        return disconnectedTerminal;
     }
 
     public String findCgmesTerminalFromTopologicalNode(String topologicalNode) {


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bit of bug fix and feature.


**What is the current behavior?** *(You can also link to an open issue here)*
When searching for a CGMES terminal without connected equipment (not imported in IIDM), we take the first terminal associated to its topological node, connected or not, if it exists else we take null.


**What is the new behavior (if this is a feature change)?**
When searching for a CGMES terminal without connected equipment (not imported in IIDM), we take the first **connected** terminal associated to its topological node if it exists, else we take the first **disconnected** terminal associated to its topological node if it exists, else we take null.


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
