### PR TITLE
Change shunt getMaximumB() behaviour and implement getMinimumB()

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ShuntCompensator.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ShuntCompensator.java
@@ -66,9 +66,22 @@ public interface ShuntCompensator extends Injection<ShuntCompensator> {
     ShuntCompensator setbPerSection(double bPerSection);
 
     /**
-     * Get the susceptance for the maximum section count.
+     * Get the maximum susceptance in S.
+     * If bPerSection >= 1, returns the susceptance of the maximum section count.
+     * If 1 > bPerSection > 0, returns the susceptance of the section 1.
+     * If bPerSection < 0, returns 0.
      */
     double getMaximumB();
+
+    /**
+     * Get the minimum susceptance in S.
+     * If bPerSection > 0, returns 0.
+     * If 0 > bPerSection > -1, returns the susceptance of the section 1.
+     * If -1 >= bPerSection, returns the susceptance of the maximum section count.
+     */
+    default double getMinimumB() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Get the susceptance for the current section counts.

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorImpl.java
@@ -104,7 +104,24 @@ class ShuntCompensatorImpl extends AbstractConnectable<ShuntCompensator> impleme
 
     @Override
     public double getMaximumB() {
-        return bPerSection * maximumSectionCount;
+        if (bPerSection >= 1) {
+            return bPerSection * maximumSectionCount;
+        }
+        if (bPerSection > 0) {
+            return bPerSection * 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public double getMinimumB() {
+        if (bPerSection <= -1) {
+            return bPerSection * maximumSectionCount;
+        }
+        if (bPerSection < 0) {
+            return bPerSection * 1;
+        }
+        return 0;
     }
 
     @Override

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ShuntCompensatorTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ShuntCompensatorTest.java
@@ -44,12 +44,27 @@ public class ShuntCompensatorTest {
                                             .setCurrentSectionCount(6)
                                             .setMaximumSectionCount(10)
                                         .add();
+
+        ShuntCompensator shuntCompensatorNeg = network.getVoltageLevel("vl2")
+                                        .newShuntCompensator()
+                                            .setId("shuntNeg")
+                                            .setConnectableBus("busB")
+                                            .setbPerSection(-1.0)
+                                            .setCurrentSectionCount(1)
+                                            .setMaximumSectionCount(7)
+                                        .add();
+
         assertEquals(ConnectableType.SHUNT_COMPENSATOR, shuntCompensator.getType());
         assertEquals("shuntName", shuntCompensator.getName());
         assertEquals("shunt", shuntCompensator.getId());
         assertEquals(5.0, shuntCompensator.getbPerSection(), 0.0);
         assertEquals(6, shuntCompensator.getCurrentSectionCount());
         assertEquals(10, shuntCompensator.getMaximumSectionCount());
+        assertEquals(50, shuntCompensator.getMaximumB(), 0.0);
+        assertEquals(0, shuntCompensator.getMinimumB(), 0.0);
+
+        assertEquals(0.0, shuntCompensatorNeg.getMaximumB(), 0.0);
+        assertEquals(-7.0, shuntCompensatorNeg.getMinimumB(), 0.0);
 
         // setter getter
         try {
@@ -57,8 +72,13 @@ public class ShuntCompensatorTest {
             fail();
         } catch (ValidationException ignored) {
         }
-        shuntCompensator.setbPerSection(1.0);
-        assertEquals(1.0, shuntCompensator.getbPerSection(), 0.0);
+        shuntCompensator.setbPerSection(0.1);
+        assertEquals(0.1, shuntCompensator.getbPerSection(), 0.0);
+        assertEquals(0.1, shuntCompensator.getMaximumB(), 0.0);
+
+        shuntCompensatorNeg.setbPerSection(-0.1);
+        assertEquals(-0.1, shuntCompensatorNeg.getbPerSection(), 0.0);
+        assertEquals(-0.1, shuntCompensatorNeg.getMinimumB(), 0.0);
 
         try {
             shuntCompensator.setCurrentSectionCount(-1);


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** 
No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Change of behaviour? (Can't really say it is a bug fix, the previous method was doing what it intended to do, it was just not intuitive)

**What is the current behavior?** *(You can also link to an open issue here)*
`getMaximumB()` returns the susceptance of the maximum section count

**What is the new behavior (if this is a feature change)?**
`getMaximumB()` returns the **maximum susceptance** the shunt can have.
`getMinimumB()` is a new methods which returns the **minimum susceptance** the shunt can have


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

**TODO** updates the migration guide
