### PR TITLE
Ignore duplicate rdf:ID with rdf4j + all triplestore impl are in runtime scope in distribution-core

### DIFF
--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -388,20 +388,21 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-triple-store-impl-rdf4j</artifactId>
             <version>${project.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-triple-store-impl-jena</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-triple-store-impl-blazegraph</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- In provided scope, so that coverage is correctly reported but the jar is not packaged for distribution -->

--- a/triple-store/triple-store-impl-rdf4j/src/main/java/com/powsybl/triplestore/impl/rdf4j/TripleStoreRDF4J.java
+++ b/triple-store/triple-store-impl-rdf4j/src/main/java/com/powsybl/triplestore/impl/rdf4j/TripleStoreRDF4J.java
@@ -81,6 +81,7 @@ public class TripleStoreRDF4J extends AbstractPowsyblTripleStore {
             // This is the default behavior for other triple store engines (Jena)
             conn.getParserConfig().addNonFatalError(XMLParserSettings.FAIL_ON_INVALID_NCNAME);
             conn.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
+            conn.getParserConfig().addNonFatalError(XMLParserSettings.FAIL_ON_DUPLICATE_RDF_ID);
 
             Resource context = context(conn, contextName);
             // We add data with a context (graph) to keep the source of information


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
- `rdf4j` and the other triplestore implementations do not have an iso behaviour with duplicate `rdf:ID`
- via the powsybl distribution generated by distribution-core, only `rdf4j` implementation can be used


**What is the new behavior (if this is a feature change)?**
The points above are corrected.



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
