### PR TITLE
Change the R and X reference values to import a line as a low impedance line

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -406,8 +406,8 @@ public class Conversion {
         private boolean allowUnsupportedTapChangers = true;
         private boolean convertBoundary = false;
         private boolean changeSignForShuntReactivePowerFlowInitialState = false;
-        private double lowImpedanceLineR = 0.05;
-        private double lowImpedanceLineX = 0.05;
+        private double lowImpedanceLineR = 7.0E-5;
+        private double lowImpedanceLineX = 7.0E-5;
 
         private boolean createBusbarSectionForEveryConnectivityNode = false;
         private boolean convertSvInjections = true;


### PR DESCRIPTION
Change the R and X reference values to import a line as a low impedance line.

Signed-off-by: Anne Tilloy <atilloy@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No. The R and X reference values used in the CGMES conversion where set to 0.05. These values are to high and should be closer to zero, but not set to zero. The aim of low impedance line is to "aggregate" 2 terminals and to consider that there have the same values of voltage and tension. This was not the case with 0.05.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

R and X are set to 7.0E-5.

**What is the current behavior?** *(You can also link to an open issue here)*

We are missing some low impedance lines. 

**What is the new behavior (if this is a feature change)?**

More low impedance lines are created.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
