### PR TITLE
Deprecate shuntCompensator.getMaximumB()

### DIFF
--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
@@ -1336,7 +1336,7 @@ public class AmplNetworkWriter {
                 double vb = t.getVoltageLevel().getNominalV();
                 double zb = vb * vb / AmplConstants.SB;
                 double b1 = 0;
-                double b2 = sc.getMaximumB() * zb;
+                double b2 = sc.getbPerSection() * sc.getMaximumSectionCount() * zb;
                 double minB = Math.min(b1, b2);
                 double maxB = Math.max(b1, b2);
                 double b = sc.getCurrentB() * zb;

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -191,9 +191,6 @@ public class Comparison {
         equivalent("VoltageLevel",
                 expected.getTerminal().getVoltageLevel(),
                 actual.getTerminal().getVoltageLevel());
-        compare("maximumB",
-                expected.getMaximumB(),
-                actual.getMaximumB());
         compare("maximumSectionCount",
                 expected.getMaximumSectionCount(),
                 actual.getMaximumSectionCount());

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ShuntCompensator.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ShuntCompensator.java
@@ -67,7 +67,10 @@ public interface ShuntCompensator extends Injection<ShuntCompensator> {
 
     /**
      * Get the susceptance for the maximum section count.
+     *
+     * @deprecated Use {@link #getbPerSection()} * {@link #getMaximumSectionCount()} instead.
      */
+    @Deprecated
     double getMaximumB();
 
     /**

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorImpl.java
@@ -102,7 +102,10 @@ class ShuntCompensatorImpl extends AbstractConnectable<ShuntCompensator> impleme
         return bPerSection * getCurrentSectionCount();
     }
 
-    @Override
+    /**
+     * @deprecated Use {@link #getbPerSection()} * {@link #getMaximumSectionCount()} instead.
+     */
+    @Deprecated
     public double getMaximumB() {
         return bPerSection * maximumSectionCount;
     }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/LccTest.java
@@ -58,7 +58,6 @@ public class LccTest {
         assertEquals(1e-5, network.getShuntCompensator("C1_Filter1").getCurrentB(), 0.0);
         assertTrue(network.getShuntCompensator("C1_Filter1").getTerminal().isConnected());
         assertEquals(0.0, network.getShuntCompensator("C1_Filter2").getCurrentB(), 0.0);
-        assertEquals(2e-5, network.getShuntCompensator("C1_Filter2").getMaximumB(), 0.0);
         assertFalse(network.getShuntCompensator("C1_Filter2").getTerminal().isConnected());
         assertEquals(1, network.getHvdcLineCount());
         HvdcLine l = network.getHvdcLine("L");


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Deprecated


**What is the current behavior?** *(You can also link to an open issue here)*
`getMaximumB()` is a `ShuntCompensator` method with an ambiguous name.


**What is the new behavior (if this is a feature change)?**
`getMaximumB()` is deprecated


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
Not a Breaking Change but this deprecates a method
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
Sonarcloud or Coveralls may not be checked because all tests of the deprecated method have been deleted.
