### PR TITLE
Reactive capability curve addition

### DIFF
--- a/iidm/iidm-impl/pom.xml
+++ b/iidm/iidm-impl/pom.xml
@@ -75,6 +75,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-testlib</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImpl.java
@@ -83,9 +83,11 @@ public class ReactiveCapabilityCurveImpl implements ReactiveCapabilityCurve {
         Objects.requireNonNull(points);
         TreeMap<Double, Point> pointMap = Arrays.stream(points)
                 .collect(Collectors.toMap(PointImpl::getP,
-                                          Function.identity(),
-                                          (point, point2) -> { throw new IllegalArgumentException("Duplicate point at p=" + point.getP()); },
-                                          TreeMap::new));
+                    Function.identity(),
+                    (point, point2) -> {
+                        throw new IllegalArgumentException("Duplicate point at p=" + point.getP());
+                    },
+                    TreeMap::new));
         return new ReactiveCapabilityCurveImpl(pointMap);
     }
 

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImplTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImplTest.java
@@ -6,11 +6,13 @@
  */
 package com.powsybl.iidm.network.impl;
 
-import com.powsybl.iidm.network.ReactiveCapabilityCurve.Point;
+import com.google.common.testing.EqualsTester;
+import com.powsybl.iidm.network.ReactiveCapabilityCurve;
+import com.powsybl.iidm.network.ReactiveLimitsKind;
 import com.powsybl.iidm.network.impl.ReactiveCapabilityCurveImpl.PointImpl;
+import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.TreeMap;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 /**
@@ -19,18 +21,23 @@ import static org.junit.Assert.assertEquals;
  */
 public class ReactiveCapabilityCurveImplTest {
 
-    private ReactiveCapabilityCurveImpl createCurve(Point... points) {
-        TreeMap<Double, Point> map = new TreeMap<>();
-        for (Point pt : points) {
-            map.put(pt.getP(), pt);
-        }
-        return new ReactiveCapabilityCurveImpl(map);
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void basicTest() {
+        ReactiveCapabilityCurveImpl curve = ReactiveCapabilityCurveImpl.of(new PointImpl(1, 2, 3),
+                                                                           new PointImpl(2, 3, 4));
+        assertEquals(ReactiveLimitsKind.CURVE, curve.getKind());
+        assertEquals(2, curve.getPointCount());
+        assertEquals(1, curve.getMinP(), 0);
+        assertEquals(2, curve.getMaxP(), 0);
     }
 
     @Test
     public void testInterpolation() {
-        ReactiveCapabilityCurveImpl curve = createCurve(new PointImpl(100.0, 200.0, 300.0),
-                                                        new PointImpl(200.0, 300.0, 400.0));
+        ReactiveCapabilityCurveImpl curve = ReactiveCapabilityCurveImpl.of(new PointImpl(100.0, 200.0, 300.0),
+                                                                           new PointImpl(200.0, 300.0, 400.0));
         // bounds test
         assertEquals(200.0, curve.getMinQ(100.0), 0.0);
         assertEquals(300.0, curve.getMaxQ(100.0), 0.0);
@@ -50,4 +57,60 @@ public class ReactiveCapabilityCurveImplTest {
         assertEquals(400.0, curve.getMaxQ(1000.0), 0.0);
     }
 
+    @Test
+    public void equalsTest() {
+        new EqualsTester()
+                .addEqualityGroup(new ReactiveCapabilityCurveImpl.PointImpl(1, -2, 3), new ReactiveCapabilityCurveImpl.PointImpl(1, -2, 3))
+                .addEqualityGroup(new ReactiveCapabilityCurveImpl.PointImpl(2, -1, 4), new ReactiveCapabilityCurveImpl.PointImpl(2, -1, 4))
+                .testEquals();
+        new EqualsTester()
+                .addEqualityGroup(ReactiveCapabilityCurveImpl.of(new ReactiveCapabilityCurveImpl.PointImpl(1, -2, 3), new ReactiveCapabilityCurveImpl.PointImpl(4, -4, 1)),
+                                  ReactiveCapabilityCurveImpl.of(new ReactiveCapabilityCurveImpl.PointImpl(1, -2, 3), new ReactiveCapabilityCurveImpl.PointImpl(4, -4, 1)))
+                .addEqualityGroup(ReactiveCapabilityCurveImpl.of(new ReactiveCapabilityCurveImpl.PointImpl(2, -1, 4), new ReactiveCapabilityCurveImpl.PointImpl(4, -4, 1)),
+                                  ReactiveCapabilityCurveImpl.of(new ReactiveCapabilityCurveImpl.PointImpl(2, -1, 4), new ReactiveCapabilityCurveImpl.PointImpl(4, -4, 1)))
+                .testEquals();
+    }
+
+    @Test
+    public void onePointError() {
+        thrown.expectMessage("A reactive capability curve is expected to have at least 2 points");
+        thrown.expect(IllegalArgumentException.class);
+        ReactiveCapabilityCurveImpl.of(new ReactiveCapabilityCurveImpl.PointImpl(1, -2, 3));
+    }
+
+    @Test
+    public void sameActivePowerPointError() {
+        thrown.expectMessage("Duplicate point at p=1.0");
+        thrown.expect(IllegalArgumentException.class);
+        ReactiveCapabilityCurveImpl.of(new ReactiveCapabilityCurveImpl.PointImpl(1, -2, 3),
+                                       new ReactiveCapabilityCurveImpl.PointImpl(1, -1, 1));
+    }
+
+    @Test
+    public void addTest() {
+        ReactiveCapabilityCurve curve1 = ReactiveCapabilityCurveImpl.of(new ReactiveCapabilityCurveImpl.PointImpl(1, -2, 3),
+                                                                        new ReactiveCapabilityCurveImpl.PointImpl(2, -1, 4),
+                                                                        new ReactiveCapabilityCurveImpl.PointImpl(4, -4, 1));
+
+        ReactiveCapabilityCurve curve2 = ReactiveCapabilityCurveImpl.of(new ReactiveCapabilityCurveImpl.PointImpl(2, -2, 2),
+                                                                        new ReactiveCapabilityCurveImpl.PointImpl(3, 0, 6),
+                                                                        new ReactiveCapabilityCurveImpl.PointImpl(5, -1, 1));
+
+        ReactiveCapabilityCurveImpl sum = ReactiveCapabilityCurveImpl.add(curve1, curve2);
+        assertEquals(ReactiveCapabilityCurveImpl.of(new PointImpl(1.0, -2.0, 3.0),
+                                                    new PointImpl(2.0, -2.0, 4.0),
+                                                    new PointImpl(3.0, -4.0, 6.0),
+                                                    new PointImpl(4.0, -4.0, 9.0),
+                                                    new PointImpl(5.0, -1.0, 10.0),
+                                                    new PointImpl(6.0, -6.0, 4.0),
+                                                    new PointImpl(7.0, -4.0, 7.0),
+                                                    new PointImpl(9.0, -5.0, 2.0)),
+                     sum);
+
+        ReactiveCapabilityCurve sum2 = ReactiveCapabilityCurveImpl.add(curve1, new MinMaxReactiveLimitsImpl(-3, 2));
+        assertEquals(ReactiveCapabilityCurveImpl.of(new PointImpl(1.0, -3.0, 3.0),
+                                                    new PointImpl(2.0, -3.0, 4.0),
+                                                    new PointImpl(4.0, -4.0, 2.0)),
+                     sum2);
+    }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
A feature.

**What is the new behavior (if this is a feature change)?**

This PR in addition to code simplification and better unit testing add utility methods to "add" reactive capability curve.
In the case of 2 generators connected to same bus with 2 differents reactive capability curves, we sometimes need to build an equivalent reactive capability curve corresponding to an equivalent generator composed of the 2 generators. This is particularly useful for loadflow but could be also useful for network reduction. 

