### PR TITLE
Handle unexpected modes for HVDC converter modes during CGMES import with best effort

### DIFF
--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1ModifiedCatalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1ModifiedCatalog.java
@@ -511,7 +511,7 @@ public final class CgmesConformity1ModifiedCatalog {
                         "SmallGridTestConfiguration_TP_BD_v3.0.0.xml"));
     }
 
-    public static TestGridModelResources smallNodeBrokerHvdcNanTargetPpcc() {
+    public static TestGridModelResources smallNodeBreakerHvdcNanTargetPpcc() {
         String base = ENTSOE_CONFORMITY_1_MODIFIED + "/SmallGrid/HVDC_NaN_targetPpcc";
         String baseOriginal = ENTSOE_CONFORMITY_1
                 + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_HVDC_Complete_v3.0.0/";
@@ -519,6 +519,101 @@ public final class CgmesConformity1ModifiedCatalog {
                 + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0/";
         return new TestGridModelResources(
                 "SmallGrid-NodeBreaker-HVDC-NaN-targetPpcc",
+                null,
+                new ResourceSet(baseOriginal, "SmallGridTestConfiguration_HVDC_DL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_EQ_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_GL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_SV_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_TP_v3.0.0.xml"),
+                new ResourceSet(base, "SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml"),
+                new ResourceSet(baseBoundary, "SmallGridTestConfiguration_EQ_BD_v3.0.0.xml",
+                        "SmallGridTestConfiguration_TP_BD_v3.0.0.xml"));
+    }
+
+    public static TestGridModelResources smallNodeBreakerHvdcLccRectifierRectifier() {
+        String base = ENTSOE_CONFORMITY_1_MODIFIED + "/SmallGrid/HVDC_lcc_rectifier_rectifier";
+        String baseOriginal = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_HVDC_Complete_v3.0.0/";
+        String baseBoundary = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0/";
+        return new TestGridModelResources(
+                "SmallGrid-NodeBreaker-LCC-rectifier-rectifier",
+                null,
+                new ResourceSet(baseOriginal, "SmallGridTestConfiguration_HVDC_DL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_EQ_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_GL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_SV_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_TP_v3.0.0.xml"),
+                new ResourceSet(base, "SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml"),
+                new ResourceSet(baseBoundary, "SmallGridTestConfiguration_EQ_BD_v3.0.0.xml",
+                        "SmallGridTestConfiguration_TP_BD_v3.0.0.xml"));
+    }
+
+    public static TestGridModelResources smallNodeBreakerHvdcLccInverterInverter() {
+        String base = ENTSOE_CONFORMITY_1_MODIFIED + "/SmallGrid/HVDC_lcc_inverter_inverter";
+        String baseOriginal = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_HVDC_Complete_v3.0.0/";
+        String baseBoundary = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0/";
+        return new TestGridModelResources(
+                "SmallGrid-NodeBreaker-LCC-inverter-inverter",
+                null,
+                new ResourceSet(baseOriginal, "SmallGridTestConfiguration_HVDC_DL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_EQ_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_GL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_SV_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_TP_v3.0.0.xml"),
+                new ResourceSet(base, "SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml"),
+                new ResourceSet(baseBoundary, "SmallGridTestConfiguration_EQ_BD_v3.0.0.xml",
+                        "SmallGridTestConfiguration_TP_BD_v3.0.0.xml"));
+    }
+
+    public static TestGridModelResources smallNodeBreakerHvdcLccUnexpectedInverter() {
+        String base = ENTSOE_CONFORMITY_1_MODIFIED + "/SmallGrid/HVDC_lcc_unexpected_inverter";
+        String baseOriginal = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_HVDC_Complete_v3.0.0/";
+        String baseBoundary = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0/";
+        return new TestGridModelResources(
+                "SmallGrid-NodeBreaker-LCC-unexpected-inverter",
+                null,
+                new ResourceSet(baseOriginal, "SmallGridTestConfiguration_HVDC_DL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_EQ_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_GL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_SV_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_TP_v3.0.0.xml"),
+                new ResourceSet(base, "SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml"),
+                new ResourceSet(baseBoundary, "SmallGridTestConfiguration_EQ_BD_v3.0.0.xml",
+                        "SmallGridTestConfiguration_TP_BD_v3.0.0.xml"));
+    }
+
+    public static TestGridModelResources smallNodeBreakerHvdcLccUnexpectedRectifier() {
+        String base = ENTSOE_CONFORMITY_1_MODIFIED + "/SmallGrid/HVDC_lcc_unexpected_rectifier";
+        String baseOriginal = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_HVDC_Complete_v3.0.0/";
+        String baseBoundary = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0/";
+        return new TestGridModelResources(
+                "SmallGrid-NodeBreaker-LCC-unexpected-rectifier",
+                null,
+                new ResourceSet(baseOriginal, "SmallGridTestConfiguration_HVDC_DL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_EQ_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_GL_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_SV_v3.0.0.xml",
+                        "SmallGridTestConfiguration_HVDC_TP_v3.0.0.xml"),
+                new ResourceSet(base, "SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml"),
+                new ResourceSet(baseBoundary, "SmallGridTestConfiguration_EQ_BD_v3.0.0.xml",
+                        "SmallGridTestConfiguration_TP_BD_v3.0.0.xml"));
+    }
+
+    public static TestGridModelResources smallNodeBreakerHvdcLccUnexpectedUnexpected() {
+        String base = ENTSOE_CONFORMITY_1_MODIFIED + "/SmallGrid/HVDC_lcc_unexpected_unexpected";
+        String baseOriginal = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_HVDC_Complete_v3.0.0/";
+        String baseBoundary = ENTSOE_CONFORMITY_1
+                + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0/";
+        return new TestGridModelResources(
+                "SmallGrid-NodeBreaker-LCC-unexpected-unexpected",
                 null,
                 new ResourceSet(baseOriginal, "SmallGridTestConfiguration_HVDC_DL_v3.0.0.xml",
                         "SmallGridTestConfiguration_HVDC_EQ_v3.0.0.xml",

--- a/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_inverter_inverter/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_inverter_inverter/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
@@ -1,0 +1,12953 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:5bc75f63-85bc-d020-02d8-1d9358dae159">
+    <md:Model.scenarioTime>2030-01-02T09:00:00</md:Model.scenarioTime>
+    <md:Model.created>2014-10-22T09:01:25.830</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment: Small Grid HVDC Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E "as it is". To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.version>4</md:Model.version>
+	<md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://GB/Planning/ENTSOE/2</md:Model.modelingAuthoritySet>
+    <md:Model.DependentOn rdf:resource="urn:uuid:a97cec76-42cc-bf53-2269-4f5abcce7244" />
+	<md:Model.Supersedes rdf:resource="urn:uuid:2fea4dd9-083b-f2b0-7b57-568efb25ccf9"/>
+  </md:FullModel>
+  <cim:ACDCConverterDCTerminal rdf:about="#_7780ec9e-6743-4c53-aac2-f123637d5274">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_c4af08e0-9608-4654-b74f-e359a7a29dfc">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_0193405c-4f37-421a-b7e6-9c4a8904eaf8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_9b40dc62-2c36-4b70-b931-db436ddb3fad">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_412aed14-a85f-4828-a751-221172c48263">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_61a0a556-ae4c-42a0-bda3-7423cea7e6ff">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_e4b9540a-1a8c-4f8b-a8a5-b7c0dc0d1df8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_3844652e-cd36-43e8-9e90-a1bbe2d85dfa">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:DCTerminal rdf:about="#_a03cc8fb-fe85-4a7e-b96e-5c074abed705">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_e768024e-1c0c-4c0f-b023-5deb11d64dfc">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_5be89c2c-b370-46ce-8844-338414489fb3">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_d2dac22c-7798-4a59-b5db-3e4fd307abda">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_6bc9072c-735e-4016-9ae8-acc2d37f1fba">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_02d46e89-85fe-4756-aeb5-4869950f8776">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_bbc66594-69da-46d5-9a1b-2f4a706fb6a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_600ea926-a53e-4f42-92b1-aa10bfeb79a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:Terminal rdf:about="#_0471bd25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04682030-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe868-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0470d2c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0237-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667281-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0234-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c4474-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a1673-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc79-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500450-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bfb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640186-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04776270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04619088-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d8a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce94-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d86-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465fd54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e431-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d851-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893cc3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c6b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b148-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453add6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459a142-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801509-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04597a34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464289a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c633-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc426-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0661-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465af34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04860874-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500454-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505274-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472a784-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452c378-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2b7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b5fa2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e12-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd35-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0447c6f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812675-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e2a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04773b69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b092-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc82-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459c855-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483706b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4da-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04507980-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481514-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f00-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab84b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c33-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452ea84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b202-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046cb413-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801506-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454e651-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046735d6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492681-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662461-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865694-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e193a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1184-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745537-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472f5a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837060-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c8772-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0450798a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684744-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea71-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455347a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479ac63-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04636547-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea76-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b47-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b978a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828601-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b207-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2947-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725960-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b55-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2ba-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481517-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a3c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046030f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04605808-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a2194-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae80-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048badc2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf53-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04795e46-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04719611-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047abdd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04885261-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04878f1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044bbe98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e224-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531190-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a4e31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed161-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04686e5b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b366-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f94b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b095-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c906-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0467f924-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837069-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cdb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468e383-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500455-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f01-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04675ce4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04656113-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9786-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04845acb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04880440-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e227-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745535-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a7548-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793738-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460f444-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2949-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453fbf5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487b620-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a6a26-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04854522-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549834-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb43-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837066-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2ea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e13a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725965-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9785-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7600-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b44-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457f391-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531198-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0475188b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04561ed6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c877a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b066b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047ae4e0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614262-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04834957-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765105-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d379-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046205b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485452a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f8f24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ef879-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04887972-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492680-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477feb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab848-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4040-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e436-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0233-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c17d3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479102b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d645-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04670ec2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d7a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449e9d9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b5484-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04798557-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed164-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8348-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bf2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642899-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a6fbb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466e7b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b4ef6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045386c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046f4c22-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe865-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461697a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04742e24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0668-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d856-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e91a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d5054-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f0395-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04483c21-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0238-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fbbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bf65b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04806320-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f4103-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b5a14-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1180-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044974a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04616975-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04723258-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482860a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789af1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044778d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492688-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047cb9a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f017-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047120e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486336-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f51b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04558294-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471bd29-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04529c66-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04753f92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d910-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667287-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04518afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048ac362-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d294a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662468-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6817-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640181-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047df222-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9139-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3895-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04817494-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d2ed5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448d862-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e225-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531196-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b792-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4317-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a623-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf49-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048915b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc78-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812676-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a2722-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570934-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044be5a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453d4e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b36a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d83-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745533-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046eafe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b2254-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c1c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b364-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c7110-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452755a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e8e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840ca7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489d905-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04633e38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7606-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab846-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4316-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522732-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047eb572-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a627-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd36-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840caa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cd594-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fe2d8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047147f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc428-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8340-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04736ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b86b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c638-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044aad27-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b209-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893ccc-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8346-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf48-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047084aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04607f19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500452-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a754b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480ff6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04542305-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d7cf3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474553a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e75-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481749a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614268-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e3ab3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9138-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e88d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4693-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b27e3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d71d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04731cb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047da403-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b140-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e6758-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c1240-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486334-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f70-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480150a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448ff77-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522737-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cd2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570939-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046476b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b62-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492686-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04590500-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486337-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631ccc1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474f17b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0488eeab-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d376-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765100-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3307-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04767811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3303-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d5-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ecbda-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04622cc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b205-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e432-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d4536-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b799-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483e592-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482ad17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047fc6e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531191-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0486cbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454983a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc88-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048433b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549830-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c902-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4047-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d641-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045163e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474ca6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478c20a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f018-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476ed4b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466c0a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c8d06-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b094-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04494d96-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489b1f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04513cd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045dbff8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e64-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04851e16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048481d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:about="#_0448d86a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044bbe92-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>16</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044d1e22-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04819ba4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>46</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048433b6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ca8f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854525-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f08-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047fedf2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476781a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0477627b-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04697fc9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>90</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0481c2b3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448d863-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>61</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>28</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04747c44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>130</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047e1936-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cae82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>48</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045b00d5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>62</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046efe03-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>71</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b89-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0447ee05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94b4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048bfbe0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ea4c0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>52</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e4a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046205b5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>7</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048b5fa5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>70</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b7b95-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>15</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04716f06-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0483be82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>31</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046d0232-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>6</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453d4e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>113</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044aad24-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a219a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0489b1f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04798556-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>277</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>113</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047abdd7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04791028-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04817492-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94ba-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ecbd1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>2</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0463da70-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047b0bf0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0461b790-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b0665-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04689566-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04547126-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>77</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>14</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>54</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04812679-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04742e27-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2257-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0466246a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04488a49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048740f1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047d7cf6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2251-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047dcb12-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046adf5a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476ed42-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>13</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045c8777-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>85</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854520-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04778989-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>27</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cfca7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0479fa87-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>45</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0449e9d7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>53</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0451d918-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>42</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0482fb36-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>66</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>20</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0484cffb-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448b150-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04867dab-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04481515-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>36</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048a9c51-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e46-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0485e168-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>21</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046c3ee3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f6da2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>60</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>34</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c0cb3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>5</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>65</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04682035-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04887973-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045645e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>51</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0474f170-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046a4319-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>19</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>2</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045d4ac9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>17</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0462c904-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045163e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>87</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046dc585-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453add4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0450a093-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>84</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044974a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>63</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EquivalentInjection rdf:about="#_5631ccc0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>184</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d4-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>6</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>20</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>8</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:ThermalGeneratingUnit rdf:about="#_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044ca8f0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-85</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_668eb671-5c36-4351-a95d-53ca850581db">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.680008</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_f26d4eb3-ebdb-4025-8080-f856ce656b42">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-450</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_7566f2a7-61eb-42fe-a59a-8276257fdbc6">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>230.999985</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e5a479a8-ab8d-4a54-bb52-376874ae2784">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04856c34-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-7</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b55d80d5-720f-46f9-897f-ff8c5eaf8b44">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.644</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_9a6bdb3c-346d-4426-8127-5f6cbf0150b2">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047fc6e6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-4</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_98f667da-02d1-4a31-b826-44314a1fbbfe">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>33.495</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_fec62959-21c5-4921-90b2-7c85e9f3bfab">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0452ea80-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-36</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_9db08c95-4586-4a2b-87e3-5a17c944b43a">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.36</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e54b499b-436c-4b89-9803-b1d75e2fa364">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044cd00a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-252</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.243988</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_27799004-aa1e-4889-ba95-ee6fdae64895">
+    <cim:GeneratingUnit.normalPF>1</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_048aea70-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-513.437439</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>62.1325531</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_827a9c80-183d-4e33-9e73-ef0aab3dfb13">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>136.62</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0458ddf1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-391</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_12b01822-ca11-4cf8-a6b4-2f8ff805ca20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>221.1</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e3753d6d-b894-4cce-b6fa-307c50dc107f">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04859346-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-204</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_dff93c01-9c84-4c1f-8529-66c054ed9e37">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>135.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d9948603-709f-41dd-a0ff-2ebda091255a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047f0391-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-392</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_23727856-fd9b-4124-a981-4e862148f3bb">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_56975783-9739-40fc-8ec1-e1de8cb06c9a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045ab2b0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-220</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b8449cd9-5a17-497e-bf04-70f728b0f9f2">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e56da2eb-bb6a-4133-953c-40073c5bc5f4">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046bf0c4-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-40</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_d41be6b4-155e-4c8f-b46b-16b50c49f0f4">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.319992</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_83fae784-1da1-4055-8108-ba978276d1b6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04633e31-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-19</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5f711f63-f631-45d3-b26c-33821ab2ee56">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_a6ec9760-88da-48df-a23f-7877e7c85ccd">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-477</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_e6131af8-c298-413b-84e3-4e21c3b6b06f">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>137.28</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_2621b09a-22e3-4630-b3bd-32c102e36741">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0489b1fa-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-607</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b0d662e5-64c9-4d59-b8e0-9b1ed175769b">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_05df66ba-3f64-40cb-8b18-c66d26c4e2c1">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0483224a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-314</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_c1d29442-5f57-41d1-bb60-4b74b4994c20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>223.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04839777-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-155</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_29df1e0b-36ca-4536-97b4-6f98b84d49d8">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.02</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_17852426-f663-4add-9a2b-0a635d51f101">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0472a789-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-160</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.34</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_b97aee41-3115-4cfd-9071-b52fb44d0b66">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046c3ee7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-48</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5005c073-28d1-4a7d-b257-649dec43ec73">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.06</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:RatioTapChanger rdf:about="#_047df228-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_047d2ed8-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044974a0-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_045eaa55-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0488797a-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044b4964-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0447c6f3-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+    <cim:RatioTapChanger rdf:about="#_04682034-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>31</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0487dd39-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_04549831-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:LinearShuntCompensator rdf:about="#_04553478-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_f4cdc674-4a66-4ab8-8d4f-552cb066e259">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.935</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0475dbd6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_a7768441-642e-48a2-b4a8-0ae06bebf676">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.419</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0447c6f6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_c701959a-91c1-4a35-9a37-71fb790426ca">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.676</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_048b5fa9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99c6c4ad-5247-4058-96d4-ee8495103e85">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.723</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045b00d9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_be267a3c-f7a7-4bdf-bb17-71b773247fbf">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0460cd38-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_069d84c6-bd26-4c26-ac6c-e801a0202a00">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.814</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0489d903-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.423</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0450eeb7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6c36f421-303e-4932-93a9-5b0ff86cb7d4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.565</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045c6067-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2d222dd9-7306-4afd-baa5-fd303b0eeb40">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.066</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04558293-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>124.763</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0466c0a0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99931a87-ee15-4fd0-b251-9556df7fe598">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.002</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0449e9d5-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6cc38790-c6a6-4309-99f4-a3258e24e785">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.403</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_047825c8-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2a6c1dcd-201b-4911-83b2-c16acc50a0f4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.212</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04684741-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_eae61817-d3cb-488f-a1f3-13bc8e31431b">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.323</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:CsConverter rdf:about="#_7393a68e-c4e6-48dd-9347-543858363fdb">
+	<cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>480</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.inverter" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.dcVoltage" />
+    <cim:CsConverter.targetAlpha>13</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>0</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:CsConverter rdf:about="#_9793118d-5ba1-4a9c-b2e0-db1d15be5913">
+    <cim:ACDCConverter.p>-63.8</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>55</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-63.8</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.inverter" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.activePower" />
+    <cim:CsConverter.targetAlpha>0</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>17</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:RatioTapChanger rdf:about="#_ee9505e1-96d7-49b3-9d1a-924397ffb27e">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_a5bf9702-545a-437d-9663-773550202828">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_739658a7-e08b-4395-8d79-93e87b7855e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:RatioTapChanger rdf:about="#_ea8cd467-31f0-40dc-95d7-4064463724c4">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_c089eb25-9f67-4d82-88a8-635dd4808bae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_453bdc57-5855-4eb5-8712-d6a0255e0da8">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:VsConverter rdf:about="#_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd">
+	<cim:ACDCConverter.p>-153.5</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-153.5</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.pPcc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>213.54</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:VsConverter rdf:about="#_b46bfb8e-7af6-459e-acf3-53a42c943a7c">
+    <cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>360</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.udc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>218.47</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:Terminal rdf:about="#_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe0e60b-3870-44fb-ba93-a056228f9636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_071bb138-ff00-4874-8acc-a884aa5cf4a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a168e701-bd48-4f66-8f0b-0f69b2545530">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8cac1e7-4826-4ecd-bac1-f4085fc15956">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dda862d5-7727-420c-be3a-a6a30e0b4c65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f72bfe50-f1ae-4f21-a477-f62e75a636af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfe1e320-861b-4d31-a076-5ddc474e4a05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14d37503-25e4-40e2-b20f-4de429a0dd00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c7f5674c-44a0-42d6-a701-4706b14c3eac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_21e25548-adca-48b3-b2a4-c000485222ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb3e09c9-fee1-4407-935d-ce2d342dbd7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e141e4b7-12e4-4b78-ae07-e8ab741ef9cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5de34198-471c-48af-a0b2-e5ae14970738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b862807c-b874-4b47-ae4e-59e4479bfac6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d88d693-242f-459c-bf12-267c22ba7809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d1cfe9e-3f42-4b3a-af90-111257354f8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41a94bfb-c430-4007-b29f-b89204ec913f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42ee39f4-ef6a-421c-a581-5da2682980ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_43724816-f5f6-4374-8ac4-96565bd5aa59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f1e8a6-8e32-479b-b73b-79823a3e1a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c37e51b5-c01e-45e9-88dd-957334a720ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe09b58a-7b27-4460-b596-c5886b3645ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8219d169-b5c2-467f-acbe-b04e0d39a7ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bff67964-ffa7-4243-943a-07c911e18dcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f4d752a-acee-4ad4-93fe-ad3cb6722d51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88d448f2-1777-46d4-840c-f64a7bea8a12">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c5dcb2-81f9-4076-b9d6-fb43a1a76d9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8e16607-1e6a-482b-8b4e-e5d990b93a4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cd484cd-37a9-4454-88e4-ab538b00a7da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3184d830-8702-40c1-9f52-c8e23eb3feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e68e5c02-683e-409e-8371-bb2e5f947c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b97c5dc2-7cd3-4a6d-9f6c-d18ca2229ea8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb5279-2c55-4531-b91d-3b71fa7f1674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a90f437c-e33f-4571-baa4-14f6e6a5be19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b64e6a0-436c-4389-be48-9dd120beb218">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe9cbbd7-a68e-4a3f-950d-3b1c2278b0fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b5a3e17-a13b-4158-8b91-a4303fe7e433">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f472e138-541e-429e-aeed-e632232888b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1e00a228-c452-418b-9db5-0a0ffbc5a5d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_26698a8c-a280-406e-b882-9037efe6a03a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145597a6-9fde-4bf2-b2fe-8a4c6c5f4774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd76d8e2-4515-4964-af8e-67885c73ad5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_883bebaa-0b47-45b9-8d4e-75f8784dbabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9145eb98-9d67-4793-b83a-967c6ff56e1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7c10087-4ab2-44cf-9362-3ead8a066326">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a5780b7-5e74-4532-b3c1-d1617bc090b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aeb3fe0-66f5-4f34-a79b-14f777313348">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b60203f-42be-4959-8f9f-10aa7e6812f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca41ef76-12a4-45d9-8665-946b5d46b7f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8de12885-e525-4726-a2a9-80a9eaf637f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef70c25a-ab63-467c-a0c5-c0d5ecf22f82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_79ae9e2d-942f-4878-be1b-a9e7e2971740">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a22db682-0414-4fda-ae6e-9e48d11a5565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5578e708-945c-468c-b7ac-56a738f7701f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4820525-8b5e-4f46-9a5d-7b93cadc813b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b95964af-8fe3-44e0-91ea-d1d71c7bf25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c58d4a-2ad5-4eb5-abe7-e79c1cde9d71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9bc8d338-1940-419e-98f6-8ae664bde365">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e5bfa23b-0c58-4ef8-a317-bc7a65457ba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e64d1ea0-1cc8-4317-9d6e-ec2fce5eeb77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d5377df-3bb0-4d2d-b6e7-e08f369a28df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f2156a1-b0c1-4bd7-aff8-17e4acfb98f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e030a6dd-e9c9-4aba-bb6e-8ed4b7add9e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae1f9fe4-1234-4ec7-b2a9-c6077a19d401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9385a5d5-0ce1-4218-ad3d-2645077a1bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cf89592-6284-4711-a283-848c6e97203b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91291202-267f-4ca0-b8a0-0ef3cd7b0d3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eb152b46-922a-48eb-a401-854a48d592dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a74688c8-f01f-4419-91e1-790b7d8637e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b85df60f-96a8-4187-b01f-018879647feb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_730d18de-6962-40b1-94cc-b1175fc098f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca3640a9-b054-4d3a-879b-8ed41d028ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fd6a4b6-c0ec-44b7-9ab9-b8ec781850d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c23c7c69-c302-4315-ad2e-4d5389140def">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c801bf-3eb3-46f5-8295-4c816d9bb318">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d3c4d8e1-11c8-4876-b4b0-906e5b7a73a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c06fc0e0-1893-4e97-b465-e24f6a934e84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_085ccbba-fa65-4793-82ac-f8d599966ced">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4c27dbc-6761-4286-9c91-debd13ac59a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_11f29b11-5932-4ba4-9a4d-7295d9ded126">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d64d90c-e2bc-416e-bc3b-75cb2866b13f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7097128-535f-4435-ac2d-dc1f01b38b72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43252980-acea-46e9-a46f-0b8d923cb4fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a9bc577-2923-4546-9c2e-a28d8a2bb2d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4de6e42-ee62-432a-a8f9-311154ca4545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1e250b6-b8c0-4b8f-86af-d654b592efe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77171614-596f-4d4c-8f88-9603a8225203">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_800fb8b4-0209-40bd-9a5c-098a9d5bd46a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_599a8732-3d99-4067-b506-3fcef610c47b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b90d47e8-e306-4b82-b7de-071f8ba139a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_50413d47-3ac4-4933-8d6d-6136134d1cd1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_51ff9c76-7b34-490d-af24-56521461f98e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0a4f-8817-40ed-b729-55c92d171c5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ca5e61b-bce8-4488-9a89-a13faf616146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_07aeceff-a2da-441f-9c1f-65f5bea46ddd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60dbae27-1064-4d48-8b63-60969b90b01c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1d5b0f7-a631-4cb6-be6f-ff459dafede2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3a46f9cc-a382-49d4-a2e0-5353e7f09803">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fb1a0d9e-d78a-4f35-b1a7-4e77ea9cab61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_974090ae-7987-43d6-8dfd-965bf0b8c7b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed826093-243b-43c6-9cba-b5487b34d56b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_987874b2-d6b4-40ae-84c2-09d47aa16fe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c11374d8-1dfc-4494-8c10-8ee6e792dd41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_baca14fe-c74f-453a-88ed-bbcbd0aa5a6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10fba6d2-bc82-493b-b4fa-928668273f68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a02c16bd-ad21-47c2-a34c-c1cff1e19015">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3de5af1e-30d0-4503-b58d-b4fe3a1e084c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01c6db55-d351-46fb-9f2d-13c1de997349">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e46cfed7-5361-44e6-9ea2-0be51afe2287">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_53feaad1-74b3-4cdd-98c6-045d45061593">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c5c6689-a80f-488a-b9cc-23667dd2e923">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b2ee2f-b05b-4c5d-a1f6-addff43e7070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_745264ab-02d8-4377-971d-38e58d86f3cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_902e06e1-e0cc-408f-987e-4483dcf5a4eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_39019b70-09ba-470e-8dd8-e35080b2b090">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf0d0769-33ed-4bab-b86a-a34f6fa059d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_066fe35b-8e2d-4bdd-97e2-b66d2d6a1147">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0f32dc6-eeed-4c00-98dd-22b8191b674b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da140b84-888f-4608-8a2a-b355ff10e175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1dd52921-a7ba-4bd6-ab24-1240f2f30301">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9809db90-fa03-4ea9-a507-c327adb29ec7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_349a9ac5-71b8-442b-ad95-93d514881b07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449ad8d-0b1e-483c-a333-adadb108d264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83cf2f18-0417-4b5f-915a-a8610df259b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17901350-2daa-4c42-a4e5-3a39dd813f13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8c102c6-1217-40c3-b05f-bda872504328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b557b2a5-2259-46ca-9681-73ed8578bb64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_85c693ac-04b6-4bcc-a3bc-1a47837f5c51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12e9d7c1-ec4a-435a-9f87-af7519f81d19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c2feb87e-acf9-42af-b093-c69ca64b0282">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc64ae88-ea38-4e5e-a850-c965ad4811e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_205ce345-8ff3-4f47-97d7-0c00c0f51259">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_110d1aa8-d200-4684-8266-26b5f69ab5f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57bea695-1bcb-4abf-9a2a-a2270d257a2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b687f746-a11b-4250-9a2b-92fb615faca3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff90c538-e532-4da1-85fd-f966a3e6cfd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c9aabb45-f6be-49f5-81c3-6a6fff595b20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b10eb7dd-58cd-4846-92e3-4371938950e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbee05eb-f6ec-48ac-8f45-6e801f352b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24b4767f-a3ac-45e4-9c9e-1e6f63c13e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10f7b85d-f7a2-4346-93f3-d026b3437ae4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_120699d4-88c2-48e3-a094-737b515cb65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_47f09825-70f4-4225-9a99-167a37ed724d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d95135a6-a2f3-42f6-ac01-44e9459fea02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_32b22d72-0891-4711-b2bb-7cb89e348e00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_360c39c1-9801-4f23-858c-459a2eb08725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_298e3c2c-e3fd-4cd7-b38e-a5cc7790dd05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ce1d70e-9fdb-4110-829d-d3f0e2144b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a59ae689-2f80-4159-9641-7a9286868f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_62f6a018-d394-47f3-9f1d-66303cc80a53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7c55b814-99a0-412a-b837-150f33b099c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f280c3c-7c31-4233-8845-42d0290431dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a5f2d-17cd-4194-a8eb-ee4f3cb5b22c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2afa6c27-acaa-4d28-a6cf-3283b98c8fe5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac4c08a2-5201-4366-b7f1-d86fae43245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_308169e1-3f4a-4bec-b3ea-0ebc76d5bc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fd08ae73-ab6a-46a2-9cd7-4316852a4604">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ee5fdbd-b7db-4e3f-bdd3-b5de81dba6f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07bd6984-102c-4162-9555-858f90689d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34e5d3b4-7e84-4389-a389-b1e799c1e2f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7796b60-d57a-4401-91d9-fdbcabab4dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1fb6f240-a6c7-4597-ba87-ab70943b397e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae668ec-5d22-4cc9-aa65-749a4098cfcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13521110-8ae1-4f60-b218-5e8b75bfd923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3368d4b-4206-4671-91ea-350fba2e9039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45ddc3e8-863f-4519-8fe7-a4f746cbe9aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_20705efc-e9d4-4664-b3d0-095d62ff29d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_822fd5ed-1f12-4abc-9487-8e98657da101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_201811a2-df0c-4ff5-ac68-2956151d94c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8103baed-0e59-45ae-b521-6118cbe2da01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe1856-7c93-4b98-bee2-9dabc7b62fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_708aaaa8-e7c6-443b-8285-91504fe45b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8cc8b9c-5b5b-4b4a-8610-03d974c74739">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9a1601-96ee-495f-9f88-e5b1e439d9d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b3ae708b-6f42-425e-8dd5-00d6daadb551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c0edefe-d42e-4966-ad5a-f120620ea284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8345da91-c150-4265-922d-5308fdc44671">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6df484-0741-4f53-81e2-6e70cfd5a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67785dbe-ab63-4618-8737-6150fce2c56c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39312527-1286-4662-9cf5-c5e3cae10de6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3f499c2-f337-43b0-9b6f-5849b58eb1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4d1a84b-45c6-410c-b4c0-e74399ba3f6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35414171-4c4d-4f95-9580-9fba40cfbc2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2be79109-4947-48be-9f48-587e8cfdaf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db602221-867c-4da7-8f29-8ce8ac7dcdce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6651b16c-1772-4788-b21a-93531b87e488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6d3c05da-fa71-4424-8c56-8400c9528908">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_98dd0655-72b5-44f8-8950-70ba30e70bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd1daa5c-eefb-4712-89b0-a81967839921">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7bfef0f0-3061-4827-b75b-29bb615a2586">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7706ff68-778e-47fd-afb2-a9b19a1021df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422336f-9b82-4511-8613-997ecb41c564">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_919ef501-e345-48f4-92f6-f3f9917d961d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38d1ea1-2686-480d-a8e0-70c6f7c4a6f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb56fda5-c1ce-46dd-91ec-73fc396a6ec0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f85a3a47-79fc-408c-a671-6dae0a3fd2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2af82b02-99ad-4353-95d9-8933f1f03ed8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_90bdf796-f9f8-439e-88c4-2aed057f8728">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acb6cbec-a463-4186-816c-13d6f9e8f8f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2671dcd-4825-469d-92a4-11a7c1168e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f199ee7d-42c2-4eea-b369-8605bb280c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db969abf-2a57-4780-a11e-d100009e1c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853c07ea-f383-48c1-86f3-88e38fb111b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d74efa59-9559-467d-847f-20c752ef7a0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71f3eff0-c211-475d-bfc7-5761e3d51925">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2083790-f439-4a1a-be0b-3d40dc6bd591">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_830f9eba-407e-4c21-b958-58c1c566bdc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5c932ecc-c9fd-407f-ab7c-bc6bf6d37c42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c16a8f4c-9b2e-443f-b642-9e425306592c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_516714e5-4f88-4718-976d-98699566123e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_731906a3-3e0d-4904-9226-5bce546bf1be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6bba47d-244a-47dd-8cf5-f9ce2d619482">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c299175-5b93-4a5d-98e3-1e0d98759953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac9424f2-22d1-41ba-b520-0674ebae6a33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0bed41a7-c52e-44a9-a378-8ee6057a60c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f45c35c5-e0b7-4a4a-a7e5-065f2cc79a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92e84348-2aad-427e-8224-863e9c987476">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_42abf657-9f60-4bda-b557-ea055a58f606">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a88a858f-a4f9-4a7c-a7a1-599aa2a98bd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c82ed1a8-5ed9-463f-87e9-21df6f621661">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c754faaa-23fb-4cd8-b9f8-64a692c467e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c548e424-3e91-469d-8d41-c15924cc0735">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e79f20f-77d1-440c-9517-b03244fcb642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbdf8582-a8e4-467c-ae4f-6bc08aba7057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_352fef36-0467-4ec6-8b85-d38af06da2f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_71a7543b-d3e6-4c6b-a724-4d34681cffc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c2f7966-0719-4ede-ac47-c93bcec328ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cda62ce-a773-418a-8562-975eff37d6ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf038e04-bf8c-4655-85c0-657b65fda472">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f91ff24b-4608-42bc-8165-3845d9d89a3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c57369e1-70f0-4ab7-ab95-0ca6d1d20b00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f05307b2-779f-4931-ab27-1c812eec0e09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10cb7e56-91ea-41b4-9698-9ed591d4a610">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b54615f-86ab-42fd-a7b6-091f420c6185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159809cd-32b7-4d81-bdc3-f4521a5611dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40021451-2f6c-4c08-8206-0f9577efbc02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53df2bde-0065-4e2a-8f79-8b9887289cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da880e10-59e4-42f9-88ad-bb19fd0995df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ffb2763c-86ee-422c-ad01-19a27c2f5d95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82d50004-0240-44a0-946b-1136ce73ca33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddd3b955-2005-4764-9bb2-94f1a0b57ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1072268-4956-4f91-999b-829a5160c6a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3f6df38-eaa2-4ba8-8267-2ea812b5b730">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4808825-dec5-4d4e-a575-d6b617e60f4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a243601a-7f53-42f8-9e0c-7d3ddda35309">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8713048a-be6c-4fbe-af8a-018305cb793e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7508d369-6037-4398-a0f5-85136d240f10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_215eef72-26d5-43d5-9728-b716a6eb398b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cf45286-0bc4-4244-9187-d90880603533">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4dd81da8-8ce2-4aed-81fd-54b4ee4566ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2edf2c26-ba96-42a7-bbca-bdce425dc719">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_37451d52-ada3-4155-9718-f2cbac55ea7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bb72b3a9-db44-4120-b8d2-ceae058fc3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e20cebb-95f4-46a1-86f5-30706c326241">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c5cd262a-00eb-4b1e-aa14-af39769452f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f41b17b5-937f-41ee-9be3-6582238dfde8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e39b164c-e8d1-4120-92c2-d51ef5331858">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c794fbfb-111e-4bd4-bc4f-22539cf5a14b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_481b6412-4dd5-43ec-a4f3-fd0cceb8fbd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_75da10ab-1e91-4b8d-94a6-022e3a31020a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35b12500-941e-433a-a80e-43850be4aa09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e2e8adb4-e6ae-4d8d-b946-bc510782ffb8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f8d2d0c-a59b-43c9-9c09-0d5ab82e3b3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cf6338c-83dc-4336-a40e-396191812535">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_19c6f61e-b720-454a-a47f-7f2c51dd0de1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9de4515a-0b24-405f-9920-6beff64f39fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35fa07b6-905a-43fd-aa2c-c1b6ba8c2738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a74196-8d0c-4d96-9eff-1db74605a665">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572e87e4-428f-4ba0-8148-585a3ad489c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53cb22fe-b2b8-4b42-9c90-c46f4b52e32a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b61be02-219e-401a-84ab-137d8a522a31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49649668-8e65-46b9-a759-ed5b1c2f3475">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_12b661c8-e048-4af8-8e1b-6fcaa75e0a27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8967ed7e-f69e-49de-87c5-3e424ff043ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6c92e2ed-107b-45a8-8618-4bbe372d15af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1ff47f6-e080-4f99-bfe0-0d44e36ed6af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f13674a-e4d9-432a-931f-7e823ccf41ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_569d3c0b-1dd9-4175-afa1-b4a43a0f768c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c51731eb-388b-471e-84ab-39c64b56d1f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159e2c73-99e7-4c61-84cb-8b56e8703a78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d4a77b1-cf38-4213-9584-62d8813b8e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c3cb471-aab3-4d54-a738-d6deb20a22b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92c4d859-708f-440a-b6bc-cbbdfd0c6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8500b6e8-3687-4c94-b665-b84ee822b1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a8407c09-50cf-42be-a06a-3ffb9affbea3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9552f175-d04f-4789-94a1-8cab3ce656da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1a64602-04ae-4adf-be2e-03f2f6f8d1a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1693cc70-297a-4d11-8f9a-6da05e8afabe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b40a4b1a-6ec4-4eb0-b09e-274f28a19e10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d50ed217-8664-4101-a79c-02e1b5753702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6022dd0-29a4-4921-8b60-dc855a2794a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ea3ac4b-c6c8-4d96-b1bf-47d064be4317">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ffc5985-1458-44fd-85eb-755b32fa5b9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_32b4075c-eb28-480f-9770-c79c28617f2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26970c44-1c28-45a4-8327-f9d544822995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45ba6338-e010-4c7b-bb0c-22c9bfc0e435">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_326c6626-3a7d-4415-b9ab-8a2a4f0ada10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_388c280e-dcc7-45f3-98e1-587260e1b369">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ba14b260-4f8b-437f-9464-3aaf7d17ebd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fa746ea-521c-4ebb-ab9a-961099f261c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_333cb385-6e3d-48ae-9653-e6ca5835a27f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_609f5d51-8bad-46ea-a50d-cb2725642283">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e09087b9-1874-4158-910a-a468d445f4e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c8def7d-c9c6-469b-8115-d832ecd100e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acda9192-b001-4925-99a2-7ea65a81b267">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_178dfb1a-7c01-459e-805c-2e2046495275">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203eb441-0e19-4f62-804a-582232ecb670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e44585ef-eaea-423e-8531-d641e8826802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c6dc912-1aad-4cdd-a31e-73d43122e59a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d057d3c-d61a-41e0-9737-432b5ada155c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab849915-3e6b-4677-991d-e447a4db0f5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_041d24f9-1f82-4572-b813-ef4155a06173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23f9448d-9c57-4843-b921-aa60104ed2fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_96016276-135f-47a4-8755-188a64bb58d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27429877-cb1a-4b4b-85c7-92ae6726c79f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b39b22f8-b659-4550-9084-67aa7f7f0ffc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7fadc3a7-981a-4da8-a7eb-7085ca13e62f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_24e5c55d-e28b-45c9-a430-c9726b2914c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1043f8f9-8018-4203-8ec3-5fb793a1aa65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd347645-1c88-4697-9cc2-3e4abee5489a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a675d01-61ef-416f-9ded-1e5f734fce59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fccb783a-2f63-428c-b673-df05f116a386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23dc57ad-b8f9-462e-bb07-e2a7b879e944">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70cddb78-0926-4f3d-9f04-d0f2992a53e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_91c5b0ca-964c-4e71-85ce-3e4c34c39c62">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a330abcb-4a34-4ccd-9608-a09ca5e660d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc62a2c3-2da0-400c-98cd-1b8c3d1e1851">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_123ee6c9-8eff-4182-a6be-b14ade88b4fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b05826a5-4010-46c7-8cc1-2a4e588b911a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e52c2f08-e57b-4336-ad61-e315ddd425d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdff05a2-d002-4be8-a815-794b6a1f4025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_08cb8736-36b3-4225-997b-9e9d8b24398e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_664735e6-7c6d-4483-bb17-1b04b78187bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be1c75ee-d6ef-4c9f-a1f6-1e0f57d8aa6c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f91f072-ee1c-4484-8d13-5beacf3327b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8216652-9e1d-41ce-a916-e3087ea5b445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4569417d-00a0-413e-a233-981ee337f5ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d38f0bfa-be3d-4373-b90d-25b44a3a5da7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbab36af-ad99-42dc-a330-7631cf62d18e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_198ffc44-f46d-4f3c-9d2b-b00564f56603">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_785b252c-70a9-4f1c-bb8b-0144e0c34393">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7ee4f1cc-2ec3-487b-be5f-448ba1098364">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1dc6a8-5807-4b72-8352-aa38b7ef65c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47f462e0-6cc8-4085-b44d-a737dcfc58a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3698d996-dbcd-4ca1-a37b-ccee8e5dd75d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebf4e82b-8581-49d3-af44-466ad5ea5beb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88fc4b51-b403-4d0e-ad17-53a083adf8d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_67dc16f2-6949-47e1-b0fe-24ea05e11bed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d802a3bb-92c9-4fd2-872c-8ea459589526">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2769e0a4-1dd7-4690-a2d4-c2a4e877d6ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fbe8ded1-d7f0-4670-b721-ee137eccc9f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a07a7054-1160-4fe1-8753-18700a3178a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21084cc5-b2fb-49fd-b186-93bcf6b7cacd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0e40411-5b47-43c6-bd1f-f26ef82c761c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4322f8ba-4c64-48d6-85f7-7feb029e02ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8152d58-e869-4e34-ba72-e6a0250f09d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de2baf32-b5d9-4bbf-a286-ee7ad91c29ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d6d8c290-8ac9-4364-8e20-50201070dd1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cb3d25-f7a4-464a-9530-c0f6f2b11aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ee4ec5b-6b89-4d91-ae82-fa24d7d9e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2de64646-e09b-4942-ba68-2162bb1d979f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0945558c-d1dd-46ef-bfd3-6d0cdd75b650">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d98fdbd5-ddbe-49ce-bcfc-259d2c399282">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_da23cbf5-92fc-402d-9e75-2007112a3f65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca3b225a-2b14-4324-a2dd-00ff96571ecf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ea2d464-a933-4e76-8c57-df5e29dd0948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72dff77f-fc9f-4ef2-b366-9aed8d81046a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e461b2-8712-4afa-b271-2132865b1341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816c2a66-edc1-46f4-bd0d-4e699b823836">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2aa0739-9784-4743-814d-ad6a586a59c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_480e9cf2-a17d-453d-8f6a-013c28fcf0f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8feb73e1-4390-443c-ac47-834bde0ea038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c7e854-bf10-4c96-8f26-2ae14a703e31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e4e2100-c19c-400b-9b6f-2333e3808b98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_359a47c4-a101-430b-9db8-7408d78f8461">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76475b35-db74-44f3-abff-712442eb405a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba94349-afaa-48c8-bfee-61910d7d1d3c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3885f06d-f07b-4cad-92c4-0f8080c30303">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f69ab1b-604d-4ae4-ab51-9cd0d53c37a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5e8a806-f0b1-4bf6-9b57-929d670efd58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c338198-266d-44fd-8764-ff2a3268a067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1f7e1e82-5754-4fa6-8940-937f91087a25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8ca6df3e-0210-4e88-9620-4bee4bbe7072">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ea84499-a970-45ee-8be2-8cc9ab5dc2c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7993d16-c661-40a6-be19-d4fa0622950f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52870298-2d98-4bdf-ae81-2e477350eb87">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8389405d-9280-4803-bace-2ee38355fafa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e75b0fc3-f421-4ffc-b561-fc9ee5815972">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9128d5db-cbf5-4234-bd30-22c604210b35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a64ecd0-d2b8-4bac-beb1-bc8c8c451a4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2973b3c1-7d40-4ce0-bc30-b8bbc9245641">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a061825-baae-4496-8f93-6c3283ca85dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d662cb35-3827-44a5-a3df-576e423d7f32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b254ac83-1713-4c0c-950e-e82a7202e4d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43473fa2-f081-4f68-9b5f-69d2a75f5e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c43f06b7-fa8c-4aa1-bdd3-6e194480695e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a789d5-207a-4059-9cf4-0d8c5c0bb4a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4b8a765-2040-4572-a6e1-26c29549a549">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_865773df-833a-4310-a335-9e014d4e4d79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_abce531c-5509-4558-a719-7e01a9ac9005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1162fbcd-0df3-4aeb-b5f9-0d8fe58c55eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b22ddb30-b0d8-4a03-bed3-36ad77a3c2d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ec9d5e7-5de2-4792-9a86-03be2cb1838b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24630e95-086d-4fb7-ab52-0c8f447b4010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75e6fea8-348a-43f4-81c6-c5c1410ad595">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_825b65e2-24f7-4b23-adac-ad62053e0323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e1293a1-22ce-491f-a2f3-35e030a88667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d658fe4-38bb-4b80-89eb-d8f550a95fa2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e10d1db8-788a-44de-ba42-57edc9539967">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b554668f-bfb9-48f1-9bae-7d23e0f421ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beab0b69-1a8a-4d32-a111-6129bd8e468f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bee5c82a-500b-4921-8166-d664da1fdb2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_584dde80-3141-4bf2-99e9-cfee485d38af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df108430-9a62-4d23-ae3f-411cfbabd93a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03564f3b-c300-43ef-81d5-5f32696ca734">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0d79f3b-ad55-4f76-8d1c-e1b086da71ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20a90dba-1a5c-4f63-94a6-4bdc9a797602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6616d5e-edaa-4a8f-80c4-ee8ce85b31e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_065b6429-bfb7-4474-8500-887ec059494e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afa75dae-3ef6-4a83-95f4-1ed757b73580">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7974968-25a3-4664-bfd6-eb4e57880faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b7f411f0-e6f4-435b-a618-b1801a393d7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cacb34e5-35e0-4430-8c83-3ba4662fe7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76de976d-9edd-41e0-a14a-9c3bf5b509c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a8f004-7214-4a5b-89a8-fb99d5ed06d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dba29713-3989-41b0-89f9-a00883e9ddaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e685a6c7-06ef-4810-b74b-02c66aaa2f40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e458bc3c-51da-4496-9872-65d448af1133">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_870a57ae-f39d-45a0-9a9f-8402539c2c44">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd06f193-5870-4dd1-b594-b3e3b0ed6c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f02ee40c-f678-4ffd-b9f9-25285e43451f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d989ccb9-8582-41ba-8028-96a149e9402c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bc00a444-0894-4316-9fcb-508834ba9c38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd28ef43-261d-4dc5-afb6-8af0e9b6a2ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_142dec8c-d69e-4dc5-99a7-77ec0eb1dc03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef5f45e8-622c-49d5-a98a-71d47862d0ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b3d29cd-0a79-4315-af49-9d8c938ed76d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cc9423f-d622-43ad-bae1-77352fec565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a86fda-ad55-4b0a-b89c-2249a3d87c62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfcf9a1c-9418-4f53-b867-ecf7a735786f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b066d371-c699-42ce-aa1f-9262e331dd58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa0532a1-f44c-4447-936b-5241f29b4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cd198483-e657-460e-a753-771668b6455e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b0697f6-9428-422d-9bc5-3c95eb881ed4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b0e4433-ebd5-4af9-96da-62c2120aaccc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8cd999d-efb3-4d33-8565-1ff34a512572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e5e024a-be13-4ed4-b298-cbd85e03eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b04bbd4-394c-4fd2-a57c-5b0ce7b8328d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c82c6f0c-0683-453c-be75-9d1292c7b04a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f770f7d-f55f-40a9-b77b-2249a6771467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_add69c46-4996-4189-b8c5-496dd7f98a9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d255438d-d4f1-4e0e-b09a-ac843779dac7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4cac272-ef4d-4576-b391-284439f9c285">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58193dca-5bac-436a-9292-9ce96ba22418">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed897479-dbe9-4fde-93dc-15e7e0ff68e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_964dece9-6c0b-47df-9d43-e9b422360913">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67877821-e62a-4526-8b36-3115e852e88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29f5c6f6-b2ad-4aa7-96a1-cc8d2ff4b614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_81a13e90-2b4b-4a09-9ee2-eeafd9e00bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cab260bf-1740-4f3e-8882-f4cbba442795">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_46e90e7e-887f-4771-8caf-07f3ddf5b3e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a8e8f80-5d6c-4b17-904b-64dc2fff2262">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa77f9ed-8a3f-4d87-98ac-0a7375a86fb6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4374bc16-61ca-4b5a-9d9f-798fa48b665f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd77817-e562-4b18-928e-a519da1f2124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac14aa5b-4fde-4251-b311-33015973af60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5131569-0960-445b-8cf0-340c24986c0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6744f681-5c6f-4566-826e-524754bf8a1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4173c4e7-f582-40c2-b317-fa1d8edeb448">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cf483c45-14a3-419e-91df-689c1dffe6d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce3cebcb-219c-4426-a7b9-a174401a66c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aeb54478-bfea-4787-b466-90df885b1c33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4a408d5-2c11-49a8-b0e1-fb4e7b4545f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebfeab9-b411-4d19-a937-e3e9c4ea19ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b367e89a-724c-4a9a-a2de-a7d44de2c1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac672323-d104-419f-a71f-4ce30e297d82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_91dab2ee-b23a-4591-88be-d0020bf6ca9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_51f3b44f-e443-401d-84ae-b8e86c4b270b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4725e87-14c3-431a-814b-d7e174e12658">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_76f12467-9fe0-47f8-9c3a-79c8075d0c39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88fd8c00-aa5d-4bba-9d81-40538478b744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fdb1052-84a7-4bc2-9e00-b6c03e26adca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c8707e87-05c6-4f12-97be-5c71b626e8b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e0d1edb-a714-487e-85d0-0023872faf7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bda506a-f6b5-4f4a-b8ee-1d4957f48cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2851ba40-fad5-4db5-b45b-481d141f197f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f14bee3a-c4ad-4778-95c2-0211fc182eb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91899442-8c02-44d8-8b35-c512b257104e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4eba8816-da7b-4a57-8825-62061d59eb8a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a30fa62-5391-43eb-9ef9-81d417b7d445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55bc9730-8c40-451b-8199-cdd4170be47a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_187cb72e-9561-44b9-9624-a40a68adf40c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaf25965-83e7-470f-9207-e8729d4bd007">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003c3228-ae26-4e1e-b2ba-173885fa9f5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba63da6f-556b-47f5-9e8f-90f8b8e7fab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03e26ee9-a3fc-4c22-b0ec-5b56c9659504">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b5cbc4c-3b65-4de1-960c-20cbb7a93c23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f9f8103-498e-48dd-a025-031b7a357d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4876f051-8bdb-4900-9acd-a5ccfefc9732">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6ca903-3d8e-4566-8497-69c094b27fdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8c2d0e3-0b5f-4fa2-ae70-769bc1e229ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97528f91-9197-4833-a0ef-509553c108ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af52cd86-fb78-4aae-a5e4-899bbb32afad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_844c3edc-a332-4684-bd75-d2dfd5f3bb0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79e5c665-133a-40c0-b624-24695482f6b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6dddc74-a83d-4295-aee3-81685a166f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba1543ba-b338-437f-b377-c21d79b8f66a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0ab92b74-70d0-4546-abc9-4ebe526966fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_188dd9c9-8052-41a6-918f-dad2f04072e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c03b674c-609f-4376-8ef6-e5c8cbc8a37e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51cdcacb-8528-415e-96c6-d5ce8b2ef440">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c38b13a2-fdfe-4efe-952d-66ddf616d722">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a66aa870-a14d-4ebe-98fb-56dadc7cad89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7bfbf56-b417-4d5d-969e-2dc60af24f55">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aaa9f9d2-61a4-48c4-8b74-9f1cea3dcf19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7eb7cd9-22bc-4182-9ace-4a7283dee574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59a28b95-3bb8-45b4-a0dc-93bf57a4621a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53fd4b3d-190c-44fa-a4da-a06af831ee73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4442b941-d4d5-4ca7-bb8d-5a427f0e3821">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7ba9ee4-7854-4f0a-8527-e67110d01ca7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_83bd7a12-4fbd-4219-b9f2-8a70e5d36a69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5fcf6744-b487-434f-8a95-531fb0ebeb65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2e562797-dba0-4f5a-9c34-5bd39c9d4694">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c864bd86-d942-42e1-ab35-ac890c49f5de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ded25e34-2f5b-45bf-b847-b9f87b9de7ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_412cb19b-097c-4378-b3f3-cf5b731e677d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1b501608-150d-4e0e-a33d-403a1ddd70de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f849bf17-7777-4aac-a443-f34aef90c1c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea9a9a67-57b3-4e54-8850-9634c88b0fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07cdd920-0989-4add-afb5-de33f3e28212">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af78f809-0fca-4913-8e81-0bf6d1836582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_721fb0fa-b655-4188-9fe8-639356861427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_280c464a-a4ec-46ed-8a3b-b18e807ea7cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d578c1f8-6516-415e-a1b1-18a592ca45ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3bcafc5d-6dc8-4de5-b4d5-eb468c889fd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c1fa00fc-fedb-41f0-8a45-09c6856a38cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7289d742-f3ca-4b60-9e58-b6da7497219c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_219cf87c-2e4d-4254-ad89-9ee4bce93e99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b04a6c9b-435d-45e2-8e43-d7b159a64e6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f145836d-2f92-4563-90ff-55f68863c206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d824f3c2-f6b4-460b-8875-8e822ef5d542">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45101256-dc1d-41ee-aeef-65ef96bddfe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9e3c9fe9-71e6-4a25-b457-8fdade0cf6d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2925711a-ecfe-4584-95fa-216a76889e0e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbe15b06-0197-471d-a3bd-08a22b40e4e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_53a237e7-aee3-4680-b1e0-3204ddaa07a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e6ea76c8-471f-4d7f-afd7-df09fec29637">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19490fb3-067e-4068-bcea-4a2ee8a27fb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56d744cc-18d1-42a8-b559-be005071f72a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5540a41a-7beb-456b-ab92-d6e9bac08adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d15ece-a13a-4f72-a22c-d0df5b4d42e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa27116c-d2fd-4d60-ad61-0bba8bf76d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0570db62-851b-4096-89b3-306a830f9d08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7b243c85-0fcd-43e7-9caa-16aef19823e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a2d7e12d-d6ad-4b3a-afd5-1259bf58612d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0afde8ea-487c-4f36-8090-f72727664eef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8aa5a02d-03c8-4aea-829a-ae2aae86f897">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba870de3-4f01-4c36-a70a-836982d78be2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b712d454-cc47-4381-a23b-83696157c215">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40872517-e212-4794-ba82-e587fedd9a57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1122014a-cc7a-46e2-a3de-4b03c23b43f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d3d8bd1-1bd8-4b9b-aa6a-d3057c751e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c1fdd5a1-0341-4524-aca5-6b77f18930c2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30b48ec4-7a67-46d8-927f-f135edf85da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce183715-8db9-44a3-b4ff-c224869d4f5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a29c607-c616-4405-a680-f472693b6c02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f872969d-a939-45c4-9254-acf26f5d05b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6788a97-75e7-4609-806a-927f5ab7b097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fc04519-665e-4785-adf1-846f1bbc4bab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8c8eaa7-f1a5-49ff-b392-8eeafc898658">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f99fb43c-62c5-4639-8053-66758542a7fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b6fc7aa-035f-4630-9048-7dba8d02450b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33c4b2d1-1210-4147-b097-77dbc9bb672e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac04fce3-ee20-4127-a581-50bc78421887">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f49f8d8-32b1-4522-92d4-19c3a726e0bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5cdcb762-8802-4370-ade2-f2cb1ff713c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ee50c6a-92c6-4446-ab9d-f18863a55bcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e81b0bc8-2b54-4ea9-b9b3-1f0bbe7afbba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_859c4ebc-14bb-432d-829f-70f94d346847">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e317ddfd-c060-46a5-8279-74abf6b28979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad1e1809-32f2-4cf7-b9f4-3eae73b294c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36c4cd74-a5e8-4ae8-826d-7a82578086a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2436005-f7ba-4729-b7ce-4c62da0adf39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92d4a147-300d-4b06-85b6-741b6700f71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a706fcf4-819a-4598-96f7-c9647368a248">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6e3ad789-b748-46a5-9c80-1b60f334e802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50679c3e-cfb5-4a11-a9e1-e578f88371ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddb0e6eb-82a8-4246-b77a-2155477ebdd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fcc31e9f-277e-462f-bc16-0330cd3163af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e25f3ef4-5c5e-4546-ac7d-53ecf70aa9ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea847c13-d0be-4616-ad58-1769b7d799ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fcefe6a-7bd6-488f-8dd1-26b7e23b55a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5c51845-f008-4108-9e64-1a913591741e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3334eb38-fe2d-48f2-978c-c7088acf1e7b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8f4e9bf-7c05-46e5-accf-e021501658e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6bbc18a0-9898-4620-9dea-8a547b996fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4927304-e6d5-41d4-b669-d0ddf7d05853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5909fee3-e912-47ac-ac18-990aa009f211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b0d4c18-9941-4d4c-865c-88b1a8c0dc12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b8877ec-b6e4-4f9f-b1e5-18ea5e1b35e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_507de8fe-a640-43aa-94b3-8be6dabe22b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5d4c518-715d-4049-aac9-002f60e13bbb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_390d1cea-c5b7-49db-9a04-226290e027ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9ab11de-1ca8-476d-8c7c-7364b4bc3bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3cb7a299-166a-4ec6-98c4-21c0708e92bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_716eb523-8ac1-4154-b7da-92242b3b61ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb7a7e2-47e8-47b1-9f51-ac53838a652e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6a85b772-385e-4c24-b4c3-e16d66dc1603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb7bc05a-c1be-492f-80da-4eace7ca08cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7c5c0d1-9a22-4edd-8bdc-386f781bce15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_daba953d-958b-4002-a3d8-ee9944bfd07d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57a5e5f7-befc-4422-8f0e-26335a11c5ae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f3318d5-eccc-45de-9579-2f989e144c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96cdf652-f2ac-4e90-b56f-1cfdd4c21cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a21110ce-7fe9-4dc1-b2d3-cf4704ca6c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c94db8fe-c4a3-4178-af77-d688d8a64408">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89fe4a5c-784c-484c-8337-9768c6689f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc8b7ccf-7888-4967-aed6-eb5d343179f2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29113799-f271-4951-a18f-ac987e0e09a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7c3c200-930b-4a90-8dfa-9f839cebf79d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a464cdf-d261-4c53-a320-9be8618fa0d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24ea3acf-ec02-4609-b9e6-da4f477b7a60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ce04a2f-8e18-4bae-9267-07ade5132cb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ebfcf35-fa99-4bb7-8204-0c94fccdaff4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d6c972a-8fb2-4dbf-aa6a-ed82e0c0b3be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dccf116d-491e-4e69-9ea8-8101ad6ec043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66e91c22-b40e-4e8b-8502-27007d0accc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d2bdda8-6ba3-4fbd-acac-7a14cfd8552d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d80d39f-69f1-4dc5-946b-cc151ecda5ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12ba20-35c6-48dd-9694-bdfa799fce94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_167c8171-868d-4aea-a0ee-46d2620d07ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b888c561-d178-45ad-a230-1e5addfe2106">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c344ba5-2ccc-4a21-be2c-aeebe2b6483c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95fd436e-f77a-473c-91d7-6aa7715a985d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb51de1d-6ca3-4a05-a78b-aca3707e3fa0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b295e329-a5ba-405a-8300-6eb7751d5f42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8667e660-8674-45c6-beb5-7a8c5016497c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37a461fb-e8ae-40e8-ba2d-04176c0fc86a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_990bab29-8285-4d4f-9568-8d76adf2e329">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7615cd28-6642-4ed4-aa07-41fcf005901c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70fbecbd-a570-40b0-b924-9dee18a0033c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ceab391-9b32-40ae-a4ca-a1876f5c77d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36783286-75df-4d91-8996-b28c539c0af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25834ef0-16fb-4334-bb5d-f4573046692b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b78831ec-6458-4f71-83df-dc4911f17fe2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c8111a2-d58c-4cd6-ac92-65b5016ab9b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_049942ff-eb3c-47b7-8037-dbe0742de940">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41484357-f128-4be7-8ae7-27bdc4b86019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d612c351-c679-4e42-929d-30dabcf165ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06343fcd-f7cd-463d-9be4-e945953fd82e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e983c04-7dae-4061-9233-f5654965744b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_547bd475-13fe-483a-8458-71d3c783493c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1f1508-11df-4d70-82af-061d2ca91351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e03205d7-a924-40f9-a3de-2b83f1e37bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fb84e7-ad1f-4124-8c51-051ac93c5a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c1fa02e8-02f0-456a-b06c-ccd75879889a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9fa2e723-ed6d-4a1f-858b-423dabe74184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af9a95ae-eb9a-4491-a957-2829445d67a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2406d38e-44d5-4ed7-af86-823636e9a488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2c6b929-0196-4434-88f1-a805d4c48986">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6db42efe-97eb-43c5-bc1b-c47c564f3066">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1d6ce52-59f2-416d-a8fc-10fe7e19096c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_560bf83d-89b1-49c8-b344-48c32eaffeac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f38de7a-9d74-4d51-b1ab-5da7b960ffc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c88a1ec0-0fd6-4ba2-81e2-be367d0f4df2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca498289-9312-4a5e-8dd2-23cef664abb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9fd6394-daeb-4698-b348-275e808d6afa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86d88bbb-ea78-4904-b49f-53fd2bb4d191">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31accc74-faad-4484-b101-f73ef44a6936">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41526c5e-6b58-416e-8b3c-6424b0acb3fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11cf92b2-84a0-47fe-a195-f0e64010f8dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe7369-d00f-473d-8b0f-691d98291bb2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85c2b8e8-79c3-4ef8-8c1e-d6827a6d718c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81228225-5cb8-46cb-ae11-d29586a1e2ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d6f3a82-2659-40d8-ab95-8a2bd5fc6265">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a960f0-930e-4403-97ad-3691fb54d700">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc031930-2fef-4625-8e81-5e393e3ae979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8d28d23-305d-4634-9eab-d844d194e774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84f4f334-5f2c-4c88-8d1e-28203511eca2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd1091dc-e3a1-4166-9ec9-dc1722819f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7801660b-310a-46ec-be58-28a687126bec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a4c90d8-4c22-4948-8791-53f8ca5d4622">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27d75556-9ede-437c-b23e-d79dc1dc96ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c51a0cdb-d467-4d24-877a-7775e82b53c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_86c18cb1-3611-4361-8a20-4b8fe0384de6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15a078c8-16a6-459c-8f79-40a9ca4a6572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c4d4d990-9de9-471e-b1e4-694e37b7b9ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37502de3-cfc1-4b05-bd5b-ed9030f8f189">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4e417d1-226a-4b14-bd6d-28351e5628ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54ba944-901e-40df-840a-d23df6f7a88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d318d295-ccfd-47d3-8f1a-043d208aceab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a68248c1-14fb-4dda-b56f-e13a5aa7f527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b135ab26-112f-420d-85f0-80758a7585db">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_31101594-c7f5-45a2-ba6b-27e8f669cefb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd1b6f49-5364-40a3-bdbe-2d82edd1437b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_55cbfc96-cde3-435a-a7f9-ba18fcd0638e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b67b401a-51a7-4330-9d7c-943ffec2f6a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b749a48c-ebf1-40f5-a322-68053428edc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c4f9c0c-1a4b-442f-a4bf-406aeefcc4c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90c30a29-5734-4a13-aad2-5797a77639d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d0a545b-ea46-4ed8-a24f-40c92b051ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b81fa63a-0bc7-4b07-a18e-659a715bcc1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_762575f8-bbb2-4377-bad1-861be802222a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dbad50ed-ffe1-4f0b-b052-2d78375b5463">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e782e39-34a0-4f10-8569-f499394ff261">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1657588a-9956-4af9-ba4f-5b748460b57f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f61f229-a94e-4cfd-9fc1-0399486ffc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c221c69-bd4b-47e5-a647-7f1159e00af0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f53e5a2-d64a-4f0f-8c2a-a443eb46ca6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5a83883-e82c-4672-8b1b-1f636ef7e8e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ea96345-5a97-4a05-b4b2-310f4d0afd29">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f84a5f8-b9a7-4872-9053-b1ef88e2d05d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8819d649-f8e2-4e89-a972-a50bc9c9fcff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01cb8d57-9bad-4964-88e1-b30f590fb4c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7a1d0c9-9b78-4278-af7a-b2b1231cad51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a74a4aec-0927-4239-9575-0cb091400067">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee9adf37-e0a5-4e76-9283-7f1724ad6853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68cc2320-f052-4f83-bb13-d1f4fba57eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38c9825c-4892-4cd6-b9e0-c4adad69a028">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_210557c6-8c1e-46fa-9045-fe56f0c89153">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c1d4660-f77d-452e-8aad-55c5eb44d24f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98b17987-57ae-48d2-8676-f875506d5927">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1b979e7b-cfae-4605-b8e4-9a5fc3be5cfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37f05fac-fd02-4322-9f59-d7defa1c9c2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01df9095-b5fb-4e49-a1a5-1aeedb85f23f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08675ad1-6474-40b2-97c3-0a52b7663139">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7dca1366-a6a6-4577-bd7d-d653e9739366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_25539bb9-f941-43fd-b933-79a889e1038f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203587d3-1f66-4dce-bdbb-222273112bf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e31e4207-59a8-4219-8cd9-900e92f76717">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ba58280-2b98-4ba2-9e29-94e847ae6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64485f9e-8a5e-4388-92fa-f558d6b90e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95bbe69a-d4d6-4ab2-836a-1008b8caffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_479ea762-732a-4eb9-915c-2b88c78fabe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e835c60a-dc97-4554-9544-fcabed551f58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0c82da2-3dea-43d9-9cc1-4d39c9a43b78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_342803ad-2a21-431e-859e-5ee83a93cc91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_93c8c2ee-ca43-4e2b-84a0-2f1bfec243ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_84e84bc3-3fc5-4759-8a09-3bac5643687d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e83af75-d5fc-49f9-82f5-4dff21fbbeae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_315a215e-faf9-4824-9446-b23a5fbc46f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1822bb-61f2-41e3-9f6f-2803fb0e53f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e859328e-c8cb-48ba-81a8-c3d69072787f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bb1238d-127f-482f-b129-003cafd854cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00d4de7f-97a1-4ee1-affd-236e5ca7669a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_06cf8848-6457-458a-8535-40f3b914107a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b2a2428-1a4d-46f3-85de-fb147e11f451">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90836758-b0f5-4d95-8b21-a6c1003de8ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_feebd7e5-b054-4c98-a96b-b28c48f82243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b097aa4-01e9-4d1a-8f1e-c63c4131ad9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_771f6532-a3aa-43ac-b1ce-0882c959f109">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acbc514-341a-4d18-ac85-8e4cfe2f382b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea41c901-8756-447c-bf4d-2d335b26ca9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77fa6aae-4ad7-4b72-b051-e6f28d5b142e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_76d4e8f2-3f11-44e1-9f63-8c2be3ec5162">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99da10c6-16c3-4dbd-99d6-83f1e0842025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd575cc-c1f8-4bdc-a62f-ef6220a31456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72cc6651-81f7-46ef-b37c-7fc46aec73e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62b9e7fb-d6f3-49ac-9a42-d77ee831eee9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07aa0735-959a-42b2-b4f3-6074067aafec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ae60514-69c6-4288-8e65-a598a25c9c90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3cf6bc3a-337d-4393-9090-f9060f0eb182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_129bf6e2-5b6b-4bfc-87e2-fe9b5212a467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80972da9-13cc-4b7f-9e1e-6343fa94224d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5316a4bf-19be-49e9-98e9-e7509b4a2a23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45e90f13-81c0-49fa-8677-5b58fa5ffd80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2234ba5-52c8-40a2-acd4-9a57460b3d57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4427f2f-4949-4d59-a3e0-79721efd6e71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e599f57-e8ba-4a78-a8de-93389bc0e6e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c931db7-c9c1-4d7c-8659-a78594c06d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3edbfddb-96c5-4997-a24f-d7a1006a01f0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5406d33f-9fca-4c3f-b933-88d01f6f3bad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7b8d64a-03f2-47cb-a62b-4f6a877e7f7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38ab5d22-589a-4032-863f-ba589156bbf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af8788c6-83ab-4c1a-b888-97f10d25ae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df6de0f5-def4-4f68-a871-8ad85b2376a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0020cf33-6189-424f-ada2-6c74c3ef22c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e3b7333-bcb7-4fdb-bda2-0947a573ea26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7602d239-dfe6-41fa-b6af-2ef200468081">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ca892ebc-e51d-46dd-95dc-a78a20f8626e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7438269e-b295-4183-9b94-7417d16c8b14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d382ea-800f-4f9d-80c3-8bef6e8a5dc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7085f2a2-88d6-43f3-b486-d8fee1e75218">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99134582-5a8c-4bcc-bebf-da4676e7a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7133333-4a33-46f6-aca2-bc7c432aa30a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f47a5586-ebe9-41b1-9844-44ed52052550">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_724e7034-65d0-4d26-995d-2cc45736495e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10ff5cf5-d7d1-439a-848d-788d77dbd40a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5b8f1c43-e90c-4587-8669-bf331953a643">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d35a277-c55f-4836-b36c-14fcb66f8f77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_593d0b12-0c6f-46f3-a675-5bc320b23e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c8577d7-eab5-453a-b5ec-3e88c1f69a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01fb6448-cd88-4c99-a93a-ce66fdf0b9ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a1e5cb-d60d-49bd-94b5-ae5ed77d95e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fead62ca-3226-4feb-94aa-7ef14946dabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bcb2d8c8-abb4-4b80-9e8c-4fc8d169dc6d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef66a335-fc26-4701-9790-79f6dd980150">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe0d6475-e165-45c0-8a0a-def79cf38182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0f65e91-5055-49e6-bcf6-9f607dd0ffa2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8fd01294-d5fb-4478-aab0-0c6b11eb195f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e7791f3-2f85-4c7c-87fe-f530bc9c34b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_055f6a1c-d9c4-4ec7-b72d-c385976c9b2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5adae9e3-7054-455b-8e44-93c55e875bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_717e37b0-3fcb-4c83-8c61-6f3bb9b305da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4490fe16-8b5a-4687-a603-3873c45cfb86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abc18a4c-d871-4631-a190-ec032f93d5df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74fca12b-d271-4fbc-82ff-70cf20e508a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d4a0b0-a444-4a06-8929-ae495a0f2399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59f4b07a-765a-4139-ab24-2040c49e6fef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1a3d91f-fcd8-45d9-9068-17367aabe864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aa8d0b3-7c00-4d3a-bc74-c2b2e6b93bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da927dcc-2cf1-405f-80d4-f7dd92117518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_66f28d02-03ca-4604-bfb5-31ab54d621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7848a48-ec4c-4aef-88d9-a75acc3eb65e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0f4a0f9-4c5d-4893-98c2-19b42e6ec40d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea7cda5f-7955-441d-a706-62050000be98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d4de290-a5a6-4525-888c-67cb8386065a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_658c5fbc-8d6d-40aa-a7a5-a2c5101bdb02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13119acb-18fa-4ac9-9d96-0a98c69b66e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e3c1c910-6fec-48e6-a071-f1bc05bff568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43709e36-106a-4bf0-94a0-67e433f9d58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_29d86cfe-511b-4b0e-886f-d808af28ac00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_58ce1bb1-e8fb-44c8-ba47-2325967e7140">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b67afef-e077-4f0c-8754-e862f2be799e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca6d3234-c045-4487-a1f2-023eda3c6b48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13db0e89-518f-422c-8ee0-bebcda57c914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37085430-1118-460f-86d8-a58274c29368">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6cb1b71-d49d-4b44-a7ee-8f8379ca6c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b876ab67-4bdd-45bd-a5b8-02c3b9e6492f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0975e90-01cf-440f-ab2c-1cbda073793e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c2797fb1-b15d-492c-a86f-900dc054eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c15a8b9c-87c5-4765-a698-bd3a743ea0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e900d4f0-88a0-4f10-b450-ecc7289fe172">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2fa583a9-e27a-445f-b11a-3cf60a6c096a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62b2ccb4-0d9c-4592-b19d-d21ac06c6bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9343a5e6-3fff-4379-b4b2-88ac2b9d5e30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fd34c6da-f9b4-4edb-abbb-229e9c0e6507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4576d17-b9dd-481e-a99a-9b2e86fe2c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5659175d-91c4-4e77-b2e3-de41cfee7a61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_88f90584-8048-4836-aed8-557a1be25574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4425d538-82c3-45f4-a79f-468ce22b1277">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c15e468-811f-493c-8431-c78323ee7261">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ef86e14-8dd5-4f53-b834-3693fd04025d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41a92499-948f-42e0-99d4-4c81b1763be6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aceea622-96cc-4cc0-a4ef-c0985a14aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef55c6e2-1559-4898-ae94-bf5aec5eee35">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c1066bc-6435-4370-adbf-6e5e9dca8a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b46e9d4f-f807-442d-b48e-25f59c33a0fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7a197074-f6dd-496d-98d8-ece105892059">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_afdda05b-9fda-4c5e-b67f-5a8835a9f019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6c15186-72d3-4946-a857-f709eddf838f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b63e438-cf9f-4456-a2e4-1d1600bc4943">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99c5da9f-56a9-4126-8ec8-27c0ffa69c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a721d8e-f3b7-4d26-8044-ff5e90d0cd32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd52bbb8-eb82-4bb2-8c14-37ae895d7f14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_021c9ae9-3d30-4a67-aa98-7c86f9f2669f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4db08985-bfd7-4f60-ae09-e3044e1143c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dd33081-800e-46fd-ab6d-3688e6d05155">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5d4dc3e3-1d65-421d-9995-ae5fe9b9ae99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_12e40f94-2cdc-4991-8c72-28352ab765ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b26843e-a219-44a3-8b10-e755dd65cc50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2b84dd51-5672-4c25-9b6c-eda83c8e6aef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8dce3f98-5a3f-47b6-8671-6264edb60f38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eef57a7f-1b38-43a9-a2a1-88d1d43c41ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2e8d3533-e650-41e8-ba9b-36b5ec94aadc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4957a875-6ba5-46ca-9ebc-5842f66e92f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b51b1dc-b52b-4d98-ae80-713d27ba53bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_571fbb8c-c22f-464a-a009-75887e5265cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f02a089b-51ec-46fe-ae11-2aab8b340bd4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b9574069-9cdb-498c-80b6-bacf8e33d6d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f67e88-6aa3-4155-953d-51300aefea7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54015ba-0d13-4c36-861e-13d092f9307d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4190d3e0-bea8-4b68-a705-a1359a5b8022">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97917706-3686-4103-bed3-0588a7169e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7536f1d-7c3f-45d7-8a79-842bf0992eec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61ef9abc-a0f9-4c1d-ad7d-cc9d81ca9b68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dba72ef-c7a8-4f5a-9b83-2d8dccecea7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aff8a4f6-0ddc-49cc-b04f-492336fb78ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7a42f18-f442-49bd-809f-5af6909a5bb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f11a1291-627d-47f6-8d13-d122d2907fa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a7027d7-d811-4bbb-9fbd-ea325624dac3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c354d477-f0f6-491b-af74-faf74282d996">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a1d8cdf-7ea7-4554-ac6b-d7755614ea93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b906ef20-f829-41ea-a58b-bee609b03812">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab799eb1-046f-4efa-a790-46f648e33aab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c44198e5-abbc-49d9-9b4e-8d5c545425fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5728316b-1343-42ef-a0dc-2582ddfce4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01957b23-1950-4ef7-9f12-e88028223835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aaf9837e-648a-4328-a7f2-1e524528ec4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2a8261e-43de-421d-a8cf-d18e51356b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_745a62ff-fa7b-415e-a80d-58499bd979a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfd66150-92b7-4637-96a1-10bf16bad932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19709704-48f5-4360-b6bc-454dabb4a91a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc0bebe2-35b8-4d32-a5dd-c866e110519d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ade4e44-a1a3-47c7-96f7-58ef549c8881">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ce1137e-97af-4f0c-8e97-d8362f9a6681">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_704bca7a-a16b-44af-a3cd-63ef88281c92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_771f698d-78d2-45f4-be66-2d71d49dab8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f86c5a9c-3aaa-4913-8c02-8ad29f83cda3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0371a00-0b14-46f1-b09c-25eefe811e0a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b541a7b-677b-4452-ba63-04630664276d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28cd2978-aafe-4b1d-a72b-800c2057fc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9114bea2-7789-40e9-b181-5c37526bff09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46d738cb-d6df-44ea-b946-4d780d06ceb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_625e468b-920d-4c28-805b-434508aafc60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f76818f-5a86-44b6-9f8e-2fa8425cf4ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c00a6123-f67a-4394-b0a2-9703b6fe7c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46a60d8c-5ee6-4b88-9d77-bf14dbd42e13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_842f35d2-8bc4-422e-9c6f-482c3319c75e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_223736f3-2dd8-400a-ae21-23490dceb5a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e7184e6-b0eb-4071-8f5b-ce9d3575ebd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d990be00-2c1a-4878-91fe-9d411db99e7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14de64f5-2498-4d4a-93fd-07ddc4faf4da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_248960f7-2bb3-4e4d-8ef5-9e4b5256e242">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc787984-7965-4911-874d-63951b71c9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_beef0f3c-1063-47c8-8c01-980f9d0ace04">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_efefc590-7ccf-4e2a-b1eb-29ce71bac7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2851c207-d0f0-4afa-8459-93e67ab046b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc647ca6-b570-44c6-9a95-9017a0d9a6c1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f69a138-dd10-4d1a-b4fb-bdaebbdf6bb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb12c256-e1e0-40f4-8409-f632dd91a567">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_197813ee-99dd-4dd7-8c7d-953125010823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad326602-7990-4820-b11e-d30fe8712f1e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c7f1716-7a9a-41f1-bbe3-a0c786036aee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e5e210cb-1713-4b5c-ba13-a23753fc6357">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6947b0e4-2183-40fc-bc41-71fb9826a566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ed6be82-6f0e-4e3a-9290-5440ac0e3210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f2ef388-bb24-45de-ad9e-e1d81b0a70e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d34ee87b-12ea-4264-be1d-77523cba6664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96509c69-be8a-41c3-aecd-cfe5a78a347d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fc8b50-beba-4f1b-9b37-44be779b4008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d93a35c6-2778-4e43-ab3a-949e0ba70465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5812071d-a8e9-43ca-8ccc-b51bad61713c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b8883d7-bfd7-440c-8b70-b542def33958">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7f4e2cc7-9c7e-4591-b673-e15674599f33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_69312939-c515-43c2-9907-6f7a9b4c2844">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5feef99d-86e6-42dc-9c15-685a70a1f1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88aa5ed7-9987-4bde-ba31-fb3b30f70285">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c18d4158-7fc8-4153-ae44-3b69c9326167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb77820f-64bd-4d5a-8a1a-a712fd8c3dd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8185f40d-99c0-494a-8fb6-1c2c1e36d884">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d843d9d-ad4a-4ceb-9ffb-1f9b8b2a892d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2ac50ab-cc63-4365-8bc8-5a0a2ec32143">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70091785-81cb-45d4-a120-97a3784b6f40">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f82c11fe-c49c-4676-98df-a97998557859">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b24f203-4333-4e3b-a822-f022244e1d92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cde6c0e-e554-4167-b71f-62b67afc85cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4e1a8fe-b9e8-42da-acd6-6ccec8014bb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e045e99-8d68-4ed8-9391-4309be949fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52120d04-2b1b-47b1-9581-72ba5a43d32e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c5d7ca3-84b6-4bf3-8e80-a725069ff9fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_877e8141-40e2-4022-81d0-7ca6b91fcfb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a36a24-459e-4f26-ba5f-5da5af49a4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_eca88a11-bf8b-4a75-ade9-2de5bea4877c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d827f489-f33e-4019-87af-4414e8baf08b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff3ff395-0043-4d1b-b7be-f7a978500713">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74b2a3b7-700d-4d2d-a24b-de95f780984f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d3b9648-41fd-46c5-a65e-4770c2379091">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38bd0277-d889-46cc-a57f-4dce84db3179">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac35b9f6-9769-4ea2-b7b7-a39fa5afe1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6487111-119f-4c04-b03a-4f358ad555ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a3956a79-3d90-444e-b18b-babe0a24c7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0886d513-eb42-4bfe-a1d1-91dd552d985f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3ef6f07-77db-4073-9b75-8c884a8227b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fe67305-2b8c-4275-b395-ab7968cd0272">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ad26464-ac9c-4a4d-9367-9adb3cc20cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac0b47a3-728f-4a27-8c82-47187058245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ae765c-598e-4e7a-a7e8-7ec76be26ff0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14440212-9e9c-4a98-ae20-bd02c0389b11">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b558016f-c443-4453-a846-56cb92195255">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9f1df3e-d035-4107-8c1a-ae630c1dd0b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6891853-d085-4539-87e5-a3b8c0a18445">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74abf6b5-ec41-47bc-bcd7-ead4aa9b4d4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a024617b-feac-4a5b-a1c7-5ceec0238f98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_053ae80c-2f62-4b2b-87ae-759d2bbafe48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_72caf4ce-0392-4a83-b9ef-66c1bf18cd42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_618b6fb8-cf30-49ec-98a0-16a816909cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6869cbe8-5336-4075-850d-5689210ea8b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5efa4008-dc17-4aec-8c9c-d3d19f2be5cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71b4a9b6-82e0-4375-805b-2116c6402f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4698229d-cd6e-4c86-8cca-e6d2005f3fa8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f83db32-bf0c-4cae-b788-13c0365c7c20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a97f14b-bc34-47b2-8772-22c5879d1cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1fdfb51f-2996-4790-b046-72e240d1e0ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f253934-45a9-4b3e-ab30-7e2ce8327ed1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_132e5e39-3f2f-418d-b826-1376ee0c715a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2db62614-6569-4e78-94a3-0006780692ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e3da9b20-f585-4c9c-93e5-14c19f2b6399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dffd3c04-567a-483b-bd21-95a2c659040a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f622f73b-4f50-45e7-a314-dd7abc1fbf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fafe1dfc-054b-4ed7-91ee-8d379326eec6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_835c90d6-b524-4dfc-baa2-91154554bb3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af61f0bd-2d4f-41a5-8108-5d6bbb9ceac5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62aee4c7-b396-4790-a96b-58735a58099e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8543a6eb-0473-4bcb-8ab0-59ba2fc58b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13c4e177-274f-4c6c-8a54-1666fa02f5cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b4f2a4b5-de1b-46e6-9caf-819d0d5f7756">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec6c71c-fbd3-47b3-a7df-259f8fcf18fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9cf81c-329a-40a9-b846-02b92c38b584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45d1f6db-a578-4885-86c4-fff085855ffd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60d8d59-4416-4646-a1cc-0f85a3ac109f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_63c4a7de-7676-4226-901b-6e8a9e63491b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27f1ae3b-e45d-4997-9a2f-af8fccfc9c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ede0ad83-2917-45a9-a53d-17dbf251a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2d6aa302-62c8-40ae-b6d7-4872d0a2c81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9187f8f4-cb9f-4497-954c-4e9470855a9a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b023345-3d98-4426-8967-f6be81e1828d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ae07a8e-253a-45de-a576-a70bd5668d58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1d3ead1-3f0f-40ee-943f-f1dee312b0a3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3b3ede6-1f39-4cf6-8970-363427783803">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e58009b8-1f83-4974-83fa-f2044fb95808">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5022d2fa-b3fb-4a51-9b0e-65566f9d8473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddad94f4-3682-4c83-839b-0aae8dde7bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be420f6b-ced7-44a1-ae07-7c136bfb1e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e65535d4-bfcd-41b3-96dd-2a50f50ab590">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5f92fe6e-b0e2-41ee-a046-28611580b915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87635d3c-7a14-4f8c-952e-6ee385bb6d83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4052ff8-e2da-4b60-b80c-c68fc1a60619">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ed5519f6-7ead-4c66-bd34-fb76ff46cafc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ceea3926-ece0-4b7f-a7d9-909e150d3d84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_29c7f86f-dcfa-4ff4-bce0-b1d88b129da2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_32467b45-4242-40f6-ae90-399a071e765c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c229d207-3189-4df5-85e1-37b21b353674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34394c63-2e6d-4553-ade0-bf94a78e4382">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f84f5c00-f7e2-404f-b646-fbab051c5d78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6d3aa49-e3d2-46b1-8d53-3f1f75e8aa4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d8d3d57-7ca8-4460-b92e-0970be0092aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f792f6d0-fe8a-4439-9e46-e461869601cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52b96eec-0446-40bc-818e-dc037aca27d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b92b26-84f9-428c-b42e-767cde1ee485">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c1572f8-54e9-4f58-b58e-4be8dcb49b80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddc2ea92-8895-4269-9512-fe42270e9a5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6904c68-be16-4784-a554-5e37a8906992">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_893b7d03-19c8-47d2-898d-eacffd52b8c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1285083e-4048-4afa-a315-b3cb3fd4781c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4ffcd89-c4be-4992-88b2-db12df2fc476">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a862cbfd-9088-49a4-a91a-4e32c22e9e43">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d015a1-51d9-46ff-aba2-2a10b7abc94d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b88e545f-683d-454e-bf38-a4b4a11c66e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df0b8e73-382d-4260-9489-8114c52cb9f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0d88a48-c7e1-46d7-a314-85c4f870919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f95ea0c-7967-4cc2-88dd-62ba25802230">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0cca45f1-e599-4046-bca2-f221f2fd0d69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7df41223-5692-4dbc-a02c-d0d7c1576298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1bcd4be-f73b-4aa8-9b0a-7514c7c50bc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e93dd0e3-db03-4ae7-bb2a-30ea502339da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_145e4229-0762-4f9e-95cb-fed99ad79e9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e360b1-fd0c-4c11-bbe3-c543d1af1a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_513d4e03-731e-4486-853e-49ec395312a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45a4646a-3dda-4a59-855a-ecd1fb44263f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_08aeec0c-32d0-40db-82e8-cff84194afd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b59d6e2-48d0-44d8-9a67-0106c94f0142">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45aee435-3966-4bd7-a2df-ccc5ed886045">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_20f86f62-6dcb-4b55-94fb-3f3e6de5521a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad48cbcc-0af7-4f32-9433-2fcbad64670b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_27ac5033-50ba-4225-9d50-ef7282186c0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74c4fed9-ccd6-4a23-abbe-a8d0d429460a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca797025-3a0e-46c3-92bb-00c36c229c63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed8e5966-f137-439f-aa01-b1cc7d49e74b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33b677a7-46fc-43c4-85ea-ad1351da9c4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2070290-3e27-42f5-80f9-8f6035aeb75c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cc431a-3e19-4339-851c-f5b1c6f85d36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9878ef4a-3f92-4c4f-8b67-6eaca87fc58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1163857-e5df-4f81-adb5-de5b3f4b13b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d94d4a5-e15b-4126-b4f1-c774996c1587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6f592ab-96ec-44c9-8837-3fa9668144a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94e72f33-d0b1-45eb-b58c-abc95358f80e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8cf22fc6-6d20-4aa0-81f0-3f34586cde7e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ff9c845-5984-4ddf-83c5-cb948ea978dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9cb09ce-880f-44da-8356-5e62c28e9556">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87db2dcf-7381-4bd1-af56-900c29170284">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d0c504a0-1dc1-4a84-a77c-dd4356d9c45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62836935-2777-43a9-b6b1-2d8ce915e99b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_301306f5-441d-42c4-a85b-b4dd619b1d54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d98d033-219a-4647-8ef3-214a241ceba0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_649ff81e-a994-439c-a3e1-79ca4b97f467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ee3600e-761d-444e-a54c-3b231bf6b0c6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_651d7211-bcfb-47c6-a62e-546f97cbdf31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d660b3a2-36f4-46af-965e-9ccf63921b99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06ef8f5f-ced4-44b1-89fe-636fde5295f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de006bd6-6239-4d9b-b431-975fc883ef69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2409fcc-0d8a-491c-a8ad-caf94d44c866">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8953b98f-b6ac-4fd9-b382-280dd9f83848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51c81d09-778d-4eb7-a792-b13cd11990e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_030fd25e-8a7c-4067-956b-95de2e43ca1b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eea0f6ae-4a78-41b2-8fc1-9b24e9bb1b2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_799401b5-7bad-4628-936c-272a47afe701">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b30e5c53-c685-4975-9ff7-395f24f94933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfdcd1a6-2100-459f-801d-cffdecc34978">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ac17236-8641-4330-acc4-a3546fa3be0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c2b5717d-14ab-4735-84c7-f08eec3c5151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92093091-9def-4b01-a1f4-97281f352dd7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_457739f8-564c-4260-a9b3-6e7ab51f19a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_29f45a6a-1c54-4cf0-82c7-18f8a94aa832">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b59ca157-0966-4c44-b922-2203edb1b072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12b76adb-53b7-4746-81e9-b6b66f3b395c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677cf6a1-0bef-416f-97a0-cfae59065c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e11c9d8-c96d-45de-bf98-be3f0191af7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b085e19-fd8b-4a19-8ef7-75a2a1b340e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_14b9ba51-ca52-4687-8618-aa9a4680a7fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3f25543-e935-456b-bc76-6fa1074135df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_09448cec-6754-4734-a17f-dfad905c44a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a3baf0e-2dbf-411b-b020-a2de9b0020df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_547408ac-ad5a-4f0c-b307-254a70440a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5862bea5-3fec-4d62-8c22-91f359b85c16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb76ec3-366c-44c5-8d38-728ed54ff389">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a8ab2f4-2478-432f-8c9e-8f2cb5f5d630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82e14c8-843c-4eb1-9432-72391eabdc02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03284608-2cac-46a1-9ff5-fe40d306eec9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc5b8041-f904-4ed5-8244-e97962a5caac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9489f62f-c3ab-4790-8054-ad01c5b0d5e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ecef8e03-2ae5-4c33-ace4-eb88a1ddd005">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_063f483b-b293-4c29-bd55-d372d3f4a341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17042f33-0046-48aa-ad84-d9efbde7078e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395a61b8-006a-4196-bb79-5cb27b25eab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9239f57a-e9c5-4fad-89a4-b8ea2bb28e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fcfd5cfc-f4e9-4a3c-acf7-ca2702751185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff76a3ee-bcfb-4db4-9bb2-974d6c21c42a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00e7942a-8a44-4f31-b35b-6c88bd506e89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72e10721-4709-4f0d-b005-2572bb18c770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2362f3c-d255-4610-958d-0e10053bc77c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f7c9d871-1586-4d82-bacf-c192bc284e34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145bc878-e3d0-4a68-999f-86ea26ae1990">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea6d0cf2-bf23-43f7-8409-991f9ae05b48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_337e83fa-bd65-4743-8321-42b10816e5fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676e07d5-62ab-4f73-8081-8f032b081774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f58dafd0-b948-4a63-bdc5-4ede3acb6afd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5afccff9-daca-4c68-8816-fb0044885a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7134e652-abe4-43ba-a026-b7e9d691a8ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3f60a0e0-4a65-44b0-ac9a-ecaaff0568f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d79d96-ba63-41a9-9ce0-85a38c48b050">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f14d84b1-2685-4ccc-a131-7dc23a20cad0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08e585b5-f18b-48b8-890e-b58b94cbf885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b9bf5836-6dbc-41ff-9ff1-0d01024ba9be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_52ec1e35-44c6-4fcd-a770-aa08f88d7795">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4dfb00b6-e3bb-424a-8e2a-3dc0e75138b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27b64a1b-ef39-463d-9343-1468c0720811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_992ca25e-c4db-43d8-8de3-7d4236242e8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7ecc7d69-bfd5-4fb5-8431-2b10b70edd88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4ea322a-da37-4bd3-b3f6-0e78ff502bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c40abacc-9e8b-489d-8671-de0b37aa8636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7a85746b-e339-4d05-972e-ff0e3eac549f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef89fef9-47bd-4286-b6ea-a99a281f039a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c24582-f9d5-4bbf-b7d6-b61f103a44fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_efed0d03-d7cc-4f26-8ea0-45848fe13aa9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_967d5338-3df4-486c-afa3-b5e88ac715d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd19b3b6-f6d1-45a4-8dc4-0fae74d2c3a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e919a839-3083-4a1c-b235-9336097753f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7fe68b1-6ed0-4ca7-9ade-c169c8374eed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14085fc9-b39f-419e-83e5-e2cab1d55160">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c821c5d-c3f3-4c50-b6db-ac35e16b97c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ce0efe1-62bb-4a5e-9733-f1cbdf080af5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3d8e9855-b1b8-40ef-ab65-b3c547a83cba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e308ac0-5c77-4bc6-a8b5-5ec33f548691">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d75db8c-3edc-4746-bc88-43066fc4ceb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6db6bdf1-075a-4fe6-9fde-b9591bc20d23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29fdda51-879b-4420-9d67-a14259902e2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bcae2b91-06e3-4f90-a51c-142614f8d6ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b539dc50-2b2d-42cc-af9e-8edcec28839c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3210626d-f10a-4215-a19c-6e68ee613be0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05e16d9e-15b8-449a-9037-b399ae6087a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c629896-e4df-4b62-bc96-f1258ec5c947">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f6e0ab3-52d0-46dc-b58e-93c5f22bd0f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_265e5d25-3027-4f0a-8a18-975067551770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26a6c4f6-6c52-4721-82b6-3c78f69b0ee4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d317588e-e08f-4292-8aef-6be6170c335b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ace3fb1-ff34-4a2e-bef3-e579c91380f0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cfa32d7-a521-4c3d-bb3c-265306a0320d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_272e6f11-15a5-4195-8a44-ecb091d1500d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b5baf11-9a74-40d5-900b-7352ec34da1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a85f927c-7844-4f5e-9391-108fa014f96e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d281e9c5-8246-4cd1-b81e-e8ff1b538a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab98a3b9-d124-440c-9f3d-4a4884dfb95d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f451588-ac24-4bbf-b20e-8cb3da0f0c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e441009-4aca-4646-b423-3b43c9fa7d68">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a281b9f5-89f0-4a22-8d46-b194d9bb411b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be3aced-f45f-4110-b799-7588f844f08e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d38dadbb-5707-41a9-b85e-66dc8b70f583">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d937e822-cd68-4dcf-8832-87c36ed4c7cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d492ddf4-a60e-4fb6-abe4-821fd2501932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca7cfc2c-1aa8-48c8-85ad-b0a1ac53495f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5bee6c3-edef-487c-abc4-66038a4fc79a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43e6fa8b-1193-43d7-9292-dd54a91e29e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f692ed1-d190-466a-b31d-138e71b9d2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ee620ab6-e452-4ca0-9e44-9133cd745cb4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b68fda8f-bd7b-4a4c-8983-fa5e733d294e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f51bca0-95ce-4cdf-baab-e02610175e71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1f96919-4686-42c5-b11d-80413fbf695c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1175e53-6cca-43ef-9550-4f088dfd2c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44975eb4-b7c7-4098-bf5d-076229b9598a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59fb8ddf-dbac-416d-b576-ff27c78f97ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3425cd4c-f477-4c35-9414-a074fcda03b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dbb3127d-13b6-4b18-a82d-429d7a661cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff1b53e1-3ba7-4331-b32a-431fcbe569c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48d3cfe4-1850-45cf-a38f-2463e84bbf4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_132a6e57-05b7-40f7-936d-8ad215faa067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec22b841-2d09-4c40-9094-2910f9d18f47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69dee46-8d4d-4321-bfb5-695e8cafc361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784648ac-b7c7-45b9-8b04-cd52657911de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16a4890e-2299-43aa-85aa-60d568a6f55b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c85bb9e-b82c-4148-9151-33ae459b1ea5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_31d058e1-7999-4900-8304-e699855178b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f055a8-4a29-4f1d-afe4-0a6255d8fbef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bd353fe8-a348-4ac3-93ae-173919e4b699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b0262344-289d-4b5c-89fe-a2ed32b4ca12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6ea1e1a-dbe8-4939-b05c-809b216ad452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02aa59e2-99d3-4957-b768-41f796d55d31">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b1c55cf-a01c-4f0c-a008-0f4c3f91f1b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6611048-9b76-4265-b03c-75500718c097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9024f22-f8e8-447b-875b-4ca9b01d799b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e3ba0a3-59cf-4d02-8c5d-e5a6846a0eb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fad1e6b7-5f14-4853-a74b-6677b5c0719e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6b142fa1-1890-4e15-9044-a1c3910f6538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27c3357b-8a1b-4130-bad2-fc753b66ec3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a94aefe0-21b4-462d-aff6-7aa79d6af0ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_255ca98c-c55c-4369-8358-031e6aae3279">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b627ac26-6fab-4f5b-b08a-f0bc8281227a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dfeaa24-c478-40bb-aacb-337c3ba958c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_533a0fb7-2cac-45af-b21b-6bc5e424689e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7e3c55c3-c306-4bad-86dd-f8cd84a7adac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8010fb5a-ccd3-46e8-bf62-76ddb2c39d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20c7a56a-a0b5-42fc-b168-b4256f98459d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d7307f8f-a895-4152-9146-3dff1dae3a45">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a42b677d-a545-4739-ab21-0906bc5547bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fb41ff7-7704-473d-a4d0-051663aaa078">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c26a2a3-27ed-4b94-83cd-17e4c607df1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_343e6a5b-fbe6-4747-8c53-1eb52d084263">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a640bd3f-ea54-40dc-a069-ae10b7b98e8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b63f3186-9667-4c33-871a-7e97ca96d072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0d68b555-1b95-423b-821a-2d321b2e53af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_090e9885-ef0d-40e5-abb6-e43fb1b8f24a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9fb9ad9-e629-46b4-850b-445a76ca39cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0acb4c9e-f5c0-4ab1-b811-10d8c74c7e95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a54a35ca-7b80-4008-af79-e44cca11d323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dc30822-bc18-4884-bc98-f167564638bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebd0ef2a-c759-42e5-bd7b-6bedcf57e560">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0b2aa62-3d71-41fc-a067-bcdaf1bdb2ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d02435-6273-4736-8568-3ac72f70d876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9365ce5d-c4b7-46f5-b929-259b1c0acd25">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dd5b60f-7c8e-4cdb-8e48-e1f8e14d54b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c854969b-0dc0-4d52-8549-20b433c77a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2dff895c-7df3-43b1-9d6f-371d946ceb94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a85cbe00-e62d-4fdc-a20f-7a5f3429f811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7e9c7d6-aaae-4c63-80a4-c463d4186c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1550bc6d-0c38-4f43-8aa5-d2ee7fb75810">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e269512-714c-4f4b-bea4-0ec09ad3c5c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_108759a7-92be-4837-a459-530d3d469d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3f15ee8-97f9-484c-bd1e-5497a0d3695a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_581aafca-3016-492f-a1f6-1dccbe761b20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eecb8405-190d-4db7-87d2-c00a985010b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a166efd4-dc5d-4c8c-b621-be5ae04ee995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_658e17f5-93f0-4cd9-a55f-bee355ab6427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97265ab7-cedf-49ee-a787-73b89c0bea8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cff70ad0-2745-4c83-92b0-9d2674884e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8144362d-e099-434f-98e0-5c5956d76c50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ecd98a2f-c81b-4ba8-80dd-c5e870ae5a8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b462b4-2e7e-4314-b5c7-a982f303dde4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf6cbd2f-5987-4ebc-b776-19232cd670d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2149a1d5-743e-4433-b55d-4ea03cb9d96d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b0bee1d-f5c8-41f8-a196-e0055949116f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d516a33-6095-49c5-91b1-7897d6d4af68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34608c0b-a18b-441e-9131-bd56073e45d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd94ebd3-d19e-4a18-9765-6701c33c17b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2166479e-4319-434c-b484-21ef1be759eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0101d57-44da-4395-9bc3-ec5770bb993f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5eecedbf-d6e1-4a37-afb2-ca148b34a874">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b353f73-ab00-437f-a2d4-9eb81e2b9298">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1e1fb9d-607d-4053-9be3-c699b18bb749">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c9559fff-bf85-4c78-b609-8673ac1ac5b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e8b6bc49-dcc6-451a-a59a-bbb38cbe4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_62ecfa5d-20ad-4605-951f-1b1ee85fc9cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2dcdd11f-f143-4f62-bac3-2648ed438d44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72933c8a-6d75-4fd6-a111-3912cdca4993">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5707f101-1574-4ac9-b315-76e8d0bdea8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fc51695-79d7-447d-b7d0-2d441a615dbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6eac4e6-904b-49e5-8643-fa10dde8dee3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6367f18b-da16-451f-9398-4dcae9461dfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d2353b1-df8a-4d93-aca0-e4755108539b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_62bf7bf9-411d-4e21-b3a9-598f88e52265">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71909016-4df2-4de9-9017-0af613c378a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72c8d946-969b-4911-9ef6-98c84304e8fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f86f8992-c397-4968-b61b-5d1ee0be135e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0bb4e66-8e2c-4258-b9bb-9d5f6fdb68b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b641ad1d-8f25-400d-8d06-0ee76124ce9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_06da1fb2-d197-4746-8669-418acdd11ef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f0b74cf-101a-4fcc-8b7f-5dfb37885d42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61d59f3d-dd4b-4488-b6dd-eef9d4cdb561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e91a7605-459b-4d91-bef4-eca132a0fe79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_60fa5a5b-8d4d-44b0-abc2-c2c9805035d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6604084-2693-4dde-a853-88ca9da67a80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_330ca30b-c80f-48fa-8bf7-1be251e000a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4d9534a5-0e6e-4bd8-8537-bd4919ff95d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_282c0f6b-a099-4c0d-80da-497535cf380f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db5668b-6269-42dc-8cf0-4d5f1edd75bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec70b485-7a69-4fb3-afc7-ff87095266f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_063a6c89-83de-45d6-b507-d333070c2f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9dab1799-adaa-4517-977c-ebe6a16d2549">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bf0fb38a-3e9f-4346-9366-6875ce97be73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a568e818-3e12-4ef1-b0d9-5bd46fd927eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b814bc8b-78d9-4faa-afd7-8ab401b6340f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff01ab24-a8a2-4a7f-9c5b-47940f37410a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db4eff7-f3a7-4b86-9c3e-414ab37d6771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57802d22-bf06-4f03-a7ca-3c8ef8b8d251">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_048330d9-3bbb-4b3d-9923-9a39eaead778">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e79f72e-ea6d-4cfe-aa54-d9261d98436e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d30f340-85c7-4d92-9577-cd96cc2f5d1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac74c520-a4ed-478d-92a7-4f485a50822c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_820e4f42-5173-4d16-b4b6-979e62ae9f35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f491bbb-1277-4229-a3e1-f8f10ba1b923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4796e0b3-1a9c-486e-bf68-fcdf5eb1bd64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7af55883-cbd1-4b4e-a1f3-ec6a28f641e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10c65879-6984-4e77-9fa6-34c3640edd5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb403c1c-7c91-46bf-b50b-424f2bc0cfd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97c4755c-1514-4404-ba19-5e804bba3b5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c339a2b9-fb0e-4670-b01b-0bc99c288d38">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_36ca438c-ccc1-4d35-949f-54817dc7d31c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec171de2-3ee8-4f73-96b8-bafd19f04677">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4b578fe6-79bb-4f4e-9a6f-4ac9b840d579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a456902d-0412-4ee4-b228-8a714ae36878">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315b18a-8654-4766-971f-dc5ddfac8ce7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9858fd9b-b96b-4df8-b153-e34219045db2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7419c7c5-a3e9-40c7-99db-621c91281ebb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfb0ee89-1778-48e7-aa6e-c2e0e042d331">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ea1abc7-2de0-4679-8e7f-631374e6a83a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fb07bd1b-bacb-4795-9c75-8cb1c5fa83a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9151fb81-9550-45d4-bd07-4683d29009aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83940b4e-267c-4c4c-b9a9-0d9027a52d67">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9372795f-ca2e-48b3-b41d-0880ae5d7991">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b7cbc2c-e5b4-4e1c-80e7-8de1fba51664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5fdfe70-9a41-492b-9f27-da15ebba8a72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7166895f-1edf-46f1-b802-40c4c0f7ede2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f2d5b22-dc04-4ed2-9638-317a3a8499d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ad8b9f-65df-462c-a914-26b406488a65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_450e1f78-108b-42f4-875d-bdb70269e9b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c831d6a-b29c-46bb-9ec0-e8e1a95f3ea9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c4a824a-2713-459d-a73f-ea5de799b0fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd3db492-87dd-4b09-8170-de53b4ab0249">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f2cded8-25d1-4851-9d10-76805fbf0350">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_432654df-26ec-4b72-bf22-d2ed67081a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a5c821d-15ab-4aad-b751-c9b46bd2fb53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a6652b1-3a02-467a-9ac4-07e00c70450f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b023ed9-5451-4e72-ad37-cf8ed02ce876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d69413cb-36c4-45b9-96a5-197a238a21d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50bbc7b2-6b08-4a8d-a9c2-d375ef380e6f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffe8f414-26b1-49eb-bc04-f72708ab201f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf7ffbfa-817e-4a65-a0ab-2c237a4ec04e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40abf24a-4c0e-4c70-91d3-a07e95c560d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e0e0d2d2-3a63-4684-a023-2daa39568822">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef5fc63f-d2c3-40e5-a1a3-092327cf3a5f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2733bcd5-5171-4254-9b71-d7d4822da04e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce699638-1fd6-4cc8-b5e7-da5014317b9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6dd43f1f-50a8-41ae-b7ed-ce110f47260e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_19f9acc1-d6cc-4cba-ab1a-39bc6330c6bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d58c01-2816-42b4-9026-b4a864be5971">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab88280f-88ae-4d19-9293-87d20c9555f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4c1ce33-8835-4644-85bd-df6b5d895e97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfb91ec8-3c9e-43b3-b0eb-2d8d432ff514">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2c2ebdb-c362-4dbd-8cdc-106859815a67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4512872-e0b0-49c0-a886-abcec20ed4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92d457d4-5831-4817-8dd0-252285238b17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11586e77-2f1b-48ef-a43d-3c3ccee74e9d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0ffc407-f68e-47c7-ae3d-e0357444b057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_488812d8-5ebf-42e9-a429-6e647b84fa5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf5edb31-3e2a-4b1c-824b-623eda6f0d49">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34d7c069-adc0-41a7-b8b6-2031ce11ef40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4736319-8c40-4ba2-9349-388c6e2231f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_feb099cd-62e8-4b2c-9a35-31961fa7f751">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfa33102-fb3c-40b6-b982-16f1db6cabdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f158ee-3379-452f-b5c4-3e6a6e9869e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e571827-4bcd-4f9c-a4ca-8f43fc1bf1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fcb52fed-20b5-48de-9187-a5bcc4b4bc55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e556c88-b5e0-46c7-9acc-cee3f394c3d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9993779b-feea-486a-ae35-2b21258ad63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be7c3e94-4419-4fed-aacc-75ff147f2a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b834a45-5de1-47ed-bb11-411d4631e322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_783ea7ca-a48e-474c-b2ac-d904da9ca09a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e96c03c-3d23-45ee-aca5-4dc6260b00b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66399c4d-6f60-4c2c-9275-23fc994898b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86670c41-42da-4ce3-8823-8c140a50621c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_846aed1a-7886-42e1-bff0-9c1d20867b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ac9a23a-c7b7-4368-9495-6a79740ccdd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ecc55ff-bf91-4ae1-a6b3-ae84c0f5a1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e04f8a12-64bc-402d-8135-fde49c9456a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2532ec3c-b602-428b-add3-c397c469e629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8747ee4-c3fa-4da8-9f95-523edc656e56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70e32c10-3c2b-439a-80a8-67794b3a501f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd59329e-ae4c-4ea7-a16c-1ed5ae6986c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6a44534-92c5-41c4-8e55-f21f2746c102">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39113052-5b6c-414f-8b14-c45da77d0961">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4becd58-5c0c-4842-98cc-22eb03b299d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c1270b9-bac0-4dc8-8577-5e54ccace42d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736d9926-2933-4786-b3f9-d831a26d493f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea268416-1911-411a-9871-a5e4e0d8532d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_810a4f75-02f8-47f8-a59b-bbe4a9e9fd32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_645391ee-b5b0-4663-a5a9-219880d387d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac44bb69-b7c8-4510-8e7d-27713ec34d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_617803ce-c01a-419e-bdc2-8ad91881204b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5a4dbd71-77ca-4909-a368-d4199225e92f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d0caaa59-77cf-4704-a71a-5771f0f65948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2dadea34-e273-4d47-bddd-e5811a5f3060">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de945cfb-1c19-454a-a288-3631d0d33d82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91a822b7-c670-4873-8a6c-60b180b100ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4c9a7e6-05c0-4b9d-bfb7-f0df1a033d94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8db43a7-acd3-42a5-a4f9-31bb793ebc41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec950292-2658-44d0-94e1-7ab461b27707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd883edc-c0de-417b-b378-06b106f94a05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_abcf9ee5-7753-4307-9a56-b119fdd62d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9feceb23-85e1-43cc-b4a2-c3e2465caa9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_15685edb-292c-4afd-ae2a-40d35a35ed21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a8c3fd-df2f-4963-8b4b-a55141d2956d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17092b96-3f07-4c32-add1-f029ffa6a018">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4dd4bcd-df20-47ad-b0d0-994799f393b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_734f6749-fc85-4447-b206-97e1b9a6da60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2ba4c89-a65b-4ff0-8ec2-1cfc6ba62415">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe36402a-ceef-4899-8e68-563a5528ef41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18ce150f-356e-449a-81f3-c71920e26569">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7575bc2-040d-43f4-8b66-98a8736a20e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b49bd25a-dae8-4ee3-8034-79541d1f2b19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ed6cdf6-03b4-4d44-bd05-cf1415e2e538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7367cd2c-ab45-48ae-b600-1b361ed30b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6204fe90-8afe-44b9-9daf-b27d4d1e054f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc1cbce3-d371-40e6-b379-af34f2e14c8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_070caf31-fafe-4ad3-bb49-81f0d801fe0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fa8b508-ef32-436d-a22d-2f1566b4c571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c6db05-c475-4b69-bf7d-98b2f77d0c30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0b69b9b8-0a43-4693-a724-ee34791e2049">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd7e3f-68ca-40bb-a4ec-bc4d38416f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51441483-9728-461b-ac63-30e57f41518e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be873af8-4dd3-40c5-8167-d27d925e3573">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc2cd4e1-70fe-44f1-a685-6439199241fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e9f43430-6b51-4306-99fa-e543c431f3f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f63b05d6-b2e1-439e-952c-63767d0ca702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4438e97-ec0d-4908-9114-7d6c48f89284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25b2d034-7d7a-4db4-a467-987c5b19b4cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_24b6307d-23d2-44a2-95f2-4f8d39d70e0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06334274-246c-4230-893a-302a747331ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_193894af-6766-4066-8dea-9fb9ffcedd4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c5785d7f-56da-4e61-83d5-2f18adb7b233">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66c811f7-adff-4a4e-94a1-b8038daf18d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b21b057b-e4f5-4cd2-90b1-32617e981260">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2fa674ab-5a22-48f8-aec0-6fae8dfed969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bdafb8c8-a619-4936-9f6f-79d0767617eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bdaefda6-56c3-4fee-832a-c7b1abfebfd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a74705c-5bbb-49e1-926d-d4aa5c52ab36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3becd1c-277c-4d5b-88f4-9c355ee975e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d486dc1a-d28a-4880-be97-4814c9a25b7a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2943a5be-cb31-4d8c-ad96-227e0193ace1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0853d553-a35d-45ec-a9a0-0d8184f76a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76b45095-2687-4271-805a-7bf60ed3551c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ec6b68d-ba61-4c55-b09c-bfbdb80ebcf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85214598-6383-438e-a4d2-ab029b7530e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc5543ec-b224-4bc7-9eba-a827e3058465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f733246b-e52f-4ed1-88c7-aced475bbee2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d86a131f-8960-4881-9ff7-7ae1a6d6d354">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0177aba7-d4b4-4e75-8e40-62222b87bf6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7742836c-da33-49fd-a00a-cc7e0321277b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d4c4a91-3ac3-4e24-903e-8ed844e5dcb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_512335a8-1004-4cfe-b462-f7ac341eef60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b4df3c1-a13b-40a4-82f5-66f82deb2cbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ec66737-2300-4657-9389-6282cbfed896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_710e51f5-0e13-41aa-ad39-0e6e38c4c5c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8e247e25-f821-4e40-bcc2-84579384b6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a36c16-7af8-49e7-bcf6-503669668780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d296778-ac03-4544-9620-df7302d93702">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ce08e898-8a0c-4b22-b375-651840464974">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8f229ad-ca28-4a4a-8277-eae642c78a9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5a98d74b-051b-45b8-864c-5bc17b868079">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_935533c4-c8b4-4d12-91d1-e357e32bb1cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee8c3a5c-d53b-42a6-84a6-d109057f66f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6e4f67c-da26-43bc-81e1-d91efef4bc0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_985a89c4-0962-4b76-9685-1cbb1b755fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e181c7ce-9b27-447d-b60c-7bf20fb74fd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7ca85a2-5dec-4379-924a-7bebfcab592b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b87135b-9de3-4278-936b-77fc18f47f98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaea47ae-5e05-40b3-9f34-6f857dfe9902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d4f4a91-6e54-42b2-8f8e-0b9c478cfc4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a799f946-7cb8-4538-a661-ebc68828235d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a5d488cb-2a2a-4f74-bf60-4a7c2afe5167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ab32114-c60b-49e4-b16d-59f43ae9b429">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d9ceb6d1-ef81-4fb4-999a-5c4a09bbda2b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_79a6ad94-a07b-447e-85c6-61dc4e3f2c41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c072731-8b09-473e-b65f-5d1c595f7d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f8545bf7-29e8-488e-8f7a-27d45dd27584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_001e3e3f-9f35-4adf-ae09-beaf7310f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76f3cd08-a9cf-442c-b664-7ffae80f34e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c8477581-f647-4fd1-bc0f-38da40a5c34b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_941ef755-9542-4b5e-bf50-bcc38e4e3e0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f65b7928-e759-4f20-96d0-03563432dcd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3c9d70ef-69b7-4294-888c-a1db7a6cd16e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84e2fb08-9c7c-468d-99da-88aef49b8955">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c6209ae-c301-44d9-a9f4-39e503aeeea6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_35d6a3fa-41cb-4def-a6f0-02242f07cc8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af3599f4-876f-413a-9e2f-61e4f97cd772">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_925cb008-fbf8-41b5-bccf-a9ba0207496d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3544d101-9166-48bf-8d7a-9830f8bd7e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c4961b0-db79-44fd-b894-3e3ca701e148">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_751f3c0b-38fd-4d93-92c2-210d657c929d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ad3d6235-3931-404e-96c9-eefea6cc2a51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_15f6523a-a6ca-4929-b2a6-797fe5165942">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_607ee7c9-c194-4980-bbeb-4871d045b117">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d595630a-5c38-41ca-8d89-e6de86401784">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4879caa-544c-436a-b481-ca7782fa14ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d468b176-1c1b-4e70-b89c-cfdb358d12c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39e8728a-cf2e-40ee-a6f3-60eeeb2b3bed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99a7243e-cd1c-4944-878f-353803f16173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f579bce8-a5a5-4af5-843f-b6774ebdc50e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e7e06c9e-85ac-467d-95a1-dee3fba2db7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2efd19a3-19a9-453b-8a62-1358a678e54f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_50cb2407-1a48-4d05-b50d-0eb7d0fe0d5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_59921408-ed5f-4010-8874-8c7cfc9cb99d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a6832ef0-2d40-4b67-81ec-7a22195700d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d14c5eb-de52-47c4-8527-6c2d90f6ba09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4257e0c0-571b-465c-bd0d-e6dd32b83599">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0fd26d9c-7a97-4480-a4c9-5927169899b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce509f30-fa28-4fb8-b93d-2e7d0753e01a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06be5c7a-6d6d-4bda-989c-3de94c0ad642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39381952-7a93-4505-b431-38b454ddf896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d75cbc77-7b81-46f7-a818-c80eb0b51a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2aed15b5-05d0-46a5-bfde-aa18a6e58bca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff83925e-7032-4d39-808f-131c849e3c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ad21880-4865-4369-a402-af2fe2d06469">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_823e97d4-6e60-4330-a062-2dc6dbd6aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7de33c3c-f761-4510-833e-4e658bb155ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bd21b61-bdd0-4bf4-baec-1df6fb7aba04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e097cc96-68b0-4776-9baa-0e05ac6d2079">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8f842892-67fe-404e-bb86-ec52099e76bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_369c7b20-7a1f-4e27-b826-b22fd852f92b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d3f27b3-8901-4993-a783-1c5cc360e39e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cc984ae-ba96-45d2-ae4e-36e988202551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85b55d99-54a0-44c9-be12-73aa01d85025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9438622-ec39-4de8-8bfe-8b7a7acb728e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2020f19d-8579-4c6a-bb85-33cbcf9c80fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2512e2f-f697-49c5-88ed-472ce66102d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ebfb91ff-e57a-4c99-82de-0f5c7bb20361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77f21387-12a9-4a66-a13f-3650ea2a0626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be648bd2-646f-465f-82d8-fc18fff2565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0d9d1f9-ac28-42fb-a3bd-873d848c0bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c1eff410-da05-4ed2-8a83-6d72a5b1ed9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f36d52fd-a011-4d3f-9886-ef1558392dd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b130e0c5-4e18-4c5e-9630-96c1e8523961">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3d60d422-5a45-4fde-b96e-83fcc351399a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71dde336-035e-4993-bf5e-ff65d982884a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5fc7015-c249-4da2-b59a-fda46e003a21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c25e18f8-ca13-4e18-8e6e-106713a05817">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003ae024-12b6-41bd-afb8-dbff8fc0716f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1fd2a69-ab09-4a4f-8e0f-1b3b2a7ed8ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4b5ce0e-676b-4e14-952f-0e70e5eec005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cabaaf52-7fc2-4375-b423-17217e547d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bc43aea-edf5-40ea-bb93-360747aaa871">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_35f390d0-fc3f-4dae-a334-b28e27ecd4cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d09ce77-c1a0-49c5-9da4-1743097d6b5e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2f12e17b-a03e-40bc-9633-3b062f903a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_befafd88-9e45-4aeb-bc91-72989f037361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4642aa0-952f-4c0d-a380-67e9ca5798c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_19ff8aa3-4c9a-41fd-8b5c-fb88ea00d914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23992233-1625-467a-afb5-7c7db2154274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d18c73c5-9283-456d-88a2-ed56c52068f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40db0b6a-2fed-42ff-b3fd-4146ac3a6b9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab9dcac3-38d2-4998-ae2e-743e9e93dbf7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87844dc5-0f00-4fdb-83bf-4df6a5a66c00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_397a5ac6-c21c-41e8-8bc3-37030f7791e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_46777efc-f783-4fc1-91de-03444ae43579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cac650bd-26a7-4597-8d04-f5210c60e5d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c7661b-773d-4e82-a011-20182f0d879f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72eb8f4f-06a8-4acb-8749-7c2c83001667">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0591bf58-eb3c-4ea5-9379-1dc6ff597412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a6ea8c7-7bb1-41ac-98c8-ecf05ba41d55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e35d55cb-7309-4c84-b62c-24c5701faed7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f22fc970-4d7c-4dac-94e9-f52e0faac4e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e70d3d1a-6c78-418c-97d1-03544787f442">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de1d2205-000f-412c-a692-27e23e6cb8ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d7a2c8d-6bdf-4432-ba34-64126abef849">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_14dde051-a9ec-4ec5-9832-422934488527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13f572fd-94dd-4eed-8ef3-ace0e748a2af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de08189c-2421-4654-b7cb-107162c73d63">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3a29e1c-911f-4564-a654-c6fa2f73900c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b0a3b7e5-2272-4789-b17d-9fc98ce6b190">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676d9d34-6500-4af6-b5b0-a64590ebdc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28831048-7986-4d83-9322-ad7b45aa6979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02c24ba5-c256-4bb1-8aca-18aaf5a4119d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cda097e5-c55f-4370-8046-a22566d23aa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3db309f7-b0f0-438a-9619-158dcf92e77e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7f5cd2a-e199-4fe4-8a07-000b61f6b849">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3559ab6-f11f-4163-9018-fd2d381786b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7080f5dd-d253-41a3-8978-1acb7fb725c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec4106bc-ce58-4d3b-8e92-880efd0b1664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10977b32-fdb7-43a9-ae61-93d4bf8d7afe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904d3954-8cda-412c-9749-e8bb17d66a92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0111008-7282-4c97-885c-7fab48bd8436">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_876454d7-7628-4133-9422-2ca5424ca361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9ff15473-2981-407b-a9c4-b2fb35aa3674">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_55ef1165-5526-42a2-b3bb-e8ec92717df8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c28c5416-4d5e-4bb5-abab-96a1565edfa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d927603-3d20-40ce-82ad-83b83ee19f72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_229408e4-2c2b-4574-a315-b735a27c779d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68082b8f-1b58-448c-b179-bb3cf663ae68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70edef45-f5a6-4dcc-8ac3-0ddabf759635">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ad9b069-1fed-4ad2-8270-2d803e8bb18a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdf583c1-b367-4df4-aa13-61564d6ab6d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92c79159-1d7a-40df-9703-3a5db5829183">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dae057b6-7b1a-426e-8e5d-2acbe7a43672">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd8175-e9d4-4ea7-ad36-55850bf37124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fa57a151-cb4b-467d-a0e5-025f0e879340">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29fa0b37-8927-4e2e-ad4e-fe8ace32f522">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372fb999-5a14-474c-a762-df4ec45be325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59a4afca-74e7-42f7-8568-57ad4f7f5a7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eb5af546-4e64-4615-b4be-c5f84c5afc69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e2e577d-945f-428e-96c0-85a30ddfb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc4aa6d8-c784-42b1-bd46-b5a7b0fbee37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ab4e7e3-cffd-4fb4-9903-775b019afed0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e958a796-f688-4058-ac62-e7ff354a8b2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba240b0-4442-4e3c-9b12-92037859dc8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58cefcd1-4074-4f65-b238-c8bd2807bb62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b7e5f911-cc7f-4035-b405-dce36c696979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b105dbf7-08b4-44f2-a809-7659b9b0c0f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dc8c8d-842c-4d37-9ddd-729767e27b17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a87b7beb-c39c-4b09-81e9-5ac4e5d6dca6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c5a9d89-ddb0-44bf-bc81-169851dcd038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ae060b4c-d898-4866-8934-72ad68a61d2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ff2d666-0eca-4c6b-909d-de8c8dcd5ff5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2416d8d-eb9f-4c0d-992e-584910dc95fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13563e1b-bc67-4100-a744-0b15bdcbc8f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b50e0e0-9880-458b-8ec1-df2b45b77707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3003a0e9-678d-4407-8d92-8ef9f603d17f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8927687e-896b-4610-9f61-0ff4ee7f0355">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_836cc85a-d634-47ce-9f91-cad257677a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9185dc-ee0f-48c3-be9b-0999eccbbe09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2608e084-b64a-419d-ae01-4b6cc1e71585">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_167d679d-7fd9-41f8-9d06-caa39dba4d17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f458e59-de2f-4f0e-b34c-3964259cb7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e60f6916-d41b-4f3e-9e12-d053db17fe84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d5f4047-8216-4d31-ac16-4a9a054c9322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a3bcd38-457d-4fb3-8e07-3bbd70861a2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_208ee53c-3823-49b8-a07e-4c96709a6290">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_132fabf0-f06c-484e-88e6-745ec73dc90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d366858-cfa5-4734-ada5-a1d4e1de96bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73ae19d9-1ac3-4fed-99c6-6a4638bb06fd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dbff479-ccd2-4bd7-9d0d-d7699ee4f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3af795-f0ef-42e6-bdcf-5998074e2330">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec7efa15-a618-44c1-9777-6d7d98c12e77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_105b771b-417b-4b18-9aae-2edb5c322c6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e02995be-5319-4997-89c6-0baa13af4633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c61435e-e1f9-4541-89e2-6263603b3b69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dff476e-df06-42c9-9efb-b4090eccb100">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1efff4-9a22-42b3-91df-2c842ef69d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_23c32af9-38b9-4c72-a024-eaacce4cd25a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67c313c3-0537-41d9-bf5a-0ce46862778e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c78abdb-f124-4796-b624-ca207adf405d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6df2135-d56f-4ede-ab61-32537752244b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bc5c2ec-af4a-49b9-8349-b9267dbb909b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4f648f4-68bf-4e8d-a158-24c7ff934d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b9a43ab-5f04-4a70-8105-4d1d6dea5cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07d9c908-2ca6-47f5-9b54-23668c13aea1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_188820ff-ff28-4597-8755-16e1f383ac16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92ae4c05-9849-413f-9950-08e73b719f53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3e291d07-59ff-4e54-9816-99637c944ce5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e993253d-fa2e-425e-8a54-ab9d59eceeb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bb91660-0de2-4d77-8dc0-b2dd97689d06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0be57c-dc2c-4fb6-83c3-f9dbb5bedcf9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe303d5b-825b-4378-83a0-91aad62189bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97347a26-0a57-438d-8632-a5da61335545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc4d10a6-b3e1-4e1a-9417-a6a54c099ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53554a66-e2ec-4121-a84f-bc5f58c3a39c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81767925-5b0d-4258-9684-c3609914ad4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_190cac75-5579-4ffe-844d-db8817b5c500">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8714d145-9c20-4532-852d-751b41958aac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904f003e-1ce9-4007-aa9f-00aac3c62a98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_214096b4-1ddd-4b94-a7c5-67cb764c0a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cdcc05e-df32-4ee8-b7a5-cb1f696db621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e32b1e8a-316f-47e4-a283-9b8dd0642e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3aece19d-4dd7-402b-a8d2-5d26d7ee3b39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db8c2187-33e2-4116-ab89-78beab00ea57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_78ead1cc-f404-4ee7-9fdf-ef48535800a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_22055254-fa36-47e3-a1a2-155d0a0cc771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_557a2416-503f-4222-9308-f18bccbd1d01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2470f09f-6853-4749-9034-4f203dd05145">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71fccfe4-5391-44df-b2df-5d66fde7db4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c091e57-8b19-4353-8d4c-313ee3863561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3cefb57d-57e1-4e3f-903f-69749aa540e3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f2d8a7d-95b2-4973-bef9-175379b439ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7f34bf2-27c1-481c-b244-d5bf555288ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_072343f7-33d8-44c6-bfb3-86f4b517797d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f53ca695-3ad2-436f-b57b-a0d82976e489">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b72db782-c1e2-47a6-bfee-76d98a50ed7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285196f-6ba9-482f-84b9-7bd3923b8e05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9c86c4c-2491-4427-ba0f-710ebde97af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec3d8a3-15ad-479d-a33f-5c01230dfc8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7d59712-1642-4092-9ee5-f67caca03a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f4c0f5d-b870-41b8-b34e-293e4d986355">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dbdc2b2-f9a3-4c59-b067-f65e01e1c62a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_74ea36c6-2edf-4166-96d0-d0d8e03ee4aa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c8effe0-03d0-48cb-a537-7a5e9e2809a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90803e77-364e-4047-8ac4-d4d18032eed9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_82adc907-8d3a-4b68-bb4e-6a74b4c9e7f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7306d11-ce28-4c9b-ad6f-e38fd8311161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5f35c9b-8ba6-4cc9-a4a7-30b3c05f361d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d94625fd-9209-448e-ba9a-d9419e7c7184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8621c35-abc4-4aea-8aa1-7c4f318308e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afadb174-03ee-420e-85b7-2cc1b03b5fc9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b9f9fa5c-16be-4030-ab78-85df203a3689">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ba01acea-929c-4066-b7f9-8a44679d7278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_868bdae4-132f-4de9-80a9-235a2f7649b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c93f0b0e-710f-45df-b479-efe99898bc58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4d7cdc2-47c4-4d81-8813-1307da791074">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c182723-b6c8-469f-8368-664cbe6c5ae9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a826a3e-f47f-4547-bc86-8d5c29802073">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71d7fc82-41ba-4769-aec6-c28a028c24f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6f20f8e-1d3b-463d-bcbb-74e286d08e4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e3de8b-6459-4ecc-9a7a-f07ad5e41dad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51015e38-eafb-4bea-8fda-d7254a752591">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7f865691-09f3-49ed-a046-6a9f927b88f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb298e3f-8717-47ae-8c74-0352837ea9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e34a8420-47f1-45d5-8a93-1a88750c93ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cc228ed-7b17-4a46-98c9-9b6dab5ecdab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0e39-4dd1-488c-9f42-261213615c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3fc35f4-afb3-4be8-9042-80c22938c1da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7fae11c-5433-4dea-8daa-573036118c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f8d7f2b5-d937-4798-8f49-2f9d6d366a37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_61654344-ea9d-47f6-bc0f-4c1f512f6460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71e972be-0b67-4baa-b9aa-d2af29f81dd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b836030e-56ce-4bda-a621-1cd3898f7a3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8905b57b-c2f5-4004-a604-898087cacd6e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c31d0b56-0d49-4611-bb21-4da3c47be957">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e12d10a0-1652-43b7-acff-b94dd8e81d99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285cad5-6de7-4403-b3f2-3cc8618a8428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62f45f9b-4214-4227-8a3d-8ec5bf11c1bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27857a57-dc46-46b3-be78-4a3e508faa27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_97ef7eea-fbed-4cca-8155-059d768bd25e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aad83482-c91c-4404-b6c5-2e4b0cf2c430">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_741b144a-92be-4316-a667-6d77127a3c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e783a6c6-9325-45bf-ae94-3e58253dcb28">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb5e5403-2a79-44a4-9175-3e0c6cde1a7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6ee4820-527a-4806-9ce4-2f0d42f31276">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dd1d63-111d-4dcb-a900-09f637cb1718">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70cd53c9-69bc-4bcf-a3ac-4e7ac464b1e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f3ff468-9121-48f9-8210-265dc8d4bdc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56f4ed47-0029-4843-ac3d-c989194a4f6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f57fe36c-18fc-40f7-8f07-d908b0a444e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec5c7335-88e4-4853-80bc-bff5cc1fec3f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c90725bd-093b-456b-b293-35b3d24e93e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b8b82bc-e378-430a-8d32-a757dbac9654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315475b-5bda-49ee-857d-d4909e35ac00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8605a6ae-08aa-4247-a681-37bfa08ddcab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_947b0817-ebfb-4448-9e46-1b205c39cb36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06dc1e7f-54a1-4ca4-9bae-106fa4fc0b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_34fba600-df3c-4444-92e6-44820bb53700">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d5b75fd-ef40-4687-9465-b9813bff0c55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12f3da88-6382-4ee0-9944-8ee455b9d12d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b80ba0c-7c2c-4247-9376-4d6c8150fe09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b246ab5-1854-4074-a138-ced059858bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9088e061-ab8e-4b2b-9c0b-b84ff5986524">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58ac5024-a283-465d-96e4-3958b4e5d587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_113e04bc-404b-4a53-ba47-2aae867c3bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_025d8e4f-7965-45cf-98c4-7cfaefcc2b38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06847793-4f82-43ea-9d81-98aa1e2596dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77a92fc5-b352-4ac4-9526-2c325a319aa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f575e4-4d82-41ad-a7e6-0c4a89a7846d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74525261-c7ef-4d31-9b26-15b564328d3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c95a00b3-90f7-4ae0-94c2-50696538217c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_707a27cd-6e44-4b2b-aeac-ec7fe86c87a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_acde90a6-1736-4d99-996f-f94f40387275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0de56081-b8f4-46b2-a104-342f7c06f81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06b6e45c-cf6e-49e4-85ed-66b9519391e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ade7d271-d264-48f8-9f66-84ae1e80ef77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35fd6ed3-a06a-41de-8588-3d779ab51fb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c861879-751f-4428-a068-75a4aa42e588">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_220d4678-9c77-48ce-aa02-b302549280a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_235615be-43b8-4c5b-b4cb-14db7ee8d61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5226f2b8-6339-4e7a-b351-7b464c9fcd25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31e9896f-9c68-4f37-8acf-d2c43cb44200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bccf7bb5-9fcf-41a4-8cf5-b5cf08d878c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a07fd55-9727-4c3b-aab0-14051933c782">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf5a4f02-dffe-4020-a13a-e045e31e4aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2efd1a7b-4bc5-4856-b2de-bcc27f4a2cde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0a9a1b03-c9e8-4187-956c-bac2bf1926d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_353093f4-bcf3-4890-85da-8c4aa9d6d6d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b6d2fa48-1a37-474f-990d-10d2d794bce6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_13574538-536b-4538-8e26-c6241ee2d5ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27efc09c-a8ce-4383-b44b-a4400909f8fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8b00173-49f3-42b9-bcdc-567771ef26ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c24f1de0-8b83-4a10-b680-d7cd903045b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e12f605-dc64-4ca7-bbe2-8b1a99b0e82b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acc178ac-8fb0-4df7-a38b-28fe75a170d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_49ef34e8-d89c-478e-806c-58fdfff64426">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6c25f839-f61c-4929-8ed2-75621b54683a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24a54926-5757-44e2-b82e-671a97a4246d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3419e66e-ddd7-49e3-8c10-6ad6c5f5c49d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d0a4264-7e61-4421-a1e6-90882ba91d0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95d6b06f-a866-4954-98d2-4e1f36a7d499">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5f288ec-4c79-4843-ad2a-10afd29f69e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4946888b-0e94-4c37-9f66-56b71e7e256a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a30cb194-1934-4fc5-b1f4-a49039bf46a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f58e858c-6f20-495e-9732-36ccfd05cf5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d61dc199-1ebe-4435-bbb3-8701fbb7df76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0acdfc8-d22b-44e5-b98a-e3beb4bc431d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_517ca612-cfe1-4358-ae6d-b05efa7f5171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6893ad1-b526-45a1-9b4b-82de55b52fcf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7618e19-9e6c-4a93-a8e5-7c0a3ec3f2b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4838ab73-e852-4a4f-8e14-d36cc6dde894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e64818e2-9253-4d51-ae0c-81d112e2cd5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c3a36588-a846-4a37-b181-afe3af3cf915">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_714070e7-1af3-4863-8885-8920f896f2f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_05372493-820b-4768-b6b3-b06cf4c88040">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2e0649e8-ae5f-4146-b539-55df36ed26f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dbb7f413-9cbd-468a-b57c-023e980826b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f829759-3787-4e7b-9c49-51fb44f490de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6586012-dd0f-4349-81ef-057a9818e91f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0551774b-ab93-4cf6-9afc-3f49ff2e5339">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d90700a-b751-46d6-9883-1afa754ca728">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ee00881-e663-4ef8-8e61-5a9d373b60eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_029a4186-6f37-475f-b0b2-d4888ec78456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7417b3f0-f39a-4da3-ad99-a0c5acd31dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7bf60b21-3cfd-4c15-92be-de3bf3987969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebe2830-5530-45ee-bca1-03f80a144de1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6857768a-9ce5-4491-856d-121d10953832">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45b979e1-6499-4853-8bae-ee72dab68308">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cd8ac52d-b2f1-42be-a279-de43a535b633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_318892f0-18d1-415a-8a4f-12e16802ed01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3896d698-274c-4aa2-b2dc-85550339e7e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0586ae6a-a2dd-42a2-8280-def5212f1885">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe7d3d87-0991-43d4-982c-3bfd6eabac43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67fb0682-a5a6-4906-a36d-cfa2097397a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d83d8c12-075f-48b0-b5f8-38259d641027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d886ae8-6347-4a11-965d-4486a842b72b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c1ec08c-6b4c-48a8-bf02-006c60e178a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37d7a305-3c5e-45e3-9792-0aa39d89a087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b89a5862-62ee-448a-adfc-b98dc77a6c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_466e04fa-ecf7-4c12-a305-5264e60badfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e4ab9e7-323b-4168-af5d-6cfe6914e92a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_782b4c70-97ca-4ac2-a57d-c1e49802e962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47c94546-4aca-4eac-b3e2-0f6ae04baba5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bfa323-d130-4b02-af40-1743043ef9a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_365b45e5-9725-4467-992c-44a30aa3aeb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02fde0e5-c682-4a0f-9691-475fb76be114">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5a0d3ee-b330-420c-85ff-dc7216fafbd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_370ed0c9-995f-45bc-91e7-b340199efb75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97f67aae-d210-4862-8d2e-78e4ee1057e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae5e385f-d5a6-4333-9bcd-13f60268cafe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5559d554-2049-48cd-8104-20ceed7b4686">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ba7f2c25-8fa2-41f5-8355-8beac83b5a65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_408d47b3-1f97-42f6-b331-0d61e5f90670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_965d13f4-485b-425b-8dfe-c897500fdf2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5b6d87d-a141-4762-80fb-6ade51c8d259">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a63b1ae8-cf67-4f81-913c-0470719183fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d01c2bb4-c8ab-4007-861b-449bb235e3f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b221fecc-3f56-466d-a7e0-7ede7a1aff0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_42d8d499-e591-46c3-96b0-0fa80adbf923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_18c74b81-234f-4bf6-9d2b-38816c082d78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed2cda40-9e01-4b05-a44c-17e790367156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63c6dbd4-a478-4642-b02a-ec6a5bd2d82d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c05a0e46-1a0a-42a7-8033-274b947fad1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_49ffe632-11ab-4d04-b22e-1a7de4ca7746">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c0115ef7-fd26-4d5e-b841-07d14b72b16a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_beb12705-81f2-4cba-8b89-321726c2ba08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_808645ff-087e-45ef-940e-26389858902e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_236ea25a-9487-490f-9886-1854ecb7dd5d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de290528-0feb-4427-a306-11c0789ad3a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c31e8fd-473d-4142-b1ef-a7741eaa41eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea5970d0-fe70-4953-8353-e1f908f04833">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cb01ec5b-3693-4d3a-9bbc-7433afe2c562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b906c8fe-3028-436c-a6e9-ebe0aa0bd0e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc43effe-3bcc-45c6-addc-8790363e2e81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4bcb575-87ea-4553-9bb2-c6114aea6ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_574d3b76-05e7-4206-b43a-2406be300e73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e809161f-b94e-40e1-aa05-c26b5db8319a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90532d5c-51b7-42e8-b997-7cd3aacb3b01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89ed2c1b-8753-49f4-a90c-1469a1db2d6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c321ce94-d20a-4ca1-ae56-0e345f8d8f39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d1b4265-e043-4df1-94d8-c9b3b2a2d74c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6ef71c8-d16f-43a2-a67e-c3f882aa5898">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d291384e-072c-4e36-ada9-1d78743a5f17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb70152-e11a-4835-b3b8-9607ee61012f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b347ac3-f5b9-47b8-a5be-86112eb518ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a1af822-b372-4f65-8a5a-fb7c2bc9fa46">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70bc8a62-4b3f-471c-8f26-4de6dcb587c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f47ee7a-dab5-437e-928d-f5fa1a931021">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_37259d03-2688-4269-b724-a019708c03c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ae7edf1-44ca-45bf-bdcc-b9f2db3d3383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a629244-1958-4b39-8124-9299af3f90ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25d6bfbc-0406-4021-a7a3-eaf27c8bf87b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbaa2b91-19f6-4276-a1a5-bd29c05847a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92cb244c-751d-45a3-a4df-744118e58171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34f3366a-08b6-4ff2-8d8d-25bd186e23d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88ad481f-2dc4-4bed-b6ad-4eb45eff8c85">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_073bf8d7-6f1c-4bdf-8589-f3e7118b1419">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15de3a48-a951-4860-bf45-0a7d3e496232">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40f29c78-d193-4938-964f-009a195cfcce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cfd8928d-63f2-491b-8f99-7f12bc865a43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a21eb818-fb97-4531-8b5f-fb94643421b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0bceaa1a-cde7-4481-a6ec-fc1f00e4d173">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dee9f7f-ab45-4ad1-97a5-1ed775bc0a1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d87472d-343d-4508-af27-99ba0013009d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76ca6183-d22f-4b08-90f6-608c23ae01e0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89fd8582-7f8a-4635-9309-c36ab173d8d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e54502c-3e0d-4961-a3f2-e1a19f9f15be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bbdd559e-0803-4e99-b9d6-73d9343ea7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0568054d-a321-41c7-8ae0-7f3e4e6d6efe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae5c783-5004-4cb5-902f-6c2e49f16d2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e65738a1-a385-46d9-bfb5-a85aa03dd1af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db28d434-76f8-4140-b103-101d760da602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64e9f5fc-90f4-4b7a-aaf9-87364ee47047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2fa69bc-0690-4b00-b689-0c313b529130">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2310d678-df3f-4460-9315-9346518888c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42a60441-ee00-4407-bd69-61ce56d08585">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_999e6491-6e9e-41fd-bd90-90ea018661cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0d8bf12-31cc-4ab3-a046-31a57efa5aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f192d0c1-711e-4760-8b00-fc1b798d7a02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc53a16a-a3c2-4f8a-8b0f-fd3ee7701b92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0d478a92-27c8-4122-8f65-e89167e50c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be723ea-f9a9-460f-88f6-f6ce88b9adc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3707ae37-c9f8-4bed-9e83-767995f2904a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f748d44b-1f22-4a0d-aac6-e9abfcd344d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a040a884-edb3-440e-8118-8473a3c88c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_12360317-55cf-4c68-86ac-bb6d7454dc66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_792975a0-5c5b-4c55-ac56-01684e17cb4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21034b29-0370-4459-ab1d-d54d10337173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cae54e92-78b6-443c-a94e-3808610aa607">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877f697-fbf0-411b-8b70-de015b64ed2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cefd7b3b-3bc8-414c-af54-efef4551a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80564bd9-c46d-48a3-9ee0-fe1d044715b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_470d84cc-b496-47b1-997a-3bc5b2898568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4b700d6-4419-4e60-96d4-f054f596ebb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f829f61b-477f-45d8-b5a4-cb19a3097682">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a700bfb5-accf-4acc-aef6-75b5b4b9d283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c319766-eb32-4975-8ef4-5ec8b325c3d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6572c581-24a4-47a9-a39e-74085116d4f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bfdb9f7f-01ce-4490-b1ff-42b5e2cc0317">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebdae831-2ebe-4c64-96e1-7b91aa2db64a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2acc7925-5dc1-4c32-a264-f384326d40b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67d15e4f-3211-47ca-a162-20bc863f456a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c17ac3-19ad-4a74-8105-be69ace57902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d447f6d1-7ced-4a18-b489-a848ecdd8f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_82a2c0de-02c4-48cf-a2bc-43c3b43f70c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a799c07-5afc-43ce-b6e5-07bf3ed01299">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23e5c5af-5021-486f-9313-ced0a3c0f78e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a54d4bb-318a-4594-accd-f73e0717c332">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30418a78-e345-4166-be71-c6811a5139a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c5983df-c5d5-4543-aa10-8c9d879a6374">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67dc3e00-7773-4b9a-af3a-8078a00423ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0c34f271-4f47-410e-a4d5-e6f3c8be9d05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_715f00f3-4358-445d-9f13-346e0ef19af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_493944a5-fdaf-4639-a919-4c5e720a062e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c822e6e-dbec-41ef-87fb-3d352bf3b4d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9fc9618-b87a-4744-9548-0d53ca4522fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bff94f8e-926e-467d-a828-c9f16173009c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edfb58f9-6d6a-4008-946e-e5b27b49797b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b7e37f7-ad7c-49a3-be0d-d7ac833b23cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aef1682a-ad01-4e95-8f68-29f223e6f177">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3d42bd6-cd90-44f7-839f-9c7d6dfe9649">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b68c57c2-3f55-438b-8c6a-3b9dc7666ef0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1be73187-7c73-4469-a943-23ea7399b3cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_967043a8-1caf-4faf-918e-70fb1864c57f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7dbcb3f2-427d-491a-a73f-b8eab7746d5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa6059d4-f302-448b-b6fd-62d762a2997c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_19697a59-ebbe-422b-b0d1-4a07469d2c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3009951e-b1d4-4b82-a877-470a516b3361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1221a04-19b6-4b6f-9cb6-06bed845b81e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f70cdd53-344d-4c70-a11b-c4bb7c9fea2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbe11006-c06f-4120-a209-0ac2fa08164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_755105c1-f410-4e09-87d0-5ef15746ff1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_034f40e3-2783-4202-8189-fe8b6e11bcdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c605939-9b97-448a-8051-6de0d751931b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3415f772-e20d-4104-ac5c-44683fffe2a2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bf36e9c-2d4c-4d3b-aaad-b21e7e3085ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd408c9-e801-423f-97a1-a5857d1ad4af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0e75e28c-718e-410b-b2d6-1539bc5e017d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d2dc1dfb-bedb-4a06-aef6-073ba5573610">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3e57554-31bf-4fba-9fcf-72fbcf3c24c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48b08358-167a-4ba5-8716-c7c79c76f989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_440d5403-5712-430b-871c-f1449bc683fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07f052be-64dd-4fca-907d-6852e038a6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3b04fb0a-9cc9-4ca4-9603-38b983258538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_475b64aa-d502-4417-8208-594fa2af4bf7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aff9e12b-a0cc-40ff-ad4c-21354b0de88f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1a973e3-96be-4a6f-a7ec-2f2862e2ffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53fe31c7-898e-427a-866d-f9d639564156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fafbfd-5596-4044-8d74-0992f06c8c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_233d686d-90e4-49df-91ed-b5ee6fbd0cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_598db54f-b81f-40f4-84b3-d92f72daaeb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e61eb85c-b7b0-4336-8e32-6a5c2a7145a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1d98bf9c-8243-4f7b-84eb-ec54a4b21b90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eee51978-7250-423f-9dbe-827906d8c019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_466b004f-e572-4666-84a1-2a772ee0b5e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_026dedc8-5998-4752-926e-f2cc48db14e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0df05e46-9c77-4f7c-9c28-38b92d66e07f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_85ab2be6-50f3-4381-9947-70df840ac3a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb8a4d63-989d-445b-b112-1e304b518cc1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd353504-cb09-44f5-8b25-f1e3e8801e61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_058f2f86-c3f2-4ba3-97d1-9f6906004cfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dcc4cbb-f0a3-4b73-9079-8d7c8c4941ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_342151b7-663b-47f7-8b53-2fa6224c2828">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f0bc0c2-c9e7-4e8f-b803-28c6f5b6548d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395651fa-2b08-485c-95e1-17a893d7d3b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2ac23bb-09bd-4ea7-b41a-5bf5ece19009">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee8c7797-c83e-44d7-93d5-cc60b64290bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b935634-82bc-4212-a612-3d84f1ca3962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d5bcf04-bd8d-4514-95dd-e69f13c19274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1c01a24c-a208-4b22-9903-79a2ec531d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6637d54a-210d-4025-92c6-4995da491520">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_264c6f54-7b73-4d1d-b95b-aa94cc0c0648">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b87edfe8-d64d-45c7-a4d5-5f6ade3ed928">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fab46ba-9cce-4e10-8989-9b54974aad69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2bf00d-7b46-40be-b277-a0840a5c63d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2569cf1b-e90a-4497-a949-7c29fb699a7c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0be40f90-cbc9-4369-94b5-2601506fc161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edfc8def-f6fa-4677-89aa-538653292967">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_020f3c9f-49b5-414c-b4da-8a181c4aef4a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a7038c54-b029-4d0f-b91a-a528c0603ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8ff51ca-83d8-4277-acc1-b260d7d222e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6149b0c5-3cdc-4fa3-8743-c97d0b1f1d09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efeffccf-a6c4-4517-9821-d938ee8fa3af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca2de83b-7f42-4e32-8d5a-0ece354dda71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_94e6073c-06ab-4928-bd4a-16d8bfcc85c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01d168e6-ade5-4828-9749-c9cedd71eebe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_606a464d-cb9c-4a42-b5a9-6bd5ebbb6595">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bc2c3508-b5d9-49b8-a05f-570e28feddc3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_83795781-3114-4144-a04d-4c0218a2526b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b6d0b90-ac02-4a7a-9af1-fdf9ac0d1968">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_829d7f0f-f7f6-48b3-9fe9-40f3e80ee793">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_556c4014-05ce-4318-9c92-92047428cef3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cee22e6-3110-4e02-bed4-8ca368110b4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d64beee8-381e-4dd4-867a-de9eb2a66310">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e49c05e0-c6bc-4d7e-960c-d3fa31a486b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ba5019-26cb-47d3-a5de-6ae0d1ef25b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9963b957-2de8-4a05-af6d-0661f387330f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_268f36ab-f34d-4460-887a-0dbc24dd712b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b443e54e-315f-477b-84d6-6d83a39f6582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d8011e8-c7b6-4240-b4e6-c084fcc656f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ae136d0-afbe-4cd3-8706-8d321ad21e77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c56bbb1a-8c33-4ac7-808b-5e5d608cf875">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4109393-e03b-4c7b-a1fb-68f16c5a7cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb22b97b-0a84-4bb9-a4b6-5ee546825505">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9305c134-9be1-4026-a7be-325c101808c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c44701df-674b-48c0-94e7-2c620ae5942c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52bce418-da4c-4366-9147-90f23d9ee414">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a611e83-5034-4d03-b49d-c2259085480b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2fd42f2-672e-49cb-89aa-ac029b972620">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a04b87c-e6be-43d4-8deb-64099c5ca9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c5eeef0-5d1e-4edf-9502-650fd596cb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fea85a80-5dad-4838-afcf-75cd6d1fb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_713b3db6-d6ea-4a82-b06f-41b9783f69a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bd036bf-ba6e-4988-ad02-c1aa6666ac71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9552d0dd-3606-49fa-9aff-3dabc358798a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26940964-aea6-404e-8941-bdef013c8cdb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1adf3588-5d2b-4eab-b7d2-30a16cee0515">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65930981-025c-4bdd-b596-7f62dd2561d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dfb9aa9f-a159-4fba-92b1-6699c5351725">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6498579-f6c9-456f-902c-9d19b549b62f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26f0578a-c48c-4ed3-9405-7136aa508830">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_124f89df-1b77-4379-9104-99b98925be65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7fe7db13-1783-4d2a-a28d-5f544b258215">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7865f19-c83d-4d89-83a1-c97ffb796b50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f232587-ef4e-458a-ba35-ef158ef922b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7e35b494-953f-4999-bfdb-bbd338329e40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d1b5735f-c0de-4f92-b6d5-ef48cbf3acae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cd4c469-6355-43a9-a5e0-ce8c00e18dab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_49de03bf-9e1e-422e-a69e-992d88da11b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_582c7383-519e-4e95-9adf-d9f4682eb24d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f563d686-694c-45b3-b865-a4cd8600efdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b25096d-00f9-493c-9281-086f23040240">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2729e62d-154b-493f-8d64-5be7d09e89f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7303683-4312-4b4f-b006-f19d2bdb4a53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4698552-6cf7-4edc-bd48-63f44e816764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_733c06d2-d42b-433a-9896-e0d6fcf9f32d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8d144de-e131-4d9d-8c7e-5bf07887df32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf630364-e744-49bd-95e8-ef6d2aa4a7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_158a8112-d449-451c-8048-c6f0a9ccc502">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56365e0e-6d39-4996-a813-c06ce027b7f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9154b45-62d9-4cec-bb90-8b7da0fe72ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ab1a7a4-b512-406b-bd86-e321a39b3c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee320934-b8e9-4ada-9357-7eaee8eb3086">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1410e2a5-1a0c-494f-9145-13ae508493ab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_06741fd3-bdac-4576-8d99-ce74f8873229">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10371938-cce5-4d1c-b82d-62a4e06bb278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a82616f9-19ad-4009-812a-a4242ea9216d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a3f956b-efc6-4e70-923d-9029413a0f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e81259a-44ee-43e0-90ef-ff3b7230fc06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77c54f25-f344-4794-b5ae-abc64a604c19">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_65928fe7-3119-4e0f-93c4-0efcb16c9889">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d09255f-8e8c-4e03-a33b-be6fc2d42cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a2b9d6d3-d281-42c5-b456-e3774492b58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cc24ef5-3e02-490c-aad5-eab050a7a09b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d16de56f-7bd6-444d-9033-50ad12a2dd17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49e72d64-61bc-49e4-a565-03efa5d1acac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6cc99e3b-ca3f-48f3-8bfb-3568f4bd8d3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12968947-f95c-4b8f-83b2-5f0be6468cd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b754364b-ed30-47a2-a7da-9e4d6b03e0b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a13b69a6-56b1-4302-b0aa-3e0d081eecc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8eca3ce7-0b31-4a9d-b32f-c3950b6a566b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e27937e7-537c-4e95-a726-226798fad970">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ad17838-e54a-4c82-8a76-e0fcf5c2164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e698365-e833-4996-9473-f06a71d5589d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dacf7f3b-2ff5-44ee-a2b9-2aa57613a8da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bf6e629-c40b-403d-a645-d75c413c1eb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71c7c564-e605-412d-b6c0-23bbd162ad74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9c399c4b-5712-4062-ae0f-b688af0abf8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82b12011-cf89-478c-a37f-7641faed076f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_622cc0c0-28c8-44df-b59f-442849dc17d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f50b0d66-c542-4520-82d6-cf362ae23dd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_981f8d40-cca6-4b14-a267-a52df3e27e28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d39fcc1-e4e8-416a-a1b8-23bb62b77122">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72e08efd-5a8c-4c2f-b168-945b4c3186fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f47a4f9b-2995-48d9-b4b2-15c179da2be0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e1969e-aa96-4aff-af51-289b2f5f6184">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_68762a18-5f8d-4758-81bd-9239b9599167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b12a945-b2bb-4f02-82cd-4b59978c2b6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55c94c33-048f-4560-bb89-1a7ee27877be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f2b990d0-4495-443b-850f-d159ff7b487d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ee9f380d-06d6-4eeb-b07f-74433ee23ef5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a0063-77eb-48c7-8a3a-108717a1e342">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_471d2814-6487-4a03-8f1a-20fc685d4574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4f45b63f-e24a-4d36-b81d-35a032a7f094">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69246fd4-e827-4c4e-814f-937e24af9cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857769c9-5ae7-4e03-b421-b496cd37e421">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0188ffa8-b7d9-419d-be90-546712bd99d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0caddb83-6772-48c8-8392-b8592da29ce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b030c208-5e93-4339-a4df-49716f2f7ca0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_665fc7dd-b3d6-48af-9489-a931ec2d728c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae9ad4b4-9db4-45ee-bc7c-507982451c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73bb8f1b-7fbb-4501-b6a6-2d62532da861">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69ebf4e7-8f76-484e-bfec-e17f43ca4fcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4770649-3999-4da1-aafa-f310796bfb38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cd6bd8f-b186-4bda-83d9-9978919a34d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6de1c0f1-63e1-4838-9ee5-50fa9c7b441f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9d29ca-490f-4343-a83a-e789adae5850">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48ee110a-0ae2-43e8-bc1b-7abd771bffa7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9fb29ff6-0f14-4848-815f-df067a483b21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b40a5b9-55e1-4e8e-a264-d6a2bc01bee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c693cbf3-a4e0-453b-adda-4025e954d286">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6eb2ea9e-ae8e-4f15-8a8e-256d297537a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fde71d0a-4cd8-4273-bc10-76dd1fd19e66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d2d2a00-7af0-40a7-9847-bc28c0c1ea23">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e83e957-0488-4692-88e3-8bbb2a691173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cd9e84b-d0d0-4f34-8381-a7b6f7c03ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44020251-68c0-42b1-a413-3a748a1ab55a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57c0a3a8-7306-47e3-9934-a50251ef5bba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_971c083b-37d3-4e4e-a1aa-cfaecacf5562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_712d9aa7-73f9-4897-8147-a85039c14211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a9e577e-ad31-49f4-8389-4ca6efa6181b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8453e888-4f01-4fa8-83cb-972ee72535dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91cbbb58-6fdb-4496-93c3-bbb3fa994bd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90c5968f-502f-4af4-a99b-500f99be089e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b748562-c7fa-4923-8e6a-4427939ab97d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_31215c2b-0e3d-4bdd-88dc-45dd0d473877">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_03388553-ce12-4a8e-9cfe-74622fe2d729">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91c214fb-62d2-430e-bc9a-76d136d1b683">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7b97d0b-2cab-4ff6-91a0-ec87303b18d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc8f845-7da1-477b-a7c6-418956ac6e80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b46d5c4-0bc9-4057-b52a-b3ce593eae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9b90290-a864-4599-8c79-4638611ba5de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e50dfb35-302a-4194-affa-eb06048ced86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_565f7f95-7442-4d72-82bf-cf99d732e17d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_884f8d38-b876-4ad6-b4c2-5ed16c445a58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5070e00b-3d37-47b2-97d3-5950de3bda10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3154beab-9876-4812-828c-aee1690971ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_508d06fb-a64b-4e4a-a836-e866b64db8c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_885fff4b-dc0a-4883-bb41-faeef51ebca5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0db9c722-ba04-452f-af36-e304d10c09fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_23a2a4e9-dc99-4a8d-9add-3ca0c97933f6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c02a9d5-d136-481b-997e-0dbb22363151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5653476c-dbd0-459f-b3d0-d2ad9975dbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d3dbad17-c193-4f54-b0df-c903d58903d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b288691-206e-4af0-8daf-e9a2dd7030f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27025919-dfe6-46d6-8488-095eb2927d08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec1df18b-3e04-4dfe-b264-82b497dace66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b1e30c4-d9ef-4c9c-a476-ce98100f35c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e579b00f-7530-407c-a998-3dec9b484ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_105bc9ed-8b9c-4aaa-b534-174d2f8126b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebcc901d-16ff-471f-9893-98de344c8277">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a096101-135f-4769-a102-be67822c8b8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10bb5ba5-7e15-4c5d-af9e-a947afbcde01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1ff25a54-512b-4914-a35d-98ca1342ae4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac6351d2-74a1-4f8c-8406-4d39c66676a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1e98c83-9051-49f4-8f9d-8e5203f765f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00933292-540a-4140-afeb-a6d0921a1994">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7aabdc4a-f063-48af-9976-cd6d5698db14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2de76924-7d29-4ac1-aa0e-cbe05c315c21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4842c5b-2bcf-4b09-bbd1-530fc01bf44e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad91ff76-5a92-451a-b74f-438c17d16665">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56feff01-9529-43ca-992c-b9f7ed0df41c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39ddeef7-8343-4da5-9c9b-283f25344dbd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5d7a62e9-15fe-4fcf-8a5e-c18e280317ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cb38a95-411a-4892-815e-6f272a1fe602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_22ffe2f8-2c9c-4d97-b486-5f92260163c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_96ab21dc-4b8b-4149-8a04-a61050c092a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdfaab97-2d5b-4a29-984f-e8e221b59ae1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e875bb6f-949a-431b-8199-7b2eeb3c7f14">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_84efe136-ee31-43dd-88af-ffd1637858fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a55355e3-2084-4438-8018-10d3755a97ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1899ca-0520-4a4c-8045-faf978e483a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37a31de5-f6f0-4ee5-b7d8-386f81866e35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b7a9125-651e-4392-9214-d4ddbdb52247">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2f0b9923-7398-4564-ad82-4bafa9778688">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_624525b5-e21c-4305-9ac5-ff7388b1001f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d37217f6-9cec-4c6f-805d-deca7c019fbb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9461a04e-4368-4f49-b3b6-2f05deb219bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae0b6a0d-a5eb-4f61-8b2c-a02e751e84d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04c8a74-9253-46b9-b6bd-9701dc35eab2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be945639-e526-4e91-a7df-a51110b91db0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1dfc97c0-c7b9-4c31-8f4a-a6d6ab182d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed9ad61e-b067-4f4c-bbb2-c41dc385d6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79603aaf-2a57-4463-8db1-671b1a2e220f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efabaf18-727b-4c00-a40c-f17833ed29dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe002e4a-1ec7-4895-86ac-558b453b515f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_20262ba5-86c1-47f2-932b-e0127e4f76d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1f99cde-ae8e-4ba1-9d73-01d49a79cb15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f86804b-4b7d-44a5-aa8c-8be0a817dcba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18f5c8ef-7b91-4ff1-ad12-25013fb2261c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b10151b-bb1c-42d3-a1d4-2405ed3692b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd81079-c54c-4362-a512-99e1574343ec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_46326a22-e670-4bea-b1cf-9c254602f2fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_671ff075-93d9-4eec-9954-3d1615290aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bfde40f-72b0-449c-8d42-637fbc9fd2b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9cfe9126-4dc0-4fe7-b98b-211301ed1b99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_706882f5-592d-4dbf-8de3-c5573164ff4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82267948-83d9-48d3-b8bd-a253eda0320b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86674381-d6d0-4318-88ff-c1894543ae67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bfcb49f7-6405-44d7-8045-14aea9e30b6d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9009bf32-48af-45a1-9d21-011ed8761328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1826f25c-9775-4f4f-b2b1-ae473c49e3b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7a71e962-82ea-4db6-a0fb-4975df482e2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fed39c-b567-4583-b5e7-b7b55af29412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b17a4fe-7e52-4091-8ed0-3aaeb20bad36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f5e9ea3-87cc-4bb8-9367-89a722729922">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5273405-4204-4386-a10f-f7c54e4f4238">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4bf260bd-da56-40ac-b0a9-aa914db52552">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0308fee4-f4a4-42a9-a181-5a87b1d39278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cb7100ed-7dcd-4b33-83d3-d2a0c4f3d3d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_356e63d0-5646-4a7b-8572-342dd3328f76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bef3a4e-f3ae-4cb1-835d-0e5d9f063ad8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c9e7d8-6d56-48b4-b8dc-a71f2d4b224e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1bb11d6a-188e-42e8-9304-e8a4ee0872a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7e54d3a-d5aa-4f53-afd7-6549180a071c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c78dc3b-842d-45a6-a8c7-430b2ba7b894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_520c328d-8cdc-425a-a674-f704abb85b1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_511860b2-8d73-404f-ac31-3690c0941043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd8849fd-c520-4587-9a6c-18d0f987bfaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4001dee1-5a46-480b-bee2-4f49f8336ed5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173717d5-e642-457d-9561-712c94fe0c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4c221fa-68a4-4b6a-a352-bb79f98caa60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2bdfd341-8eb2-4212-8f13-d86974a0d2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8f7de386-3c11-4fbf-b624-23fd3c1c562e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8e1bdcf-845f-499e-ae37-18f99362ad08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c797ea5-c893-4c9d-9e67-c90e8e199411">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1c420df-1842-41ad-819e-009e2c6b9a29">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ebf6639-df4d-4202-835e-d9a6be726cf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71632e7a-40a5-49e8-9ddf-b674a3cd0aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_849161e7-454d-4c72-a0af-047c5336f94e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89d54c89-fac5-4820-9e7c-2bfe46e356b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7f2ab18-b44f-4ff0-ae23-624e27b84d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4986ee49-2f30-4ac6-86a0-753bc271c311">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17b41316-5349-4bc1-8cf0-478a08f5b456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9b0f671-71a8-4cef-9ec7-8e98fbc6ae19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18b0b238-e39e-46d1-8b44-c343c305efde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_73c9270e-8671-4fdb-9c60-e5adcb17e72d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43cca838-8ddd-409c-b337-2e67b51a1d4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b1289ea-c81a-4e41-adeb-e00ddfa67bbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877c860-1f30-404b-bcc2-973e5eb01818">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3fed168-71e5-4be1-ad94-9cab9c37daa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5b81bb78-faaf-4c79-acd9-dee20dc0c61b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bd400616-4892-4133-be8b-398ae2219c89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d654b4a2-619d-472f-ad7a-f6da11cf4d4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc89f01e-591c-46f7-b57a-88b2deb6f051">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_734d06cc-67f7-4711-9fd6-fbdf778ab26c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b7472e2-0209-480d-afea-3cdaa1f3b566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f419035-11a2-4fb2-9aaf-9dd5d2f68558">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_868cbe39-38ec-4502-87c3-89c675fd01d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c59826ec-f49a-4f2e-9bff-450f400089f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d29eddf-8a9f-437b-915d-a171ba75e4d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b8f651fe-90c8-4acf-935b-3a28bbda1010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12d4f8ef-1503-435d-a08d-1172f0e8d4a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b4d225b7-cae1-4c84-a2cc-ec8d86545530">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3851fa4-a3e6-4620-9d84-e5f2e223d882">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0201cee2-9ba3-469a-a163-ff4d8f90339c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4a1bc43b-f726-47b9-af5c-c555b9460663">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e7c03dfa-74bb-4ae7-aae2-e3b13867e39e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22893df4-f066-4d77-9b20-41996fada264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713eb8dc-b3b6-40fb-ad61-4d88de8074cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a425377d-6338-4a06-ae87-a353daba71e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_234cf63c-93ab-46d8-a942-c61871c6c1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96120813-56ab-4482-a890-46d757bc9053">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_895c4d4b-23c3-4aaf-869a-84176c9c5ed6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5215b7c1-8498-4aa2-b3b5-d35d65fc4432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_540d8499-d8a6-4731-aa87-d0ac791ded2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88906a21-f574-4aef-915d-859acd1e22d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70afba82-3536-4952-b226-a329a794c7e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2090b49-5a3b-4f65-bf81-6fb949c6e77b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69b76bd-7138-45bd-bef8-e6a69172e021">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41196d74-dde1-470e-a114-485ebdbf53a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e80cb5-a4bb-4fb0-8754-25a61418b53b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67dfd7f9-e5a9-446f-aca5-9480722e279d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f1c9764d-7a62-4b2e-976d-8eceb473c52c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e8c1bf-b50c-4089-8ec2-7fede6310b5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cc8a469-7e37-44f6-895b-a38e53ba8c61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ce44f7a-e1fc-4554-8a26-2532ad150716">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_216b5db8-fd97-4534-8794-ef399bba9f06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_274432a3-9f3f-4229-a3ac-ac465ad8834c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86385e2b-890f-41fe-a051-ce32d787268e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c5d1874-528f-4b5d-b918-1808616d7d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_756d2942-df77-419e-b7c3-e43b68db0205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bed2fb-0f11-4f6b-b3e6-54108ce9f48e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb29035-f491-4bb4-85d1-a52b9731a61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e93ad931-1622-4890-99f5-1a0b86bb5cc8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8140af2b-d5f3-42e9-a3b2-b00593fe86be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ffc6a17-e0e8-4922-8d3a-6e5eb7c98cb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_402cd84e-9864-43f4-8dbb-63bf7cd1a0c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f41d01a5-a611-4390-a26b-18fa617aa345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713ca869-bea8-42c1-89c9-748ac1a2a210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_55fc5e5b-0d1f-4bcc-bf93-c8b921aed1fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d84ef8be-1d52-4db0-8f0f-982228b08963">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b740b750-4224-4059-b382-78942d33d819">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4971b9b-47da-4d2d-a33f-aca6a40ebb5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6fcf9d44-0aa0-4601-acec-32f45ad7d508">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82f01d0-3f3a-4fbd-9a3f-98a1e954e09d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c3cd7e7-115d-4869-91a6-70bd2e8a0879">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b134ce8-e167-4933-b483-9abc85f82a68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bcc360a4-e0de-4270-b3e3-2c0729527a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0de34ed6-5f54-4d96-b85c-f9cef605702a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3231c97c-9430-4350-8fa2-291f9293ff8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36da5543-1c92-4034-9537-b7236c3523f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4aa7d6c9-5036-4a5c-bafb-8aacb7e07fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da489a8-37d1-42fa-b44a-5ca3ec46da01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c597a409-1d5d-4f8b-85f1-afc3b592df8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_995c307a-76a6-4c64-8cb2-e814cbfb12fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5693ab73-76c1-422a-af9d-4b3bcd6d3a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f644f1c-6ed3-47c9-a38e-08a9485b207f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9bc005-cb3f-409f-820c-a5e040ed86e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fd822661-fd79-443e-b070-216e9012562e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_251ff7a5-1ad4-4805-a523-f27406ba6d79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce12731c-2b18-4e1f-aae9-29964c988cc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c161c630-05f7-4404-9947-055080df59a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_54136fba-4c59-45e0-95da-af7801dc09d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8734587b-a66e-445a-bd1f-6cb940b51c00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e6d45e9e-66db-4bb9-8d38-86c61edab12a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42e6c5ff-2a1f-423b-a9e3-9664e6627f4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2af328b-5185-4c38-b82f-0c4efcbd4ec5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67450fc0-6b2a-44ab-9128-d96d9676f9eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3aaff381-983e-4c90-a188-21ecb252229b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9041fe38-9715-48d6-8f4b-00ab3676a859">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8a2be9b-a47a-4ac6-8746-2c90af9e406f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb0e8f84-c639-49a9-a371-e1853cc9c701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9b24d9c-36c5-4858-87d6-2d837c4230bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7b028d2-f6ab-4e46-86f1-9afc8ef4aada">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16c68725-79d7-4807-aecc-018c600ca5d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_068cba16-15d4-458d-8d1e-14680f6a0841">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a442a01-9c9c-4edb-805d-fc3b45f89e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c8d0fb8-e4e7-4e8d-bb20-179996e179b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7bf7ffc-0480-4a79-a24d-b2d6601acb16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e46b1d1-347c-445b-a227-48aea8b8e2ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ba5d05a-ea6e-4f08-92de-61331f4b7ce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2e5fbe0-2c25-416f-bd5b-e04d9aa999f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ccefb321-71a9-4304-b680-6cd833613598">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc84b185-167b-4586-83b2-d6caac6cb45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68f575ef-5627-4282-9c58-c1e41eba70d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb56196f-75b4-4eeb-83a6-10e82c03a842">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_821c5870-ece1-4e61-9ff7-55588a7550b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6e6c67c-a057-4fe9-a74b-bde8f770bb4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cac2fa32-b7b9-489c-bd7c-a6db746f42d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fc8453e-ef8c-4bb4-9294-2a4e227544ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65e5a63f-cd9d-4a6b-81c9-8297e8add12b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb6439c8-04f0-407d-93ff-be80b9fda84d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3444efea-71a8-4c63-ba38-2ed9a6bfacaa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bc73643-70cd-496c-a6c0-55f2a679ef50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8599188e-23be-49ef-8aaa-2bfe07131eba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_51d5398f-d2cd-40f5-943a-48c008f0cd91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4b1710b-5144-49f7-aa16-78538eb731c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0026b68a-d9ca-4f76-8bed-993b99226fdd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_034d70b1-92d5-4259-a101-27f795ef79e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9b2f023-60c6-4246-bae8-1f304d7c046a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6065275-b0ba-4fe1-8c93-51befb9431a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_824a0775-e3d3-4af9-9950-5ad9c0f2acb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c3ecb7-c758-481d-af0a-85b852631da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fdfdeae9-a5ac-48dc-9b36-7779d7c45b07">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef7f8f3a-7613-4529-bf6a-4beb89a652e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0dffafff-ba7c-4bf2-8345-b32936bb7d86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b375a1eb-4e15-40e6-8931-21f756370ad8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a17eaf05-1e9d-47d9-84bb-52098403ebf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccf1734-7ea4-4030-b8ee-7a82d958edc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a878ee53-c51e-4a70-a80a-fb13a8db928b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8657f8e9-55a2-4388-a722-de31eec99cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42fbeebc-27b3-457f-b780-23328d760a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2ef59be7-e550-41c2-ad9f-a4e7fae6d3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ec6ef57-cfcb-47d1-b38b-6ca3220c5e02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20979194-0a0e-4f2f-8f25-8612d79fb907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c4ee866-a65f-4f9e-8d76-0a085de8e748">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0cb1e098-2473-44ba-8ace-88063372e452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ff52ade-2687-43e4-8fcc-5f099a77ae41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_568590c3-5871-4f14-ba81-c7895686ce80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0769e266-9d4a-4af6-b15a-89f29e34da03">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c16aff2-0a52-4ef9-a47b-8542e0c753ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd8422e1-afb2-4d1f-8ebb-931b8458508d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9d9b5953-6a6b-4b2d-8776-8f0a554bacf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c308372-aefd-4a3f-a694-4f9269fa5587">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4055725-3496-4afd-9eed-220b29535c3d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25d44ccc-4df7-4ae4-8c71-c7b06699a507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e984b7b-5485-47b0-b49a-043ae3aacbd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e6cfa0-aae4-4c01-8062-3dbe496f4574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87b48993-4fff-409e-8fac-71ac7496438e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60f5fdfb-bb99-48bf-8281-1a716d1e9cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c49006c-db19-4e93-a62f-4f74ce7b5671">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd9d62f0-ad1c-47e8-ab65-be18b6eecbae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_032e8c7b-951c-4471-bc78-04fa2abc164b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5400d815-e041-4be6-8e24-f4b4a55ea557">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6403f818-0982-411f-8685-1a954d578710">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab41767f-a4c3-4501-8fe6-2c53b0b29faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_518b887a-c883-4f6d-96bf-fefd70874c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5937e65-8f83-4221-a7ea-1b171d13f761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2964a972-3a4f-4f4d-bb34-2a87fbb7209c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_803e8c65-63e0-44e4-95b9-4a68587c9ebf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_28a90dc5-c31b-479c-8bd0-36ae75d91886">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7b5b4d52-a9b7-437d-b626-5013d30b573a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8809330-10c9-45a1-ba8e-56983312a283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15a8e6b-dff9-4599-a3f4-cc992e64a5eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_da85e8dd-137f-436d-8551-4c667949a953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c990151a-be6c-4ab6-bea5-3fa861d3f487">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c68683c3-4c6d-41e7-910a-f8fb69106e2d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9cd6b6e3-2fe6-4b21-a527-04ee4da982fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea51ec29-12dd-4c22-bd1c-f8b4d6c88c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d73ee5a1-22bd-479a-b8c2-cfac03997d0b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_00d337e1-f715-40b3-ba0d-330107be943a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e35079e-d21c-42b9-a71a-bd371ef325be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba54f75-4322-4260-a3ea-5c8a1fd8da22">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02cced8e-b04a-4c14-99eb-effab66cbbfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f499942-c1d7-47e2-b0c3-94f2db7b5d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db50e30-5d8c-41fc-92ae-ce10b51c1142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c76a037-c8f3-43f0-809f-c2d22fdc7c61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_942009fe-1099-46ff-8dfd-39bb6c8db838">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8330d965-e14a-4069-9ba5-af9cee313c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9a94a356-74e9-46df-97fb-5bb574ce5aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74896b7f-2442-4b14-9fd4-a345f81988ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80d06191-1b0a-44ba-8966-72b2cb09552f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_721cb49b-421d-4b7b-9009-5e492dc2fff2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cf5789-1e9f-49d3-bca8-81720d2a2e85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_042500b2-456e-440a-a299-70b68697b78e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61d12870-7112-4a95-9fdf-bb0548490252">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3f46115-af74-4aa6-86ae-154180f55b59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_766c7c0e-c479-4fb3-b381-e2664ad819a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_184724c2-9322-472e-ad84-f3d5ed3e8ab3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1a75e146-4a56-451c-9165-17ea4fb4a25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_effcbaaf-8216-43cc-b073-cfe772572506">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_44dbb378-126a-4790-98a5-6e6b6da2c8d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f4a76a-d81a-490a-85c0-8f01b63ab5ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2edeaf8b-6707-40c9-9fe2-ccf1f8eb347e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e3c8c14-3636-4f67-918b-08d3187d513d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ad35ae9-afda-4659-ac88-72a2bb9fe44e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f77d3121-7cef-4297-bc8d-745375d989c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_63e90e7a-e502-43a3-9128-eb540c6c00c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e510fe3f-7d44-4d7a-9f1f-3388843068d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01d20bb2-a8dd-407a-a54f-f4d90f2206f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc0eb440-7432-4aa2-8900-5a7646660733">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dafcd693-b165-4b36-88f9-6bd171a206ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47dcc68b-7686-488f-b77e-cbedaf655b09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a44d56b-3af4-4d12-831e-161bdb3b7217">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de415489-e0f2-4512-b73a-135b3e345a95">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4a169528-7bec-471a-8892-3f66276e37d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74ef52d5-c88f-4177-9d50-2a6e408bc8a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cef415e9-2e4d-41ec-8d65-54f834f290e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4df8a044-9965-4a70-91ad-3e0dab7ccc17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb6166e-1b65-4c55-94c3-b2157ed3517f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e19eba57-e9c1-47cf-ad50-59fe6b08c01e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_346a5319-3ec2-40a2-aefd-38dfacbbe97c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63c7ea9b-23ae-480c-b27b-f7764ef9d5a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_168c2329-960b-4f86-91db-ef94ad8f7dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_686e884a-a0b1-454e-b7d1-33c7ad46f89f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ec1f350c-c2ae-4665-8e68-45edcf92d1fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4edf081-2fb2-4da4-94db-98a2a596247f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_312f25f3-55bc-4417-848c-236d31d823f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f359893-b7c5-41b0-ada8-8df06cf7a8e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db1a4a3-7c77-4e7c-8a3b-65499a81fb30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc4c311e-d167-4d5f-8a36-c7c1c915bc04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ddcf7aac-e7c3-45e9-bd81-6146e951addd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af420f53-37ae-44db-abdd-79138f483c56">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13b3e3a3-d932-4e97-83f4-d63c4e1c8527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2463ff2c-7690-4dd6-bf44-039f9f475bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df6b50ee-af5a-4e61-9bda-0752ef238e3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d67568e7-c48d-479f-a4ef-51e35b018f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3be2355e-0065-43df-a264-57a295042faa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd875ee0-a6ef-4ca0-87ef-f6b5b079308b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41386a39-3f57-424b-a8b5-8d3b5a32bd79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eaf7e467-44ab-42e3-bcd7-70692bebbd62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aeb672ee-e2c9-4172-b7c6-3d3915821c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbbbea53-8f92-48c7-8cdc-a3fbd920c43b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bae580a2-0dcb-4ed6-86b1-f5f603b937dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4eb83445-5e74-42a9-9b92-e1cb3c6ba13e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33f8b01b-0fde-4257-bf74-20588be588ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_876a178a-7474-45e5-abc8-d9e3eb0d231c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2f24cd6-459c-49a4-b93d-9c6817cb1488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84507e60-680a-4b67-a596-c214ae0b8c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56715438-6a4b-49f6-bc4d-605136e0a3e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f46a611-ff04-4bda-a0be-9d29131f4b4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b1a2061-0ac8-49a9-9954-847d9862df0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec63eedd-ad1e-45d6-bae8-c797162a1e4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3971a8d-94bc-4b4e-973b-16844ffdbf18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8526a3ae-9742-4e33-ad46-dcb5e89af11b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f31a7a93-b405-47bc-82e0-5862c71ef7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1bdcf5ed-4a96-4d08-93db-65c2d5dd908f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90ffc2e4-3f7f-4b32-81e6-c4c2a792b458">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73487593-2e52-4172-9f55-c27fb539b609">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f7eb4e4-8de9-4352-8986-c31fbf58723a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6137d3e5-4586-417f-93c1-dc9e2b46adff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_696dc02a-5cfa-4723-913e-a5885b3e5885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_843f4407-c335-4824-8f2b-7f2ed4094014">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_947cb703-a50e-4602-b5a1-60cbeb8832c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f8860a6-75f7-44b6-94e5-01dbf0aa3de8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0220034a-1a6c-46b3-bfbf-a984702d3c1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4f54cbe-fc62-4410-bffb-0521959fc2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d3a0ccf-17a2-4beb-ac9b-7be3dcb0fb73">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc80f782-5c36-4239-8442-fb25c5d61c4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c216355b-0f57-4118-89bb-b2780f146bc2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6d75d35-3089-4dda-b69f-ff471b24aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ab9cfc0c-b194-4af0-9fa2-77978e43c0c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_63a8f42a-c8a8-4e9b-81c8-001bed4d2a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7f09426-095c-459e-8e0b-e38500fab1b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed7f9c93-a8e7-4999-9d18-f5bd01b65933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aa3a3f9-c86b-4641-b368-a099f8583656">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0fd18f1-856f-461f-bdd7-997115ef1044">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c78936d7-acfd-4a0d-aaae-0153ebc7d768">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_09e0f824-f92f-4e4e-92ec-7d6770b9d243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70993686-256c-46bd-a2fc-674f52ac59dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_65b03961-f9f6-420d-8f61-f44ba99fc4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de9a7b88-6748-4089-9d89-911dd957bee7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec4cad68-f17a-445d-922f-8a419d3fec9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7850bffe-8b78-4551-8f92-d52ef0addadb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c912ed7-2d69-4118-ac02-b9035f0d9e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_43b6fcd3-4a29-4e9f-b597-518117e3f111">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_009a7bac-59fd-4b36-a39c-a635cdf04418">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b0739c1-a932-452f-b10c-356d293b82a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec5176ac-a1d1-4f5c-9546-e9e47f6ad8e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ef8ecc8-7d0b-4507-9877-9f640b323ef2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b6c251a0-7f4c-4930-8e39-7a91fce144e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66e59497-02ee-4f54-ad5f-4f399b2eaab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_891c0f42-fb9f-4390-ae0f-307bc6cbfc64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04a2dbc5-819d-41de-a987-8d334031c175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc5d543b-bfcd-46be-8fea-1b2490b1ea9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9f5d49d-922f-44b2-9d78-ba41b47542a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41955f1e-f88d-4160-8879-ade4e9d027f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d97bfa8-9abe-4275-a2b0-1acbaa779613">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dfc5b8f-fecb-4041-ae98-3c2b1f96feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8dfa0c60-9696-4870-87d5-ec7d3e2b72a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15c0d9e-956d-4afe-9654-9ae5cbeae473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0a4153e-156d-4852-9921-6d1a1c1064e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df7dc1b3-5ad3-4697-b808-103a9b2e22a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d69e028f-ecb0-477b-9fdb-36594afce196">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c04f249c-6bbe-4db7-9637-a3bef2cd6599">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04b9b246-5df3-43be-a733-5aec27fd9be1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_00fbdcfb-3d3b-4378-8dcb-5608f6eaa51b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef59a32a-bc5c-4512-9437-86fdef2ac2d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a208f474-056d-48b6-a271-a7123684f108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a20e1cae-0b90-4139-b87d-9ce76e6219f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23db024a-d255-4402-b2cd-e7e0052f6e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816a0247-2a88-43d5-8de0-d4709dbffe98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9749f3a4-64c5-482c-87c6-37322d113948">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_580de0e9-f8c1-4969-811f-46712414524e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20f43d84-963d-41ca-8548-86be349e8471">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2bd46877-a632-4ddd-b880-1940461fb45d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_02f193ba-e746-4eda-ad79-9999ef27fe47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b569c39-9301-424f-959e-c45e0fd99f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91e9275d-053a-4d88-9d20-c094f2ccc85b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69f112ef-9f4c-42f3-9ac8-472698d68257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e47741b-e0d0-4985-913c-d95c500b7e48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1178ee67-c92b-4568-bdd2-101440661e16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8960c67-75b6-4aff-8b83-05fffd558dc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc81403a-372f-4310-824b-112e7bfcb323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1d717e38-50cc-44ad-a538-cea12eb5e1b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5465ff43-da95-44ae-b8e2-7f3b590e6c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9e6cf153-1255-4a4e-a3cb-8931792c077b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a29bb72-2f86-4d29-affe-b2391894c13d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d58201c-4d98-41ba-beb2-ff5d742fcb66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98fdd615-f480-4b42-9bb3-cea3b7c2fda8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0a978e78-aa93-426e-9765-368315bb94e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c873a17-42f2-4abf-8c47-e47021e0e3f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a5a6dfce-8298-4b76-8289-9e3fee8a8583">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0df7090c-0218-49e1-a3f7-cf30c8f9f8b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_177bf3c3-c744-4321-836a-a2fae0b0bbb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a551b9c1-3d7d-449a-84ee-1743fd7f9366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38a5688b-b7c0-45c5-9243-0293e2e48b94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad56fb97-89e8-4c97-84fe-98d7049617bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee95150b-76fc-4ba3-a9e3-8aa2a41479b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3304e735-d4f2-43dd-bb3a-22e720aa6d7d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2869b4e-01d4-4787-a309-e5c09b2214e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45bfc964-e77c-4912-993c-6ed38877d6a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d598576e-9992-4e55-ab22-7ac5e336c167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0387494e-d16b-44b8-903d-3aae7c4b2d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ea8cb0d-f908-40e8-8be5-f6cf397fc6c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47badf30-a042-4cbd-b2e5-027b03e98eca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a2503c0-15d6-484c-9d50-dcaf87e40afd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ac3075d-b630-4f72-9637-9e0d639eea21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a73abc8-c136-4d48-8b72-ccf7c89b569e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_443d1b23-9393-4b67-9596-b24170a7715e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2003d398-4989-457f-96d2-1d171aaa3496">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_467e0941-4ce6-41ca-9c73-fc30a3a465d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_434f488b-72ac-43d7-ad91-7397a8d1064f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e39401b-8a3e-45f5-9b9a-b23d200ded9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7396260-dcb7-4643-8440-4c22300245ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c6c8c-c3eb-4c10-9ed8-60b192b7e93d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10d7ad43-0c5a-4691-af6f-b2784e71188f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5169785-0581-44f2-ab10-12791b566cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa81dcb5-3516-4f66-8384-f28ec6470452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84b7f2f0-27e0-479f-93ac-7e5575559334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9da5e21a-cedc-4d7f-975e-b895d61a5b4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8b07eabb-e9c1-45a8-854a-b0e19382565c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d7048bf-1d51-442d-a7c5-42af545b53b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_667943d8-8735-412d-b993-d7f49ec6ec56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_78ab02ba-6e28-40f3-ad7c-e904efb2dce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f55d08b5-1ce5-462f-b19d-7e59303c7055">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0adb0e5d-57dd-4b49-9fb6-4b542a78e281">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fc722a0a-b5d9-4c9d-b2c6-aa57aa347267">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f46dacd-ec53-47a3-9ad0-e69d01af2a32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47e98763-4205-4c3f-9fca-580e6716eb93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7c51871b-8c97-4823-8108-47c7d756d416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422d93f-8f56-4ece-b98d-d6bfdacfbced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73252c52-15f1-4024-8dd3-b7f5c081e5b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c7306cd-aaf6-4452-bf95-aa1b65184654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a90aba9-d586-422e-8011-ee94ca4fa7c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bcf3d63-4745-4934-a4db-6c7e999c6cc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_acdd21e9-23fa-4c1f-adce-ec12996b7bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec2c9742-eb7a-4c04-84e9-7ff3c8cb7325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ddaae786-f86a-49d4-ab4e-8f62cf002977">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0b79f1c-045c-4a78-b3b6-8646f10b3864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39ac3d07-5ad3-4af4-85ed-08bd818a9c57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_febc165c-7c90-4f43-afb5-b99fcd6d0ae5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e8d3745-e50a-4068-91e4-fe628f09b912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b72232-5245-4b60-be58-4f5e8ac5fbfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_27f3ab55-1b69-46a2-817a-20f140d8cd91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dbcfdcc-7bc5-4654-bfd5-0eb2a6764f4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9985dadd-4bc9-4c0a-9952-68e4674633d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eeb5e115-4fd3-465d-846f-a8b94662e138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a93a0ae-8c5b-4578-aee6-66d0adaa0034">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ed23ba9-347c-4522-ab04-d6987fff54a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3321c52-80b8-43a6-ba29-433ed615fb9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e7079d-f268-4eb7-ab0d-986277db80ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd245486-24f1-4bd9-a5a0-8566fb209f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4585259-822e-4a6f-b0de-a7c1df729d57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d66a7f2a-ec30-4686-bfa9-5804598b7f1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e0a586e-4363-4731-9ebb-852e63184386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b2993f37-953a-4fc6-95df-364a30765e93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_879b6ec0-699e-4c45-95e1-8ec2b6f0b1ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_75e908a2-18b0-47cf-92ef-1c6e2d0b87ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af84240f-9aed-44db-b2fa-e1e428b93e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b675fdd4-61f1-4375-accd-7b6aa01e61a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d19a72c-2062-448c-8aec-ef4299deaef9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_85657dc2-b4a9-4900-90bd-9841b7283960">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0b1f34a-3695-4717-ab24-afd7b7f2a4c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_278a371e-c8a3-443c-9812-da6d05023804">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea4a6b35-dcbc-4dd1-a1c3-41af5b692519">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_387649d4-7c09-476e-8f8a-88778b3433f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1108f037-931a-4c97-ba81-1d3945e8a108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2796ac28-9104-41f1-a0f7-8c2b2b8c7e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6d589299-a69a-4252-af49-c04675260ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c00ff0c-aaad-4bd1-a28e-b2814d8544a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8045156f-db54-4b51-ba78-c03b95abc2a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a34bc6-1275-48c0-9620-13d697e84771">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6978d4dc-db26-4438-b821-7dc2d6de928f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_293a7321-4d59-4ac2-a737-ecf77e9722e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2e2ad7f0-44f4-4af2-82e3-77bc37ef1f54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d8ac7a7f-ddbc-407f-9405-dc3215bc0b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b09fc32-acb9-4459-877e-24322a0a83f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c41c99-9bf7-4d09-8101-027de2575f03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572a2fa4-34a0-449e-9795-578123117344">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_959ae440-87a5-461a-8c69-d91c6be97d4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_373278fc-18a1-4abd-b048-691670efb49c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc776d4c-f4e1-40d8-89a2-218707466d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2bab2b3-e4e7-4ef4-9ed8-fe3468bd5127">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c260bc-94c7-4cfd-a4d9-f2539e71b7fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10b57bad-d28a-40cf-8f33-3c48cf7fb4f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48680022-5b7b-4547-9e96-7fb49bb638fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8095e658-d0bb-43dd-845b-f036a180d704">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e90719ac-9754-4a36-bbf9-fb321ace6d2d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88b36e46-3e08-4a9c-86c8-a35e0556771a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1305bd82-d13f-463f-b23b-0a7beff54c8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27490d8b-7f83-437c-90e2-38655ae49692">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5812ba09-aecd-452f-ba1f-37c16d76b2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_83030d83-d89a-4ba8-92fa-3a20313fdd4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_38c2fb13-f108-471c-ab65-5731a64b6cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_109ddaba-7a47-45ac-877e-b4d0edefd18c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25c10f11-aad4-4271-9b83-6f26879a49b2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90193171-e667-46cb-a5f8-a79f5fb9a047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c4024fb-6fa3-45d1-bf4a-1a1c9e967701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75034b3f-0566-4bc4-9e77-4589ec5a3529">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ee4a0c2-7707-486d-b061-60cb3639131a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0cbf76-5e70-4ac1-a14e-1aeb435db65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3debb7b8-d827-48c8-827f-6dceae6c47fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1bf7aaf1-e4f6-4795-abd1-863d1c5e481a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6799f164-6554-4fc2-8c0e-83c42fea4ced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b3e639e9-c7a1-4eac-9134-b7ae9a1019d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_108be304-cf43-4c5a-8bf3-94fa3e8d74fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372e32b1-1aab-432b-9c3e-bc1b489d9e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dac4a438-5467-461a-87f3-b7a53957f069">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eebbadab-e107-4699-8e8c-fa9c1f93e384">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04be338c-4123-4d3c-907d-cfe7e46e082a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dc3386cd-4655-4bdc-97fa-b6d42a53a6dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df932d23-c0fc-424d-b8c2-f3e6599fa319">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1cf568f6-4c0b-4a61-918e-d6ff3351b8cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cb029e5b-97a2-4f2a-abcd-e6e0fdefc53f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f455767-aa17-45df-8151-164007b94c58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe42c63-3b53-41e3-b839-0f65d0069446">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1eb2294-922e-4794-8a02-65e81ca3371c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee5a5db3-c2b3-479e-80db-614dd45941e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44a01d28-5f0f-433d-9765-93694bb03814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_91c721ce-fd9d-42b6-85d7-574a9f1ac063">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35eb4da6-136b-4bca-8604-47e75286e65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4044b56c-de8a-49b2-9a24-8d72190aa272">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da881031-0b0d-40b6-86a5-aafdbfa81931">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a94c14fa-0352-43d6-8f52-27d7ed31fbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_982d9d6c-a0b3-4977-9ac7-6542cc61f4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2e1acf0-3a18-4654-b0c6-1f49191aa7f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac2f8368-74fa-4e99-9ecc-00d828bae587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db7e5d95-3bcb-4838-8615-e20786189b81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2c8b805-99c5-4822-a5e0-8b7715404d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39133449-53e6-450a-bbb9-2a9f492816ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52cf4172-5261-4ed2-b0f2-153da4661c73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_759a9435-a21e-4f99-a560-85da57a1d290">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0ab7585f-f58b-4966-873c-f67bb20f6b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4406299b-b743-49fb-aaf9-da8a976adf9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_149e05ed-ded0-4b52-9f8b-a74fd2961737">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d81de1fd-80d7-46f9-ab23-eb276e288ee6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da192a0-4748-4919-af6c-739d407d0d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d3e78a-4c0d-4af9-91b7-ad6b70ac9a08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4de32c8f-fbec-44e8-b08c-4b1f7f0ebaff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_247f2ed6-5a4f-477e-b5de-c71d021f919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0b877750-4384-4ec3-bb38-08ee5ccf16d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9c8c518-9a45-4371-bd8d-47e5a3520e74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be89e92c-bdaf-4807-acb6-4025d0a88244">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee9c1f11-acf2-44de-905d-5f284b2f2e99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7540f357-0df7-4c75-930f-21d4e0cf46b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7948fd33-023b-4cba-b871-f34288cdd5e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56081645-b0f9-492d-a015-67797a891d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7eacae3-b893-4773-8a15-c0c58eded027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aa5ddeac-c8e9-40cb-a1d1-9f7ea09b3630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12af6be9-e7c9-48ed-94ec-5d6f90db8dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a34654ae-5aee-4fc6-bdc2-5ec098a6a2e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_60196fc6-3c06-45c7-ad3a-d58ffcea6351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d6ffcf6-4c89-431e-8efe-472592c985d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c4fe896-13ef-487f-8ff9-2dfedad5b2b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8cd607f-df0e-4528-8b90-5b4718af222f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7fda72c2-1863-4339-a7a4-f6b3e2b6fbef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6d1299a0-430a-4b38-892a-45af9c3963b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea273147-7151-4e4f-9db9-1fcb630b401b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e24c6d73-f009-4bd6-8a3f-55799db87823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_018b9ff1-6444-4689-b68c-97b463b09946">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6a79ce6f-d266-4de9-a41c-650ab243444e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70a7cf98-4c62-4403-b08e-76c9392f56eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c4f817-3a34-431f-a6fe-db0ca3ad14b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_242be4f0-4ccc-4c64-8ca8-285c5f801e05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1747a54e-2f1b-460a-96e9-f1e004c0fc50">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1cf3a401-e334-4e2b-b888-747c70fcee33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5923661-1d0c-4844-b6d1-4ee4c6953345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dbd09afc-8674-45f5-a0ec-f55886cf9441">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f120ca0e-d965-4061-ba03-9ddd552b5aae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd539541-75e6-4ca8-9f8d-b27aef8a0d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cf00de-bf8e-4a71-a89e-ba65c7d70449">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_21bb583a-c74f-4282-8144-3cf309cc0088">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a65ee9f-719f-4f47-9dfa-ba9ff879cdd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9d9a73b9-313a-4e9b-8fa0-cbba3d566d96">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_585ae3c4-d76b-4fb1-bc52-cc2665b7bff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a471487-7727-4db6-ac27-ea7374e03907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc862be6-abcf-4e48-b9bd-d1865d75558e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_df93daff-7fbf-4ba9-9486-40503806d1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bc441fb3-f4a0-4696-9076-82679a508d59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c3d8d60b-befc-4d71-a319-22ba6e25bb74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1d980b-aaf8-4ee7-b7b1-bbce95a7748e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486d1e9b-549a-42df-ad67-29d2016f4571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fe878612-3cd3-4f69-8d54-6f4fd236cda8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dcd0ebfe-3623-4fc3-89df-ad719955b5f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4446022-9134-45c6-bb58-b7a27696b416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24f3e454-8e14-4307-af4c-b8767213f69f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c57189dd-499b-42a1-b6fb-40bc90d3a310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_804162b3-4b87-423b-9dad-13464536caea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1eff0e72-3247-4107-9993-1298d21ecee5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bc82a1c-068d-4239-b014-3e770cd1c98f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e61e1ae-4fb7-4b1c-bf38-bb156bdb052b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_abc4c98f-3c84-4a3c-a195-03f724cce1e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53d5747b-9ebd-469e-a3e4-df8d5abb2c28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad5a88de-f5bf-4fa2-b3fc-510e9e8d3c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_64d83d6d-d0cd-4903-8112-392b2344dfb9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e85227f9-582b-468f-ae33-3c98845cd6db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a53cb408-2e26-4fa5-b28d-20627309624e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_86b5e424-cfe9-4df4-a2e0-2c9029f68f74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6137780-8fde-4ca3-91f1-64a5945e332b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_520b33bf-bad6-407f-a1a9-6f9105538d74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29d5088a-c14a-4618-ba86-5567efa2066b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7579990-1de5-4ca6-9653-82ccc5732f00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_095d7783-c130-45ad-917a-c2dd3768cb3e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c9b6315-c3b1-4e8e-a21f-67f978c07c5b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57779485-dd57-4100-859b-10cacc1c835f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_240ef7c2-1e73-4fcb-a83b-0d111cbf2e37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd5f3cad-2a76-4762-94ec-98a3c293daf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfdd1c93-6dfd-46b6-813b-0a5845e15134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a5be388-1f63-4417-9d57-f6a8d7f6c174">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0fa19015-6980-4456-aa50-cf912583bbcd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ab6db68-d9ef-4fab-9e9a-3375d6ecce58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9327214-7ce2-4fcb-8be7-d157202b62a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395280f8-b83c-4445-8d46-c5e5796fd2c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1cd39a2-57f4-477f-b935-966f5a9b061d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f20a0e2f-0b05-403c-981a-8b622394964e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f60585d4-e1ef-457a-85d5-a0cc458b1138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4f6fa4a-f388-4aca-a526-4034b8eaa0f6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fc3f67-b589-46aa-9a14-df1c38f536bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b901fad0-2935-4ad2-8c60-ca6f514d7ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c82adf2-700c-4e2d-8783-691c7eb0739e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a18a8468-b108-467a-865a-cc01df943616">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2c51b1a-fe39-428c-8e64-d34cca938997">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afe375c5-fa11-4fff-8684-c4c3797d88aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b864d96c-56d9-456e-abbc-339fb8a509a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e788d4bc-4664-4c67-bbbf-1e2b9efa5a73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad243881-6037-440f-9c2d-b0a9e64c6a64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0832547-0582-43c4-aec9-e5c9f203a373">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3edfd931-7c3a-46eb-aafd-7dd35d41352a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6efbdd1-ef1a-40c6-ac2d-27d367139d20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b902ca3b-88e7-4ccd-ae42-54fd37157ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1af658f5-3255-4bfb-93ea-05de03e79987">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d5e9708-d4db-4e19-aae8-90f09cd7929c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd656c03-02f2-49d2-8ac6-ad27bab92a22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf134a58-533c-41d9-9b3d-064ea328e676">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_36b31222-5177-44b2-8c7e-386051e7f428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0f32ce7-ec0d-45f2-83f0-a0de0b3f6667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36e242c4-596e-4412-9920-1ca45dfd68d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8cddec43-6655-4716-bf29-100b760b612f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7d2dad33-7520-4b06-bfe3-cebda9ee7513">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9815c625-a36f-4d07-b707-ec66d33859a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d0de5dd-fd98-4de6-bad1-e85580ba0e08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1c91801-83f7-4a77-956a-ca55e5d1e3a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ceaba128-fbcf-4166-9394-68d7f0ca3752">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b15b72d6-5cdb-4d59-9668-79ef523ce4f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8e480977-b24c-4952-a093-809cb4d24763">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5c1c711c-85e7-4fd5-be4a-ccff8eb4b5ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbb9371f-1a37-4003-b48a-8988d30d076c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5b42e1f-179a-4c97-bcee-364d1ff170ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ff6fe352-30e8-47cc-9b3f-0616a04687a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f677199a-7a7e-45a6-8b95-8237f459bc82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02e3ac29-d97f-43d1-b090-d6a871b884dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_601283cb-11d9-4caf-87c7-fdaed3433b0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_654a5c27-2a08-4691-8295-275e8d822171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77f5430e-044c-47e4-817b-bb82a39203cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00ecf5a0-0f32-4b79-8e19-ea08c4983582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af84eb50-6345-4236-85e1-0ec2f50a2809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dcbbc1f4-df6f-4356-a98d-e3b93cb2e392">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d404e4c-8304-4c93-8b97-ed2d89c816a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ca824ca-5d7f-41ff-a5ac-f3de76328507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e7f5a4b7-165d-4279-9faa-59831ac0e6a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f1c65454-d63d-47d1-ab82-933a498abc9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853b1603-5024-4c08-bca0-8e16defc3084">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_950ce21d-3058-4a86-8fc5-5c6da09dfd7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_087cf93a-9ea4-4c8a-9e45-9fc42acee0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92dd2c93-1279-472f-8d40-7e64631b28c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_84fe57a7-bdaa-4724-b43f-d941fb289764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e098bffa-f41b-4b69-a028-c4feab4acf86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4bac56f-597b-479b-b57b-b2aac2d58bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cac11f7-d0bf-44d0-8b8c-a10afa30e275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e44de395-9fb0-4220-ac41-10c9c37f6b98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea85bc90-6724-4580-b1e9-bc7626750460">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed8ba83b-973a-43bc-a272-e96e8cdf3621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e19b554-54eb-4aab-a6d2-7a770a88753a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736eee20-3b0c-44b1-b424-ab399710d6c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_010e4f03-e0d7-4cb8-bac6-98ac3f8de025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_042c4356-75cf-4e9b-891d-aa5d10db05cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_208fa1ec-4809-4807-9ec4-23588a1fb467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f657ecda-9d23-4a5a-9c0b-4fdf40cacee5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_523f1059-be27-4b98-818c-62a820e334d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a29f47d7-80e9-4691-8ada-76fc5c2f6bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53f12aec-e862-46fa-8bc0-4d0d0cfda200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69205394-a998-48be-b6b9-371c49e07ba0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d0b9c19-7f40-45d3-9f15-b20a17310fca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82888fdf-f683-41d7-a848-5279ecc53dcd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63289c77-5071-4fbb-ab73-7b68d4ab818f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8725834-bc02-4f24-a7d1-29c293e23121">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a226cea4-b1cf-4320-a67b-3bce18909a0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5ffb8a8d-d3c4-45db-97bf-b76c935dc4ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c8f602-8ba4-4b42-a483-280414838fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9634de15-4459-4e22-b5c5-17c70fde0999">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdec0538-30f7-4067-8987-308455db1f8c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a77b59ef-a76f-476c-babd-80ad5708e843">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0666e484-9392-43de-83ac-819c383b3a55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b81a42b8-e4e7-478e-ba0a-50a6e0d60e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3bb2f1c1-4602-4b78-b837-bb503c6934dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c551043-5d5a-4968-8a63-7f6a3b7132f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4637e379-f30c-4a31-84bd-ffd62fd2e46f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c03176f-cf7d-421f-9fa6-a1d8c92c4fe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aeb7f15-4f3d-4387-8586-53359e2c0bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c9b0c3f-561c-47b2-9629-81810731b547">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10641ef0-825e-4819-a601-f845fd541f49">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4649cd4e-eb8e-44c4-8cf4-8b52de8527b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cdc2941-1a71-46b8-a3f4-022f1702baab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5b696508-e2ab-434a-8d1b-b5f5cf48933d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1377b5e7-b31a-411f-a56d-254840d49146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5af16294-f0ff-4adc-9a35-fe26c735a205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7086329f-c75e-4401-bf18-c12448d0599c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da05ed8f-45bc-48dc-93a8-aaaea133cc93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_249cc69e-c3bf-4569-98df-982eb0b02755">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_519ff774-dfc3-4080-874f-8c6dffd4c9db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c12f960-6db8-403d-adc7-63d01d1f7b05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cda35508-43fc-4439-ab19-434bb3f04372">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acfad03-f47a-4c03-aae3-33bfb6afefe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a638d024-ed4a-41e5-929e-cb4854c84eee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fa30b0a-0b40-4e75-9fcf-a2cb760bdd7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1248a6-fecf-454c-967c-b71aeb1e0089">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_681ff111-c345-4c75-969a-1eb7a391a4e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_207f8550-12ba-4999-b92e-624be0b8dda4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f167c3c9-799a-4e7f-8bb7-32cf1b7b4f11">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a07ffd7-8004-4de8-9250-9c6429d6f865">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2875bd0e-b8e6-4ecb-a19f-cb48be23d6d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0c7a8c2c-1ae0-41ef-8239-2c3104922d12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83705ed0-b3f1-4918-9fbd-c8cc40df7d22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74e6e7cb-dc2a-4415-ae20-1573ff8836b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90663f13-bdea-49ae-9480-f45efa86e5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0eac8aa6-0f09-436a-8629-5f7028184b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65fa9ac4-a534-448f-8cd0-c38ac7424048">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ff2d05a-6222-4638-9733-1eef61762494">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6820822a-c4d6-4729-90de-29b9def7cf36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a93a36f6-3a25-4c76-9cd9-78c3d42fbdde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e472adfe-10a1-4a92-b3bd-7b5b5ed2486b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83cf789e-d6e9-41de-b519-aa03739f45f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6d58856-e665-4d79-98f5-afd84db54f69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784d6612-2600-4426-92e4-7027acffd95f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13896b4e-3e41-420f-b862-a0a3d21ceb96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_666c7a62-6e20-490a-a1c0-cbfb3c7436a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ff7ed84-33d3-43ab-8376-70a048059152">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14854eba-847f-49b3-8e20-ca94a2f5b9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a9b204ab-1f6e-425f-90cf-898fcd1a7407">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed504220-d7be-48d7-9805-32d3e3c0e5d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c227f1c0-e34a-4741-8d9f-fac803867ef7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb64a662-23fa-4075-9a28-e41e6adf1d71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2d83d0ac-c4b2-47de-a28e-ab512147e83d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7cda8444-ab66-4c14-87f1-12402e45c61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c737ad7-aec2-4180-a72f-d72e244d844a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_133ac243-cbba-47fe-9390-45cbdb008ccb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_872f7b3c-5276-4ce6-b962-0d8b25432d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_189e8e34-f99f-4574-9f08-b8b440464c4b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67cb191e-4133-42e0-add2-607ec93ac3bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb848d85-ce2a-4998-bc42-c56e2faaa553">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_992ea9eb-ce43-4464-a1d3-194fbc6b4ba3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677076a2-8d3d-4f6b-a22d-43b9d496a2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60eb085-3818-4f34-93dc-e7c38e532bfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c0b212b-ce81-4c15-929a-40cc841586ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc7d3b4-6640-49a4-bebd-48161c16bf96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_287c3a3a-9ab4-42be-abe8-142a3b70bf16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_277a94a1-0bcc-44ec-8db1-eb5021c13cab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5a7c9d0-d63d-4e0e-9bf5-95a77cf9cc84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e70d7203-74eb-4383-8a46-da218ed8dce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0614cd6-77e6-463b-98ec-e93ffcba4e75">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e905378-e9c1-4fca-b4a0-c5acf1066973">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99e9719d-ed7b-49f5-b9ed-f4ed85e139ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_37e88aeb-098a-41fc-9e1a-52baadb16798">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd243800-375f-4158-9a2e-e99a8b0a8977">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffc28114-bb4e-476b-9411-5930ed3c523d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acbd5f5d-d985-46d8-9b39-51c1ec77654c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a8f2b10-d625-4291-bbb2-c1fc90c3d4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f23c38bc-87bc-4431-9393-a0cc4d3170c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fa31a3b-1cdd-4926-98eb-7e35a81b18bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f3c2261-ef07-49ba-b884-bebd1494fb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b045d88-1984-4a69-bbf1-f50f6b1ed6ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38fd34c-89a5-4c12-84f2-09fbd8009033">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edbf147e-3aa0-4d6f-b4e9-39601d31597e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a58f4ab-dc05-48bb-9b39-3cb5f45fd2e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8bf36f7-97e0-42ad-864f-2f2edcb88bfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2323e83d-47dc-40de-a144-16eb4e03305b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3c11ea-49cb-4716-9818-5c12949903b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87f4fdd0-5e5d-42bf-97b2-4cff37d86182">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb9b8e19-399f-4574-822d-52b132b2a422">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02522a83-995b-4bcd-b3e9-375364be6b0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_798b3459-1bef-4fc3-8355-fdf9bf179a3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43a027cb-d98c-4ca4-9d54-5af8fe884f01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7c12a36-2bc3-4fab-9d03-d242fdc47304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95306b19-c314-4249-9726-7ef3f94e0d01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ca2305f-ff10-4b1d-b5ac-044bb4c10f74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_78b67db8-75de-4d10-a3d3-fd218675b991">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c76d6e4-2822-44a0-a623-695a0e7f9d3a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e202178-e806-4523-a1bd-f93869911a50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfe9440b-926f-4cce-bf8c-a8f6d487a36f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33626ba5-36b3-474a-a6c7-2c281ff87ec4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e6e2210-e273-4be6-95f9-5688af27f518">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ee8789c-7502-4fe5-90a1-6e73dc9c505e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6133f8b6-0bde-45e5-8f0f-028ebdcf5e51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ad218d74-0a8e-4012-8e2f-0e4b7a336d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c1e52ca-76a7-4811-a892-befb669f3507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_18fd6434-e78f-46b5-82c2-d3ebc9a988de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e648bb24-7214-4a6a-b0a5-a9fe6b8b61b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94d3e68e-9865-4ec2-b05e-248a8bdc3d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_101f17cf-add4-42aa-b827-9fcee3063868">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_93711071-4cf8-4adf-86ec-c6a32d98f266">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64cca2a6-8c18-4f0e-a042-fee853c9f2fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_180895e9-b096-458c-8c97-9c4a72ce7baf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f9420713-0860-41dd-8ba4-9afeb786243f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61f2d29b-5e0d-45e1-8dd8-d0420e496f28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71cfb5dc-ba9d-408e-b18a-81f2094e2f7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17ee7463-034c-4288-8bc7-137ac0a633f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1322195a-a94f-471d-97a1-36aaa5291e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01b1f9cb-d4c6-49b9-8308-a4fe08646434">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab4438b3-f56e-46e0-8d20-4e4129be3372">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f297db3a-e6df-4def-8490-9c3a9b21c27b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_890cc6c9-ad70-4730-a9b0-cdf9c5cac5ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8c6fcf8-d0e6-4535-a745-c08a0054f3ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dcba6d8b-5108-43ce-a5fc-b36e4b065d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52753638-c365-4f1c-81f0-f9fb6fb0d58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ba74212-2d31-402a-b2b0-f3634b0fb61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c87a5c7-5bef-41a5-962c-12bd1cf3d6a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2bf5b977-f2d6-46aa-a673-2f66e395b78b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef3a0e9c-40ac-4a1e-a041-86f72e7d5b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5e0a7a8-420f-4cff-b55b-e6e139165aa5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13ed373b-2943-4988-ad54-980c97b6289f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d6452b62-9209-4e95-b4c8-b3f87293609d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e679a526-99fb-4b23-b39c-566137ce3f75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8a4eb8a9-a1a9-4251-bf2b-4f8c975cf86e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a9bf8bd-6672-4e21-b8bb-e9e91f34e994">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_294557d1-3730-4819-8d03-96456f3fb912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e2daf53-4341-4911-980f-3022b8066b06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7fc0c8a-db70-4c61-b04e-6169c45e6742">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b83a5d31-4ee4-4219-98c9-aaf54ed1f572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_16af6b93-4e31-4e18-a77a-e4539fbbc6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_766b42c3-ce28-41e3-bbfc-786e84c88654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18029036-faee-43a5-8a1c-6439d7404892">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2d90918a-2664-43ab-ba72-50862a4cba1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5fc88920-3f1a-4427-8110-f4bc8a88aaf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1768cfd7-5909-4887-8b25-fc3e38b59dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0147f1f9-332e-4e9d-a8d9-e49d4605f776">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_866002ce-f7f8-46ce-921d-f83f33ee8d46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9226ad6a-e864-4c79-a107-ac6669389ece">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3fa8af05-471c-4f84-9804-2364ab4d0142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f8e378-97b4-4f9d-9b3f-be0fa08c737b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6abb7518-e189-477e-bebd-3b47fbf2925f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08dbcd9f-0cb1-478b-9d54-9251d09fd380">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6c00c6b-4fb8-42b9-aa43-be4aedf68d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395ebb43-da61-4761-9bd9-015b17860fc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b177b6cc-2918-4ee8-a5f2-bd619448a2ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c167ce0a-7228-4516-973a-d0267c640bbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9224a58f-f44c-4dad-95f9-d57b2f19fdfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_009bd855-5a73-40a8-b2db-4147028f51e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d617fbd2-7202-4dd8-8747-bcef9c2c5304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b667f9d-2ac9-4b00-b8ec-120472c203a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39552eb2-2347-493b-a342-36112dd61761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca73dc61-46db-48cd-b6ac-020490792c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12e678-c7ef-46bb-93dc-bd6c4fae421e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3635c9b3-b303-457e-8e50-6af4bf971c81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ed3d1d8-306c-4634-9e74-e55ce4231da4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5431f42a-4340-4948-81f8-b6dc1d46bd85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a549c145-0195-47ab-9ea4-77c6d452a452">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e8510213-3fae-44cd-8c15-4af0efd3142f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff76ff5b-f84d-4bfc-b06f-19f833592c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b52eaa-13cb-4ac3-a2e7-fced09e07ce7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9de60e0d-f60f-4269-b79b-392086bc26e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7954e8ef-e8fa-45c9-a1ed-cc05cb0e38a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11316af2-1bf8-40c3-a347-97344c20ad02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50f7ffe9-6211-4a14-a182-778413891848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_87540be5-5b92-4ea2-bc7d-5b3a26a87c91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f97ece6f-a45e-4473-8e6a-44a98b809134">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c02fc72-0dd4-4386-9b66-933757038c0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_867a6bed-e19c-48e8-a2f3-1926d9616bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02bf56b6-a3a2-4fab-bf0b-44e24794fd3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ecf22d39-597b-4818-b5a8-c31e0720bfc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ced36e4b-41e8-4728-b496-b75bab9931a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34ba3909-aa3e-4d0b-a427-063609b352eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf9be7ff-0016-4672-9459-a0b1516a2101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3227f4eb-27db-4eb2-969a-3af0b573b8be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_22693f43-01c5-4cc4-87d4-61d6b5fc763d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cd4e84e-7059-4b13-9285-4e8f4c356a2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6640ed22-d3ed-4ece-8619-61a1d5d51798">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e7ea311-332e-47d7-b933-6c6df5c31f77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bca5d88c-41fb-4e64-ae21-d1cc14551a8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ab93ba3-8eef-4341-82ab-71ab7e39fa30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e6e188b5-450f-4a43-86af-ba5bcfd661ee">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2bcad28-b999-4f20-bacd-724c9f78c298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cdca876b-026f-48e4-8bef-c9b1dcf12eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9c318374-62a4-4ff7-9cb1-d9a784db08dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca11ec26-3b01-4bf9-84db-24ac4f0248d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8705133d-cdf1-4be9-b24f-e9b2e676a388">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b540bd1e-385f-4dbb-9e2b-56ddb1eb21d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a47fb97d-2d7b-4251-9f17-312b1e07eac5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18a57444-1e35-48a3-a599-55c7a6e7af15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebe2f330-1adb-431a-aeee-4a6a21167603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4c70b357-5014-42b6-a0ee-fec1c2469a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a01662c5-96de-418f-91a5-b16db1b66c81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_87c006b7-bb18-4a80-80da-0eb053d7b15a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f276409-96e1-405c-9e75-4d9fccc8bf87">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_034ec4b5-bd8c-4a92-99a2-1f730be3f002">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bfc273d8-d57c-4ca6-a117-69a5e0ecb2d6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_392cef6c-b0ef-4cb7-a61b-d92b77e1f8b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82bd5ada-01e6-4702-b2bc-43685a564dca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0203b79-c207-44ec-a455-1076786151ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2957eef7-ef17-4284-8b72-885290a5d4c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb554827-e2b3-4174-8618-2fac9fb13cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68ca1c46-e3bc-4281-a44c-882106869b58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_081ff2d8-2c7f-4dea-b78a-d67d6abc4db8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d02ad0d1-25fe-4737-9c11-d7409abb063b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8be185ca-2d62-4f9c-8e1e-caab88cc2025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9664ae2d-68fa-4059-9ffb-473fe2c0cd86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9284884-794f-4ee0-8ef3-402a142e0bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857587f3-78c0-4084-ad11-e09272976390">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_432d7e6b-c2e8-444f-b028-b234d1ef1e88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a5b57d1-932a-4f96-8583-89781b773ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf0a0c29-48a3-41b7-bf37-d440fd41eba2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a7e0964-17b7-46d6-8d1a-268c8cdf3e64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23d6d5b0-ace1-4f4b-865e-5a827364f543">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ef890e7-a6b1-4294-85e1-3fb193760bde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb9c11-e256-4e10-8312-fdfe2385c71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc21f7b2-afe6-482f-af4f-92fd14b5abfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad6c979f-657b-4e73-ba68-257d15d08a72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9990ad7d-38f1-4620-b15c-019273d58f41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c87e7e5-b2a7-40c8-98fb-101f3db6c73e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b79df498-dcfe-4fa8-b694-04d76cfe87b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a676aa7-4dd9-446d-986d-794ce499f297">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f1f0e9e5-3f7f-4a7a-b8e0-3dad27794a06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e9770c9-db90-45bf-84af-be3839c382c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7565f8a-903e-4b04-91ee-dce04a6097a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2eb48637-02e4-4857-bf33-7421a2bd903e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5cbe4d57-0c5a-4e3d-8104-c43f35f3b8c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe00b674-5c44-4794-9a2b-525f35f7f13a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_038e4bd6-fe6e-48cd-8b3b-8617fcf53b16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b8f4ab56-0cae-479f-b994-a089285bf453">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fc5009-d32e-48a7-8fa4-0a892b95543d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f170f287-d4c0-4aa8-bb8a-be6a691759fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1173766-06ad-455b-8adf-663574665ef2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbde89f5-f08e-478a-8a73-f1203842d380">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26c96fbe-07bb-454b-bafe-0b66e0d91779">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66f5f987-6746-4ddf-8291-e079aae6f88f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d1abd8a-4a75-450b-9814-efee70c1f00e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7203f60-7692-4edd-919e-212721c83323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_314d2ba4-7d01-4433-866f-7ed52d8c266f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e1c9ddf7-9f1e-46a2-b210-fcc7a90dd361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e781a75-395c-4675-b1c9-8090f7136a9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d88cc96-bf93-4569-aaa9-b85447f5d6b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5e012982-8c5b-49fe-a915-9984a9844629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99f7bda1-69e0-474c-b2ef-27c28b95a477">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21a9a1e4-817d-4f3c-a06a-88c050bd8a01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a461b809-62d4-448d-8596-070fbc82bcd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88c1f50f-7065-428a-a48e-3955c95e0a83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3633500c-289a-447f-84ea-ee2adf5d8f06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0fb79a27-0296-460e-96bf-344c9748e998">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_320e4ca8-bc24-41ca-89e8-88fb69a20780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d52c596-f3b5-4ce2-ad1f-c662b2590caf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0c87d80-0936-4412-8a9b-c023ac69a7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46f656f6-4f2e-402e-93de-2f4de8fe6b6b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_86fe6bb9-d204-429d-8827-606b790a951a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65a6018d-1102-48c8-bad8-c5a8effaff81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fb4c745-f703-47ce-8de2-bfbbcaeaafc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc383940-5969-4abf-92be-59f7730681f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a02474-3467-4c31-80c7-4c1d43af0cbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1e7c81ed-90ef-4fff-9d64-df1dbba18891">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_270bc494-7c22-455b-a3e0-e1c31732dfc0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0da6b145-a096-4b6a-8359-91e83a938787">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ef5af20-1c4b-49a2-8110-1d688fa10a75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b698233d-7707-4afc-a8c4-ef3860860220">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2d5eb8c-d2e4-461a-a3c6-af74b86875b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_067b340d-de06-4c93-b738-322c9e63f326">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_884b6d2f-b17f-47ab-b894-29709041ea27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_175d59cd-5dbb-4625-981c-cb434b49c02e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7701a0d-bdd9-4f72-b55d-db2c6b054614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b1fe23e9-b568-46d1-9b05-3976637f31cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aab9f87e-3481-4ad1-9af4-85bab1baad21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc158be9-9c3d-46f8-894a-bfda40b4e8d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a8f056b-8c01-4df9-9819-6fb78eee91e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d3637a3-ce8e-4969-a955-19e3a93f2460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb458537-8f24-43a4-9114-692c0daec131">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e806f44d-97f4-44e3-8726-a61f5883335b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a7c0188-4d39-4dd3-8004-9b473b22b3b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f71a10a7-44bc-463d-abb6-e483dc630541">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2e8ced2-7ebb-4a01-a1e4-55f059b92fa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2f6cea0-e313-41ad-96f5-87800121a518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ad72c6b-d938-497c-8618-859b5d3e5884">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f1cf396-8d86-4e6f-a52d-e1af86772ceb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3251f608-0688-4dc4-9dc8-e3091bdac7ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8fd3fc61-31a0-43bd-b0c6-cafdd829679a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fbbd787-319f-444d-a059-3a5536c03ff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b7f797d-4bd2-4df1-9cc2-a888aec7662d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d2eb25c9-57ff-4877-a01d-57ad4b5ad6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f8d3ac3-bcdf-4d13-afbf-63bf24e38d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1342fe65-f28a-4ae6-97ac-46ffc8b6ea76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b546ffa7-d00d-44d4-b9b0-f2a6dc043c97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486326b9-4614-40ef-b499-57360c1454e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65e01f10-db8a-405d-96f2-ecb2436ea1bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173fb145-6c85-4837-8c26-642a031183cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39748ac4-8994-41ef-86ad-aa593876e300">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8feab797-7f0e-4657-8282-79c8b499523a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5838d0b-841c-4085-876f-1356e29461b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66238552-d9de-4b1b-9b46-7f3d2f028039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce8a387e-0ea0-425c-ac7a-1e5dbe93e6f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_28e4a7ba-04a3-4c8e-9d98-9b47f86b7ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dff8a9f5-f6be-4746-a6cf-9e0fb46ef3a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dd48faee-7455-4f0f-8f4a-77e7491becc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50ef0e35-d57a-446f-a4d2-2c9554e2d57e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e0f1d46-62c3-4360-90a8-bff00e7cf60e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b424c2b7-3a7f-497f-80c7-0a30f96676fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a833d30d-19f5-4e6b-9f91-19343a3ef516">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95506cd3-1c3d-4793-89f9-65cb4c8dbe8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3991ca5b-3c5e-4b1e-a604-17fc2269d13b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0b6e1d-6cc9-4cc1-91eb-2548f3a71765">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df182f4d-e0de-492d-a328-0043b36cc033">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21bf0113-445f-4a34-9358-bf53c533c485">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80a0e5c9-61fa-4204-b743-9351bb56ed69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_632eb5a9-9e2d-4eaa-a7b2-00d881f0b85a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b386a96a-0e25-40f1-acd0-e6db2ead045b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10196086-9e19-44bb-b597-102575b853e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b6bb26-e66c-4d36-b242-8da8298dfbcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_40fa729e-1cbc-40e8-9150-07e62aeff0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b2ae2b3-068b-4f40-b89c-183060300298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_233b7c4f-1118-4246-b7b4-8ffb83cea2d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47c6c1b2-0598-4985-ac70-ea6696ec5bc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec420356-2092-46dd-bd46-319011559d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffdebe6f-5731-427d-a69f-bb6a72a5842c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b6b8c7a-4fe0-488e-a01a-1e14170230d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_516c7e02-238e-4cd1-9e09-495bdeb37206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ca2a83-900c-40db-b703-573ca798e017">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2026e7a-6ae4-4e02-9429-3d7c0044c104">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_16daa926-0bcb-48ee-9fbd-f92fda0d41f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0d4db3-6da2-4152-bef0-416b2d5b0f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c08f3b3b-a1c8-409a-90e4-8a48873e7d62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c9829-f820-487d-9ff7-f9d743f2bc6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01815773-3d66-4ea9-a4b5-7e3bc5e21bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11eb003e-8feb-491c-aab0-f4290351e574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3fc6d901-d47c-45b8-932c-9503f5e191e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_346ad448-e260-4eb5-ad22-909cf41d55e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0aa15e9b-4db7-4647-80f3-6faffbbed9af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e186c8cf-20ad-49f0-8181-cebfb9de7644">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2695dfad-50df-46b7-a2f9-455baf0a39eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ccb801e0-67da-49ea-9ae8-eb6b74fd3796">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_518c2ad8-6722-49fb-aeba-027b9834fa12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_768736df-6aba-4013-a7fe-5a4d2415efc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c98ae667-4b00-438c-a4e8-11eaac1449fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aa48cfef-d128-4b07-a145-71146779f621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dad66b7c-ead5-4597-b4bf-97239b0854d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_571e8263-08c1-4586-a8e7-327d1f5ff2be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c344c2f7-1f7a-485e-ba0d-980abab192a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac2bbd87-5d42-4fff-967c-30d4052d4a0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d381ddfa-6e11-4efa-b898-c5d0ecdda246">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a14bcea2-8848-4ed2-8671-6e9c1db7b38f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7eee8ba0-c290-4cc6-9b99-cc978ad4a55f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b660b46b-f89e-44ba-a2f2-5f7ce2e38699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f5a225e-9d00-494d-90ec-44352d98d4e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ba7b635c-3031-40ea-8907-63881e80b42c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c94e6b68-da6c-43d1-94fd-09ad60c74134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6fc20583-c9d8-48f1-833c-e332515ccb72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ff1d968-f352-433c-91e4-2086b875b068">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f57e0ec-227b-48ba-8a55-8b1792a44c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4caf17b-3b80-4f50-84cf-3c9800262e53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_750abbc2-9c8f-478b-967e-5bca6ccb6649">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d877c8a9-ebf3-4468-9bf5-bd35e802914d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dbdb1b4-0575-43d8-ac61-faf72cb621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1b858452-c35d-428a-8b4b-90f21ad07836">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa7083b1-1a9b-4973-84b9-df7487d7f4aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4462db5-e42e-40fb-827a-196a16d123c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df2d3e44-0edf-416c-98ab-3efbaf98a66c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_64b2c7d7-d7b7-4c1c-9f86-b1adea0698d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2f1d3e-8f67-47c6-8e9a-dbd477da2acb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b75cd36a-7f05-4fe3-af88-ff32fe39e6dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0897b098-e2d5-483b-a708-28f47c435413">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc31b2ff-8ba5-43f8-947a-2f11dd26492b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69d4e272-32f2-46ff-a0ee-95358129563a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe46cdb5-2ea1-4fcb-b508-6ca5aa09db3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69d1ccd2-3730-4278-99bf-9ca956be4401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa397ea5-dffe-475a-86f9-d00d21ac01e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25cee9f9-9bef-42be-b860-ab3beead7814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f441e1ff-6bae-4314-98bd-5b1689de1b2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ada9951-1e02-4889-8745-f13dc4148ad6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed408729-5a92-4002-8a8f-ae384ce3620a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_688fc72b-057d-4a98-98c3-f962aeaa22d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_347aaee1-bd55-40a5-99e9-fa9bdc3a9ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3e50ea0b-e624-4ac7-8e6a-29876963b392">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6f1e5e9-d979-47a3-83d4-817003628745">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5318967-afcc-4fcc-b0de-d5f2522a95a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8082da6f-11ee-4cba-96f9-5258414b720d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e704656-b276-46da-b8cc-b757bc42fabb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e9f91b69-a29b-44ea-aa0f-cff86ee80320">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5adebd33-20e8-4c94-b02c-d9033c3a891a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad86e83d-6334-4dd8-b642-b4c16d65329a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c96e50b9-ea15-4421-b6c8-bd9c9158a69a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f43dae36-6df4-46ba-9dc2-01543e80e0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b8b0b9a9-af8b-41d2-a4f8-940637e63f70">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b345e74a-9570-4cb9-9a59-928390e3dc44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17abdb92-0180-4bcf-8ae7-dd923630f360">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0b78ffaa-9859-4658-af17-c8d355633556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9acb676e-054f-4e61-b60d-3371c3320b52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9315b98-af75-40bb-bf8e-05bd03d43db5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9dfeeaef-5c49-4c2c-97b1-03876970bee4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36d76f23-8e75-492b-8f9d-4d68d2dab71c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6a076be-4135-4592-85cf-1f22fb0528a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6fcfb68-394c-4c29-9cef-9e41fdeeee26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_420cad1e-e8fd-47fc-a747-b9032181f6c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b664adb-6099-4a04-a498-dc33ba0fd5b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39cf2a82-5f62-4cef-9bd1-1af4f783291a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7eaeea7-ce64-4a47-86ac-0eec8c65c8aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fa594a2-56ff-41fa-aaf3-c9491755b684">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00865800-7a32-4d63-91f6-88217af4743d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0b0cafd-9ee4-41aa-ad86-965a7e4a00bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_287ea6e7-a365-4038-b8d7-d7f01677255b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd5768e1-dc34-4e62-b9ed-bc8ffcdc0000">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f383c35-5d1f-410b-a60d-d67e1f48f646">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_679919d3-fc46-4791-b7d8-8a87d0bfbb91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_835c00ee-21be-46df-98ff-e6cc1cfabd3c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0434708a-79d9-4740-b697-2bfbd525260d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed1043ac-f6fb-4f30-8a2f-177e4fdcb26b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cafaa7fd-26d1-4609-8186-f9af8022be4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d43e0f0a-5253-41b4-9e43-ef864af5b857">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3d02781-552d-4bbd-952c-f753034b5ece">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46c8e67a-37d6-4498-a6e1-148ad0fcf682">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74a95e4a-dc88-479c-8aa2-fc194cc595ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d27fc6e-5da0-4d89-8d93-8bbee127638d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_17cb9e95-1fb1-4fad-95bc-9cb4cb1eabd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a6b0d1-4103-414f-98f3-14009ce91e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1286c4ed-c414-4282-af59-91af27cb856c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b591b30-bfd2-49b3-9bd5-4eb808638a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38733a74-2927-4247-8fe6-065cd9fdf7de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abe5f6b0-6e09-41d8-b326-685828bb5fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57e7e6c3-e0a6-4ac3-a0e3-392e749b3dd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40d166e5-8a94-461c-96be-c7b40c9b0c26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_159904f5-dc85-438e-adb2-0f7accdab22e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2eb9abb5-9566-4c1c-9e11-c2f6ee115cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba08c29-26cc-4706-ac27-26692aac8c88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c7d6536-ea8d-4b7b-be12-6be542b1db2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d62d7e5-64c4-4d08-8a84-543433b71491">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff03ac62-f2e0-4beb-a79e-447a8dbcf53c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b729ff6-e8d4-40a8-a250-8546f9d43ff9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d917556d-7af8-4d62-912f-cee8779b78ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57df35dc-cdbf-498c-a3d5-7f5da2618ba2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3e47bb0d-8a7d-4e68-bab4-e4b55c2be04c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_09b5337b-759c-4cda-b09e-fc2131692bfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6554fd18-1d49-48eb-88d8-289134c6e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1baf8007-34b4-410a-bd34-21ba83f132e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ea887338-df13-41c6-81c8-10ddf6501626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dbf3737-7c17-4e23-b698-a6231fc95c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cf25bb9-e5be-466a-9eda-76d00e20aead">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_181c1a17-a777-4729-8e13-5d427ad49c94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7bad0622-8a66-4e8c-ad40-dc0a25bf0123">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73e5d2d1-d756-4b50-8069-e663130f1816">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6296a5-b265-47cf-b634-c8e0e8fff1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90364382-c1c6-4471-850f-7ebf7e718070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3ba7162-1168-4478-97a5-1f522aab0b8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34818fdb-09a6-4567-be70-0bfe57e6cba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dea346f3-01e8-4b63-bbe3-5aeea6ea9129">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0e08d7a-7d6a-4cb3-8a77-447b121443cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d8569a51-3dcb-49ee-95e1-193d570db5be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ccffd22-4277-4a42-9dc9-86b270a0f291">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e8f404b-ad7e-4684-bc52-e3464e34ee79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fa3678ca-1dd0-4be0-aac6-a5cf857e7d60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19bb3455-dba7-4049-8350-9fc3c29ff4cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4274888e-6e49-4d9e-9563-b483331f8424">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80fa1756-f607-4448-ad06-dd7b5e69ec38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ac383d2-d853-4b4e-b0af-171813d0b7aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff8e4c1c-ad07-489e-ba11-43217dd68dad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8d3d915-6065-4890-943e-4cf5c69a97a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_563b8841-aa4b-4bf2-a54f-8f069829f070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f1203b6-43c0-44bf-ba48-25564bbefef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57a42edc-5e05-4604-b596-f01ab114f5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd023497-58d7-4396-8f9d-a9bd364f8c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45d740ad-e86f-40d0-9008-fd671acbef6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33c8f510-825b-4689-a374-f96650937c33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe2c5d47-fa92-41ec-b454-3cb1c878437e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9f2dc0-6618-4f8f-a284-22aa15d23fb7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cfe03e9-7d00-4eb7-be53-4b443d69703a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a26ae26e-b636-4503-ab26-2f5946d511a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0759a425-647a-4247-b66b-26357a147542">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6ae1641-50f7-45be-9833-bf04ddcf7697">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6cc414f9-05d7-45a2-a19e-958faed12395">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eda4be62-674c-4d62-bec3-33bf3bdd6294">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a241b4fe-ce93-46b3-ba20-126ed4574adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fdad08-fd5a-4f4a-8ae4-296ea3184087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0d653c1-85b7-4edb-b412-90836f207efd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a897e54e-1f4e-49f0-a8b8-d1b79c28413a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b3d8eb66-45fc-4b9c-9206-5b87bd362315">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bffd0293-189f-4b46-9e82-f8951326d01d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bda2a584-06ba-4aa3-8af1-945d6ad9829d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b37c45-5751-4c50-862e-d2f811623bd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e9f123e-b540-4391-833f-84e5f9b7e63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8911f118-6ed7-4424-b8e1-a6885482ddbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3da39f62-762a-4533-9485-f1849e5f8812">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dffdb415-95a8-496a-ad1a-93cdeb444fae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7ed6624-d332-4a9a-a96b-b31bcb1ef24c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccb6edb-253e-4e1d-85da-c68ef40f59a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa063f2e-1205-4d1a-a549-3ccc5b31e65d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_443775ac-c8ba-4e4d-a91f-d1926ba21744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ef85f09-3622-4a12-87bf-fefcecc01e4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28b3e895-483c-478d-a5a3-7b9d7c9e11f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a0244ab3-80e5-4c20-b201-a142d50e6ec1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c8e0d41-008e-48dc-af1e-e988941e71ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0ba9bc8-9cb8-41f9-be4e-a8f6184e1432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4e958ea-f50c-472b-8c35-9b2a606d4310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d0edeee-fb82-46ff-9ad7-8937813fd4a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf4393c0-21c2-4e35-b330-c1acda2647ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_72627757-688f-4752-a751-c9e2bd554d2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3d5e8cc-be34-4d4a-a586-ce582737826b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10180352-5b41-43e5-8bab-bbd40fc3053b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10313794-08ff-4455-90e6-a439d474d0ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_22ac1bc2-c0f8-4d04-897f-c24e25f28f4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aad73b40-3e9c-40ac-834d-4c0243a5c334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f492ecb1-1a65-4013-99f8-49edc9d7d556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_307df982-5918-4ad2-8c83-1cbc9b7906ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31cfec00-6695-4126-b60a-98c4cd7132e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cf36442f-8f07-4110-aecd-1c7124608dd2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53e398ff-d48d-4e1b-acf0-be0965777d35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4615f36c-51ee-4eb0-945c-d57636d7fbb3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_db7be977-a065-4bb0-8b27-d44e0a6cac16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c3bbfbe-faab-4429-8c29-799f941f9add">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed71bbb4-203f-42dc-8a01-e3b144ea8ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_54cc9d2a-325e-4545-a35c-d322e006a8d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5731482a-7053-4716-866b-ab26f39cad97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aea5de0b-5724-497a-b712-f813e6c55462">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_350e99eb-81c8-4938-9014-f14d16cc0989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a83373ad-d7a8-400b-9d4d-cf7a0dac3d73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_030a749a-f8db-4c51-a67f-571efd180ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fe0f5c1-8319-4dc7-ac10-643c4d4ac0c4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3105ff97-c823-4905-b049-f467bc8e0810">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d4658ae-163f-40e5-ab58-754de44a9565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f655fe14-241f-462d-9fb3-a58dd791a31b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_97da8dc3-3290-45e8-92ae-a01611dc0b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_513211dc-4e13-49b8-b8f9-8a062e6136e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bdb83ed-36d7-4e74-9e77-1237f7695622">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f605145-f6fd-4665-9672-8fef199d1592">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e8c477a-837a-416a-8283-44318182f678">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47b201ba-930a-423f-b4be-a71805471077">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4bae3a8-84d1-40fd-b83c-a9bf8c206d9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c6145b2-effe-4953-9f32-2e49388dca38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fbbaea94-c6b8-4492-99c4-08893180b6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4decc4c0-9950-4fdc-8682-dca579e200cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f851b27-33f3-45f3-aefb-2c134479e2ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b061adbe-26eb-4721-a6c9-e78026e0f915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b79434bc-5187-4184-a806-7a39037a7640">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b395e7f-bd27-41ce-a590-eeb60a5f502b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee96be74-4d86-4eb1-9150-2d594bfcfe1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d08a684-cdcb-484a-a767-03b10f4ada7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb24cba-8dff-4ef9-9ba5-dbdb086e77e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_706e83b8-c1de-43d0-bafd-57766513c62e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f468d841-1bf6-470e-85d4-55d34fab8bff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a78dbd51-f64b-4abf-9154-3c138316e279">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90c04b95-703a-4bae-82b8-7edf3075aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f193bd8f-badf-4600-82ac-f212d1f33534">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_340082f1-db9c-446d-97df-80e45aa0058b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e33fc23-0e6a-411e-b0eb-67b1271cf383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89c3d444-cf42-4e48-9825-96160ba9895f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71f8df70-c805-42fc-9a09-c9527e6f8175">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_09c871ac-e7a9-40ac-9580-ed616b994397">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6a25879-018d-46a3-82a7-81b9b99b609c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf08be5d-b85e-46be-9378-6eb35540e070">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6398ff9b-368e-4aa0-9a7b-8d9a2d095835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a94e93-5272-46b4-85ed-7a173200852f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e87b2c5-e7b5-428a-b836-5e55a23693a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05d6e5c3-2268-437e-829c-9e9107a18dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7951c520-ccd7-46b8-a3a5-fd879cd12257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6adbd31d-0c80-48ec-84d6-000aac8d9a85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:ControlArea rdf:about="#_1f9ecd81-e069-4040-bd64-f34b0fac3a60">
+    <cim:ControlArea.netInterchange>210</cim:ControlArea.netInterchange>
+  </cim:ControlArea>
+    <cim:Terminal rdf:about="#_65a95678-1819-43cd-94d2-a03756822725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c96df9d-39fa-46fe-a424-7b3e50184f79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c6a1e49-17b2-46fc-8e32-c95dec33eba8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_rectifier_rectifier/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_rectifier_rectifier/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
@@ -1,0 +1,12953 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:5bc75f63-85bc-d020-02d8-1d9358dae159">
+    <md:Model.scenarioTime>2030-01-02T09:00:00</md:Model.scenarioTime>
+    <md:Model.created>2014-10-22T09:01:25.830</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment: Small Grid HVDC Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E "as it is". To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.version>4</md:Model.version>
+	<md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://GB/Planning/ENTSOE/2</md:Model.modelingAuthoritySet>
+    <md:Model.DependentOn rdf:resource="urn:uuid:a97cec76-42cc-bf53-2269-4f5abcce7244" />
+	<md:Model.Supersedes rdf:resource="urn:uuid:2fea4dd9-083b-f2b0-7b57-568efb25ccf9"/>
+  </md:FullModel>
+  <cim:ACDCConverterDCTerminal rdf:about="#_7780ec9e-6743-4c53-aac2-f123637d5274">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_c4af08e0-9608-4654-b74f-e359a7a29dfc">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_0193405c-4f37-421a-b7e6-9c4a8904eaf8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_9b40dc62-2c36-4b70-b931-db436ddb3fad">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_412aed14-a85f-4828-a751-221172c48263">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_61a0a556-ae4c-42a0-bda3-7423cea7e6ff">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_e4b9540a-1a8c-4f8b-a8a5-b7c0dc0d1df8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_3844652e-cd36-43e8-9e90-a1bbe2d85dfa">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:DCTerminal rdf:about="#_a03cc8fb-fe85-4a7e-b96e-5c074abed705">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_e768024e-1c0c-4c0f-b023-5deb11d64dfc">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_5be89c2c-b370-46ce-8844-338414489fb3">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_d2dac22c-7798-4a59-b5db-3e4fd307abda">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_6bc9072c-735e-4016-9ae8-acc2d37f1fba">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_02d46e89-85fe-4756-aeb5-4869950f8776">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_bbc66594-69da-46d5-9a1b-2f4a706fb6a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_600ea926-a53e-4f42-92b1-aa10bfeb79a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:Terminal rdf:about="#_0471bd25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04682030-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe868-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0470d2c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0237-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667281-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0234-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c4474-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a1673-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc79-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500450-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bfb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640186-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04776270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04619088-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d8a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce94-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d86-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465fd54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e431-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d851-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893cc3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c6b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b148-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453add6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459a142-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801509-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04597a34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464289a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c633-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc426-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0661-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465af34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04860874-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500454-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505274-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472a784-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452c378-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2b7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b5fa2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e12-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd35-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0447c6f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812675-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e2a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04773b69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b092-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc82-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459c855-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483706b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4da-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04507980-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481514-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f00-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab84b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c33-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452ea84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b202-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046cb413-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801506-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454e651-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046735d6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492681-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662461-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865694-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e193a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1184-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745537-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472f5a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837060-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c8772-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0450798a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684744-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea71-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455347a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479ac63-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04636547-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea76-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b47-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b978a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828601-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b207-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2947-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725960-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b55-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2ba-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481517-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a3c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046030f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04605808-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a2194-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae80-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048badc2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf53-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04795e46-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04719611-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047abdd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04885261-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04878f1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044bbe98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e224-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531190-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a4e31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed161-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04686e5b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b366-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f94b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b095-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c906-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0467f924-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837069-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cdb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468e383-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500455-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f01-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04675ce4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04656113-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9786-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04845acb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04880440-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e227-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745535-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a7548-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793738-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460f444-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2949-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453fbf5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487b620-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a6a26-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04854522-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549834-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb43-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837066-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2ea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e13a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725965-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9785-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7600-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b44-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457f391-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531198-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0475188b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04561ed6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c877a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b066b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047ae4e0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614262-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04834957-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765105-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d379-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046205b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485452a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f8f24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ef879-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04887972-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492680-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477feb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab848-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4040-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e436-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0233-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c17d3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479102b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d645-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04670ec2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d7a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449e9d9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b5484-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04798557-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed164-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8348-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bf2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642899-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a6fbb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466e7b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b4ef6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045386c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046f4c22-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe865-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461697a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04742e24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0668-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d856-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e91a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d5054-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f0395-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04483c21-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0238-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fbbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bf65b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04806320-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f4103-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b5a14-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1180-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044974a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04616975-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04723258-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482860a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789af1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044778d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492688-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047cb9a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f017-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047120e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486336-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f51b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04558294-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471bd29-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04529c66-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04753f92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d910-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667287-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04518afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048ac362-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d294a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662468-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6817-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640181-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047df222-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9139-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3895-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04817494-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d2ed5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448d862-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e225-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531196-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b792-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4317-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a623-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf49-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048915b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc78-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812676-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a2722-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570934-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044be5a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453d4e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b36a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d83-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745533-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046eafe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b2254-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c1c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b364-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c7110-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452755a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e8e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840ca7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489d905-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04633e38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7606-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab846-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4316-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522732-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047eb572-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a627-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd36-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840caa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cd594-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fe2d8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047147f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc428-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8340-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04736ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b86b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c638-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044aad27-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b209-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893ccc-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8346-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf48-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047084aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04607f19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500452-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a754b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480ff6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04542305-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d7cf3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474553a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e75-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481749a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614268-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e3ab3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9138-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e88d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4693-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b27e3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d71d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04731cb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047da403-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b140-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e6758-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c1240-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486334-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f70-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480150a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448ff77-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522737-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cd2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570939-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046476b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b62-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492686-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04590500-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486337-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631ccc1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474f17b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0488eeab-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d376-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765100-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3307-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04767811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3303-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d5-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ecbda-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04622cc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b205-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e432-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d4536-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b799-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483e592-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482ad17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047fc6e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531191-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0486cbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454983a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc88-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048433b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549830-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c902-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4047-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d641-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045163e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474ca6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478c20a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f018-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476ed4b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466c0a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c8d06-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b094-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04494d96-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489b1f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04513cd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045dbff8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e64-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04851e16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048481d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:about="#_0448d86a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044bbe92-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>16</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044d1e22-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04819ba4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>46</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048433b6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ca8f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854525-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f08-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047fedf2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476781a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0477627b-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04697fc9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>90</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0481c2b3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448d863-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>61</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>28</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04747c44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>130</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047e1936-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cae82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>48</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045b00d5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>62</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046efe03-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>71</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b89-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0447ee05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94b4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048bfbe0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ea4c0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>52</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e4a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046205b5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>7</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048b5fa5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>70</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b7b95-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>15</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04716f06-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0483be82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>31</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046d0232-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>6</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453d4e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>113</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044aad24-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a219a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0489b1f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04798556-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>277</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>113</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047abdd7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04791028-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04817492-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94ba-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ecbd1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>2</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0463da70-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047b0bf0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0461b790-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b0665-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04689566-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04547126-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>77</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>14</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>54</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04812679-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04742e27-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2257-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0466246a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04488a49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048740f1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047d7cf6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2251-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047dcb12-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046adf5a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476ed42-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>13</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045c8777-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>85</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854520-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04778989-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>27</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cfca7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0479fa87-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>45</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0449e9d7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>53</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0451d918-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>42</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0482fb36-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>66</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>20</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0484cffb-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448b150-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04867dab-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04481515-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>36</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048a9c51-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e46-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0485e168-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>21</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046c3ee3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f6da2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>60</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>34</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c0cb3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>5</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>65</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04682035-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04887973-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045645e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>51</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0474f170-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046a4319-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>19</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>2</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045d4ac9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>17</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0462c904-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045163e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>87</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046dc585-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453add4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0450a093-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>84</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044974a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>63</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EquivalentInjection rdf:about="#_5631ccc0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>184</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d4-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>6</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>20</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>8</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:ThermalGeneratingUnit rdf:about="#_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044ca8f0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-85</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_668eb671-5c36-4351-a95d-53ca850581db">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.680008</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_f26d4eb3-ebdb-4025-8080-f856ce656b42">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-450</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_7566f2a7-61eb-42fe-a59a-8276257fdbc6">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>230.999985</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e5a479a8-ab8d-4a54-bb52-376874ae2784">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04856c34-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-7</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b55d80d5-720f-46f9-897f-ff8c5eaf8b44">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.644</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_9a6bdb3c-346d-4426-8127-5f6cbf0150b2">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047fc6e6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-4</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_98f667da-02d1-4a31-b826-44314a1fbbfe">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>33.495</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_fec62959-21c5-4921-90b2-7c85e9f3bfab">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0452ea80-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-36</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_9db08c95-4586-4a2b-87e3-5a17c944b43a">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.36</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e54b499b-436c-4b89-9803-b1d75e2fa364">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044cd00a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-252</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.243988</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_27799004-aa1e-4889-ba95-ee6fdae64895">
+    <cim:GeneratingUnit.normalPF>1</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_048aea70-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-513.437439</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>62.1325531</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_827a9c80-183d-4e33-9e73-ef0aab3dfb13">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>136.62</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0458ddf1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-391</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_12b01822-ca11-4cf8-a6b4-2f8ff805ca20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>221.1</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e3753d6d-b894-4cce-b6fa-307c50dc107f">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04859346-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-204</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_dff93c01-9c84-4c1f-8529-66c054ed9e37">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>135.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d9948603-709f-41dd-a0ff-2ebda091255a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047f0391-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-392</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_23727856-fd9b-4124-a981-4e862148f3bb">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_56975783-9739-40fc-8ec1-e1de8cb06c9a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045ab2b0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-220</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b8449cd9-5a17-497e-bf04-70f728b0f9f2">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e56da2eb-bb6a-4133-953c-40073c5bc5f4">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046bf0c4-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-40</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_d41be6b4-155e-4c8f-b46b-16b50c49f0f4">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.319992</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_83fae784-1da1-4055-8108-ba978276d1b6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04633e31-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-19</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5f711f63-f631-45d3-b26c-33821ab2ee56">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_a6ec9760-88da-48df-a23f-7877e7c85ccd">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-477</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_e6131af8-c298-413b-84e3-4e21c3b6b06f">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>137.28</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_2621b09a-22e3-4630-b3bd-32c102e36741">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0489b1fa-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-607</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b0d662e5-64c9-4d59-b8e0-9b1ed175769b">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_05df66ba-3f64-40cb-8b18-c66d26c4e2c1">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0483224a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-314</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_c1d29442-5f57-41d1-bb60-4b74b4994c20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>223.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04839777-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-155</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_29df1e0b-36ca-4536-97b4-6f98b84d49d8">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.02</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_17852426-f663-4add-9a2b-0a635d51f101">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0472a789-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-160</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.34</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_b97aee41-3115-4cfd-9071-b52fb44d0b66">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046c3ee7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-48</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5005c073-28d1-4a7d-b257-649dec43ec73">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.06</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:RatioTapChanger rdf:about="#_047df228-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_047d2ed8-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044974a0-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_045eaa55-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0488797a-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044b4964-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0447c6f3-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+    <cim:RatioTapChanger rdf:about="#_04682034-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>31</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0487dd39-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_04549831-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:LinearShuntCompensator rdf:about="#_04553478-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_f4cdc674-4a66-4ab8-8d4f-552cb066e259">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.935</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0475dbd6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_a7768441-642e-48a2-b4a8-0ae06bebf676">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.419</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0447c6f6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_c701959a-91c1-4a35-9a37-71fb790426ca">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.676</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_048b5fa9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99c6c4ad-5247-4058-96d4-ee8495103e85">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.723</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045b00d9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_be267a3c-f7a7-4bdf-bb17-71b773247fbf">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0460cd38-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_069d84c6-bd26-4c26-ac6c-e801a0202a00">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.814</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0489d903-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.423</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0450eeb7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6c36f421-303e-4932-93a9-5b0ff86cb7d4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.565</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045c6067-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2d222dd9-7306-4afd-baa5-fd303b0eeb40">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.066</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04558293-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>124.763</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0466c0a0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99931a87-ee15-4fd0-b251-9556df7fe598">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.002</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0449e9d5-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6cc38790-c6a6-4309-99f4-a3258e24e785">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.403</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_047825c8-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2a6c1dcd-201b-4911-83b2-c16acc50a0f4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.212</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04684741-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_eae61817-d3cb-488f-a1f3-13bc8e31431b">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.323</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:CsConverter rdf:about="#_7393a68e-c4e6-48dd-9347-543858363fdb">
+	<cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>480</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.rectifier" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.dcVoltage" />
+    <cim:CsConverter.targetAlpha>13</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>0</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:CsConverter rdf:about="#_9793118d-5ba1-4a9c-b2e0-db1d15be5913">
+    <cim:ACDCConverter.p>-63.8</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>55</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-63.8</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.rectifier" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.activePower" />
+    <cim:CsConverter.targetAlpha>0</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>17</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:RatioTapChanger rdf:about="#_ee9505e1-96d7-49b3-9d1a-924397ffb27e">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_a5bf9702-545a-437d-9663-773550202828">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_739658a7-e08b-4395-8d79-93e87b7855e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:RatioTapChanger rdf:about="#_ea8cd467-31f0-40dc-95d7-4064463724c4">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_c089eb25-9f67-4d82-88a8-635dd4808bae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_453bdc57-5855-4eb5-8712-d6a0255e0da8">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:VsConverter rdf:about="#_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd">
+	<cim:ACDCConverter.p>-153.5</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-153.5</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.pPcc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>213.54</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:VsConverter rdf:about="#_b46bfb8e-7af6-459e-acf3-53a42c943a7c">
+    <cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>360</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.udc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>218.47</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:Terminal rdf:about="#_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe0e60b-3870-44fb-ba93-a056228f9636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_071bb138-ff00-4874-8acc-a884aa5cf4a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a168e701-bd48-4f66-8f0b-0f69b2545530">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8cac1e7-4826-4ecd-bac1-f4085fc15956">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dda862d5-7727-420c-be3a-a6a30e0b4c65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f72bfe50-f1ae-4f21-a477-f62e75a636af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfe1e320-861b-4d31-a076-5ddc474e4a05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14d37503-25e4-40e2-b20f-4de429a0dd00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c7f5674c-44a0-42d6-a701-4706b14c3eac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_21e25548-adca-48b3-b2a4-c000485222ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb3e09c9-fee1-4407-935d-ce2d342dbd7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e141e4b7-12e4-4b78-ae07-e8ab741ef9cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5de34198-471c-48af-a0b2-e5ae14970738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b862807c-b874-4b47-ae4e-59e4479bfac6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d88d693-242f-459c-bf12-267c22ba7809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d1cfe9e-3f42-4b3a-af90-111257354f8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41a94bfb-c430-4007-b29f-b89204ec913f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42ee39f4-ef6a-421c-a581-5da2682980ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_43724816-f5f6-4374-8ac4-96565bd5aa59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f1e8a6-8e32-479b-b73b-79823a3e1a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c37e51b5-c01e-45e9-88dd-957334a720ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe09b58a-7b27-4460-b596-c5886b3645ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8219d169-b5c2-467f-acbe-b04e0d39a7ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bff67964-ffa7-4243-943a-07c911e18dcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f4d752a-acee-4ad4-93fe-ad3cb6722d51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88d448f2-1777-46d4-840c-f64a7bea8a12">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c5dcb2-81f9-4076-b9d6-fb43a1a76d9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8e16607-1e6a-482b-8b4e-e5d990b93a4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cd484cd-37a9-4454-88e4-ab538b00a7da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3184d830-8702-40c1-9f52-c8e23eb3feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e68e5c02-683e-409e-8371-bb2e5f947c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b97c5dc2-7cd3-4a6d-9f6c-d18ca2229ea8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb5279-2c55-4531-b91d-3b71fa7f1674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a90f437c-e33f-4571-baa4-14f6e6a5be19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b64e6a0-436c-4389-be48-9dd120beb218">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe9cbbd7-a68e-4a3f-950d-3b1c2278b0fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b5a3e17-a13b-4158-8b91-a4303fe7e433">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f472e138-541e-429e-aeed-e632232888b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1e00a228-c452-418b-9db5-0a0ffbc5a5d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_26698a8c-a280-406e-b882-9037efe6a03a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145597a6-9fde-4bf2-b2fe-8a4c6c5f4774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd76d8e2-4515-4964-af8e-67885c73ad5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_883bebaa-0b47-45b9-8d4e-75f8784dbabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9145eb98-9d67-4793-b83a-967c6ff56e1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7c10087-4ab2-44cf-9362-3ead8a066326">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a5780b7-5e74-4532-b3c1-d1617bc090b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aeb3fe0-66f5-4f34-a79b-14f777313348">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b60203f-42be-4959-8f9f-10aa7e6812f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca41ef76-12a4-45d9-8665-946b5d46b7f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8de12885-e525-4726-a2a9-80a9eaf637f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef70c25a-ab63-467c-a0c5-c0d5ecf22f82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_79ae9e2d-942f-4878-be1b-a9e7e2971740">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a22db682-0414-4fda-ae6e-9e48d11a5565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5578e708-945c-468c-b7ac-56a738f7701f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4820525-8b5e-4f46-9a5d-7b93cadc813b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b95964af-8fe3-44e0-91ea-d1d71c7bf25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c58d4a-2ad5-4eb5-abe7-e79c1cde9d71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9bc8d338-1940-419e-98f6-8ae664bde365">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e5bfa23b-0c58-4ef8-a317-bc7a65457ba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e64d1ea0-1cc8-4317-9d6e-ec2fce5eeb77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d5377df-3bb0-4d2d-b6e7-e08f369a28df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f2156a1-b0c1-4bd7-aff8-17e4acfb98f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e030a6dd-e9c9-4aba-bb6e-8ed4b7add9e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae1f9fe4-1234-4ec7-b2a9-c6077a19d401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9385a5d5-0ce1-4218-ad3d-2645077a1bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cf89592-6284-4711-a283-848c6e97203b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91291202-267f-4ca0-b8a0-0ef3cd7b0d3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eb152b46-922a-48eb-a401-854a48d592dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a74688c8-f01f-4419-91e1-790b7d8637e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b85df60f-96a8-4187-b01f-018879647feb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_730d18de-6962-40b1-94cc-b1175fc098f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca3640a9-b054-4d3a-879b-8ed41d028ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fd6a4b6-c0ec-44b7-9ab9-b8ec781850d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c23c7c69-c302-4315-ad2e-4d5389140def">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c801bf-3eb3-46f5-8295-4c816d9bb318">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d3c4d8e1-11c8-4876-b4b0-906e5b7a73a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c06fc0e0-1893-4e97-b465-e24f6a934e84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_085ccbba-fa65-4793-82ac-f8d599966ced">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4c27dbc-6761-4286-9c91-debd13ac59a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_11f29b11-5932-4ba4-9a4d-7295d9ded126">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d64d90c-e2bc-416e-bc3b-75cb2866b13f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7097128-535f-4435-ac2d-dc1f01b38b72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43252980-acea-46e9-a46f-0b8d923cb4fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a9bc577-2923-4546-9c2e-a28d8a2bb2d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4de6e42-ee62-432a-a8f9-311154ca4545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1e250b6-b8c0-4b8f-86af-d654b592efe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77171614-596f-4d4c-8f88-9603a8225203">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_800fb8b4-0209-40bd-9a5c-098a9d5bd46a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_599a8732-3d99-4067-b506-3fcef610c47b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b90d47e8-e306-4b82-b7de-071f8ba139a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_50413d47-3ac4-4933-8d6d-6136134d1cd1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_51ff9c76-7b34-490d-af24-56521461f98e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0a4f-8817-40ed-b729-55c92d171c5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ca5e61b-bce8-4488-9a89-a13faf616146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_07aeceff-a2da-441f-9c1f-65f5bea46ddd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60dbae27-1064-4d48-8b63-60969b90b01c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1d5b0f7-a631-4cb6-be6f-ff459dafede2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3a46f9cc-a382-49d4-a2e0-5353e7f09803">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fb1a0d9e-d78a-4f35-b1a7-4e77ea9cab61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_974090ae-7987-43d6-8dfd-965bf0b8c7b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed826093-243b-43c6-9cba-b5487b34d56b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_987874b2-d6b4-40ae-84c2-09d47aa16fe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c11374d8-1dfc-4494-8c10-8ee6e792dd41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_baca14fe-c74f-453a-88ed-bbcbd0aa5a6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10fba6d2-bc82-493b-b4fa-928668273f68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a02c16bd-ad21-47c2-a34c-c1cff1e19015">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3de5af1e-30d0-4503-b58d-b4fe3a1e084c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01c6db55-d351-46fb-9f2d-13c1de997349">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e46cfed7-5361-44e6-9ea2-0be51afe2287">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_53feaad1-74b3-4cdd-98c6-045d45061593">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c5c6689-a80f-488a-b9cc-23667dd2e923">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b2ee2f-b05b-4c5d-a1f6-addff43e7070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_745264ab-02d8-4377-971d-38e58d86f3cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_902e06e1-e0cc-408f-987e-4483dcf5a4eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_39019b70-09ba-470e-8dd8-e35080b2b090">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf0d0769-33ed-4bab-b86a-a34f6fa059d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_066fe35b-8e2d-4bdd-97e2-b66d2d6a1147">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0f32dc6-eeed-4c00-98dd-22b8191b674b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da140b84-888f-4608-8a2a-b355ff10e175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1dd52921-a7ba-4bd6-ab24-1240f2f30301">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9809db90-fa03-4ea9-a507-c327adb29ec7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_349a9ac5-71b8-442b-ad95-93d514881b07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449ad8d-0b1e-483c-a333-adadb108d264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83cf2f18-0417-4b5f-915a-a8610df259b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17901350-2daa-4c42-a4e5-3a39dd813f13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8c102c6-1217-40c3-b05f-bda872504328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b557b2a5-2259-46ca-9681-73ed8578bb64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_85c693ac-04b6-4bcc-a3bc-1a47837f5c51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12e9d7c1-ec4a-435a-9f87-af7519f81d19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c2feb87e-acf9-42af-b093-c69ca64b0282">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc64ae88-ea38-4e5e-a850-c965ad4811e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_205ce345-8ff3-4f47-97d7-0c00c0f51259">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_110d1aa8-d200-4684-8266-26b5f69ab5f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57bea695-1bcb-4abf-9a2a-a2270d257a2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b687f746-a11b-4250-9a2b-92fb615faca3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff90c538-e532-4da1-85fd-f966a3e6cfd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c9aabb45-f6be-49f5-81c3-6a6fff595b20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b10eb7dd-58cd-4846-92e3-4371938950e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbee05eb-f6ec-48ac-8f45-6e801f352b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24b4767f-a3ac-45e4-9c9e-1e6f63c13e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10f7b85d-f7a2-4346-93f3-d026b3437ae4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_120699d4-88c2-48e3-a094-737b515cb65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_47f09825-70f4-4225-9a99-167a37ed724d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d95135a6-a2f3-42f6-ac01-44e9459fea02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_32b22d72-0891-4711-b2bb-7cb89e348e00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_360c39c1-9801-4f23-858c-459a2eb08725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_298e3c2c-e3fd-4cd7-b38e-a5cc7790dd05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ce1d70e-9fdb-4110-829d-d3f0e2144b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a59ae689-2f80-4159-9641-7a9286868f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_62f6a018-d394-47f3-9f1d-66303cc80a53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7c55b814-99a0-412a-b837-150f33b099c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f280c3c-7c31-4233-8845-42d0290431dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a5f2d-17cd-4194-a8eb-ee4f3cb5b22c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2afa6c27-acaa-4d28-a6cf-3283b98c8fe5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac4c08a2-5201-4366-b7f1-d86fae43245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_308169e1-3f4a-4bec-b3ea-0ebc76d5bc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fd08ae73-ab6a-46a2-9cd7-4316852a4604">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ee5fdbd-b7db-4e3f-bdd3-b5de81dba6f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07bd6984-102c-4162-9555-858f90689d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34e5d3b4-7e84-4389-a389-b1e799c1e2f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7796b60-d57a-4401-91d9-fdbcabab4dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1fb6f240-a6c7-4597-ba87-ab70943b397e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae668ec-5d22-4cc9-aa65-749a4098cfcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13521110-8ae1-4f60-b218-5e8b75bfd923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3368d4b-4206-4671-91ea-350fba2e9039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45ddc3e8-863f-4519-8fe7-a4f746cbe9aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_20705efc-e9d4-4664-b3d0-095d62ff29d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_822fd5ed-1f12-4abc-9487-8e98657da101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_201811a2-df0c-4ff5-ac68-2956151d94c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8103baed-0e59-45ae-b521-6118cbe2da01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe1856-7c93-4b98-bee2-9dabc7b62fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_708aaaa8-e7c6-443b-8285-91504fe45b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8cc8b9c-5b5b-4b4a-8610-03d974c74739">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9a1601-96ee-495f-9f88-e5b1e439d9d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b3ae708b-6f42-425e-8dd5-00d6daadb551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c0edefe-d42e-4966-ad5a-f120620ea284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8345da91-c150-4265-922d-5308fdc44671">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6df484-0741-4f53-81e2-6e70cfd5a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67785dbe-ab63-4618-8737-6150fce2c56c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39312527-1286-4662-9cf5-c5e3cae10de6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3f499c2-f337-43b0-9b6f-5849b58eb1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4d1a84b-45c6-410c-b4c0-e74399ba3f6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35414171-4c4d-4f95-9580-9fba40cfbc2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2be79109-4947-48be-9f48-587e8cfdaf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db602221-867c-4da7-8f29-8ce8ac7dcdce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6651b16c-1772-4788-b21a-93531b87e488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6d3c05da-fa71-4424-8c56-8400c9528908">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_98dd0655-72b5-44f8-8950-70ba30e70bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd1daa5c-eefb-4712-89b0-a81967839921">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7bfef0f0-3061-4827-b75b-29bb615a2586">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7706ff68-778e-47fd-afb2-a9b19a1021df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422336f-9b82-4511-8613-997ecb41c564">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_919ef501-e345-48f4-92f6-f3f9917d961d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38d1ea1-2686-480d-a8e0-70c6f7c4a6f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb56fda5-c1ce-46dd-91ec-73fc396a6ec0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f85a3a47-79fc-408c-a671-6dae0a3fd2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2af82b02-99ad-4353-95d9-8933f1f03ed8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_90bdf796-f9f8-439e-88c4-2aed057f8728">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acb6cbec-a463-4186-816c-13d6f9e8f8f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2671dcd-4825-469d-92a4-11a7c1168e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f199ee7d-42c2-4eea-b369-8605bb280c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db969abf-2a57-4780-a11e-d100009e1c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853c07ea-f383-48c1-86f3-88e38fb111b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d74efa59-9559-467d-847f-20c752ef7a0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71f3eff0-c211-475d-bfc7-5761e3d51925">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2083790-f439-4a1a-be0b-3d40dc6bd591">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_830f9eba-407e-4c21-b958-58c1c566bdc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5c932ecc-c9fd-407f-ab7c-bc6bf6d37c42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c16a8f4c-9b2e-443f-b642-9e425306592c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_516714e5-4f88-4718-976d-98699566123e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_731906a3-3e0d-4904-9226-5bce546bf1be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6bba47d-244a-47dd-8cf5-f9ce2d619482">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c299175-5b93-4a5d-98e3-1e0d98759953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac9424f2-22d1-41ba-b520-0674ebae6a33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0bed41a7-c52e-44a9-a378-8ee6057a60c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f45c35c5-e0b7-4a4a-a7e5-065f2cc79a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92e84348-2aad-427e-8224-863e9c987476">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_42abf657-9f60-4bda-b557-ea055a58f606">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a88a858f-a4f9-4a7c-a7a1-599aa2a98bd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c82ed1a8-5ed9-463f-87e9-21df6f621661">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c754faaa-23fb-4cd8-b9f8-64a692c467e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c548e424-3e91-469d-8d41-c15924cc0735">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e79f20f-77d1-440c-9517-b03244fcb642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbdf8582-a8e4-467c-ae4f-6bc08aba7057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_352fef36-0467-4ec6-8b85-d38af06da2f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_71a7543b-d3e6-4c6b-a724-4d34681cffc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c2f7966-0719-4ede-ac47-c93bcec328ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cda62ce-a773-418a-8562-975eff37d6ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf038e04-bf8c-4655-85c0-657b65fda472">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f91ff24b-4608-42bc-8165-3845d9d89a3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c57369e1-70f0-4ab7-ab95-0ca6d1d20b00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f05307b2-779f-4931-ab27-1c812eec0e09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10cb7e56-91ea-41b4-9698-9ed591d4a610">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b54615f-86ab-42fd-a7b6-091f420c6185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159809cd-32b7-4d81-bdc3-f4521a5611dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40021451-2f6c-4c08-8206-0f9577efbc02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53df2bde-0065-4e2a-8f79-8b9887289cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da880e10-59e4-42f9-88ad-bb19fd0995df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ffb2763c-86ee-422c-ad01-19a27c2f5d95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82d50004-0240-44a0-946b-1136ce73ca33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddd3b955-2005-4764-9bb2-94f1a0b57ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1072268-4956-4f91-999b-829a5160c6a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3f6df38-eaa2-4ba8-8267-2ea812b5b730">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4808825-dec5-4d4e-a575-d6b617e60f4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a243601a-7f53-42f8-9e0c-7d3ddda35309">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8713048a-be6c-4fbe-af8a-018305cb793e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7508d369-6037-4398-a0f5-85136d240f10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_215eef72-26d5-43d5-9728-b716a6eb398b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cf45286-0bc4-4244-9187-d90880603533">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4dd81da8-8ce2-4aed-81fd-54b4ee4566ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2edf2c26-ba96-42a7-bbca-bdce425dc719">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_37451d52-ada3-4155-9718-f2cbac55ea7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bb72b3a9-db44-4120-b8d2-ceae058fc3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e20cebb-95f4-46a1-86f5-30706c326241">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c5cd262a-00eb-4b1e-aa14-af39769452f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f41b17b5-937f-41ee-9be3-6582238dfde8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e39b164c-e8d1-4120-92c2-d51ef5331858">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c794fbfb-111e-4bd4-bc4f-22539cf5a14b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_481b6412-4dd5-43ec-a4f3-fd0cceb8fbd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_75da10ab-1e91-4b8d-94a6-022e3a31020a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35b12500-941e-433a-a80e-43850be4aa09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e2e8adb4-e6ae-4d8d-b946-bc510782ffb8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f8d2d0c-a59b-43c9-9c09-0d5ab82e3b3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cf6338c-83dc-4336-a40e-396191812535">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_19c6f61e-b720-454a-a47f-7f2c51dd0de1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9de4515a-0b24-405f-9920-6beff64f39fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35fa07b6-905a-43fd-aa2c-c1b6ba8c2738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a74196-8d0c-4d96-9eff-1db74605a665">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572e87e4-428f-4ba0-8148-585a3ad489c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53cb22fe-b2b8-4b42-9c90-c46f4b52e32a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b61be02-219e-401a-84ab-137d8a522a31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49649668-8e65-46b9-a759-ed5b1c2f3475">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_12b661c8-e048-4af8-8e1b-6fcaa75e0a27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8967ed7e-f69e-49de-87c5-3e424ff043ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6c92e2ed-107b-45a8-8618-4bbe372d15af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1ff47f6-e080-4f99-bfe0-0d44e36ed6af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f13674a-e4d9-432a-931f-7e823ccf41ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_569d3c0b-1dd9-4175-afa1-b4a43a0f768c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c51731eb-388b-471e-84ab-39c64b56d1f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159e2c73-99e7-4c61-84cb-8b56e8703a78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d4a77b1-cf38-4213-9584-62d8813b8e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c3cb471-aab3-4d54-a738-d6deb20a22b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92c4d859-708f-440a-b6bc-cbbdfd0c6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8500b6e8-3687-4c94-b665-b84ee822b1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a8407c09-50cf-42be-a06a-3ffb9affbea3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9552f175-d04f-4789-94a1-8cab3ce656da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1a64602-04ae-4adf-be2e-03f2f6f8d1a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1693cc70-297a-4d11-8f9a-6da05e8afabe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b40a4b1a-6ec4-4eb0-b09e-274f28a19e10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d50ed217-8664-4101-a79c-02e1b5753702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6022dd0-29a4-4921-8b60-dc855a2794a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ea3ac4b-c6c8-4d96-b1bf-47d064be4317">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ffc5985-1458-44fd-85eb-755b32fa5b9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_32b4075c-eb28-480f-9770-c79c28617f2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26970c44-1c28-45a4-8327-f9d544822995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45ba6338-e010-4c7b-bb0c-22c9bfc0e435">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_326c6626-3a7d-4415-b9ab-8a2a4f0ada10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_388c280e-dcc7-45f3-98e1-587260e1b369">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ba14b260-4f8b-437f-9464-3aaf7d17ebd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fa746ea-521c-4ebb-ab9a-961099f261c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_333cb385-6e3d-48ae-9653-e6ca5835a27f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_609f5d51-8bad-46ea-a50d-cb2725642283">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e09087b9-1874-4158-910a-a468d445f4e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c8def7d-c9c6-469b-8115-d832ecd100e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acda9192-b001-4925-99a2-7ea65a81b267">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_178dfb1a-7c01-459e-805c-2e2046495275">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203eb441-0e19-4f62-804a-582232ecb670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e44585ef-eaea-423e-8531-d641e8826802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c6dc912-1aad-4cdd-a31e-73d43122e59a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d057d3c-d61a-41e0-9737-432b5ada155c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab849915-3e6b-4677-991d-e447a4db0f5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_041d24f9-1f82-4572-b813-ef4155a06173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23f9448d-9c57-4843-b921-aa60104ed2fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_96016276-135f-47a4-8755-188a64bb58d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27429877-cb1a-4b4b-85c7-92ae6726c79f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b39b22f8-b659-4550-9084-67aa7f7f0ffc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7fadc3a7-981a-4da8-a7eb-7085ca13e62f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_24e5c55d-e28b-45c9-a430-c9726b2914c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1043f8f9-8018-4203-8ec3-5fb793a1aa65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd347645-1c88-4697-9cc2-3e4abee5489a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a675d01-61ef-416f-9ded-1e5f734fce59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fccb783a-2f63-428c-b673-df05f116a386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23dc57ad-b8f9-462e-bb07-e2a7b879e944">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70cddb78-0926-4f3d-9f04-d0f2992a53e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_91c5b0ca-964c-4e71-85ce-3e4c34c39c62">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a330abcb-4a34-4ccd-9608-a09ca5e660d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc62a2c3-2da0-400c-98cd-1b8c3d1e1851">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_123ee6c9-8eff-4182-a6be-b14ade88b4fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b05826a5-4010-46c7-8cc1-2a4e588b911a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e52c2f08-e57b-4336-ad61-e315ddd425d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdff05a2-d002-4be8-a815-794b6a1f4025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_08cb8736-36b3-4225-997b-9e9d8b24398e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_664735e6-7c6d-4483-bb17-1b04b78187bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be1c75ee-d6ef-4c9f-a1f6-1e0f57d8aa6c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f91f072-ee1c-4484-8d13-5beacf3327b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8216652-9e1d-41ce-a916-e3087ea5b445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4569417d-00a0-413e-a233-981ee337f5ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d38f0bfa-be3d-4373-b90d-25b44a3a5da7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbab36af-ad99-42dc-a330-7631cf62d18e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_198ffc44-f46d-4f3c-9d2b-b00564f56603">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_785b252c-70a9-4f1c-bb8b-0144e0c34393">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7ee4f1cc-2ec3-487b-be5f-448ba1098364">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1dc6a8-5807-4b72-8352-aa38b7ef65c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47f462e0-6cc8-4085-b44d-a737dcfc58a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3698d996-dbcd-4ca1-a37b-ccee8e5dd75d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebf4e82b-8581-49d3-af44-466ad5ea5beb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88fc4b51-b403-4d0e-ad17-53a083adf8d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_67dc16f2-6949-47e1-b0fe-24ea05e11bed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d802a3bb-92c9-4fd2-872c-8ea459589526">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2769e0a4-1dd7-4690-a2d4-c2a4e877d6ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fbe8ded1-d7f0-4670-b721-ee137eccc9f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a07a7054-1160-4fe1-8753-18700a3178a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21084cc5-b2fb-49fd-b186-93bcf6b7cacd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0e40411-5b47-43c6-bd1f-f26ef82c761c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4322f8ba-4c64-48d6-85f7-7feb029e02ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8152d58-e869-4e34-ba72-e6a0250f09d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de2baf32-b5d9-4bbf-a286-ee7ad91c29ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d6d8c290-8ac9-4364-8e20-50201070dd1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cb3d25-f7a4-464a-9530-c0f6f2b11aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ee4ec5b-6b89-4d91-ae82-fa24d7d9e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2de64646-e09b-4942-ba68-2162bb1d979f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0945558c-d1dd-46ef-bfd3-6d0cdd75b650">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d98fdbd5-ddbe-49ce-bcfc-259d2c399282">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_da23cbf5-92fc-402d-9e75-2007112a3f65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca3b225a-2b14-4324-a2dd-00ff96571ecf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ea2d464-a933-4e76-8c57-df5e29dd0948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72dff77f-fc9f-4ef2-b366-9aed8d81046a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e461b2-8712-4afa-b271-2132865b1341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816c2a66-edc1-46f4-bd0d-4e699b823836">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2aa0739-9784-4743-814d-ad6a586a59c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_480e9cf2-a17d-453d-8f6a-013c28fcf0f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8feb73e1-4390-443c-ac47-834bde0ea038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c7e854-bf10-4c96-8f26-2ae14a703e31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e4e2100-c19c-400b-9b6f-2333e3808b98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_359a47c4-a101-430b-9db8-7408d78f8461">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76475b35-db74-44f3-abff-712442eb405a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba94349-afaa-48c8-bfee-61910d7d1d3c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3885f06d-f07b-4cad-92c4-0f8080c30303">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f69ab1b-604d-4ae4-ab51-9cd0d53c37a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5e8a806-f0b1-4bf6-9b57-929d670efd58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c338198-266d-44fd-8764-ff2a3268a067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1f7e1e82-5754-4fa6-8940-937f91087a25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8ca6df3e-0210-4e88-9620-4bee4bbe7072">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ea84499-a970-45ee-8be2-8cc9ab5dc2c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7993d16-c661-40a6-be19-d4fa0622950f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52870298-2d98-4bdf-ae81-2e477350eb87">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8389405d-9280-4803-bace-2ee38355fafa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e75b0fc3-f421-4ffc-b561-fc9ee5815972">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9128d5db-cbf5-4234-bd30-22c604210b35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a64ecd0-d2b8-4bac-beb1-bc8c8c451a4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2973b3c1-7d40-4ce0-bc30-b8bbc9245641">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a061825-baae-4496-8f93-6c3283ca85dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d662cb35-3827-44a5-a3df-576e423d7f32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b254ac83-1713-4c0c-950e-e82a7202e4d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43473fa2-f081-4f68-9b5f-69d2a75f5e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c43f06b7-fa8c-4aa1-bdd3-6e194480695e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a789d5-207a-4059-9cf4-0d8c5c0bb4a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4b8a765-2040-4572-a6e1-26c29549a549">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_865773df-833a-4310-a335-9e014d4e4d79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_abce531c-5509-4558-a719-7e01a9ac9005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1162fbcd-0df3-4aeb-b5f9-0d8fe58c55eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b22ddb30-b0d8-4a03-bed3-36ad77a3c2d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ec9d5e7-5de2-4792-9a86-03be2cb1838b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24630e95-086d-4fb7-ab52-0c8f447b4010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75e6fea8-348a-43f4-81c6-c5c1410ad595">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_825b65e2-24f7-4b23-adac-ad62053e0323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e1293a1-22ce-491f-a2f3-35e030a88667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d658fe4-38bb-4b80-89eb-d8f550a95fa2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e10d1db8-788a-44de-ba42-57edc9539967">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b554668f-bfb9-48f1-9bae-7d23e0f421ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beab0b69-1a8a-4d32-a111-6129bd8e468f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bee5c82a-500b-4921-8166-d664da1fdb2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_584dde80-3141-4bf2-99e9-cfee485d38af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df108430-9a62-4d23-ae3f-411cfbabd93a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03564f3b-c300-43ef-81d5-5f32696ca734">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0d79f3b-ad55-4f76-8d1c-e1b086da71ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20a90dba-1a5c-4f63-94a6-4bdc9a797602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6616d5e-edaa-4a8f-80c4-ee8ce85b31e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_065b6429-bfb7-4474-8500-887ec059494e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afa75dae-3ef6-4a83-95f4-1ed757b73580">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7974968-25a3-4664-bfd6-eb4e57880faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b7f411f0-e6f4-435b-a618-b1801a393d7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cacb34e5-35e0-4430-8c83-3ba4662fe7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76de976d-9edd-41e0-a14a-9c3bf5b509c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a8f004-7214-4a5b-89a8-fb99d5ed06d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dba29713-3989-41b0-89f9-a00883e9ddaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e685a6c7-06ef-4810-b74b-02c66aaa2f40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e458bc3c-51da-4496-9872-65d448af1133">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_870a57ae-f39d-45a0-9a9f-8402539c2c44">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd06f193-5870-4dd1-b594-b3e3b0ed6c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f02ee40c-f678-4ffd-b9f9-25285e43451f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d989ccb9-8582-41ba-8028-96a149e9402c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bc00a444-0894-4316-9fcb-508834ba9c38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd28ef43-261d-4dc5-afb6-8af0e9b6a2ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_142dec8c-d69e-4dc5-99a7-77ec0eb1dc03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef5f45e8-622c-49d5-a98a-71d47862d0ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b3d29cd-0a79-4315-af49-9d8c938ed76d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cc9423f-d622-43ad-bae1-77352fec565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a86fda-ad55-4b0a-b89c-2249a3d87c62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfcf9a1c-9418-4f53-b867-ecf7a735786f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b066d371-c699-42ce-aa1f-9262e331dd58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa0532a1-f44c-4447-936b-5241f29b4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cd198483-e657-460e-a753-771668b6455e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b0697f6-9428-422d-9bc5-3c95eb881ed4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b0e4433-ebd5-4af9-96da-62c2120aaccc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8cd999d-efb3-4d33-8565-1ff34a512572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e5e024a-be13-4ed4-b298-cbd85e03eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b04bbd4-394c-4fd2-a57c-5b0ce7b8328d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c82c6f0c-0683-453c-be75-9d1292c7b04a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f770f7d-f55f-40a9-b77b-2249a6771467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_add69c46-4996-4189-b8c5-496dd7f98a9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d255438d-d4f1-4e0e-b09a-ac843779dac7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4cac272-ef4d-4576-b391-284439f9c285">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58193dca-5bac-436a-9292-9ce96ba22418">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed897479-dbe9-4fde-93dc-15e7e0ff68e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_964dece9-6c0b-47df-9d43-e9b422360913">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67877821-e62a-4526-8b36-3115e852e88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29f5c6f6-b2ad-4aa7-96a1-cc8d2ff4b614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_81a13e90-2b4b-4a09-9ee2-eeafd9e00bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cab260bf-1740-4f3e-8882-f4cbba442795">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_46e90e7e-887f-4771-8caf-07f3ddf5b3e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a8e8f80-5d6c-4b17-904b-64dc2fff2262">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa77f9ed-8a3f-4d87-98ac-0a7375a86fb6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4374bc16-61ca-4b5a-9d9f-798fa48b665f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd77817-e562-4b18-928e-a519da1f2124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac14aa5b-4fde-4251-b311-33015973af60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5131569-0960-445b-8cf0-340c24986c0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6744f681-5c6f-4566-826e-524754bf8a1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4173c4e7-f582-40c2-b317-fa1d8edeb448">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cf483c45-14a3-419e-91df-689c1dffe6d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce3cebcb-219c-4426-a7b9-a174401a66c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aeb54478-bfea-4787-b466-90df885b1c33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4a408d5-2c11-49a8-b0e1-fb4e7b4545f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebfeab9-b411-4d19-a937-e3e9c4ea19ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b367e89a-724c-4a9a-a2de-a7d44de2c1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac672323-d104-419f-a71f-4ce30e297d82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_91dab2ee-b23a-4591-88be-d0020bf6ca9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_51f3b44f-e443-401d-84ae-b8e86c4b270b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4725e87-14c3-431a-814b-d7e174e12658">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_76f12467-9fe0-47f8-9c3a-79c8075d0c39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88fd8c00-aa5d-4bba-9d81-40538478b744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fdb1052-84a7-4bc2-9e00-b6c03e26adca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c8707e87-05c6-4f12-97be-5c71b626e8b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e0d1edb-a714-487e-85d0-0023872faf7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bda506a-f6b5-4f4a-b8ee-1d4957f48cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2851ba40-fad5-4db5-b45b-481d141f197f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f14bee3a-c4ad-4778-95c2-0211fc182eb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91899442-8c02-44d8-8b35-c512b257104e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4eba8816-da7b-4a57-8825-62061d59eb8a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a30fa62-5391-43eb-9ef9-81d417b7d445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55bc9730-8c40-451b-8199-cdd4170be47a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_187cb72e-9561-44b9-9624-a40a68adf40c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaf25965-83e7-470f-9207-e8729d4bd007">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003c3228-ae26-4e1e-b2ba-173885fa9f5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba63da6f-556b-47f5-9e8f-90f8b8e7fab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03e26ee9-a3fc-4c22-b0ec-5b56c9659504">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b5cbc4c-3b65-4de1-960c-20cbb7a93c23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f9f8103-498e-48dd-a025-031b7a357d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4876f051-8bdb-4900-9acd-a5ccfefc9732">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6ca903-3d8e-4566-8497-69c094b27fdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8c2d0e3-0b5f-4fa2-ae70-769bc1e229ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97528f91-9197-4833-a0ef-509553c108ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af52cd86-fb78-4aae-a5e4-899bbb32afad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_844c3edc-a332-4684-bd75-d2dfd5f3bb0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79e5c665-133a-40c0-b624-24695482f6b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6dddc74-a83d-4295-aee3-81685a166f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba1543ba-b338-437f-b377-c21d79b8f66a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0ab92b74-70d0-4546-abc9-4ebe526966fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_188dd9c9-8052-41a6-918f-dad2f04072e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c03b674c-609f-4376-8ef6-e5c8cbc8a37e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51cdcacb-8528-415e-96c6-d5ce8b2ef440">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c38b13a2-fdfe-4efe-952d-66ddf616d722">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a66aa870-a14d-4ebe-98fb-56dadc7cad89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7bfbf56-b417-4d5d-969e-2dc60af24f55">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aaa9f9d2-61a4-48c4-8b74-9f1cea3dcf19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7eb7cd9-22bc-4182-9ace-4a7283dee574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59a28b95-3bb8-45b4-a0dc-93bf57a4621a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53fd4b3d-190c-44fa-a4da-a06af831ee73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4442b941-d4d5-4ca7-bb8d-5a427f0e3821">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7ba9ee4-7854-4f0a-8527-e67110d01ca7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_83bd7a12-4fbd-4219-b9f2-8a70e5d36a69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5fcf6744-b487-434f-8a95-531fb0ebeb65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2e562797-dba0-4f5a-9c34-5bd39c9d4694">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c864bd86-d942-42e1-ab35-ac890c49f5de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ded25e34-2f5b-45bf-b847-b9f87b9de7ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_412cb19b-097c-4378-b3f3-cf5b731e677d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1b501608-150d-4e0e-a33d-403a1ddd70de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f849bf17-7777-4aac-a443-f34aef90c1c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea9a9a67-57b3-4e54-8850-9634c88b0fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07cdd920-0989-4add-afb5-de33f3e28212">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af78f809-0fca-4913-8e81-0bf6d1836582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_721fb0fa-b655-4188-9fe8-639356861427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_280c464a-a4ec-46ed-8a3b-b18e807ea7cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d578c1f8-6516-415e-a1b1-18a592ca45ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3bcafc5d-6dc8-4de5-b4d5-eb468c889fd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c1fa00fc-fedb-41f0-8a45-09c6856a38cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7289d742-f3ca-4b60-9e58-b6da7497219c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_219cf87c-2e4d-4254-ad89-9ee4bce93e99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b04a6c9b-435d-45e2-8e43-d7b159a64e6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f145836d-2f92-4563-90ff-55f68863c206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d824f3c2-f6b4-460b-8875-8e822ef5d542">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45101256-dc1d-41ee-aeef-65ef96bddfe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9e3c9fe9-71e6-4a25-b457-8fdade0cf6d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2925711a-ecfe-4584-95fa-216a76889e0e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbe15b06-0197-471d-a3bd-08a22b40e4e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_53a237e7-aee3-4680-b1e0-3204ddaa07a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e6ea76c8-471f-4d7f-afd7-df09fec29637">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19490fb3-067e-4068-bcea-4a2ee8a27fb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56d744cc-18d1-42a8-b559-be005071f72a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5540a41a-7beb-456b-ab92-d6e9bac08adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d15ece-a13a-4f72-a22c-d0df5b4d42e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa27116c-d2fd-4d60-ad61-0bba8bf76d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0570db62-851b-4096-89b3-306a830f9d08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7b243c85-0fcd-43e7-9caa-16aef19823e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a2d7e12d-d6ad-4b3a-afd5-1259bf58612d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0afde8ea-487c-4f36-8090-f72727664eef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8aa5a02d-03c8-4aea-829a-ae2aae86f897">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba870de3-4f01-4c36-a70a-836982d78be2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b712d454-cc47-4381-a23b-83696157c215">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40872517-e212-4794-ba82-e587fedd9a57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1122014a-cc7a-46e2-a3de-4b03c23b43f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d3d8bd1-1bd8-4b9b-aa6a-d3057c751e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c1fdd5a1-0341-4524-aca5-6b77f18930c2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30b48ec4-7a67-46d8-927f-f135edf85da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce183715-8db9-44a3-b4ff-c224869d4f5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a29c607-c616-4405-a680-f472693b6c02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f872969d-a939-45c4-9254-acf26f5d05b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6788a97-75e7-4609-806a-927f5ab7b097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fc04519-665e-4785-adf1-846f1bbc4bab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8c8eaa7-f1a5-49ff-b392-8eeafc898658">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f99fb43c-62c5-4639-8053-66758542a7fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b6fc7aa-035f-4630-9048-7dba8d02450b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33c4b2d1-1210-4147-b097-77dbc9bb672e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac04fce3-ee20-4127-a581-50bc78421887">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f49f8d8-32b1-4522-92d4-19c3a726e0bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5cdcb762-8802-4370-ade2-f2cb1ff713c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ee50c6a-92c6-4446-ab9d-f18863a55bcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e81b0bc8-2b54-4ea9-b9b3-1f0bbe7afbba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_859c4ebc-14bb-432d-829f-70f94d346847">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e317ddfd-c060-46a5-8279-74abf6b28979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad1e1809-32f2-4cf7-b9f4-3eae73b294c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36c4cd74-a5e8-4ae8-826d-7a82578086a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2436005-f7ba-4729-b7ce-4c62da0adf39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92d4a147-300d-4b06-85b6-741b6700f71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a706fcf4-819a-4598-96f7-c9647368a248">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6e3ad789-b748-46a5-9c80-1b60f334e802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50679c3e-cfb5-4a11-a9e1-e578f88371ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddb0e6eb-82a8-4246-b77a-2155477ebdd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fcc31e9f-277e-462f-bc16-0330cd3163af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e25f3ef4-5c5e-4546-ac7d-53ecf70aa9ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea847c13-d0be-4616-ad58-1769b7d799ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fcefe6a-7bd6-488f-8dd1-26b7e23b55a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5c51845-f008-4108-9e64-1a913591741e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3334eb38-fe2d-48f2-978c-c7088acf1e7b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8f4e9bf-7c05-46e5-accf-e021501658e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6bbc18a0-9898-4620-9dea-8a547b996fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4927304-e6d5-41d4-b669-d0ddf7d05853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5909fee3-e912-47ac-ac18-990aa009f211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b0d4c18-9941-4d4c-865c-88b1a8c0dc12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b8877ec-b6e4-4f9f-b1e5-18ea5e1b35e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_507de8fe-a640-43aa-94b3-8be6dabe22b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5d4c518-715d-4049-aac9-002f60e13bbb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_390d1cea-c5b7-49db-9a04-226290e027ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9ab11de-1ca8-476d-8c7c-7364b4bc3bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3cb7a299-166a-4ec6-98c4-21c0708e92bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_716eb523-8ac1-4154-b7da-92242b3b61ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb7a7e2-47e8-47b1-9f51-ac53838a652e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6a85b772-385e-4c24-b4c3-e16d66dc1603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb7bc05a-c1be-492f-80da-4eace7ca08cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7c5c0d1-9a22-4edd-8bdc-386f781bce15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_daba953d-958b-4002-a3d8-ee9944bfd07d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57a5e5f7-befc-4422-8f0e-26335a11c5ae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f3318d5-eccc-45de-9579-2f989e144c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96cdf652-f2ac-4e90-b56f-1cfdd4c21cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a21110ce-7fe9-4dc1-b2d3-cf4704ca6c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c94db8fe-c4a3-4178-af77-d688d8a64408">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89fe4a5c-784c-484c-8337-9768c6689f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc8b7ccf-7888-4967-aed6-eb5d343179f2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29113799-f271-4951-a18f-ac987e0e09a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7c3c200-930b-4a90-8dfa-9f839cebf79d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a464cdf-d261-4c53-a320-9be8618fa0d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24ea3acf-ec02-4609-b9e6-da4f477b7a60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ce04a2f-8e18-4bae-9267-07ade5132cb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ebfcf35-fa99-4bb7-8204-0c94fccdaff4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d6c972a-8fb2-4dbf-aa6a-ed82e0c0b3be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dccf116d-491e-4e69-9ea8-8101ad6ec043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66e91c22-b40e-4e8b-8502-27007d0accc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d2bdda8-6ba3-4fbd-acac-7a14cfd8552d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d80d39f-69f1-4dc5-946b-cc151ecda5ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12ba20-35c6-48dd-9694-bdfa799fce94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_167c8171-868d-4aea-a0ee-46d2620d07ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b888c561-d178-45ad-a230-1e5addfe2106">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c344ba5-2ccc-4a21-be2c-aeebe2b6483c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95fd436e-f77a-473c-91d7-6aa7715a985d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb51de1d-6ca3-4a05-a78b-aca3707e3fa0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b295e329-a5ba-405a-8300-6eb7751d5f42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8667e660-8674-45c6-beb5-7a8c5016497c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37a461fb-e8ae-40e8-ba2d-04176c0fc86a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_990bab29-8285-4d4f-9568-8d76adf2e329">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7615cd28-6642-4ed4-aa07-41fcf005901c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70fbecbd-a570-40b0-b924-9dee18a0033c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ceab391-9b32-40ae-a4ca-a1876f5c77d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36783286-75df-4d91-8996-b28c539c0af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25834ef0-16fb-4334-bb5d-f4573046692b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b78831ec-6458-4f71-83df-dc4911f17fe2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c8111a2-d58c-4cd6-ac92-65b5016ab9b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_049942ff-eb3c-47b7-8037-dbe0742de940">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41484357-f128-4be7-8ae7-27bdc4b86019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d612c351-c679-4e42-929d-30dabcf165ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06343fcd-f7cd-463d-9be4-e945953fd82e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e983c04-7dae-4061-9233-f5654965744b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_547bd475-13fe-483a-8458-71d3c783493c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1f1508-11df-4d70-82af-061d2ca91351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e03205d7-a924-40f9-a3de-2b83f1e37bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fb84e7-ad1f-4124-8c51-051ac93c5a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c1fa02e8-02f0-456a-b06c-ccd75879889a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9fa2e723-ed6d-4a1f-858b-423dabe74184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af9a95ae-eb9a-4491-a957-2829445d67a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2406d38e-44d5-4ed7-af86-823636e9a488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2c6b929-0196-4434-88f1-a805d4c48986">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6db42efe-97eb-43c5-bc1b-c47c564f3066">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1d6ce52-59f2-416d-a8fc-10fe7e19096c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_560bf83d-89b1-49c8-b344-48c32eaffeac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f38de7a-9d74-4d51-b1ab-5da7b960ffc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c88a1ec0-0fd6-4ba2-81e2-be367d0f4df2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca498289-9312-4a5e-8dd2-23cef664abb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9fd6394-daeb-4698-b348-275e808d6afa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86d88bbb-ea78-4904-b49f-53fd2bb4d191">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31accc74-faad-4484-b101-f73ef44a6936">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41526c5e-6b58-416e-8b3c-6424b0acb3fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11cf92b2-84a0-47fe-a195-f0e64010f8dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe7369-d00f-473d-8b0f-691d98291bb2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85c2b8e8-79c3-4ef8-8c1e-d6827a6d718c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81228225-5cb8-46cb-ae11-d29586a1e2ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d6f3a82-2659-40d8-ab95-8a2bd5fc6265">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a960f0-930e-4403-97ad-3691fb54d700">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc031930-2fef-4625-8e81-5e393e3ae979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8d28d23-305d-4634-9eab-d844d194e774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84f4f334-5f2c-4c88-8d1e-28203511eca2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd1091dc-e3a1-4166-9ec9-dc1722819f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7801660b-310a-46ec-be58-28a687126bec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a4c90d8-4c22-4948-8791-53f8ca5d4622">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27d75556-9ede-437c-b23e-d79dc1dc96ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c51a0cdb-d467-4d24-877a-7775e82b53c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_86c18cb1-3611-4361-8a20-4b8fe0384de6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15a078c8-16a6-459c-8f79-40a9ca4a6572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c4d4d990-9de9-471e-b1e4-694e37b7b9ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37502de3-cfc1-4b05-bd5b-ed9030f8f189">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4e417d1-226a-4b14-bd6d-28351e5628ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54ba944-901e-40df-840a-d23df6f7a88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d318d295-ccfd-47d3-8f1a-043d208aceab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a68248c1-14fb-4dda-b56f-e13a5aa7f527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b135ab26-112f-420d-85f0-80758a7585db">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_31101594-c7f5-45a2-ba6b-27e8f669cefb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd1b6f49-5364-40a3-bdbe-2d82edd1437b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_55cbfc96-cde3-435a-a7f9-ba18fcd0638e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b67b401a-51a7-4330-9d7c-943ffec2f6a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b749a48c-ebf1-40f5-a322-68053428edc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c4f9c0c-1a4b-442f-a4bf-406aeefcc4c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90c30a29-5734-4a13-aad2-5797a77639d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d0a545b-ea46-4ed8-a24f-40c92b051ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b81fa63a-0bc7-4b07-a18e-659a715bcc1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_762575f8-bbb2-4377-bad1-861be802222a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dbad50ed-ffe1-4f0b-b052-2d78375b5463">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e782e39-34a0-4f10-8569-f499394ff261">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1657588a-9956-4af9-ba4f-5b748460b57f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f61f229-a94e-4cfd-9fc1-0399486ffc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c221c69-bd4b-47e5-a647-7f1159e00af0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f53e5a2-d64a-4f0f-8c2a-a443eb46ca6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5a83883-e82c-4672-8b1b-1f636ef7e8e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ea96345-5a97-4a05-b4b2-310f4d0afd29">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f84a5f8-b9a7-4872-9053-b1ef88e2d05d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8819d649-f8e2-4e89-a972-a50bc9c9fcff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01cb8d57-9bad-4964-88e1-b30f590fb4c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7a1d0c9-9b78-4278-af7a-b2b1231cad51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a74a4aec-0927-4239-9575-0cb091400067">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee9adf37-e0a5-4e76-9283-7f1724ad6853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68cc2320-f052-4f83-bb13-d1f4fba57eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38c9825c-4892-4cd6-b9e0-c4adad69a028">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_210557c6-8c1e-46fa-9045-fe56f0c89153">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c1d4660-f77d-452e-8aad-55c5eb44d24f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98b17987-57ae-48d2-8676-f875506d5927">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1b979e7b-cfae-4605-b8e4-9a5fc3be5cfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37f05fac-fd02-4322-9f59-d7defa1c9c2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01df9095-b5fb-4e49-a1a5-1aeedb85f23f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08675ad1-6474-40b2-97c3-0a52b7663139">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7dca1366-a6a6-4577-bd7d-d653e9739366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_25539bb9-f941-43fd-b933-79a889e1038f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203587d3-1f66-4dce-bdbb-222273112bf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e31e4207-59a8-4219-8cd9-900e92f76717">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ba58280-2b98-4ba2-9e29-94e847ae6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64485f9e-8a5e-4388-92fa-f558d6b90e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95bbe69a-d4d6-4ab2-836a-1008b8caffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_479ea762-732a-4eb9-915c-2b88c78fabe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e835c60a-dc97-4554-9544-fcabed551f58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0c82da2-3dea-43d9-9cc1-4d39c9a43b78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_342803ad-2a21-431e-859e-5ee83a93cc91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_93c8c2ee-ca43-4e2b-84a0-2f1bfec243ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_84e84bc3-3fc5-4759-8a09-3bac5643687d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e83af75-d5fc-49f9-82f5-4dff21fbbeae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_315a215e-faf9-4824-9446-b23a5fbc46f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1822bb-61f2-41e3-9f6f-2803fb0e53f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e859328e-c8cb-48ba-81a8-c3d69072787f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bb1238d-127f-482f-b129-003cafd854cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00d4de7f-97a1-4ee1-affd-236e5ca7669a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_06cf8848-6457-458a-8535-40f3b914107a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b2a2428-1a4d-46f3-85de-fb147e11f451">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90836758-b0f5-4d95-8b21-a6c1003de8ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_feebd7e5-b054-4c98-a96b-b28c48f82243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b097aa4-01e9-4d1a-8f1e-c63c4131ad9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_771f6532-a3aa-43ac-b1ce-0882c959f109">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acbc514-341a-4d18-ac85-8e4cfe2f382b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea41c901-8756-447c-bf4d-2d335b26ca9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77fa6aae-4ad7-4b72-b051-e6f28d5b142e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_76d4e8f2-3f11-44e1-9f63-8c2be3ec5162">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99da10c6-16c3-4dbd-99d6-83f1e0842025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd575cc-c1f8-4bdc-a62f-ef6220a31456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72cc6651-81f7-46ef-b37c-7fc46aec73e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62b9e7fb-d6f3-49ac-9a42-d77ee831eee9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07aa0735-959a-42b2-b4f3-6074067aafec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ae60514-69c6-4288-8e65-a598a25c9c90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3cf6bc3a-337d-4393-9090-f9060f0eb182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_129bf6e2-5b6b-4bfc-87e2-fe9b5212a467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80972da9-13cc-4b7f-9e1e-6343fa94224d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5316a4bf-19be-49e9-98e9-e7509b4a2a23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45e90f13-81c0-49fa-8677-5b58fa5ffd80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2234ba5-52c8-40a2-acd4-9a57460b3d57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4427f2f-4949-4d59-a3e0-79721efd6e71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e599f57-e8ba-4a78-a8de-93389bc0e6e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c931db7-c9c1-4d7c-8659-a78594c06d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3edbfddb-96c5-4997-a24f-d7a1006a01f0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5406d33f-9fca-4c3f-b933-88d01f6f3bad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7b8d64a-03f2-47cb-a62b-4f6a877e7f7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38ab5d22-589a-4032-863f-ba589156bbf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af8788c6-83ab-4c1a-b888-97f10d25ae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df6de0f5-def4-4f68-a871-8ad85b2376a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0020cf33-6189-424f-ada2-6c74c3ef22c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e3b7333-bcb7-4fdb-bda2-0947a573ea26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7602d239-dfe6-41fa-b6af-2ef200468081">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ca892ebc-e51d-46dd-95dc-a78a20f8626e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7438269e-b295-4183-9b94-7417d16c8b14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d382ea-800f-4f9d-80c3-8bef6e8a5dc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7085f2a2-88d6-43f3-b486-d8fee1e75218">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99134582-5a8c-4bcc-bebf-da4676e7a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7133333-4a33-46f6-aca2-bc7c432aa30a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f47a5586-ebe9-41b1-9844-44ed52052550">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_724e7034-65d0-4d26-995d-2cc45736495e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10ff5cf5-d7d1-439a-848d-788d77dbd40a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5b8f1c43-e90c-4587-8669-bf331953a643">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d35a277-c55f-4836-b36c-14fcb66f8f77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_593d0b12-0c6f-46f3-a675-5bc320b23e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c8577d7-eab5-453a-b5ec-3e88c1f69a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01fb6448-cd88-4c99-a93a-ce66fdf0b9ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a1e5cb-d60d-49bd-94b5-ae5ed77d95e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fead62ca-3226-4feb-94aa-7ef14946dabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bcb2d8c8-abb4-4b80-9e8c-4fc8d169dc6d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef66a335-fc26-4701-9790-79f6dd980150">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe0d6475-e165-45c0-8a0a-def79cf38182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0f65e91-5055-49e6-bcf6-9f607dd0ffa2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8fd01294-d5fb-4478-aab0-0c6b11eb195f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e7791f3-2f85-4c7c-87fe-f530bc9c34b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_055f6a1c-d9c4-4ec7-b72d-c385976c9b2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5adae9e3-7054-455b-8e44-93c55e875bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_717e37b0-3fcb-4c83-8c61-6f3bb9b305da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4490fe16-8b5a-4687-a603-3873c45cfb86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abc18a4c-d871-4631-a190-ec032f93d5df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74fca12b-d271-4fbc-82ff-70cf20e508a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d4a0b0-a444-4a06-8929-ae495a0f2399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59f4b07a-765a-4139-ab24-2040c49e6fef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1a3d91f-fcd8-45d9-9068-17367aabe864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aa8d0b3-7c00-4d3a-bc74-c2b2e6b93bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da927dcc-2cf1-405f-80d4-f7dd92117518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_66f28d02-03ca-4604-bfb5-31ab54d621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7848a48-ec4c-4aef-88d9-a75acc3eb65e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0f4a0f9-4c5d-4893-98c2-19b42e6ec40d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea7cda5f-7955-441d-a706-62050000be98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d4de290-a5a6-4525-888c-67cb8386065a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_658c5fbc-8d6d-40aa-a7a5-a2c5101bdb02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13119acb-18fa-4ac9-9d96-0a98c69b66e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e3c1c910-6fec-48e6-a071-f1bc05bff568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43709e36-106a-4bf0-94a0-67e433f9d58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_29d86cfe-511b-4b0e-886f-d808af28ac00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_58ce1bb1-e8fb-44c8-ba47-2325967e7140">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b67afef-e077-4f0c-8754-e862f2be799e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca6d3234-c045-4487-a1f2-023eda3c6b48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13db0e89-518f-422c-8ee0-bebcda57c914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37085430-1118-460f-86d8-a58274c29368">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6cb1b71-d49d-4b44-a7ee-8f8379ca6c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b876ab67-4bdd-45bd-a5b8-02c3b9e6492f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0975e90-01cf-440f-ab2c-1cbda073793e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c2797fb1-b15d-492c-a86f-900dc054eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c15a8b9c-87c5-4765-a698-bd3a743ea0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e900d4f0-88a0-4f10-b450-ecc7289fe172">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2fa583a9-e27a-445f-b11a-3cf60a6c096a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62b2ccb4-0d9c-4592-b19d-d21ac06c6bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9343a5e6-3fff-4379-b4b2-88ac2b9d5e30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fd34c6da-f9b4-4edb-abbb-229e9c0e6507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4576d17-b9dd-481e-a99a-9b2e86fe2c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5659175d-91c4-4e77-b2e3-de41cfee7a61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_88f90584-8048-4836-aed8-557a1be25574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4425d538-82c3-45f4-a79f-468ce22b1277">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c15e468-811f-493c-8431-c78323ee7261">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ef86e14-8dd5-4f53-b834-3693fd04025d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41a92499-948f-42e0-99d4-4c81b1763be6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aceea622-96cc-4cc0-a4ef-c0985a14aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef55c6e2-1559-4898-ae94-bf5aec5eee35">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c1066bc-6435-4370-adbf-6e5e9dca8a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b46e9d4f-f807-442d-b48e-25f59c33a0fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7a197074-f6dd-496d-98d8-ece105892059">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_afdda05b-9fda-4c5e-b67f-5a8835a9f019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6c15186-72d3-4946-a857-f709eddf838f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b63e438-cf9f-4456-a2e4-1d1600bc4943">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99c5da9f-56a9-4126-8ec8-27c0ffa69c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a721d8e-f3b7-4d26-8044-ff5e90d0cd32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd52bbb8-eb82-4bb2-8c14-37ae895d7f14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_021c9ae9-3d30-4a67-aa98-7c86f9f2669f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4db08985-bfd7-4f60-ae09-e3044e1143c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dd33081-800e-46fd-ab6d-3688e6d05155">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5d4dc3e3-1d65-421d-9995-ae5fe9b9ae99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_12e40f94-2cdc-4991-8c72-28352ab765ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b26843e-a219-44a3-8b10-e755dd65cc50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2b84dd51-5672-4c25-9b6c-eda83c8e6aef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8dce3f98-5a3f-47b6-8671-6264edb60f38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eef57a7f-1b38-43a9-a2a1-88d1d43c41ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2e8d3533-e650-41e8-ba9b-36b5ec94aadc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4957a875-6ba5-46ca-9ebc-5842f66e92f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b51b1dc-b52b-4d98-ae80-713d27ba53bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_571fbb8c-c22f-464a-a009-75887e5265cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f02a089b-51ec-46fe-ae11-2aab8b340bd4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b9574069-9cdb-498c-80b6-bacf8e33d6d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f67e88-6aa3-4155-953d-51300aefea7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54015ba-0d13-4c36-861e-13d092f9307d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4190d3e0-bea8-4b68-a705-a1359a5b8022">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97917706-3686-4103-bed3-0588a7169e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7536f1d-7c3f-45d7-8a79-842bf0992eec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61ef9abc-a0f9-4c1d-ad7d-cc9d81ca9b68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dba72ef-c7a8-4f5a-9b83-2d8dccecea7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aff8a4f6-0ddc-49cc-b04f-492336fb78ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7a42f18-f442-49bd-809f-5af6909a5bb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f11a1291-627d-47f6-8d13-d122d2907fa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a7027d7-d811-4bbb-9fbd-ea325624dac3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c354d477-f0f6-491b-af74-faf74282d996">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a1d8cdf-7ea7-4554-ac6b-d7755614ea93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b906ef20-f829-41ea-a58b-bee609b03812">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab799eb1-046f-4efa-a790-46f648e33aab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c44198e5-abbc-49d9-9b4e-8d5c545425fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5728316b-1343-42ef-a0dc-2582ddfce4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01957b23-1950-4ef7-9f12-e88028223835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aaf9837e-648a-4328-a7f2-1e524528ec4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2a8261e-43de-421d-a8cf-d18e51356b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_745a62ff-fa7b-415e-a80d-58499bd979a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfd66150-92b7-4637-96a1-10bf16bad932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19709704-48f5-4360-b6bc-454dabb4a91a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc0bebe2-35b8-4d32-a5dd-c866e110519d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ade4e44-a1a3-47c7-96f7-58ef549c8881">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ce1137e-97af-4f0c-8e97-d8362f9a6681">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_704bca7a-a16b-44af-a3cd-63ef88281c92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_771f698d-78d2-45f4-be66-2d71d49dab8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f86c5a9c-3aaa-4913-8c02-8ad29f83cda3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0371a00-0b14-46f1-b09c-25eefe811e0a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b541a7b-677b-4452-ba63-04630664276d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28cd2978-aafe-4b1d-a72b-800c2057fc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9114bea2-7789-40e9-b181-5c37526bff09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46d738cb-d6df-44ea-b946-4d780d06ceb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_625e468b-920d-4c28-805b-434508aafc60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f76818f-5a86-44b6-9f8e-2fa8425cf4ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c00a6123-f67a-4394-b0a2-9703b6fe7c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46a60d8c-5ee6-4b88-9d77-bf14dbd42e13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_842f35d2-8bc4-422e-9c6f-482c3319c75e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_223736f3-2dd8-400a-ae21-23490dceb5a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e7184e6-b0eb-4071-8f5b-ce9d3575ebd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d990be00-2c1a-4878-91fe-9d411db99e7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14de64f5-2498-4d4a-93fd-07ddc4faf4da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_248960f7-2bb3-4e4d-8ef5-9e4b5256e242">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc787984-7965-4911-874d-63951b71c9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_beef0f3c-1063-47c8-8c01-980f9d0ace04">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_efefc590-7ccf-4e2a-b1eb-29ce71bac7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2851c207-d0f0-4afa-8459-93e67ab046b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc647ca6-b570-44c6-9a95-9017a0d9a6c1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f69a138-dd10-4d1a-b4fb-bdaebbdf6bb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb12c256-e1e0-40f4-8409-f632dd91a567">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_197813ee-99dd-4dd7-8c7d-953125010823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad326602-7990-4820-b11e-d30fe8712f1e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c7f1716-7a9a-41f1-bbe3-a0c786036aee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e5e210cb-1713-4b5c-ba13-a23753fc6357">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6947b0e4-2183-40fc-bc41-71fb9826a566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ed6be82-6f0e-4e3a-9290-5440ac0e3210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f2ef388-bb24-45de-ad9e-e1d81b0a70e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d34ee87b-12ea-4264-be1d-77523cba6664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96509c69-be8a-41c3-aecd-cfe5a78a347d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fc8b50-beba-4f1b-9b37-44be779b4008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d93a35c6-2778-4e43-ab3a-949e0ba70465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5812071d-a8e9-43ca-8ccc-b51bad61713c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b8883d7-bfd7-440c-8b70-b542def33958">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7f4e2cc7-9c7e-4591-b673-e15674599f33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_69312939-c515-43c2-9907-6f7a9b4c2844">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5feef99d-86e6-42dc-9c15-685a70a1f1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88aa5ed7-9987-4bde-ba31-fb3b30f70285">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c18d4158-7fc8-4153-ae44-3b69c9326167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb77820f-64bd-4d5a-8a1a-a712fd8c3dd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8185f40d-99c0-494a-8fb6-1c2c1e36d884">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d843d9d-ad4a-4ceb-9ffb-1f9b8b2a892d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2ac50ab-cc63-4365-8bc8-5a0a2ec32143">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70091785-81cb-45d4-a120-97a3784b6f40">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f82c11fe-c49c-4676-98df-a97998557859">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b24f203-4333-4e3b-a822-f022244e1d92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cde6c0e-e554-4167-b71f-62b67afc85cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4e1a8fe-b9e8-42da-acd6-6ccec8014bb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e045e99-8d68-4ed8-9391-4309be949fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52120d04-2b1b-47b1-9581-72ba5a43d32e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c5d7ca3-84b6-4bf3-8e80-a725069ff9fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_877e8141-40e2-4022-81d0-7ca6b91fcfb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a36a24-459e-4f26-ba5f-5da5af49a4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_eca88a11-bf8b-4a75-ade9-2de5bea4877c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d827f489-f33e-4019-87af-4414e8baf08b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff3ff395-0043-4d1b-b7be-f7a978500713">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74b2a3b7-700d-4d2d-a24b-de95f780984f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d3b9648-41fd-46c5-a65e-4770c2379091">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38bd0277-d889-46cc-a57f-4dce84db3179">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac35b9f6-9769-4ea2-b7b7-a39fa5afe1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6487111-119f-4c04-b03a-4f358ad555ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a3956a79-3d90-444e-b18b-babe0a24c7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0886d513-eb42-4bfe-a1d1-91dd552d985f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3ef6f07-77db-4073-9b75-8c884a8227b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fe67305-2b8c-4275-b395-ab7968cd0272">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ad26464-ac9c-4a4d-9367-9adb3cc20cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac0b47a3-728f-4a27-8c82-47187058245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ae765c-598e-4e7a-a7e8-7ec76be26ff0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14440212-9e9c-4a98-ae20-bd02c0389b11">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b558016f-c443-4453-a846-56cb92195255">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9f1df3e-d035-4107-8c1a-ae630c1dd0b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6891853-d085-4539-87e5-a3b8c0a18445">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74abf6b5-ec41-47bc-bcd7-ead4aa9b4d4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a024617b-feac-4a5b-a1c7-5ceec0238f98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_053ae80c-2f62-4b2b-87ae-759d2bbafe48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_72caf4ce-0392-4a83-b9ef-66c1bf18cd42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_618b6fb8-cf30-49ec-98a0-16a816909cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6869cbe8-5336-4075-850d-5689210ea8b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5efa4008-dc17-4aec-8c9c-d3d19f2be5cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71b4a9b6-82e0-4375-805b-2116c6402f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4698229d-cd6e-4c86-8cca-e6d2005f3fa8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f83db32-bf0c-4cae-b788-13c0365c7c20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a97f14b-bc34-47b2-8772-22c5879d1cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1fdfb51f-2996-4790-b046-72e240d1e0ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f253934-45a9-4b3e-ab30-7e2ce8327ed1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_132e5e39-3f2f-418d-b826-1376ee0c715a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2db62614-6569-4e78-94a3-0006780692ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e3da9b20-f585-4c9c-93e5-14c19f2b6399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dffd3c04-567a-483b-bd21-95a2c659040a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f622f73b-4f50-45e7-a314-dd7abc1fbf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fafe1dfc-054b-4ed7-91ee-8d379326eec6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_835c90d6-b524-4dfc-baa2-91154554bb3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af61f0bd-2d4f-41a5-8108-5d6bbb9ceac5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62aee4c7-b396-4790-a96b-58735a58099e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8543a6eb-0473-4bcb-8ab0-59ba2fc58b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13c4e177-274f-4c6c-8a54-1666fa02f5cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b4f2a4b5-de1b-46e6-9caf-819d0d5f7756">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec6c71c-fbd3-47b3-a7df-259f8fcf18fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9cf81c-329a-40a9-b846-02b92c38b584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45d1f6db-a578-4885-86c4-fff085855ffd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60d8d59-4416-4646-a1cc-0f85a3ac109f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_63c4a7de-7676-4226-901b-6e8a9e63491b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27f1ae3b-e45d-4997-9a2f-af8fccfc9c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ede0ad83-2917-45a9-a53d-17dbf251a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2d6aa302-62c8-40ae-b6d7-4872d0a2c81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9187f8f4-cb9f-4497-954c-4e9470855a9a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b023345-3d98-4426-8967-f6be81e1828d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ae07a8e-253a-45de-a576-a70bd5668d58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1d3ead1-3f0f-40ee-943f-f1dee312b0a3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3b3ede6-1f39-4cf6-8970-363427783803">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e58009b8-1f83-4974-83fa-f2044fb95808">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5022d2fa-b3fb-4a51-9b0e-65566f9d8473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddad94f4-3682-4c83-839b-0aae8dde7bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be420f6b-ced7-44a1-ae07-7c136bfb1e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e65535d4-bfcd-41b3-96dd-2a50f50ab590">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5f92fe6e-b0e2-41ee-a046-28611580b915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87635d3c-7a14-4f8c-952e-6ee385bb6d83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4052ff8-e2da-4b60-b80c-c68fc1a60619">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ed5519f6-7ead-4c66-bd34-fb76ff46cafc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ceea3926-ece0-4b7f-a7d9-909e150d3d84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_29c7f86f-dcfa-4ff4-bce0-b1d88b129da2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_32467b45-4242-40f6-ae90-399a071e765c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c229d207-3189-4df5-85e1-37b21b353674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34394c63-2e6d-4553-ade0-bf94a78e4382">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f84f5c00-f7e2-404f-b646-fbab051c5d78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6d3aa49-e3d2-46b1-8d53-3f1f75e8aa4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d8d3d57-7ca8-4460-b92e-0970be0092aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f792f6d0-fe8a-4439-9e46-e461869601cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52b96eec-0446-40bc-818e-dc037aca27d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b92b26-84f9-428c-b42e-767cde1ee485">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c1572f8-54e9-4f58-b58e-4be8dcb49b80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddc2ea92-8895-4269-9512-fe42270e9a5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6904c68-be16-4784-a554-5e37a8906992">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_893b7d03-19c8-47d2-898d-eacffd52b8c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1285083e-4048-4afa-a315-b3cb3fd4781c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4ffcd89-c4be-4992-88b2-db12df2fc476">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a862cbfd-9088-49a4-a91a-4e32c22e9e43">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d015a1-51d9-46ff-aba2-2a10b7abc94d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b88e545f-683d-454e-bf38-a4b4a11c66e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df0b8e73-382d-4260-9489-8114c52cb9f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0d88a48-c7e1-46d7-a314-85c4f870919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f95ea0c-7967-4cc2-88dd-62ba25802230">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0cca45f1-e599-4046-bca2-f221f2fd0d69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7df41223-5692-4dbc-a02c-d0d7c1576298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1bcd4be-f73b-4aa8-9b0a-7514c7c50bc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e93dd0e3-db03-4ae7-bb2a-30ea502339da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_145e4229-0762-4f9e-95cb-fed99ad79e9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e360b1-fd0c-4c11-bbe3-c543d1af1a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_513d4e03-731e-4486-853e-49ec395312a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45a4646a-3dda-4a59-855a-ecd1fb44263f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_08aeec0c-32d0-40db-82e8-cff84194afd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b59d6e2-48d0-44d8-9a67-0106c94f0142">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45aee435-3966-4bd7-a2df-ccc5ed886045">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_20f86f62-6dcb-4b55-94fb-3f3e6de5521a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad48cbcc-0af7-4f32-9433-2fcbad64670b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_27ac5033-50ba-4225-9d50-ef7282186c0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74c4fed9-ccd6-4a23-abbe-a8d0d429460a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca797025-3a0e-46c3-92bb-00c36c229c63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed8e5966-f137-439f-aa01-b1cc7d49e74b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33b677a7-46fc-43c4-85ea-ad1351da9c4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2070290-3e27-42f5-80f9-8f6035aeb75c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cc431a-3e19-4339-851c-f5b1c6f85d36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9878ef4a-3f92-4c4f-8b67-6eaca87fc58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1163857-e5df-4f81-adb5-de5b3f4b13b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d94d4a5-e15b-4126-b4f1-c774996c1587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6f592ab-96ec-44c9-8837-3fa9668144a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94e72f33-d0b1-45eb-b58c-abc95358f80e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8cf22fc6-6d20-4aa0-81f0-3f34586cde7e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ff9c845-5984-4ddf-83c5-cb948ea978dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9cb09ce-880f-44da-8356-5e62c28e9556">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87db2dcf-7381-4bd1-af56-900c29170284">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d0c504a0-1dc1-4a84-a77c-dd4356d9c45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62836935-2777-43a9-b6b1-2d8ce915e99b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_301306f5-441d-42c4-a85b-b4dd619b1d54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d98d033-219a-4647-8ef3-214a241ceba0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_649ff81e-a994-439c-a3e1-79ca4b97f467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ee3600e-761d-444e-a54c-3b231bf6b0c6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_651d7211-bcfb-47c6-a62e-546f97cbdf31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d660b3a2-36f4-46af-965e-9ccf63921b99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06ef8f5f-ced4-44b1-89fe-636fde5295f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de006bd6-6239-4d9b-b431-975fc883ef69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2409fcc-0d8a-491c-a8ad-caf94d44c866">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8953b98f-b6ac-4fd9-b382-280dd9f83848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51c81d09-778d-4eb7-a792-b13cd11990e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_030fd25e-8a7c-4067-956b-95de2e43ca1b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eea0f6ae-4a78-41b2-8fc1-9b24e9bb1b2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_799401b5-7bad-4628-936c-272a47afe701">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b30e5c53-c685-4975-9ff7-395f24f94933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfdcd1a6-2100-459f-801d-cffdecc34978">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ac17236-8641-4330-acc4-a3546fa3be0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c2b5717d-14ab-4735-84c7-f08eec3c5151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92093091-9def-4b01-a1f4-97281f352dd7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_457739f8-564c-4260-a9b3-6e7ab51f19a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_29f45a6a-1c54-4cf0-82c7-18f8a94aa832">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b59ca157-0966-4c44-b922-2203edb1b072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12b76adb-53b7-4746-81e9-b6b66f3b395c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677cf6a1-0bef-416f-97a0-cfae59065c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e11c9d8-c96d-45de-bf98-be3f0191af7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b085e19-fd8b-4a19-8ef7-75a2a1b340e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_14b9ba51-ca52-4687-8618-aa9a4680a7fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3f25543-e935-456b-bc76-6fa1074135df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_09448cec-6754-4734-a17f-dfad905c44a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a3baf0e-2dbf-411b-b020-a2de9b0020df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_547408ac-ad5a-4f0c-b307-254a70440a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5862bea5-3fec-4d62-8c22-91f359b85c16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb76ec3-366c-44c5-8d38-728ed54ff389">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a8ab2f4-2478-432f-8c9e-8f2cb5f5d630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82e14c8-843c-4eb1-9432-72391eabdc02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03284608-2cac-46a1-9ff5-fe40d306eec9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc5b8041-f904-4ed5-8244-e97962a5caac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9489f62f-c3ab-4790-8054-ad01c5b0d5e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ecef8e03-2ae5-4c33-ace4-eb88a1ddd005">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_063f483b-b293-4c29-bd55-d372d3f4a341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17042f33-0046-48aa-ad84-d9efbde7078e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395a61b8-006a-4196-bb79-5cb27b25eab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9239f57a-e9c5-4fad-89a4-b8ea2bb28e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fcfd5cfc-f4e9-4a3c-acf7-ca2702751185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff76a3ee-bcfb-4db4-9bb2-974d6c21c42a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00e7942a-8a44-4f31-b35b-6c88bd506e89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72e10721-4709-4f0d-b005-2572bb18c770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2362f3c-d255-4610-958d-0e10053bc77c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f7c9d871-1586-4d82-bacf-c192bc284e34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145bc878-e3d0-4a68-999f-86ea26ae1990">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea6d0cf2-bf23-43f7-8409-991f9ae05b48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_337e83fa-bd65-4743-8321-42b10816e5fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676e07d5-62ab-4f73-8081-8f032b081774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f58dafd0-b948-4a63-bdc5-4ede3acb6afd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5afccff9-daca-4c68-8816-fb0044885a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7134e652-abe4-43ba-a026-b7e9d691a8ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3f60a0e0-4a65-44b0-ac9a-ecaaff0568f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d79d96-ba63-41a9-9ce0-85a38c48b050">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f14d84b1-2685-4ccc-a131-7dc23a20cad0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08e585b5-f18b-48b8-890e-b58b94cbf885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b9bf5836-6dbc-41ff-9ff1-0d01024ba9be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_52ec1e35-44c6-4fcd-a770-aa08f88d7795">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4dfb00b6-e3bb-424a-8e2a-3dc0e75138b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27b64a1b-ef39-463d-9343-1468c0720811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_992ca25e-c4db-43d8-8de3-7d4236242e8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7ecc7d69-bfd5-4fb5-8431-2b10b70edd88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4ea322a-da37-4bd3-b3f6-0e78ff502bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c40abacc-9e8b-489d-8671-de0b37aa8636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7a85746b-e339-4d05-972e-ff0e3eac549f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef89fef9-47bd-4286-b6ea-a99a281f039a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c24582-f9d5-4bbf-b7d6-b61f103a44fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_efed0d03-d7cc-4f26-8ea0-45848fe13aa9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_967d5338-3df4-486c-afa3-b5e88ac715d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd19b3b6-f6d1-45a4-8dc4-0fae74d2c3a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e919a839-3083-4a1c-b235-9336097753f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7fe68b1-6ed0-4ca7-9ade-c169c8374eed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14085fc9-b39f-419e-83e5-e2cab1d55160">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c821c5d-c3f3-4c50-b6db-ac35e16b97c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ce0efe1-62bb-4a5e-9733-f1cbdf080af5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3d8e9855-b1b8-40ef-ab65-b3c547a83cba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e308ac0-5c77-4bc6-a8b5-5ec33f548691">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d75db8c-3edc-4746-bc88-43066fc4ceb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6db6bdf1-075a-4fe6-9fde-b9591bc20d23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29fdda51-879b-4420-9d67-a14259902e2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bcae2b91-06e3-4f90-a51c-142614f8d6ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b539dc50-2b2d-42cc-af9e-8edcec28839c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3210626d-f10a-4215-a19c-6e68ee613be0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05e16d9e-15b8-449a-9037-b399ae6087a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c629896-e4df-4b62-bc96-f1258ec5c947">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f6e0ab3-52d0-46dc-b58e-93c5f22bd0f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_265e5d25-3027-4f0a-8a18-975067551770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26a6c4f6-6c52-4721-82b6-3c78f69b0ee4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d317588e-e08f-4292-8aef-6be6170c335b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ace3fb1-ff34-4a2e-bef3-e579c91380f0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cfa32d7-a521-4c3d-bb3c-265306a0320d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_272e6f11-15a5-4195-8a44-ecb091d1500d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b5baf11-9a74-40d5-900b-7352ec34da1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a85f927c-7844-4f5e-9391-108fa014f96e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d281e9c5-8246-4cd1-b81e-e8ff1b538a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab98a3b9-d124-440c-9f3d-4a4884dfb95d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f451588-ac24-4bbf-b20e-8cb3da0f0c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e441009-4aca-4646-b423-3b43c9fa7d68">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a281b9f5-89f0-4a22-8d46-b194d9bb411b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be3aced-f45f-4110-b799-7588f844f08e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d38dadbb-5707-41a9-b85e-66dc8b70f583">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d937e822-cd68-4dcf-8832-87c36ed4c7cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d492ddf4-a60e-4fb6-abe4-821fd2501932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca7cfc2c-1aa8-48c8-85ad-b0a1ac53495f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5bee6c3-edef-487c-abc4-66038a4fc79a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43e6fa8b-1193-43d7-9292-dd54a91e29e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f692ed1-d190-466a-b31d-138e71b9d2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ee620ab6-e452-4ca0-9e44-9133cd745cb4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b68fda8f-bd7b-4a4c-8983-fa5e733d294e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f51bca0-95ce-4cdf-baab-e02610175e71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1f96919-4686-42c5-b11d-80413fbf695c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1175e53-6cca-43ef-9550-4f088dfd2c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44975eb4-b7c7-4098-bf5d-076229b9598a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59fb8ddf-dbac-416d-b576-ff27c78f97ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3425cd4c-f477-4c35-9414-a074fcda03b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dbb3127d-13b6-4b18-a82d-429d7a661cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff1b53e1-3ba7-4331-b32a-431fcbe569c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48d3cfe4-1850-45cf-a38f-2463e84bbf4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_132a6e57-05b7-40f7-936d-8ad215faa067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec22b841-2d09-4c40-9094-2910f9d18f47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69dee46-8d4d-4321-bfb5-695e8cafc361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784648ac-b7c7-45b9-8b04-cd52657911de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16a4890e-2299-43aa-85aa-60d568a6f55b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c85bb9e-b82c-4148-9151-33ae459b1ea5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_31d058e1-7999-4900-8304-e699855178b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f055a8-4a29-4f1d-afe4-0a6255d8fbef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bd353fe8-a348-4ac3-93ae-173919e4b699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b0262344-289d-4b5c-89fe-a2ed32b4ca12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6ea1e1a-dbe8-4939-b05c-809b216ad452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02aa59e2-99d3-4957-b768-41f796d55d31">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b1c55cf-a01c-4f0c-a008-0f4c3f91f1b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6611048-9b76-4265-b03c-75500718c097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9024f22-f8e8-447b-875b-4ca9b01d799b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e3ba0a3-59cf-4d02-8c5d-e5a6846a0eb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fad1e6b7-5f14-4853-a74b-6677b5c0719e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6b142fa1-1890-4e15-9044-a1c3910f6538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27c3357b-8a1b-4130-bad2-fc753b66ec3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a94aefe0-21b4-462d-aff6-7aa79d6af0ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_255ca98c-c55c-4369-8358-031e6aae3279">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b627ac26-6fab-4f5b-b08a-f0bc8281227a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dfeaa24-c478-40bb-aacb-337c3ba958c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_533a0fb7-2cac-45af-b21b-6bc5e424689e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7e3c55c3-c306-4bad-86dd-f8cd84a7adac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8010fb5a-ccd3-46e8-bf62-76ddb2c39d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20c7a56a-a0b5-42fc-b168-b4256f98459d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d7307f8f-a895-4152-9146-3dff1dae3a45">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a42b677d-a545-4739-ab21-0906bc5547bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fb41ff7-7704-473d-a4d0-051663aaa078">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c26a2a3-27ed-4b94-83cd-17e4c607df1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_343e6a5b-fbe6-4747-8c53-1eb52d084263">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a640bd3f-ea54-40dc-a069-ae10b7b98e8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b63f3186-9667-4c33-871a-7e97ca96d072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0d68b555-1b95-423b-821a-2d321b2e53af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_090e9885-ef0d-40e5-abb6-e43fb1b8f24a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9fb9ad9-e629-46b4-850b-445a76ca39cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0acb4c9e-f5c0-4ab1-b811-10d8c74c7e95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a54a35ca-7b80-4008-af79-e44cca11d323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dc30822-bc18-4884-bc98-f167564638bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebd0ef2a-c759-42e5-bd7b-6bedcf57e560">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0b2aa62-3d71-41fc-a067-bcdaf1bdb2ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d02435-6273-4736-8568-3ac72f70d876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9365ce5d-c4b7-46f5-b929-259b1c0acd25">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dd5b60f-7c8e-4cdb-8e48-e1f8e14d54b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c854969b-0dc0-4d52-8549-20b433c77a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2dff895c-7df3-43b1-9d6f-371d946ceb94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a85cbe00-e62d-4fdc-a20f-7a5f3429f811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7e9c7d6-aaae-4c63-80a4-c463d4186c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1550bc6d-0c38-4f43-8aa5-d2ee7fb75810">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e269512-714c-4f4b-bea4-0ec09ad3c5c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_108759a7-92be-4837-a459-530d3d469d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3f15ee8-97f9-484c-bd1e-5497a0d3695a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_581aafca-3016-492f-a1f6-1dccbe761b20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eecb8405-190d-4db7-87d2-c00a985010b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a166efd4-dc5d-4c8c-b621-be5ae04ee995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_658e17f5-93f0-4cd9-a55f-bee355ab6427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97265ab7-cedf-49ee-a787-73b89c0bea8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cff70ad0-2745-4c83-92b0-9d2674884e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8144362d-e099-434f-98e0-5c5956d76c50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ecd98a2f-c81b-4ba8-80dd-c5e870ae5a8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b462b4-2e7e-4314-b5c7-a982f303dde4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf6cbd2f-5987-4ebc-b776-19232cd670d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2149a1d5-743e-4433-b55d-4ea03cb9d96d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b0bee1d-f5c8-41f8-a196-e0055949116f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d516a33-6095-49c5-91b1-7897d6d4af68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34608c0b-a18b-441e-9131-bd56073e45d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd94ebd3-d19e-4a18-9765-6701c33c17b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2166479e-4319-434c-b484-21ef1be759eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0101d57-44da-4395-9bc3-ec5770bb993f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5eecedbf-d6e1-4a37-afb2-ca148b34a874">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b353f73-ab00-437f-a2d4-9eb81e2b9298">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1e1fb9d-607d-4053-9be3-c699b18bb749">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c9559fff-bf85-4c78-b609-8673ac1ac5b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e8b6bc49-dcc6-451a-a59a-bbb38cbe4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_62ecfa5d-20ad-4605-951f-1b1ee85fc9cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2dcdd11f-f143-4f62-bac3-2648ed438d44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72933c8a-6d75-4fd6-a111-3912cdca4993">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5707f101-1574-4ac9-b315-76e8d0bdea8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fc51695-79d7-447d-b7d0-2d441a615dbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6eac4e6-904b-49e5-8643-fa10dde8dee3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6367f18b-da16-451f-9398-4dcae9461dfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d2353b1-df8a-4d93-aca0-e4755108539b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_62bf7bf9-411d-4e21-b3a9-598f88e52265">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71909016-4df2-4de9-9017-0af613c378a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72c8d946-969b-4911-9ef6-98c84304e8fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f86f8992-c397-4968-b61b-5d1ee0be135e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0bb4e66-8e2c-4258-b9bb-9d5f6fdb68b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b641ad1d-8f25-400d-8d06-0ee76124ce9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_06da1fb2-d197-4746-8669-418acdd11ef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f0b74cf-101a-4fcc-8b7f-5dfb37885d42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61d59f3d-dd4b-4488-b6dd-eef9d4cdb561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e91a7605-459b-4d91-bef4-eca132a0fe79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_60fa5a5b-8d4d-44b0-abc2-c2c9805035d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6604084-2693-4dde-a853-88ca9da67a80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_330ca30b-c80f-48fa-8bf7-1be251e000a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4d9534a5-0e6e-4bd8-8537-bd4919ff95d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_282c0f6b-a099-4c0d-80da-497535cf380f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db5668b-6269-42dc-8cf0-4d5f1edd75bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec70b485-7a69-4fb3-afc7-ff87095266f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_063a6c89-83de-45d6-b507-d333070c2f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9dab1799-adaa-4517-977c-ebe6a16d2549">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bf0fb38a-3e9f-4346-9366-6875ce97be73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a568e818-3e12-4ef1-b0d9-5bd46fd927eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b814bc8b-78d9-4faa-afd7-8ab401b6340f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff01ab24-a8a2-4a7f-9c5b-47940f37410a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db4eff7-f3a7-4b86-9c3e-414ab37d6771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57802d22-bf06-4f03-a7ca-3c8ef8b8d251">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_048330d9-3bbb-4b3d-9923-9a39eaead778">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e79f72e-ea6d-4cfe-aa54-d9261d98436e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d30f340-85c7-4d92-9577-cd96cc2f5d1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac74c520-a4ed-478d-92a7-4f485a50822c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_820e4f42-5173-4d16-b4b6-979e62ae9f35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f491bbb-1277-4229-a3e1-f8f10ba1b923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4796e0b3-1a9c-486e-bf68-fcdf5eb1bd64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7af55883-cbd1-4b4e-a1f3-ec6a28f641e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10c65879-6984-4e77-9fa6-34c3640edd5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb403c1c-7c91-46bf-b50b-424f2bc0cfd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97c4755c-1514-4404-ba19-5e804bba3b5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c339a2b9-fb0e-4670-b01b-0bc99c288d38">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_36ca438c-ccc1-4d35-949f-54817dc7d31c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec171de2-3ee8-4f73-96b8-bafd19f04677">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4b578fe6-79bb-4f4e-9a6f-4ac9b840d579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a456902d-0412-4ee4-b228-8a714ae36878">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315b18a-8654-4766-971f-dc5ddfac8ce7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9858fd9b-b96b-4df8-b153-e34219045db2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7419c7c5-a3e9-40c7-99db-621c91281ebb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfb0ee89-1778-48e7-aa6e-c2e0e042d331">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ea1abc7-2de0-4679-8e7f-631374e6a83a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fb07bd1b-bacb-4795-9c75-8cb1c5fa83a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9151fb81-9550-45d4-bd07-4683d29009aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83940b4e-267c-4c4c-b9a9-0d9027a52d67">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9372795f-ca2e-48b3-b41d-0880ae5d7991">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b7cbc2c-e5b4-4e1c-80e7-8de1fba51664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5fdfe70-9a41-492b-9f27-da15ebba8a72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7166895f-1edf-46f1-b802-40c4c0f7ede2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f2d5b22-dc04-4ed2-9638-317a3a8499d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ad8b9f-65df-462c-a914-26b406488a65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_450e1f78-108b-42f4-875d-bdb70269e9b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c831d6a-b29c-46bb-9ec0-e8e1a95f3ea9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c4a824a-2713-459d-a73f-ea5de799b0fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd3db492-87dd-4b09-8170-de53b4ab0249">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f2cded8-25d1-4851-9d10-76805fbf0350">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_432654df-26ec-4b72-bf22-d2ed67081a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a5c821d-15ab-4aad-b751-c9b46bd2fb53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a6652b1-3a02-467a-9ac4-07e00c70450f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b023ed9-5451-4e72-ad37-cf8ed02ce876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d69413cb-36c4-45b9-96a5-197a238a21d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50bbc7b2-6b08-4a8d-a9c2-d375ef380e6f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffe8f414-26b1-49eb-bc04-f72708ab201f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf7ffbfa-817e-4a65-a0ab-2c237a4ec04e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40abf24a-4c0e-4c70-91d3-a07e95c560d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e0e0d2d2-3a63-4684-a023-2daa39568822">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef5fc63f-d2c3-40e5-a1a3-092327cf3a5f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2733bcd5-5171-4254-9b71-d7d4822da04e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce699638-1fd6-4cc8-b5e7-da5014317b9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6dd43f1f-50a8-41ae-b7ed-ce110f47260e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_19f9acc1-d6cc-4cba-ab1a-39bc6330c6bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d58c01-2816-42b4-9026-b4a864be5971">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab88280f-88ae-4d19-9293-87d20c9555f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4c1ce33-8835-4644-85bd-df6b5d895e97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfb91ec8-3c9e-43b3-b0eb-2d8d432ff514">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2c2ebdb-c362-4dbd-8cdc-106859815a67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4512872-e0b0-49c0-a886-abcec20ed4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92d457d4-5831-4817-8dd0-252285238b17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11586e77-2f1b-48ef-a43d-3c3ccee74e9d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0ffc407-f68e-47c7-ae3d-e0357444b057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_488812d8-5ebf-42e9-a429-6e647b84fa5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf5edb31-3e2a-4b1c-824b-623eda6f0d49">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34d7c069-adc0-41a7-b8b6-2031ce11ef40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4736319-8c40-4ba2-9349-388c6e2231f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_feb099cd-62e8-4b2c-9a35-31961fa7f751">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfa33102-fb3c-40b6-b982-16f1db6cabdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f158ee-3379-452f-b5c4-3e6a6e9869e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e571827-4bcd-4f9c-a4ca-8f43fc1bf1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fcb52fed-20b5-48de-9187-a5bcc4b4bc55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e556c88-b5e0-46c7-9acc-cee3f394c3d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9993779b-feea-486a-ae35-2b21258ad63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be7c3e94-4419-4fed-aacc-75ff147f2a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b834a45-5de1-47ed-bb11-411d4631e322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_783ea7ca-a48e-474c-b2ac-d904da9ca09a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e96c03c-3d23-45ee-aca5-4dc6260b00b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66399c4d-6f60-4c2c-9275-23fc994898b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86670c41-42da-4ce3-8823-8c140a50621c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_846aed1a-7886-42e1-bff0-9c1d20867b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ac9a23a-c7b7-4368-9495-6a79740ccdd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ecc55ff-bf91-4ae1-a6b3-ae84c0f5a1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e04f8a12-64bc-402d-8135-fde49c9456a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2532ec3c-b602-428b-add3-c397c469e629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8747ee4-c3fa-4da8-9f95-523edc656e56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70e32c10-3c2b-439a-80a8-67794b3a501f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd59329e-ae4c-4ea7-a16c-1ed5ae6986c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6a44534-92c5-41c4-8e55-f21f2746c102">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39113052-5b6c-414f-8b14-c45da77d0961">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4becd58-5c0c-4842-98cc-22eb03b299d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c1270b9-bac0-4dc8-8577-5e54ccace42d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736d9926-2933-4786-b3f9-d831a26d493f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea268416-1911-411a-9871-a5e4e0d8532d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_810a4f75-02f8-47f8-a59b-bbe4a9e9fd32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_645391ee-b5b0-4663-a5a9-219880d387d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac44bb69-b7c8-4510-8e7d-27713ec34d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_617803ce-c01a-419e-bdc2-8ad91881204b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5a4dbd71-77ca-4909-a368-d4199225e92f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d0caaa59-77cf-4704-a71a-5771f0f65948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2dadea34-e273-4d47-bddd-e5811a5f3060">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de945cfb-1c19-454a-a288-3631d0d33d82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91a822b7-c670-4873-8a6c-60b180b100ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4c9a7e6-05c0-4b9d-bfb7-f0df1a033d94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8db43a7-acd3-42a5-a4f9-31bb793ebc41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec950292-2658-44d0-94e1-7ab461b27707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd883edc-c0de-417b-b378-06b106f94a05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_abcf9ee5-7753-4307-9a56-b119fdd62d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9feceb23-85e1-43cc-b4a2-c3e2465caa9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_15685edb-292c-4afd-ae2a-40d35a35ed21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a8c3fd-df2f-4963-8b4b-a55141d2956d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17092b96-3f07-4c32-add1-f029ffa6a018">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4dd4bcd-df20-47ad-b0d0-994799f393b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_734f6749-fc85-4447-b206-97e1b9a6da60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2ba4c89-a65b-4ff0-8ec2-1cfc6ba62415">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe36402a-ceef-4899-8e68-563a5528ef41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18ce150f-356e-449a-81f3-c71920e26569">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7575bc2-040d-43f4-8b66-98a8736a20e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b49bd25a-dae8-4ee3-8034-79541d1f2b19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ed6cdf6-03b4-4d44-bd05-cf1415e2e538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7367cd2c-ab45-48ae-b600-1b361ed30b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6204fe90-8afe-44b9-9daf-b27d4d1e054f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc1cbce3-d371-40e6-b379-af34f2e14c8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_070caf31-fafe-4ad3-bb49-81f0d801fe0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fa8b508-ef32-436d-a22d-2f1566b4c571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c6db05-c475-4b69-bf7d-98b2f77d0c30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0b69b9b8-0a43-4693-a724-ee34791e2049">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd7e3f-68ca-40bb-a4ec-bc4d38416f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51441483-9728-461b-ac63-30e57f41518e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be873af8-4dd3-40c5-8167-d27d925e3573">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc2cd4e1-70fe-44f1-a685-6439199241fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e9f43430-6b51-4306-99fa-e543c431f3f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f63b05d6-b2e1-439e-952c-63767d0ca702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4438e97-ec0d-4908-9114-7d6c48f89284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25b2d034-7d7a-4db4-a467-987c5b19b4cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_24b6307d-23d2-44a2-95f2-4f8d39d70e0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06334274-246c-4230-893a-302a747331ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_193894af-6766-4066-8dea-9fb9ffcedd4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c5785d7f-56da-4e61-83d5-2f18adb7b233">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66c811f7-adff-4a4e-94a1-b8038daf18d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b21b057b-e4f5-4cd2-90b1-32617e981260">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2fa674ab-5a22-48f8-aec0-6fae8dfed969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bdafb8c8-a619-4936-9f6f-79d0767617eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bdaefda6-56c3-4fee-832a-c7b1abfebfd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a74705c-5bbb-49e1-926d-d4aa5c52ab36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3becd1c-277c-4d5b-88f4-9c355ee975e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d486dc1a-d28a-4880-be97-4814c9a25b7a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2943a5be-cb31-4d8c-ad96-227e0193ace1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0853d553-a35d-45ec-a9a0-0d8184f76a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76b45095-2687-4271-805a-7bf60ed3551c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ec6b68d-ba61-4c55-b09c-bfbdb80ebcf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85214598-6383-438e-a4d2-ab029b7530e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc5543ec-b224-4bc7-9eba-a827e3058465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f733246b-e52f-4ed1-88c7-aced475bbee2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d86a131f-8960-4881-9ff7-7ae1a6d6d354">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0177aba7-d4b4-4e75-8e40-62222b87bf6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7742836c-da33-49fd-a00a-cc7e0321277b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d4c4a91-3ac3-4e24-903e-8ed844e5dcb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_512335a8-1004-4cfe-b462-f7ac341eef60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b4df3c1-a13b-40a4-82f5-66f82deb2cbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ec66737-2300-4657-9389-6282cbfed896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_710e51f5-0e13-41aa-ad39-0e6e38c4c5c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8e247e25-f821-4e40-bcc2-84579384b6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a36c16-7af8-49e7-bcf6-503669668780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d296778-ac03-4544-9620-df7302d93702">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ce08e898-8a0c-4b22-b375-651840464974">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8f229ad-ca28-4a4a-8277-eae642c78a9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5a98d74b-051b-45b8-864c-5bc17b868079">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_935533c4-c8b4-4d12-91d1-e357e32bb1cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee8c3a5c-d53b-42a6-84a6-d109057f66f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6e4f67c-da26-43bc-81e1-d91efef4bc0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_985a89c4-0962-4b76-9685-1cbb1b755fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e181c7ce-9b27-447d-b60c-7bf20fb74fd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7ca85a2-5dec-4379-924a-7bebfcab592b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b87135b-9de3-4278-936b-77fc18f47f98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaea47ae-5e05-40b3-9f34-6f857dfe9902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d4f4a91-6e54-42b2-8f8e-0b9c478cfc4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a799f946-7cb8-4538-a661-ebc68828235d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a5d488cb-2a2a-4f74-bf60-4a7c2afe5167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ab32114-c60b-49e4-b16d-59f43ae9b429">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d9ceb6d1-ef81-4fb4-999a-5c4a09bbda2b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_79a6ad94-a07b-447e-85c6-61dc4e3f2c41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c072731-8b09-473e-b65f-5d1c595f7d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f8545bf7-29e8-488e-8f7a-27d45dd27584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_001e3e3f-9f35-4adf-ae09-beaf7310f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76f3cd08-a9cf-442c-b664-7ffae80f34e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c8477581-f647-4fd1-bc0f-38da40a5c34b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_941ef755-9542-4b5e-bf50-bcc38e4e3e0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f65b7928-e759-4f20-96d0-03563432dcd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3c9d70ef-69b7-4294-888c-a1db7a6cd16e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84e2fb08-9c7c-468d-99da-88aef49b8955">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c6209ae-c301-44d9-a9f4-39e503aeeea6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_35d6a3fa-41cb-4def-a6f0-02242f07cc8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af3599f4-876f-413a-9e2f-61e4f97cd772">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_925cb008-fbf8-41b5-bccf-a9ba0207496d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3544d101-9166-48bf-8d7a-9830f8bd7e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c4961b0-db79-44fd-b894-3e3ca701e148">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_751f3c0b-38fd-4d93-92c2-210d657c929d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ad3d6235-3931-404e-96c9-eefea6cc2a51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_15f6523a-a6ca-4929-b2a6-797fe5165942">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_607ee7c9-c194-4980-bbeb-4871d045b117">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d595630a-5c38-41ca-8d89-e6de86401784">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4879caa-544c-436a-b481-ca7782fa14ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d468b176-1c1b-4e70-b89c-cfdb358d12c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39e8728a-cf2e-40ee-a6f3-60eeeb2b3bed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99a7243e-cd1c-4944-878f-353803f16173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f579bce8-a5a5-4af5-843f-b6774ebdc50e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e7e06c9e-85ac-467d-95a1-dee3fba2db7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2efd19a3-19a9-453b-8a62-1358a678e54f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_50cb2407-1a48-4d05-b50d-0eb7d0fe0d5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_59921408-ed5f-4010-8874-8c7cfc9cb99d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a6832ef0-2d40-4b67-81ec-7a22195700d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d14c5eb-de52-47c4-8527-6c2d90f6ba09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4257e0c0-571b-465c-bd0d-e6dd32b83599">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0fd26d9c-7a97-4480-a4c9-5927169899b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce509f30-fa28-4fb8-b93d-2e7d0753e01a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06be5c7a-6d6d-4bda-989c-3de94c0ad642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39381952-7a93-4505-b431-38b454ddf896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d75cbc77-7b81-46f7-a818-c80eb0b51a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2aed15b5-05d0-46a5-bfde-aa18a6e58bca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff83925e-7032-4d39-808f-131c849e3c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ad21880-4865-4369-a402-af2fe2d06469">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_823e97d4-6e60-4330-a062-2dc6dbd6aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7de33c3c-f761-4510-833e-4e658bb155ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bd21b61-bdd0-4bf4-baec-1df6fb7aba04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e097cc96-68b0-4776-9baa-0e05ac6d2079">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8f842892-67fe-404e-bb86-ec52099e76bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_369c7b20-7a1f-4e27-b826-b22fd852f92b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d3f27b3-8901-4993-a783-1c5cc360e39e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cc984ae-ba96-45d2-ae4e-36e988202551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85b55d99-54a0-44c9-be12-73aa01d85025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9438622-ec39-4de8-8bfe-8b7a7acb728e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2020f19d-8579-4c6a-bb85-33cbcf9c80fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2512e2f-f697-49c5-88ed-472ce66102d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ebfb91ff-e57a-4c99-82de-0f5c7bb20361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77f21387-12a9-4a66-a13f-3650ea2a0626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be648bd2-646f-465f-82d8-fc18fff2565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0d9d1f9-ac28-42fb-a3bd-873d848c0bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c1eff410-da05-4ed2-8a83-6d72a5b1ed9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f36d52fd-a011-4d3f-9886-ef1558392dd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b130e0c5-4e18-4c5e-9630-96c1e8523961">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3d60d422-5a45-4fde-b96e-83fcc351399a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71dde336-035e-4993-bf5e-ff65d982884a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5fc7015-c249-4da2-b59a-fda46e003a21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c25e18f8-ca13-4e18-8e6e-106713a05817">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003ae024-12b6-41bd-afb8-dbff8fc0716f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1fd2a69-ab09-4a4f-8e0f-1b3b2a7ed8ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4b5ce0e-676b-4e14-952f-0e70e5eec005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cabaaf52-7fc2-4375-b423-17217e547d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bc43aea-edf5-40ea-bb93-360747aaa871">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_35f390d0-fc3f-4dae-a334-b28e27ecd4cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d09ce77-c1a0-49c5-9da4-1743097d6b5e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2f12e17b-a03e-40bc-9633-3b062f903a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_befafd88-9e45-4aeb-bc91-72989f037361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4642aa0-952f-4c0d-a380-67e9ca5798c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_19ff8aa3-4c9a-41fd-8b5c-fb88ea00d914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23992233-1625-467a-afb5-7c7db2154274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d18c73c5-9283-456d-88a2-ed56c52068f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40db0b6a-2fed-42ff-b3fd-4146ac3a6b9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab9dcac3-38d2-4998-ae2e-743e9e93dbf7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87844dc5-0f00-4fdb-83bf-4df6a5a66c00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_397a5ac6-c21c-41e8-8bc3-37030f7791e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_46777efc-f783-4fc1-91de-03444ae43579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cac650bd-26a7-4597-8d04-f5210c60e5d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c7661b-773d-4e82-a011-20182f0d879f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72eb8f4f-06a8-4acb-8749-7c2c83001667">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0591bf58-eb3c-4ea5-9379-1dc6ff597412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a6ea8c7-7bb1-41ac-98c8-ecf05ba41d55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e35d55cb-7309-4c84-b62c-24c5701faed7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f22fc970-4d7c-4dac-94e9-f52e0faac4e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e70d3d1a-6c78-418c-97d1-03544787f442">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de1d2205-000f-412c-a692-27e23e6cb8ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d7a2c8d-6bdf-4432-ba34-64126abef849">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_14dde051-a9ec-4ec5-9832-422934488527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13f572fd-94dd-4eed-8ef3-ace0e748a2af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de08189c-2421-4654-b7cb-107162c73d63">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3a29e1c-911f-4564-a654-c6fa2f73900c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b0a3b7e5-2272-4789-b17d-9fc98ce6b190">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676d9d34-6500-4af6-b5b0-a64590ebdc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28831048-7986-4d83-9322-ad7b45aa6979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02c24ba5-c256-4bb1-8aca-18aaf5a4119d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cda097e5-c55f-4370-8046-a22566d23aa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3db309f7-b0f0-438a-9619-158dcf92e77e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7f5cd2a-e199-4fe4-8a07-000b61f6b849">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3559ab6-f11f-4163-9018-fd2d381786b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7080f5dd-d253-41a3-8978-1acb7fb725c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec4106bc-ce58-4d3b-8e92-880efd0b1664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10977b32-fdb7-43a9-ae61-93d4bf8d7afe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904d3954-8cda-412c-9749-e8bb17d66a92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0111008-7282-4c97-885c-7fab48bd8436">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_876454d7-7628-4133-9422-2ca5424ca361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9ff15473-2981-407b-a9c4-b2fb35aa3674">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_55ef1165-5526-42a2-b3bb-e8ec92717df8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c28c5416-4d5e-4bb5-abab-96a1565edfa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d927603-3d20-40ce-82ad-83b83ee19f72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_229408e4-2c2b-4574-a315-b735a27c779d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68082b8f-1b58-448c-b179-bb3cf663ae68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70edef45-f5a6-4dcc-8ac3-0ddabf759635">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ad9b069-1fed-4ad2-8270-2d803e8bb18a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdf583c1-b367-4df4-aa13-61564d6ab6d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92c79159-1d7a-40df-9703-3a5db5829183">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dae057b6-7b1a-426e-8e5d-2acbe7a43672">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd8175-e9d4-4ea7-ad36-55850bf37124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fa57a151-cb4b-467d-a0e5-025f0e879340">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29fa0b37-8927-4e2e-ad4e-fe8ace32f522">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372fb999-5a14-474c-a762-df4ec45be325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59a4afca-74e7-42f7-8568-57ad4f7f5a7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eb5af546-4e64-4615-b4be-c5f84c5afc69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e2e577d-945f-428e-96c0-85a30ddfb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc4aa6d8-c784-42b1-bd46-b5a7b0fbee37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ab4e7e3-cffd-4fb4-9903-775b019afed0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e958a796-f688-4058-ac62-e7ff354a8b2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba240b0-4442-4e3c-9b12-92037859dc8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58cefcd1-4074-4f65-b238-c8bd2807bb62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b7e5f911-cc7f-4035-b405-dce36c696979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b105dbf7-08b4-44f2-a809-7659b9b0c0f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dc8c8d-842c-4d37-9ddd-729767e27b17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a87b7beb-c39c-4b09-81e9-5ac4e5d6dca6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c5a9d89-ddb0-44bf-bc81-169851dcd038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ae060b4c-d898-4866-8934-72ad68a61d2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ff2d666-0eca-4c6b-909d-de8c8dcd5ff5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2416d8d-eb9f-4c0d-992e-584910dc95fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13563e1b-bc67-4100-a744-0b15bdcbc8f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b50e0e0-9880-458b-8ec1-df2b45b77707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3003a0e9-678d-4407-8d92-8ef9f603d17f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8927687e-896b-4610-9f61-0ff4ee7f0355">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_836cc85a-d634-47ce-9f91-cad257677a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9185dc-ee0f-48c3-be9b-0999eccbbe09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2608e084-b64a-419d-ae01-4b6cc1e71585">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_167d679d-7fd9-41f8-9d06-caa39dba4d17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f458e59-de2f-4f0e-b34c-3964259cb7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e60f6916-d41b-4f3e-9e12-d053db17fe84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d5f4047-8216-4d31-ac16-4a9a054c9322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a3bcd38-457d-4fb3-8e07-3bbd70861a2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_208ee53c-3823-49b8-a07e-4c96709a6290">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_132fabf0-f06c-484e-88e6-745ec73dc90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d366858-cfa5-4734-ada5-a1d4e1de96bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73ae19d9-1ac3-4fed-99c6-6a4638bb06fd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dbff479-ccd2-4bd7-9d0d-d7699ee4f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3af795-f0ef-42e6-bdcf-5998074e2330">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec7efa15-a618-44c1-9777-6d7d98c12e77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_105b771b-417b-4b18-9aae-2edb5c322c6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e02995be-5319-4997-89c6-0baa13af4633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c61435e-e1f9-4541-89e2-6263603b3b69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dff476e-df06-42c9-9efb-b4090eccb100">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1efff4-9a22-42b3-91df-2c842ef69d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_23c32af9-38b9-4c72-a024-eaacce4cd25a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67c313c3-0537-41d9-bf5a-0ce46862778e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c78abdb-f124-4796-b624-ca207adf405d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6df2135-d56f-4ede-ab61-32537752244b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bc5c2ec-af4a-49b9-8349-b9267dbb909b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4f648f4-68bf-4e8d-a158-24c7ff934d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b9a43ab-5f04-4a70-8105-4d1d6dea5cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07d9c908-2ca6-47f5-9b54-23668c13aea1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_188820ff-ff28-4597-8755-16e1f383ac16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92ae4c05-9849-413f-9950-08e73b719f53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3e291d07-59ff-4e54-9816-99637c944ce5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e993253d-fa2e-425e-8a54-ab9d59eceeb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bb91660-0de2-4d77-8dc0-b2dd97689d06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0be57c-dc2c-4fb6-83c3-f9dbb5bedcf9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe303d5b-825b-4378-83a0-91aad62189bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97347a26-0a57-438d-8632-a5da61335545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc4d10a6-b3e1-4e1a-9417-a6a54c099ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53554a66-e2ec-4121-a84f-bc5f58c3a39c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81767925-5b0d-4258-9684-c3609914ad4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_190cac75-5579-4ffe-844d-db8817b5c500">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8714d145-9c20-4532-852d-751b41958aac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904f003e-1ce9-4007-aa9f-00aac3c62a98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_214096b4-1ddd-4b94-a7c5-67cb764c0a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cdcc05e-df32-4ee8-b7a5-cb1f696db621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e32b1e8a-316f-47e4-a283-9b8dd0642e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3aece19d-4dd7-402b-a8d2-5d26d7ee3b39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db8c2187-33e2-4116-ab89-78beab00ea57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_78ead1cc-f404-4ee7-9fdf-ef48535800a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_22055254-fa36-47e3-a1a2-155d0a0cc771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_557a2416-503f-4222-9308-f18bccbd1d01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2470f09f-6853-4749-9034-4f203dd05145">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71fccfe4-5391-44df-b2df-5d66fde7db4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c091e57-8b19-4353-8d4c-313ee3863561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3cefb57d-57e1-4e3f-903f-69749aa540e3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f2d8a7d-95b2-4973-bef9-175379b439ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7f34bf2-27c1-481c-b244-d5bf555288ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_072343f7-33d8-44c6-bfb3-86f4b517797d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f53ca695-3ad2-436f-b57b-a0d82976e489">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b72db782-c1e2-47a6-bfee-76d98a50ed7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285196f-6ba9-482f-84b9-7bd3923b8e05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9c86c4c-2491-4427-ba0f-710ebde97af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec3d8a3-15ad-479d-a33f-5c01230dfc8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7d59712-1642-4092-9ee5-f67caca03a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f4c0f5d-b870-41b8-b34e-293e4d986355">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dbdc2b2-f9a3-4c59-b067-f65e01e1c62a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_74ea36c6-2edf-4166-96d0-d0d8e03ee4aa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c8effe0-03d0-48cb-a537-7a5e9e2809a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90803e77-364e-4047-8ac4-d4d18032eed9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_82adc907-8d3a-4b68-bb4e-6a74b4c9e7f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7306d11-ce28-4c9b-ad6f-e38fd8311161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5f35c9b-8ba6-4cc9-a4a7-30b3c05f361d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d94625fd-9209-448e-ba9a-d9419e7c7184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8621c35-abc4-4aea-8aa1-7c4f318308e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afadb174-03ee-420e-85b7-2cc1b03b5fc9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b9f9fa5c-16be-4030-ab78-85df203a3689">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ba01acea-929c-4066-b7f9-8a44679d7278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_868bdae4-132f-4de9-80a9-235a2f7649b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c93f0b0e-710f-45df-b479-efe99898bc58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4d7cdc2-47c4-4d81-8813-1307da791074">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c182723-b6c8-469f-8368-664cbe6c5ae9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a826a3e-f47f-4547-bc86-8d5c29802073">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71d7fc82-41ba-4769-aec6-c28a028c24f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6f20f8e-1d3b-463d-bcbb-74e286d08e4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e3de8b-6459-4ecc-9a7a-f07ad5e41dad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51015e38-eafb-4bea-8fda-d7254a752591">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7f865691-09f3-49ed-a046-6a9f927b88f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb298e3f-8717-47ae-8c74-0352837ea9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e34a8420-47f1-45d5-8a93-1a88750c93ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cc228ed-7b17-4a46-98c9-9b6dab5ecdab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0e39-4dd1-488c-9f42-261213615c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3fc35f4-afb3-4be8-9042-80c22938c1da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7fae11c-5433-4dea-8daa-573036118c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f8d7f2b5-d937-4798-8f49-2f9d6d366a37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_61654344-ea9d-47f6-bc0f-4c1f512f6460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71e972be-0b67-4baa-b9aa-d2af29f81dd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b836030e-56ce-4bda-a621-1cd3898f7a3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8905b57b-c2f5-4004-a604-898087cacd6e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c31d0b56-0d49-4611-bb21-4da3c47be957">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e12d10a0-1652-43b7-acff-b94dd8e81d99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285cad5-6de7-4403-b3f2-3cc8618a8428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62f45f9b-4214-4227-8a3d-8ec5bf11c1bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27857a57-dc46-46b3-be78-4a3e508faa27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_97ef7eea-fbed-4cca-8155-059d768bd25e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aad83482-c91c-4404-b6c5-2e4b0cf2c430">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_741b144a-92be-4316-a667-6d77127a3c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e783a6c6-9325-45bf-ae94-3e58253dcb28">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb5e5403-2a79-44a4-9175-3e0c6cde1a7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6ee4820-527a-4806-9ce4-2f0d42f31276">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dd1d63-111d-4dcb-a900-09f637cb1718">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70cd53c9-69bc-4bcf-a3ac-4e7ac464b1e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f3ff468-9121-48f9-8210-265dc8d4bdc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56f4ed47-0029-4843-ac3d-c989194a4f6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f57fe36c-18fc-40f7-8f07-d908b0a444e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec5c7335-88e4-4853-80bc-bff5cc1fec3f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c90725bd-093b-456b-b293-35b3d24e93e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b8b82bc-e378-430a-8d32-a757dbac9654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315475b-5bda-49ee-857d-d4909e35ac00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8605a6ae-08aa-4247-a681-37bfa08ddcab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_947b0817-ebfb-4448-9e46-1b205c39cb36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06dc1e7f-54a1-4ca4-9bae-106fa4fc0b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_34fba600-df3c-4444-92e6-44820bb53700">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d5b75fd-ef40-4687-9465-b9813bff0c55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12f3da88-6382-4ee0-9944-8ee455b9d12d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b80ba0c-7c2c-4247-9376-4d6c8150fe09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b246ab5-1854-4074-a138-ced059858bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9088e061-ab8e-4b2b-9c0b-b84ff5986524">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58ac5024-a283-465d-96e4-3958b4e5d587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_113e04bc-404b-4a53-ba47-2aae867c3bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_025d8e4f-7965-45cf-98c4-7cfaefcc2b38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06847793-4f82-43ea-9d81-98aa1e2596dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77a92fc5-b352-4ac4-9526-2c325a319aa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f575e4-4d82-41ad-a7e6-0c4a89a7846d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74525261-c7ef-4d31-9b26-15b564328d3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c95a00b3-90f7-4ae0-94c2-50696538217c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_707a27cd-6e44-4b2b-aeac-ec7fe86c87a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_acde90a6-1736-4d99-996f-f94f40387275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0de56081-b8f4-46b2-a104-342f7c06f81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06b6e45c-cf6e-49e4-85ed-66b9519391e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ade7d271-d264-48f8-9f66-84ae1e80ef77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35fd6ed3-a06a-41de-8588-3d779ab51fb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c861879-751f-4428-a068-75a4aa42e588">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_220d4678-9c77-48ce-aa02-b302549280a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_235615be-43b8-4c5b-b4cb-14db7ee8d61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5226f2b8-6339-4e7a-b351-7b464c9fcd25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31e9896f-9c68-4f37-8acf-d2c43cb44200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bccf7bb5-9fcf-41a4-8cf5-b5cf08d878c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a07fd55-9727-4c3b-aab0-14051933c782">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf5a4f02-dffe-4020-a13a-e045e31e4aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2efd1a7b-4bc5-4856-b2de-bcc27f4a2cde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0a9a1b03-c9e8-4187-956c-bac2bf1926d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_353093f4-bcf3-4890-85da-8c4aa9d6d6d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b6d2fa48-1a37-474f-990d-10d2d794bce6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_13574538-536b-4538-8e26-c6241ee2d5ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27efc09c-a8ce-4383-b44b-a4400909f8fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8b00173-49f3-42b9-bcdc-567771ef26ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c24f1de0-8b83-4a10-b680-d7cd903045b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e12f605-dc64-4ca7-bbe2-8b1a99b0e82b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acc178ac-8fb0-4df7-a38b-28fe75a170d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_49ef34e8-d89c-478e-806c-58fdfff64426">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6c25f839-f61c-4929-8ed2-75621b54683a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24a54926-5757-44e2-b82e-671a97a4246d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3419e66e-ddd7-49e3-8c10-6ad6c5f5c49d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d0a4264-7e61-4421-a1e6-90882ba91d0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95d6b06f-a866-4954-98d2-4e1f36a7d499">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5f288ec-4c79-4843-ad2a-10afd29f69e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4946888b-0e94-4c37-9f66-56b71e7e256a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a30cb194-1934-4fc5-b1f4-a49039bf46a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f58e858c-6f20-495e-9732-36ccfd05cf5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d61dc199-1ebe-4435-bbb3-8701fbb7df76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0acdfc8-d22b-44e5-b98a-e3beb4bc431d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_517ca612-cfe1-4358-ae6d-b05efa7f5171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6893ad1-b526-45a1-9b4b-82de55b52fcf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7618e19-9e6c-4a93-a8e5-7c0a3ec3f2b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4838ab73-e852-4a4f-8e14-d36cc6dde894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e64818e2-9253-4d51-ae0c-81d112e2cd5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c3a36588-a846-4a37-b181-afe3af3cf915">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_714070e7-1af3-4863-8885-8920f896f2f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_05372493-820b-4768-b6b3-b06cf4c88040">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2e0649e8-ae5f-4146-b539-55df36ed26f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dbb7f413-9cbd-468a-b57c-023e980826b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f829759-3787-4e7b-9c49-51fb44f490de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6586012-dd0f-4349-81ef-057a9818e91f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0551774b-ab93-4cf6-9afc-3f49ff2e5339">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d90700a-b751-46d6-9883-1afa754ca728">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ee00881-e663-4ef8-8e61-5a9d373b60eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_029a4186-6f37-475f-b0b2-d4888ec78456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7417b3f0-f39a-4da3-ad99-a0c5acd31dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7bf60b21-3cfd-4c15-92be-de3bf3987969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebe2830-5530-45ee-bca1-03f80a144de1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6857768a-9ce5-4491-856d-121d10953832">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45b979e1-6499-4853-8bae-ee72dab68308">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cd8ac52d-b2f1-42be-a279-de43a535b633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_318892f0-18d1-415a-8a4f-12e16802ed01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3896d698-274c-4aa2-b2dc-85550339e7e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0586ae6a-a2dd-42a2-8280-def5212f1885">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe7d3d87-0991-43d4-982c-3bfd6eabac43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67fb0682-a5a6-4906-a36d-cfa2097397a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d83d8c12-075f-48b0-b5f8-38259d641027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d886ae8-6347-4a11-965d-4486a842b72b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c1ec08c-6b4c-48a8-bf02-006c60e178a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37d7a305-3c5e-45e3-9792-0aa39d89a087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b89a5862-62ee-448a-adfc-b98dc77a6c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_466e04fa-ecf7-4c12-a305-5264e60badfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e4ab9e7-323b-4168-af5d-6cfe6914e92a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_782b4c70-97ca-4ac2-a57d-c1e49802e962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47c94546-4aca-4eac-b3e2-0f6ae04baba5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bfa323-d130-4b02-af40-1743043ef9a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_365b45e5-9725-4467-992c-44a30aa3aeb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02fde0e5-c682-4a0f-9691-475fb76be114">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5a0d3ee-b330-420c-85ff-dc7216fafbd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_370ed0c9-995f-45bc-91e7-b340199efb75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97f67aae-d210-4862-8d2e-78e4ee1057e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae5e385f-d5a6-4333-9bcd-13f60268cafe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5559d554-2049-48cd-8104-20ceed7b4686">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ba7f2c25-8fa2-41f5-8355-8beac83b5a65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_408d47b3-1f97-42f6-b331-0d61e5f90670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_965d13f4-485b-425b-8dfe-c897500fdf2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5b6d87d-a141-4762-80fb-6ade51c8d259">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a63b1ae8-cf67-4f81-913c-0470719183fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d01c2bb4-c8ab-4007-861b-449bb235e3f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b221fecc-3f56-466d-a7e0-7ede7a1aff0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_42d8d499-e591-46c3-96b0-0fa80adbf923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_18c74b81-234f-4bf6-9d2b-38816c082d78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed2cda40-9e01-4b05-a44c-17e790367156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63c6dbd4-a478-4642-b02a-ec6a5bd2d82d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c05a0e46-1a0a-42a7-8033-274b947fad1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_49ffe632-11ab-4d04-b22e-1a7de4ca7746">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c0115ef7-fd26-4d5e-b841-07d14b72b16a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_beb12705-81f2-4cba-8b89-321726c2ba08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_808645ff-087e-45ef-940e-26389858902e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_236ea25a-9487-490f-9886-1854ecb7dd5d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de290528-0feb-4427-a306-11c0789ad3a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c31e8fd-473d-4142-b1ef-a7741eaa41eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea5970d0-fe70-4953-8353-e1f908f04833">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cb01ec5b-3693-4d3a-9bbc-7433afe2c562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b906c8fe-3028-436c-a6e9-ebe0aa0bd0e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc43effe-3bcc-45c6-addc-8790363e2e81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4bcb575-87ea-4553-9bb2-c6114aea6ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_574d3b76-05e7-4206-b43a-2406be300e73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e809161f-b94e-40e1-aa05-c26b5db8319a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90532d5c-51b7-42e8-b997-7cd3aacb3b01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89ed2c1b-8753-49f4-a90c-1469a1db2d6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c321ce94-d20a-4ca1-ae56-0e345f8d8f39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d1b4265-e043-4df1-94d8-c9b3b2a2d74c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6ef71c8-d16f-43a2-a67e-c3f882aa5898">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d291384e-072c-4e36-ada9-1d78743a5f17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb70152-e11a-4835-b3b8-9607ee61012f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b347ac3-f5b9-47b8-a5be-86112eb518ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a1af822-b372-4f65-8a5a-fb7c2bc9fa46">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70bc8a62-4b3f-471c-8f26-4de6dcb587c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f47ee7a-dab5-437e-928d-f5fa1a931021">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_37259d03-2688-4269-b724-a019708c03c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ae7edf1-44ca-45bf-bdcc-b9f2db3d3383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a629244-1958-4b39-8124-9299af3f90ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25d6bfbc-0406-4021-a7a3-eaf27c8bf87b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbaa2b91-19f6-4276-a1a5-bd29c05847a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92cb244c-751d-45a3-a4df-744118e58171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34f3366a-08b6-4ff2-8d8d-25bd186e23d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88ad481f-2dc4-4bed-b6ad-4eb45eff8c85">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_073bf8d7-6f1c-4bdf-8589-f3e7118b1419">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15de3a48-a951-4860-bf45-0a7d3e496232">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40f29c78-d193-4938-964f-009a195cfcce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cfd8928d-63f2-491b-8f99-7f12bc865a43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a21eb818-fb97-4531-8b5f-fb94643421b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0bceaa1a-cde7-4481-a6ec-fc1f00e4d173">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dee9f7f-ab45-4ad1-97a5-1ed775bc0a1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d87472d-343d-4508-af27-99ba0013009d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76ca6183-d22f-4b08-90f6-608c23ae01e0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89fd8582-7f8a-4635-9309-c36ab173d8d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e54502c-3e0d-4961-a3f2-e1a19f9f15be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bbdd559e-0803-4e99-b9d6-73d9343ea7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0568054d-a321-41c7-8ae0-7f3e4e6d6efe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae5c783-5004-4cb5-902f-6c2e49f16d2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e65738a1-a385-46d9-bfb5-a85aa03dd1af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db28d434-76f8-4140-b103-101d760da602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64e9f5fc-90f4-4b7a-aaf9-87364ee47047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2fa69bc-0690-4b00-b689-0c313b529130">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2310d678-df3f-4460-9315-9346518888c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42a60441-ee00-4407-bd69-61ce56d08585">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_999e6491-6e9e-41fd-bd90-90ea018661cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0d8bf12-31cc-4ab3-a046-31a57efa5aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f192d0c1-711e-4760-8b00-fc1b798d7a02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc53a16a-a3c2-4f8a-8b0f-fd3ee7701b92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0d478a92-27c8-4122-8f65-e89167e50c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be723ea-f9a9-460f-88f6-f6ce88b9adc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3707ae37-c9f8-4bed-9e83-767995f2904a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f748d44b-1f22-4a0d-aac6-e9abfcd344d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a040a884-edb3-440e-8118-8473a3c88c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_12360317-55cf-4c68-86ac-bb6d7454dc66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_792975a0-5c5b-4c55-ac56-01684e17cb4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21034b29-0370-4459-ab1d-d54d10337173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cae54e92-78b6-443c-a94e-3808610aa607">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877f697-fbf0-411b-8b70-de015b64ed2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cefd7b3b-3bc8-414c-af54-efef4551a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80564bd9-c46d-48a3-9ee0-fe1d044715b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_470d84cc-b496-47b1-997a-3bc5b2898568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4b700d6-4419-4e60-96d4-f054f596ebb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f829f61b-477f-45d8-b5a4-cb19a3097682">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a700bfb5-accf-4acc-aef6-75b5b4b9d283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c319766-eb32-4975-8ef4-5ec8b325c3d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6572c581-24a4-47a9-a39e-74085116d4f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bfdb9f7f-01ce-4490-b1ff-42b5e2cc0317">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebdae831-2ebe-4c64-96e1-7b91aa2db64a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2acc7925-5dc1-4c32-a264-f384326d40b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67d15e4f-3211-47ca-a162-20bc863f456a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c17ac3-19ad-4a74-8105-be69ace57902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d447f6d1-7ced-4a18-b489-a848ecdd8f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_82a2c0de-02c4-48cf-a2bc-43c3b43f70c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a799c07-5afc-43ce-b6e5-07bf3ed01299">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23e5c5af-5021-486f-9313-ced0a3c0f78e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a54d4bb-318a-4594-accd-f73e0717c332">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30418a78-e345-4166-be71-c6811a5139a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c5983df-c5d5-4543-aa10-8c9d879a6374">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67dc3e00-7773-4b9a-af3a-8078a00423ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0c34f271-4f47-410e-a4d5-e6f3c8be9d05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_715f00f3-4358-445d-9f13-346e0ef19af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_493944a5-fdaf-4639-a919-4c5e720a062e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c822e6e-dbec-41ef-87fb-3d352bf3b4d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9fc9618-b87a-4744-9548-0d53ca4522fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bff94f8e-926e-467d-a828-c9f16173009c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edfb58f9-6d6a-4008-946e-e5b27b49797b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b7e37f7-ad7c-49a3-be0d-d7ac833b23cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aef1682a-ad01-4e95-8f68-29f223e6f177">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3d42bd6-cd90-44f7-839f-9c7d6dfe9649">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b68c57c2-3f55-438b-8c6a-3b9dc7666ef0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1be73187-7c73-4469-a943-23ea7399b3cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_967043a8-1caf-4faf-918e-70fb1864c57f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7dbcb3f2-427d-491a-a73f-b8eab7746d5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa6059d4-f302-448b-b6fd-62d762a2997c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_19697a59-ebbe-422b-b0d1-4a07469d2c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3009951e-b1d4-4b82-a877-470a516b3361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1221a04-19b6-4b6f-9cb6-06bed845b81e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f70cdd53-344d-4c70-a11b-c4bb7c9fea2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbe11006-c06f-4120-a209-0ac2fa08164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_755105c1-f410-4e09-87d0-5ef15746ff1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_034f40e3-2783-4202-8189-fe8b6e11bcdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c605939-9b97-448a-8051-6de0d751931b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3415f772-e20d-4104-ac5c-44683fffe2a2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bf36e9c-2d4c-4d3b-aaad-b21e7e3085ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd408c9-e801-423f-97a1-a5857d1ad4af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0e75e28c-718e-410b-b2d6-1539bc5e017d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d2dc1dfb-bedb-4a06-aef6-073ba5573610">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3e57554-31bf-4fba-9fcf-72fbcf3c24c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48b08358-167a-4ba5-8716-c7c79c76f989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_440d5403-5712-430b-871c-f1449bc683fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07f052be-64dd-4fca-907d-6852e038a6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3b04fb0a-9cc9-4ca4-9603-38b983258538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_475b64aa-d502-4417-8208-594fa2af4bf7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aff9e12b-a0cc-40ff-ad4c-21354b0de88f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1a973e3-96be-4a6f-a7ec-2f2862e2ffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53fe31c7-898e-427a-866d-f9d639564156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fafbfd-5596-4044-8d74-0992f06c8c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_233d686d-90e4-49df-91ed-b5ee6fbd0cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_598db54f-b81f-40f4-84b3-d92f72daaeb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e61eb85c-b7b0-4336-8e32-6a5c2a7145a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1d98bf9c-8243-4f7b-84eb-ec54a4b21b90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eee51978-7250-423f-9dbe-827906d8c019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_466b004f-e572-4666-84a1-2a772ee0b5e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_026dedc8-5998-4752-926e-f2cc48db14e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0df05e46-9c77-4f7c-9c28-38b92d66e07f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_85ab2be6-50f3-4381-9947-70df840ac3a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb8a4d63-989d-445b-b112-1e304b518cc1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd353504-cb09-44f5-8b25-f1e3e8801e61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_058f2f86-c3f2-4ba3-97d1-9f6906004cfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dcc4cbb-f0a3-4b73-9079-8d7c8c4941ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_342151b7-663b-47f7-8b53-2fa6224c2828">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f0bc0c2-c9e7-4e8f-b803-28c6f5b6548d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395651fa-2b08-485c-95e1-17a893d7d3b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2ac23bb-09bd-4ea7-b41a-5bf5ece19009">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee8c7797-c83e-44d7-93d5-cc60b64290bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b935634-82bc-4212-a612-3d84f1ca3962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d5bcf04-bd8d-4514-95dd-e69f13c19274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1c01a24c-a208-4b22-9903-79a2ec531d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6637d54a-210d-4025-92c6-4995da491520">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_264c6f54-7b73-4d1d-b95b-aa94cc0c0648">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b87edfe8-d64d-45c7-a4d5-5f6ade3ed928">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fab46ba-9cce-4e10-8989-9b54974aad69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2bf00d-7b46-40be-b277-a0840a5c63d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2569cf1b-e90a-4497-a949-7c29fb699a7c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0be40f90-cbc9-4369-94b5-2601506fc161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edfc8def-f6fa-4677-89aa-538653292967">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_020f3c9f-49b5-414c-b4da-8a181c4aef4a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a7038c54-b029-4d0f-b91a-a528c0603ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8ff51ca-83d8-4277-acc1-b260d7d222e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6149b0c5-3cdc-4fa3-8743-c97d0b1f1d09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efeffccf-a6c4-4517-9821-d938ee8fa3af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca2de83b-7f42-4e32-8d5a-0ece354dda71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_94e6073c-06ab-4928-bd4a-16d8bfcc85c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01d168e6-ade5-4828-9749-c9cedd71eebe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_606a464d-cb9c-4a42-b5a9-6bd5ebbb6595">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bc2c3508-b5d9-49b8-a05f-570e28feddc3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_83795781-3114-4144-a04d-4c0218a2526b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b6d0b90-ac02-4a7a-9af1-fdf9ac0d1968">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_829d7f0f-f7f6-48b3-9fe9-40f3e80ee793">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_556c4014-05ce-4318-9c92-92047428cef3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cee22e6-3110-4e02-bed4-8ca368110b4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d64beee8-381e-4dd4-867a-de9eb2a66310">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e49c05e0-c6bc-4d7e-960c-d3fa31a486b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ba5019-26cb-47d3-a5de-6ae0d1ef25b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9963b957-2de8-4a05-af6d-0661f387330f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_268f36ab-f34d-4460-887a-0dbc24dd712b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b443e54e-315f-477b-84d6-6d83a39f6582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d8011e8-c7b6-4240-b4e6-c084fcc656f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ae136d0-afbe-4cd3-8706-8d321ad21e77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c56bbb1a-8c33-4ac7-808b-5e5d608cf875">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4109393-e03b-4c7b-a1fb-68f16c5a7cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb22b97b-0a84-4bb9-a4b6-5ee546825505">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9305c134-9be1-4026-a7be-325c101808c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c44701df-674b-48c0-94e7-2c620ae5942c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52bce418-da4c-4366-9147-90f23d9ee414">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a611e83-5034-4d03-b49d-c2259085480b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2fd42f2-672e-49cb-89aa-ac029b972620">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a04b87c-e6be-43d4-8deb-64099c5ca9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c5eeef0-5d1e-4edf-9502-650fd596cb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fea85a80-5dad-4838-afcf-75cd6d1fb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_713b3db6-d6ea-4a82-b06f-41b9783f69a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bd036bf-ba6e-4988-ad02-c1aa6666ac71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9552d0dd-3606-49fa-9aff-3dabc358798a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26940964-aea6-404e-8941-bdef013c8cdb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1adf3588-5d2b-4eab-b7d2-30a16cee0515">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65930981-025c-4bdd-b596-7f62dd2561d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dfb9aa9f-a159-4fba-92b1-6699c5351725">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6498579-f6c9-456f-902c-9d19b549b62f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26f0578a-c48c-4ed3-9405-7136aa508830">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_124f89df-1b77-4379-9104-99b98925be65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7fe7db13-1783-4d2a-a28d-5f544b258215">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7865f19-c83d-4d89-83a1-c97ffb796b50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f232587-ef4e-458a-ba35-ef158ef922b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7e35b494-953f-4999-bfdb-bbd338329e40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d1b5735f-c0de-4f92-b6d5-ef48cbf3acae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cd4c469-6355-43a9-a5e0-ce8c00e18dab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_49de03bf-9e1e-422e-a69e-992d88da11b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_582c7383-519e-4e95-9adf-d9f4682eb24d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f563d686-694c-45b3-b865-a4cd8600efdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b25096d-00f9-493c-9281-086f23040240">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2729e62d-154b-493f-8d64-5be7d09e89f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7303683-4312-4b4f-b006-f19d2bdb4a53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4698552-6cf7-4edc-bd48-63f44e816764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_733c06d2-d42b-433a-9896-e0d6fcf9f32d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8d144de-e131-4d9d-8c7e-5bf07887df32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf630364-e744-49bd-95e8-ef6d2aa4a7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_158a8112-d449-451c-8048-c6f0a9ccc502">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56365e0e-6d39-4996-a813-c06ce027b7f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9154b45-62d9-4cec-bb90-8b7da0fe72ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ab1a7a4-b512-406b-bd86-e321a39b3c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee320934-b8e9-4ada-9357-7eaee8eb3086">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1410e2a5-1a0c-494f-9145-13ae508493ab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_06741fd3-bdac-4576-8d99-ce74f8873229">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10371938-cce5-4d1c-b82d-62a4e06bb278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a82616f9-19ad-4009-812a-a4242ea9216d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a3f956b-efc6-4e70-923d-9029413a0f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e81259a-44ee-43e0-90ef-ff3b7230fc06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77c54f25-f344-4794-b5ae-abc64a604c19">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_65928fe7-3119-4e0f-93c4-0efcb16c9889">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d09255f-8e8c-4e03-a33b-be6fc2d42cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a2b9d6d3-d281-42c5-b456-e3774492b58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cc24ef5-3e02-490c-aad5-eab050a7a09b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d16de56f-7bd6-444d-9033-50ad12a2dd17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49e72d64-61bc-49e4-a565-03efa5d1acac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6cc99e3b-ca3f-48f3-8bfb-3568f4bd8d3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12968947-f95c-4b8f-83b2-5f0be6468cd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b754364b-ed30-47a2-a7da-9e4d6b03e0b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a13b69a6-56b1-4302-b0aa-3e0d081eecc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8eca3ce7-0b31-4a9d-b32f-c3950b6a566b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e27937e7-537c-4e95-a726-226798fad970">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ad17838-e54a-4c82-8a76-e0fcf5c2164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e698365-e833-4996-9473-f06a71d5589d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dacf7f3b-2ff5-44ee-a2b9-2aa57613a8da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bf6e629-c40b-403d-a645-d75c413c1eb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71c7c564-e605-412d-b6c0-23bbd162ad74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9c399c4b-5712-4062-ae0f-b688af0abf8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82b12011-cf89-478c-a37f-7641faed076f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_622cc0c0-28c8-44df-b59f-442849dc17d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f50b0d66-c542-4520-82d6-cf362ae23dd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_981f8d40-cca6-4b14-a267-a52df3e27e28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d39fcc1-e4e8-416a-a1b8-23bb62b77122">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72e08efd-5a8c-4c2f-b168-945b4c3186fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f47a4f9b-2995-48d9-b4b2-15c179da2be0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e1969e-aa96-4aff-af51-289b2f5f6184">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_68762a18-5f8d-4758-81bd-9239b9599167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b12a945-b2bb-4f02-82cd-4b59978c2b6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55c94c33-048f-4560-bb89-1a7ee27877be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f2b990d0-4495-443b-850f-d159ff7b487d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ee9f380d-06d6-4eeb-b07f-74433ee23ef5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a0063-77eb-48c7-8a3a-108717a1e342">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_471d2814-6487-4a03-8f1a-20fc685d4574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4f45b63f-e24a-4d36-b81d-35a032a7f094">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69246fd4-e827-4c4e-814f-937e24af9cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857769c9-5ae7-4e03-b421-b496cd37e421">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0188ffa8-b7d9-419d-be90-546712bd99d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0caddb83-6772-48c8-8392-b8592da29ce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b030c208-5e93-4339-a4df-49716f2f7ca0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_665fc7dd-b3d6-48af-9489-a931ec2d728c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae9ad4b4-9db4-45ee-bc7c-507982451c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73bb8f1b-7fbb-4501-b6a6-2d62532da861">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69ebf4e7-8f76-484e-bfec-e17f43ca4fcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4770649-3999-4da1-aafa-f310796bfb38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cd6bd8f-b186-4bda-83d9-9978919a34d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6de1c0f1-63e1-4838-9ee5-50fa9c7b441f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9d29ca-490f-4343-a83a-e789adae5850">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48ee110a-0ae2-43e8-bc1b-7abd771bffa7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9fb29ff6-0f14-4848-815f-df067a483b21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b40a5b9-55e1-4e8e-a264-d6a2bc01bee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c693cbf3-a4e0-453b-adda-4025e954d286">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6eb2ea9e-ae8e-4f15-8a8e-256d297537a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fde71d0a-4cd8-4273-bc10-76dd1fd19e66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d2d2a00-7af0-40a7-9847-bc28c0c1ea23">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e83e957-0488-4692-88e3-8bbb2a691173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cd9e84b-d0d0-4f34-8381-a7b6f7c03ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44020251-68c0-42b1-a413-3a748a1ab55a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57c0a3a8-7306-47e3-9934-a50251ef5bba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_971c083b-37d3-4e4e-a1aa-cfaecacf5562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_712d9aa7-73f9-4897-8147-a85039c14211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a9e577e-ad31-49f4-8389-4ca6efa6181b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8453e888-4f01-4fa8-83cb-972ee72535dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91cbbb58-6fdb-4496-93c3-bbb3fa994bd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90c5968f-502f-4af4-a99b-500f99be089e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b748562-c7fa-4923-8e6a-4427939ab97d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_31215c2b-0e3d-4bdd-88dc-45dd0d473877">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_03388553-ce12-4a8e-9cfe-74622fe2d729">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91c214fb-62d2-430e-bc9a-76d136d1b683">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7b97d0b-2cab-4ff6-91a0-ec87303b18d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc8f845-7da1-477b-a7c6-418956ac6e80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b46d5c4-0bc9-4057-b52a-b3ce593eae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9b90290-a864-4599-8c79-4638611ba5de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e50dfb35-302a-4194-affa-eb06048ced86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_565f7f95-7442-4d72-82bf-cf99d732e17d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_884f8d38-b876-4ad6-b4c2-5ed16c445a58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5070e00b-3d37-47b2-97d3-5950de3bda10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3154beab-9876-4812-828c-aee1690971ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_508d06fb-a64b-4e4a-a836-e866b64db8c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_885fff4b-dc0a-4883-bb41-faeef51ebca5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0db9c722-ba04-452f-af36-e304d10c09fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_23a2a4e9-dc99-4a8d-9add-3ca0c97933f6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c02a9d5-d136-481b-997e-0dbb22363151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5653476c-dbd0-459f-b3d0-d2ad9975dbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d3dbad17-c193-4f54-b0df-c903d58903d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b288691-206e-4af0-8daf-e9a2dd7030f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27025919-dfe6-46d6-8488-095eb2927d08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec1df18b-3e04-4dfe-b264-82b497dace66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b1e30c4-d9ef-4c9c-a476-ce98100f35c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e579b00f-7530-407c-a998-3dec9b484ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_105bc9ed-8b9c-4aaa-b534-174d2f8126b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebcc901d-16ff-471f-9893-98de344c8277">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a096101-135f-4769-a102-be67822c8b8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10bb5ba5-7e15-4c5d-af9e-a947afbcde01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1ff25a54-512b-4914-a35d-98ca1342ae4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac6351d2-74a1-4f8c-8406-4d39c66676a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1e98c83-9051-49f4-8f9d-8e5203f765f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00933292-540a-4140-afeb-a6d0921a1994">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7aabdc4a-f063-48af-9976-cd6d5698db14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2de76924-7d29-4ac1-aa0e-cbe05c315c21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4842c5b-2bcf-4b09-bbd1-530fc01bf44e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad91ff76-5a92-451a-b74f-438c17d16665">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56feff01-9529-43ca-992c-b9f7ed0df41c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39ddeef7-8343-4da5-9c9b-283f25344dbd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5d7a62e9-15fe-4fcf-8a5e-c18e280317ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cb38a95-411a-4892-815e-6f272a1fe602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_22ffe2f8-2c9c-4d97-b486-5f92260163c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_96ab21dc-4b8b-4149-8a04-a61050c092a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdfaab97-2d5b-4a29-984f-e8e221b59ae1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e875bb6f-949a-431b-8199-7b2eeb3c7f14">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_84efe136-ee31-43dd-88af-ffd1637858fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a55355e3-2084-4438-8018-10d3755a97ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1899ca-0520-4a4c-8045-faf978e483a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37a31de5-f6f0-4ee5-b7d8-386f81866e35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b7a9125-651e-4392-9214-d4ddbdb52247">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2f0b9923-7398-4564-ad82-4bafa9778688">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_624525b5-e21c-4305-9ac5-ff7388b1001f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d37217f6-9cec-4c6f-805d-deca7c019fbb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9461a04e-4368-4f49-b3b6-2f05deb219bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae0b6a0d-a5eb-4f61-8b2c-a02e751e84d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04c8a74-9253-46b9-b6bd-9701dc35eab2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be945639-e526-4e91-a7df-a51110b91db0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1dfc97c0-c7b9-4c31-8f4a-a6d6ab182d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed9ad61e-b067-4f4c-bbb2-c41dc385d6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79603aaf-2a57-4463-8db1-671b1a2e220f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efabaf18-727b-4c00-a40c-f17833ed29dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe002e4a-1ec7-4895-86ac-558b453b515f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_20262ba5-86c1-47f2-932b-e0127e4f76d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1f99cde-ae8e-4ba1-9d73-01d49a79cb15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f86804b-4b7d-44a5-aa8c-8be0a817dcba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18f5c8ef-7b91-4ff1-ad12-25013fb2261c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b10151b-bb1c-42d3-a1d4-2405ed3692b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd81079-c54c-4362-a512-99e1574343ec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_46326a22-e670-4bea-b1cf-9c254602f2fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_671ff075-93d9-4eec-9954-3d1615290aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bfde40f-72b0-449c-8d42-637fbc9fd2b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9cfe9126-4dc0-4fe7-b98b-211301ed1b99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_706882f5-592d-4dbf-8de3-c5573164ff4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82267948-83d9-48d3-b8bd-a253eda0320b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86674381-d6d0-4318-88ff-c1894543ae67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bfcb49f7-6405-44d7-8045-14aea9e30b6d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9009bf32-48af-45a1-9d21-011ed8761328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1826f25c-9775-4f4f-b2b1-ae473c49e3b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7a71e962-82ea-4db6-a0fb-4975df482e2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fed39c-b567-4583-b5e7-b7b55af29412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b17a4fe-7e52-4091-8ed0-3aaeb20bad36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f5e9ea3-87cc-4bb8-9367-89a722729922">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5273405-4204-4386-a10f-f7c54e4f4238">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4bf260bd-da56-40ac-b0a9-aa914db52552">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0308fee4-f4a4-42a9-a181-5a87b1d39278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cb7100ed-7dcd-4b33-83d3-d2a0c4f3d3d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_356e63d0-5646-4a7b-8572-342dd3328f76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bef3a4e-f3ae-4cb1-835d-0e5d9f063ad8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c9e7d8-6d56-48b4-b8dc-a71f2d4b224e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1bb11d6a-188e-42e8-9304-e8a4ee0872a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7e54d3a-d5aa-4f53-afd7-6549180a071c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c78dc3b-842d-45a6-a8c7-430b2ba7b894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_520c328d-8cdc-425a-a674-f704abb85b1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_511860b2-8d73-404f-ac31-3690c0941043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd8849fd-c520-4587-9a6c-18d0f987bfaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4001dee1-5a46-480b-bee2-4f49f8336ed5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173717d5-e642-457d-9561-712c94fe0c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4c221fa-68a4-4b6a-a352-bb79f98caa60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2bdfd341-8eb2-4212-8f13-d86974a0d2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8f7de386-3c11-4fbf-b624-23fd3c1c562e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8e1bdcf-845f-499e-ae37-18f99362ad08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c797ea5-c893-4c9d-9e67-c90e8e199411">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1c420df-1842-41ad-819e-009e2c6b9a29">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ebf6639-df4d-4202-835e-d9a6be726cf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71632e7a-40a5-49e8-9ddf-b674a3cd0aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_849161e7-454d-4c72-a0af-047c5336f94e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89d54c89-fac5-4820-9e7c-2bfe46e356b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7f2ab18-b44f-4ff0-ae23-624e27b84d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4986ee49-2f30-4ac6-86a0-753bc271c311">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17b41316-5349-4bc1-8cf0-478a08f5b456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9b0f671-71a8-4cef-9ec7-8e98fbc6ae19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18b0b238-e39e-46d1-8b44-c343c305efde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_73c9270e-8671-4fdb-9c60-e5adcb17e72d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43cca838-8ddd-409c-b337-2e67b51a1d4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b1289ea-c81a-4e41-adeb-e00ddfa67bbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877c860-1f30-404b-bcc2-973e5eb01818">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3fed168-71e5-4be1-ad94-9cab9c37daa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5b81bb78-faaf-4c79-acd9-dee20dc0c61b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bd400616-4892-4133-be8b-398ae2219c89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d654b4a2-619d-472f-ad7a-f6da11cf4d4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc89f01e-591c-46f7-b57a-88b2deb6f051">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_734d06cc-67f7-4711-9fd6-fbdf778ab26c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b7472e2-0209-480d-afea-3cdaa1f3b566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f419035-11a2-4fb2-9aaf-9dd5d2f68558">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_868cbe39-38ec-4502-87c3-89c675fd01d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c59826ec-f49a-4f2e-9bff-450f400089f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d29eddf-8a9f-437b-915d-a171ba75e4d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b8f651fe-90c8-4acf-935b-3a28bbda1010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12d4f8ef-1503-435d-a08d-1172f0e8d4a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b4d225b7-cae1-4c84-a2cc-ec8d86545530">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3851fa4-a3e6-4620-9d84-e5f2e223d882">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0201cee2-9ba3-469a-a163-ff4d8f90339c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4a1bc43b-f726-47b9-af5c-c555b9460663">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e7c03dfa-74bb-4ae7-aae2-e3b13867e39e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22893df4-f066-4d77-9b20-41996fada264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713eb8dc-b3b6-40fb-ad61-4d88de8074cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a425377d-6338-4a06-ae87-a353daba71e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_234cf63c-93ab-46d8-a942-c61871c6c1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96120813-56ab-4482-a890-46d757bc9053">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_895c4d4b-23c3-4aaf-869a-84176c9c5ed6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5215b7c1-8498-4aa2-b3b5-d35d65fc4432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_540d8499-d8a6-4731-aa87-d0ac791ded2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88906a21-f574-4aef-915d-859acd1e22d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70afba82-3536-4952-b226-a329a794c7e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2090b49-5a3b-4f65-bf81-6fb949c6e77b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69b76bd-7138-45bd-bef8-e6a69172e021">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41196d74-dde1-470e-a114-485ebdbf53a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e80cb5-a4bb-4fb0-8754-25a61418b53b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67dfd7f9-e5a9-446f-aca5-9480722e279d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f1c9764d-7a62-4b2e-976d-8eceb473c52c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e8c1bf-b50c-4089-8ec2-7fede6310b5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cc8a469-7e37-44f6-895b-a38e53ba8c61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ce44f7a-e1fc-4554-8a26-2532ad150716">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_216b5db8-fd97-4534-8794-ef399bba9f06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_274432a3-9f3f-4229-a3ac-ac465ad8834c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86385e2b-890f-41fe-a051-ce32d787268e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c5d1874-528f-4b5d-b918-1808616d7d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_756d2942-df77-419e-b7c3-e43b68db0205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bed2fb-0f11-4f6b-b3e6-54108ce9f48e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb29035-f491-4bb4-85d1-a52b9731a61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e93ad931-1622-4890-99f5-1a0b86bb5cc8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8140af2b-d5f3-42e9-a3b2-b00593fe86be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ffc6a17-e0e8-4922-8d3a-6e5eb7c98cb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_402cd84e-9864-43f4-8dbb-63bf7cd1a0c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f41d01a5-a611-4390-a26b-18fa617aa345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713ca869-bea8-42c1-89c9-748ac1a2a210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_55fc5e5b-0d1f-4bcc-bf93-c8b921aed1fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d84ef8be-1d52-4db0-8f0f-982228b08963">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b740b750-4224-4059-b382-78942d33d819">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4971b9b-47da-4d2d-a33f-aca6a40ebb5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6fcf9d44-0aa0-4601-acec-32f45ad7d508">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82f01d0-3f3a-4fbd-9a3f-98a1e954e09d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c3cd7e7-115d-4869-91a6-70bd2e8a0879">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b134ce8-e167-4933-b483-9abc85f82a68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bcc360a4-e0de-4270-b3e3-2c0729527a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0de34ed6-5f54-4d96-b85c-f9cef605702a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3231c97c-9430-4350-8fa2-291f9293ff8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36da5543-1c92-4034-9537-b7236c3523f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4aa7d6c9-5036-4a5c-bafb-8aacb7e07fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da489a8-37d1-42fa-b44a-5ca3ec46da01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c597a409-1d5d-4f8b-85f1-afc3b592df8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_995c307a-76a6-4c64-8cb2-e814cbfb12fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5693ab73-76c1-422a-af9d-4b3bcd6d3a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f644f1c-6ed3-47c9-a38e-08a9485b207f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9bc005-cb3f-409f-820c-a5e040ed86e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fd822661-fd79-443e-b070-216e9012562e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_251ff7a5-1ad4-4805-a523-f27406ba6d79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce12731c-2b18-4e1f-aae9-29964c988cc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c161c630-05f7-4404-9947-055080df59a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_54136fba-4c59-45e0-95da-af7801dc09d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8734587b-a66e-445a-bd1f-6cb940b51c00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e6d45e9e-66db-4bb9-8d38-86c61edab12a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42e6c5ff-2a1f-423b-a9e3-9664e6627f4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2af328b-5185-4c38-b82f-0c4efcbd4ec5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67450fc0-6b2a-44ab-9128-d96d9676f9eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3aaff381-983e-4c90-a188-21ecb252229b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9041fe38-9715-48d6-8f4b-00ab3676a859">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8a2be9b-a47a-4ac6-8746-2c90af9e406f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb0e8f84-c639-49a9-a371-e1853cc9c701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9b24d9c-36c5-4858-87d6-2d837c4230bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7b028d2-f6ab-4e46-86f1-9afc8ef4aada">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16c68725-79d7-4807-aecc-018c600ca5d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_068cba16-15d4-458d-8d1e-14680f6a0841">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a442a01-9c9c-4edb-805d-fc3b45f89e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c8d0fb8-e4e7-4e8d-bb20-179996e179b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7bf7ffc-0480-4a79-a24d-b2d6601acb16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e46b1d1-347c-445b-a227-48aea8b8e2ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ba5d05a-ea6e-4f08-92de-61331f4b7ce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2e5fbe0-2c25-416f-bd5b-e04d9aa999f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ccefb321-71a9-4304-b680-6cd833613598">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc84b185-167b-4586-83b2-d6caac6cb45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68f575ef-5627-4282-9c58-c1e41eba70d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb56196f-75b4-4eeb-83a6-10e82c03a842">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_821c5870-ece1-4e61-9ff7-55588a7550b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6e6c67c-a057-4fe9-a74b-bde8f770bb4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cac2fa32-b7b9-489c-bd7c-a6db746f42d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fc8453e-ef8c-4bb4-9294-2a4e227544ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65e5a63f-cd9d-4a6b-81c9-8297e8add12b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb6439c8-04f0-407d-93ff-be80b9fda84d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3444efea-71a8-4c63-ba38-2ed9a6bfacaa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bc73643-70cd-496c-a6c0-55f2a679ef50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8599188e-23be-49ef-8aaa-2bfe07131eba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_51d5398f-d2cd-40f5-943a-48c008f0cd91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4b1710b-5144-49f7-aa16-78538eb731c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0026b68a-d9ca-4f76-8bed-993b99226fdd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_034d70b1-92d5-4259-a101-27f795ef79e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9b2f023-60c6-4246-bae8-1f304d7c046a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6065275-b0ba-4fe1-8c93-51befb9431a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_824a0775-e3d3-4af9-9950-5ad9c0f2acb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c3ecb7-c758-481d-af0a-85b852631da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fdfdeae9-a5ac-48dc-9b36-7779d7c45b07">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef7f8f3a-7613-4529-bf6a-4beb89a652e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0dffafff-ba7c-4bf2-8345-b32936bb7d86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b375a1eb-4e15-40e6-8931-21f756370ad8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a17eaf05-1e9d-47d9-84bb-52098403ebf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccf1734-7ea4-4030-b8ee-7a82d958edc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a878ee53-c51e-4a70-a80a-fb13a8db928b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8657f8e9-55a2-4388-a722-de31eec99cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42fbeebc-27b3-457f-b780-23328d760a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2ef59be7-e550-41c2-ad9f-a4e7fae6d3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ec6ef57-cfcb-47d1-b38b-6ca3220c5e02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20979194-0a0e-4f2f-8f25-8612d79fb907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c4ee866-a65f-4f9e-8d76-0a085de8e748">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0cb1e098-2473-44ba-8ace-88063372e452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ff52ade-2687-43e4-8fcc-5f099a77ae41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_568590c3-5871-4f14-ba81-c7895686ce80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0769e266-9d4a-4af6-b15a-89f29e34da03">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c16aff2-0a52-4ef9-a47b-8542e0c753ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd8422e1-afb2-4d1f-8ebb-931b8458508d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9d9b5953-6a6b-4b2d-8776-8f0a554bacf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c308372-aefd-4a3f-a694-4f9269fa5587">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4055725-3496-4afd-9eed-220b29535c3d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25d44ccc-4df7-4ae4-8c71-c7b06699a507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e984b7b-5485-47b0-b49a-043ae3aacbd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e6cfa0-aae4-4c01-8062-3dbe496f4574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87b48993-4fff-409e-8fac-71ac7496438e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60f5fdfb-bb99-48bf-8281-1a716d1e9cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c49006c-db19-4e93-a62f-4f74ce7b5671">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd9d62f0-ad1c-47e8-ab65-be18b6eecbae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_032e8c7b-951c-4471-bc78-04fa2abc164b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5400d815-e041-4be6-8e24-f4b4a55ea557">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6403f818-0982-411f-8685-1a954d578710">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab41767f-a4c3-4501-8fe6-2c53b0b29faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_518b887a-c883-4f6d-96bf-fefd70874c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5937e65-8f83-4221-a7ea-1b171d13f761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2964a972-3a4f-4f4d-bb34-2a87fbb7209c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_803e8c65-63e0-44e4-95b9-4a68587c9ebf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_28a90dc5-c31b-479c-8bd0-36ae75d91886">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7b5b4d52-a9b7-437d-b626-5013d30b573a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8809330-10c9-45a1-ba8e-56983312a283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15a8e6b-dff9-4599-a3f4-cc992e64a5eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_da85e8dd-137f-436d-8551-4c667949a953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c990151a-be6c-4ab6-bea5-3fa861d3f487">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c68683c3-4c6d-41e7-910a-f8fb69106e2d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9cd6b6e3-2fe6-4b21-a527-04ee4da982fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea51ec29-12dd-4c22-bd1c-f8b4d6c88c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d73ee5a1-22bd-479a-b8c2-cfac03997d0b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_00d337e1-f715-40b3-ba0d-330107be943a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e35079e-d21c-42b9-a71a-bd371ef325be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba54f75-4322-4260-a3ea-5c8a1fd8da22">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02cced8e-b04a-4c14-99eb-effab66cbbfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f499942-c1d7-47e2-b0c3-94f2db7b5d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db50e30-5d8c-41fc-92ae-ce10b51c1142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c76a037-c8f3-43f0-809f-c2d22fdc7c61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_942009fe-1099-46ff-8dfd-39bb6c8db838">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8330d965-e14a-4069-9ba5-af9cee313c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9a94a356-74e9-46df-97fb-5bb574ce5aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74896b7f-2442-4b14-9fd4-a345f81988ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80d06191-1b0a-44ba-8966-72b2cb09552f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_721cb49b-421d-4b7b-9009-5e492dc2fff2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cf5789-1e9f-49d3-bca8-81720d2a2e85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_042500b2-456e-440a-a299-70b68697b78e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61d12870-7112-4a95-9fdf-bb0548490252">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3f46115-af74-4aa6-86ae-154180f55b59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_766c7c0e-c479-4fb3-b381-e2664ad819a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_184724c2-9322-472e-ad84-f3d5ed3e8ab3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1a75e146-4a56-451c-9165-17ea4fb4a25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_effcbaaf-8216-43cc-b073-cfe772572506">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_44dbb378-126a-4790-98a5-6e6b6da2c8d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f4a76a-d81a-490a-85c0-8f01b63ab5ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2edeaf8b-6707-40c9-9fe2-ccf1f8eb347e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e3c8c14-3636-4f67-918b-08d3187d513d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ad35ae9-afda-4659-ac88-72a2bb9fe44e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f77d3121-7cef-4297-bc8d-745375d989c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_63e90e7a-e502-43a3-9128-eb540c6c00c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e510fe3f-7d44-4d7a-9f1f-3388843068d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01d20bb2-a8dd-407a-a54f-f4d90f2206f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc0eb440-7432-4aa2-8900-5a7646660733">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dafcd693-b165-4b36-88f9-6bd171a206ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47dcc68b-7686-488f-b77e-cbedaf655b09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a44d56b-3af4-4d12-831e-161bdb3b7217">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de415489-e0f2-4512-b73a-135b3e345a95">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4a169528-7bec-471a-8892-3f66276e37d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74ef52d5-c88f-4177-9d50-2a6e408bc8a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cef415e9-2e4d-41ec-8d65-54f834f290e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4df8a044-9965-4a70-91ad-3e0dab7ccc17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb6166e-1b65-4c55-94c3-b2157ed3517f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e19eba57-e9c1-47cf-ad50-59fe6b08c01e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_346a5319-3ec2-40a2-aefd-38dfacbbe97c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63c7ea9b-23ae-480c-b27b-f7764ef9d5a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_168c2329-960b-4f86-91db-ef94ad8f7dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_686e884a-a0b1-454e-b7d1-33c7ad46f89f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ec1f350c-c2ae-4665-8e68-45edcf92d1fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4edf081-2fb2-4da4-94db-98a2a596247f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_312f25f3-55bc-4417-848c-236d31d823f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f359893-b7c5-41b0-ada8-8df06cf7a8e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db1a4a3-7c77-4e7c-8a3b-65499a81fb30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc4c311e-d167-4d5f-8a36-c7c1c915bc04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ddcf7aac-e7c3-45e9-bd81-6146e951addd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af420f53-37ae-44db-abdd-79138f483c56">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13b3e3a3-d932-4e97-83f4-d63c4e1c8527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2463ff2c-7690-4dd6-bf44-039f9f475bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df6b50ee-af5a-4e61-9bda-0752ef238e3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d67568e7-c48d-479f-a4ef-51e35b018f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3be2355e-0065-43df-a264-57a295042faa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd875ee0-a6ef-4ca0-87ef-f6b5b079308b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41386a39-3f57-424b-a8b5-8d3b5a32bd79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eaf7e467-44ab-42e3-bcd7-70692bebbd62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aeb672ee-e2c9-4172-b7c6-3d3915821c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbbbea53-8f92-48c7-8cdc-a3fbd920c43b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bae580a2-0dcb-4ed6-86b1-f5f603b937dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4eb83445-5e74-42a9-9b92-e1cb3c6ba13e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33f8b01b-0fde-4257-bf74-20588be588ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_876a178a-7474-45e5-abc8-d9e3eb0d231c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2f24cd6-459c-49a4-b93d-9c6817cb1488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84507e60-680a-4b67-a596-c214ae0b8c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56715438-6a4b-49f6-bc4d-605136e0a3e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f46a611-ff04-4bda-a0be-9d29131f4b4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b1a2061-0ac8-49a9-9954-847d9862df0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec63eedd-ad1e-45d6-bae8-c797162a1e4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3971a8d-94bc-4b4e-973b-16844ffdbf18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8526a3ae-9742-4e33-ad46-dcb5e89af11b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f31a7a93-b405-47bc-82e0-5862c71ef7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1bdcf5ed-4a96-4d08-93db-65c2d5dd908f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90ffc2e4-3f7f-4b32-81e6-c4c2a792b458">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73487593-2e52-4172-9f55-c27fb539b609">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f7eb4e4-8de9-4352-8986-c31fbf58723a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6137d3e5-4586-417f-93c1-dc9e2b46adff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_696dc02a-5cfa-4723-913e-a5885b3e5885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_843f4407-c335-4824-8f2b-7f2ed4094014">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_947cb703-a50e-4602-b5a1-60cbeb8832c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f8860a6-75f7-44b6-94e5-01dbf0aa3de8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0220034a-1a6c-46b3-bfbf-a984702d3c1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4f54cbe-fc62-4410-bffb-0521959fc2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d3a0ccf-17a2-4beb-ac9b-7be3dcb0fb73">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc80f782-5c36-4239-8442-fb25c5d61c4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c216355b-0f57-4118-89bb-b2780f146bc2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6d75d35-3089-4dda-b69f-ff471b24aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ab9cfc0c-b194-4af0-9fa2-77978e43c0c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_63a8f42a-c8a8-4e9b-81c8-001bed4d2a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7f09426-095c-459e-8e0b-e38500fab1b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed7f9c93-a8e7-4999-9d18-f5bd01b65933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aa3a3f9-c86b-4641-b368-a099f8583656">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0fd18f1-856f-461f-bdd7-997115ef1044">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c78936d7-acfd-4a0d-aaae-0153ebc7d768">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_09e0f824-f92f-4e4e-92ec-7d6770b9d243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70993686-256c-46bd-a2fc-674f52ac59dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_65b03961-f9f6-420d-8f61-f44ba99fc4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de9a7b88-6748-4089-9d89-911dd957bee7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec4cad68-f17a-445d-922f-8a419d3fec9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7850bffe-8b78-4551-8f92-d52ef0addadb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c912ed7-2d69-4118-ac02-b9035f0d9e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_43b6fcd3-4a29-4e9f-b597-518117e3f111">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_009a7bac-59fd-4b36-a39c-a635cdf04418">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b0739c1-a932-452f-b10c-356d293b82a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec5176ac-a1d1-4f5c-9546-e9e47f6ad8e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ef8ecc8-7d0b-4507-9877-9f640b323ef2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b6c251a0-7f4c-4930-8e39-7a91fce144e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66e59497-02ee-4f54-ad5f-4f399b2eaab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_891c0f42-fb9f-4390-ae0f-307bc6cbfc64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04a2dbc5-819d-41de-a987-8d334031c175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc5d543b-bfcd-46be-8fea-1b2490b1ea9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9f5d49d-922f-44b2-9d78-ba41b47542a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41955f1e-f88d-4160-8879-ade4e9d027f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d97bfa8-9abe-4275-a2b0-1acbaa779613">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dfc5b8f-fecb-4041-ae98-3c2b1f96feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8dfa0c60-9696-4870-87d5-ec7d3e2b72a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15c0d9e-956d-4afe-9654-9ae5cbeae473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0a4153e-156d-4852-9921-6d1a1c1064e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df7dc1b3-5ad3-4697-b808-103a9b2e22a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d69e028f-ecb0-477b-9fdb-36594afce196">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c04f249c-6bbe-4db7-9637-a3bef2cd6599">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04b9b246-5df3-43be-a733-5aec27fd9be1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_00fbdcfb-3d3b-4378-8dcb-5608f6eaa51b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef59a32a-bc5c-4512-9437-86fdef2ac2d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a208f474-056d-48b6-a271-a7123684f108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a20e1cae-0b90-4139-b87d-9ce76e6219f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23db024a-d255-4402-b2cd-e7e0052f6e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816a0247-2a88-43d5-8de0-d4709dbffe98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9749f3a4-64c5-482c-87c6-37322d113948">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_580de0e9-f8c1-4969-811f-46712414524e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20f43d84-963d-41ca-8548-86be349e8471">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2bd46877-a632-4ddd-b880-1940461fb45d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_02f193ba-e746-4eda-ad79-9999ef27fe47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b569c39-9301-424f-959e-c45e0fd99f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91e9275d-053a-4d88-9d20-c094f2ccc85b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69f112ef-9f4c-42f3-9ac8-472698d68257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e47741b-e0d0-4985-913c-d95c500b7e48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1178ee67-c92b-4568-bdd2-101440661e16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8960c67-75b6-4aff-8b83-05fffd558dc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc81403a-372f-4310-824b-112e7bfcb323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1d717e38-50cc-44ad-a538-cea12eb5e1b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5465ff43-da95-44ae-b8e2-7f3b590e6c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9e6cf153-1255-4a4e-a3cb-8931792c077b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a29bb72-2f86-4d29-affe-b2391894c13d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d58201c-4d98-41ba-beb2-ff5d742fcb66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98fdd615-f480-4b42-9bb3-cea3b7c2fda8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0a978e78-aa93-426e-9765-368315bb94e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c873a17-42f2-4abf-8c47-e47021e0e3f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a5a6dfce-8298-4b76-8289-9e3fee8a8583">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0df7090c-0218-49e1-a3f7-cf30c8f9f8b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_177bf3c3-c744-4321-836a-a2fae0b0bbb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a551b9c1-3d7d-449a-84ee-1743fd7f9366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38a5688b-b7c0-45c5-9243-0293e2e48b94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad56fb97-89e8-4c97-84fe-98d7049617bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee95150b-76fc-4ba3-a9e3-8aa2a41479b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3304e735-d4f2-43dd-bb3a-22e720aa6d7d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2869b4e-01d4-4787-a309-e5c09b2214e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45bfc964-e77c-4912-993c-6ed38877d6a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d598576e-9992-4e55-ab22-7ac5e336c167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0387494e-d16b-44b8-903d-3aae7c4b2d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ea8cb0d-f908-40e8-8be5-f6cf397fc6c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47badf30-a042-4cbd-b2e5-027b03e98eca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a2503c0-15d6-484c-9d50-dcaf87e40afd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ac3075d-b630-4f72-9637-9e0d639eea21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a73abc8-c136-4d48-8b72-ccf7c89b569e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_443d1b23-9393-4b67-9596-b24170a7715e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2003d398-4989-457f-96d2-1d171aaa3496">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_467e0941-4ce6-41ca-9c73-fc30a3a465d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_434f488b-72ac-43d7-ad91-7397a8d1064f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e39401b-8a3e-45f5-9b9a-b23d200ded9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7396260-dcb7-4643-8440-4c22300245ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c6c8c-c3eb-4c10-9ed8-60b192b7e93d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10d7ad43-0c5a-4691-af6f-b2784e71188f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5169785-0581-44f2-ab10-12791b566cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa81dcb5-3516-4f66-8384-f28ec6470452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84b7f2f0-27e0-479f-93ac-7e5575559334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9da5e21a-cedc-4d7f-975e-b895d61a5b4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8b07eabb-e9c1-45a8-854a-b0e19382565c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d7048bf-1d51-442d-a7c5-42af545b53b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_667943d8-8735-412d-b993-d7f49ec6ec56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_78ab02ba-6e28-40f3-ad7c-e904efb2dce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f55d08b5-1ce5-462f-b19d-7e59303c7055">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0adb0e5d-57dd-4b49-9fb6-4b542a78e281">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fc722a0a-b5d9-4c9d-b2c6-aa57aa347267">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f46dacd-ec53-47a3-9ad0-e69d01af2a32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47e98763-4205-4c3f-9fca-580e6716eb93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7c51871b-8c97-4823-8108-47c7d756d416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422d93f-8f56-4ece-b98d-d6bfdacfbced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73252c52-15f1-4024-8dd3-b7f5c081e5b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c7306cd-aaf6-4452-bf95-aa1b65184654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a90aba9-d586-422e-8011-ee94ca4fa7c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bcf3d63-4745-4934-a4db-6c7e999c6cc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_acdd21e9-23fa-4c1f-adce-ec12996b7bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec2c9742-eb7a-4c04-84e9-7ff3c8cb7325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ddaae786-f86a-49d4-ab4e-8f62cf002977">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0b79f1c-045c-4a78-b3b6-8646f10b3864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39ac3d07-5ad3-4af4-85ed-08bd818a9c57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_febc165c-7c90-4f43-afb5-b99fcd6d0ae5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e8d3745-e50a-4068-91e4-fe628f09b912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b72232-5245-4b60-be58-4f5e8ac5fbfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_27f3ab55-1b69-46a2-817a-20f140d8cd91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dbcfdcc-7bc5-4654-bfd5-0eb2a6764f4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9985dadd-4bc9-4c0a-9952-68e4674633d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eeb5e115-4fd3-465d-846f-a8b94662e138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a93a0ae-8c5b-4578-aee6-66d0adaa0034">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ed23ba9-347c-4522-ab04-d6987fff54a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3321c52-80b8-43a6-ba29-433ed615fb9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e7079d-f268-4eb7-ab0d-986277db80ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd245486-24f1-4bd9-a5a0-8566fb209f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4585259-822e-4a6f-b0de-a7c1df729d57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d66a7f2a-ec30-4686-bfa9-5804598b7f1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e0a586e-4363-4731-9ebb-852e63184386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b2993f37-953a-4fc6-95df-364a30765e93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_879b6ec0-699e-4c45-95e1-8ec2b6f0b1ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_75e908a2-18b0-47cf-92ef-1c6e2d0b87ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af84240f-9aed-44db-b2fa-e1e428b93e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b675fdd4-61f1-4375-accd-7b6aa01e61a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d19a72c-2062-448c-8aec-ef4299deaef9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_85657dc2-b4a9-4900-90bd-9841b7283960">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0b1f34a-3695-4717-ab24-afd7b7f2a4c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_278a371e-c8a3-443c-9812-da6d05023804">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea4a6b35-dcbc-4dd1-a1c3-41af5b692519">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_387649d4-7c09-476e-8f8a-88778b3433f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1108f037-931a-4c97-ba81-1d3945e8a108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2796ac28-9104-41f1-a0f7-8c2b2b8c7e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6d589299-a69a-4252-af49-c04675260ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c00ff0c-aaad-4bd1-a28e-b2814d8544a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8045156f-db54-4b51-ba78-c03b95abc2a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a34bc6-1275-48c0-9620-13d697e84771">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6978d4dc-db26-4438-b821-7dc2d6de928f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_293a7321-4d59-4ac2-a737-ecf77e9722e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2e2ad7f0-44f4-4af2-82e3-77bc37ef1f54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d8ac7a7f-ddbc-407f-9405-dc3215bc0b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b09fc32-acb9-4459-877e-24322a0a83f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c41c99-9bf7-4d09-8101-027de2575f03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572a2fa4-34a0-449e-9795-578123117344">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_959ae440-87a5-461a-8c69-d91c6be97d4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_373278fc-18a1-4abd-b048-691670efb49c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc776d4c-f4e1-40d8-89a2-218707466d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2bab2b3-e4e7-4ef4-9ed8-fe3468bd5127">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c260bc-94c7-4cfd-a4d9-f2539e71b7fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10b57bad-d28a-40cf-8f33-3c48cf7fb4f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48680022-5b7b-4547-9e96-7fb49bb638fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8095e658-d0bb-43dd-845b-f036a180d704">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e90719ac-9754-4a36-bbf9-fb321ace6d2d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88b36e46-3e08-4a9c-86c8-a35e0556771a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1305bd82-d13f-463f-b23b-0a7beff54c8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27490d8b-7f83-437c-90e2-38655ae49692">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5812ba09-aecd-452f-ba1f-37c16d76b2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_83030d83-d89a-4ba8-92fa-3a20313fdd4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_38c2fb13-f108-471c-ab65-5731a64b6cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_109ddaba-7a47-45ac-877e-b4d0edefd18c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25c10f11-aad4-4271-9b83-6f26879a49b2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90193171-e667-46cb-a5f8-a79f5fb9a047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c4024fb-6fa3-45d1-bf4a-1a1c9e967701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75034b3f-0566-4bc4-9e77-4589ec5a3529">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ee4a0c2-7707-486d-b061-60cb3639131a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0cbf76-5e70-4ac1-a14e-1aeb435db65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3debb7b8-d827-48c8-827f-6dceae6c47fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1bf7aaf1-e4f6-4795-abd1-863d1c5e481a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6799f164-6554-4fc2-8c0e-83c42fea4ced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b3e639e9-c7a1-4eac-9134-b7ae9a1019d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_108be304-cf43-4c5a-8bf3-94fa3e8d74fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372e32b1-1aab-432b-9c3e-bc1b489d9e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dac4a438-5467-461a-87f3-b7a53957f069">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eebbadab-e107-4699-8e8c-fa9c1f93e384">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04be338c-4123-4d3c-907d-cfe7e46e082a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dc3386cd-4655-4bdc-97fa-b6d42a53a6dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df932d23-c0fc-424d-b8c2-f3e6599fa319">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1cf568f6-4c0b-4a61-918e-d6ff3351b8cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cb029e5b-97a2-4f2a-abcd-e6e0fdefc53f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f455767-aa17-45df-8151-164007b94c58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe42c63-3b53-41e3-b839-0f65d0069446">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1eb2294-922e-4794-8a02-65e81ca3371c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee5a5db3-c2b3-479e-80db-614dd45941e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44a01d28-5f0f-433d-9765-93694bb03814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_91c721ce-fd9d-42b6-85d7-574a9f1ac063">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35eb4da6-136b-4bca-8604-47e75286e65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4044b56c-de8a-49b2-9a24-8d72190aa272">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da881031-0b0d-40b6-86a5-aafdbfa81931">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a94c14fa-0352-43d6-8f52-27d7ed31fbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_982d9d6c-a0b3-4977-9ac7-6542cc61f4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2e1acf0-3a18-4654-b0c6-1f49191aa7f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac2f8368-74fa-4e99-9ecc-00d828bae587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db7e5d95-3bcb-4838-8615-e20786189b81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2c8b805-99c5-4822-a5e0-8b7715404d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39133449-53e6-450a-bbb9-2a9f492816ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52cf4172-5261-4ed2-b0f2-153da4661c73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_759a9435-a21e-4f99-a560-85da57a1d290">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0ab7585f-f58b-4966-873c-f67bb20f6b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4406299b-b743-49fb-aaf9-da8a976adf9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_149e05ed-ded0-4b52-9f8b-a74fd2961737">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d81de1fd-80d7-46f9-ab23-eb276e288ee6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da192a0-4748-4919-af6c-739d407d0d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d3e78a-4c0d-4af9-91b7-ad6b70ac9a08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4de32c8f-fbec-44e8-b08c-4b1f7f0ebaff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_247f2ed6-5a4f-477e-b5de-c71d021f919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0b877750-4384-4ec3-bb38-08ee5ccf16d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9c8c518-9a45-4371-bd8d-47e5a3520e74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be89e92c-bdaf-4807-acb6-4025d0a88244">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee9c1f11-acf2-44de-905d-5f284b2f2e99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7540f357-0df7-4c75-930f-21d4e0cf46b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7948fd33-023b-4cba-b871-f34288cdd5e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56081645-b0f9-492d-a015-67797a891d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7eacae3-b893-4773-8a15-c0c58eded027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aa5ddeac-c8e9-40cb-a1d1-9f7ea09b3630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12af6be9-e7c9-48ed-94ec-5d6f90db8dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a34654ae-5aee-4fc6-bdc2-5ec098a6a2e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_60196fc6-3c06-45c7-ad3a-d58ffcea6351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d6ffcf6-4c89-431e-8efe-472592c985d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c4fe896-13ef-487f-8ff9-2dfedad5b2b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8cd607f-df0e-4528-8b90-5b4718af222f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7fda72c2-1863-4339-a7a4-f6b3e2b6fbef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6d1299a0-430a-4b38-892a-45af9c3963b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea273147-7151-4e4f-9db9-1fcb630b401b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e24c6d73-f009-4bd6-8a3f-55799db87823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_018b9ff1-6444-4689-b68c-97b463b09946">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6a79ce6f-d266-4de9-a41c-650ab243444e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70a7cf98-4c62-4403-b08e-76c9392f56eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c4f817-3a34-431f-a6fe-db0ca3ad14b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_242be4f0-4ccc-4c64-8ca8-285c5f801e05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1747a54e-2f1b-460a-96e9-f1e004c0fc50">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1cf3a401-e334-4e2b-b888-747c70fcee33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5923661-1d0c-4844-b6d1-4ee4c6953345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dbd09afc-8674-45f5-a0ec-f55886cf9441">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f120ca0e-d965-4061-ba03-9ddd552b5aae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd539541-75e6-4ca8-9f8d-b27aef8a0d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cf00de-bf8e-4a71-a89e-ba65c7d70449">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_21bb583a-c74f-4282-8144-3cf309cc0088">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a65ee9f-719f-4f47-9dfa-ba9ff879cdd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9d9a73b9-313a-4e9b-8fa0-cbba3d566d96">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_585ae3c4-d76b-4fb1-bc52-cc2665b7bff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a471487-7727-4db6-ac27-ea7374e03907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc862be6-abcf-4e48-b9bd-d1865d75558e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_df93daff-7fbf-4ba9-9486-40503806d1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bc441fb3-f4a0-4696-9076-82679a508d59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c3d8d60b-befc-4d71-a319-22ba6e25bb74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1d980b-aaf8-4ee7-b7b1-bbce95a7748e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486d1e9b-549a-42df-ad67-29d2016f4571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fe878612-3cd3-4f69-8d54-6f4fd236cda8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dcd0ebfe-3623-4fc3-89df-ad719955b5f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4446022-9134-45c6-bb58-b7a27696b416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24f3e454-8e14-4307-af4c-b8767213f69f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c57189dd-499b-42a1-b6fb-40bc90d3a310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_804162b3-4b87-423b-9dad-13464536caea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1eff0e72-3247-4107-9993-1298d21ecee5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bc82a1c-068d-4239-b014-3e770cd1c98f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e61e1ae-4fb7-4b1c-bf38-bb156bdb052b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_abc4c98f-3c84-4a3c-a195-03f724cce1e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53d5747b-9ebd-469e-a3e4-df8d5abb2c28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad5a88de-f5bf-4fa2-b3fc-510e9e8d3c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_64d83d6d-d0cd-4903-8112-392b2344dfb9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e85227f9-582b-468f-ae33-3c98845cd6db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a53cb408-2e26-4fa5-b28d-20627309624e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_86b5e424-cfe9-4df4-a2e0-2c9029f68f74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6137780-8fde-4ca3-91f1-64a5945e332b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_520b33bf-bad6-407f-a1a9-6f9105538d74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29d5088a-c14a-4618-ba86-5567efa2066b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7579990-1de5-4ca6-9653-82ccc5732f00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_095d7783-c130-45ad-917a-c2dd3768cb3e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c9b6315-c3b1-4e8e-a21f-67f978c07c5b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57779485-dd57-4100-859b-10cacc1c835f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_240ef7c2-1e73-4fcb-a83b-0d111cbf2e37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd5f3cad-2a76-4762-94ec-98a3c293daf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfdd1c93-6dfd-46b6-813b-0a5845e15134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a5be388-1f63-4417-9d57-f6a8d7f6c174">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0fa19015-6980-4456-aa50-cf912583bbcd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ab6db68-d9ef-4fab-9e9a-3375d6ecce58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9327214-7ce2-4fcb-8be7-d157202b62a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395280f8-b83c-4445-8d46-c5e5796fd2c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1cd39a2-57f4-477f-b935-966f5a9b061d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f20a0e2f-0b05-403c-981a-8b622394964e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f60585d4-e1ef-457a-85d5-a0cc458b1138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4f6fa4a-f388-4aca-a526-4034b8eaa0f6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fc3f67-b589-46aa-9a14-df1c38f536bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b901fad0-2935-4ad2-8c60-ca6f514d7ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c82adf2-700c-4e2d-8783-691c7eb0739e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a18a8468-b108-467a-865a-cc01df943616">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2c51b1a-fe39-428c-8e64-d34cca938997">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afe375c5-fa11-4fff-8684-c4c3797d88aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b864d96c-56d9-456e-abbc-339fb8a509a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e788d4bc-4664-4c67-bbbf-1e2b9efa5a73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad243881-6037-440f-9c2d-b0a9e64c6a64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0832547-0582-43c4-aec9-e5c9f203a373">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3edfd931-7c3a-46eb-aafd-7dd35d41352a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6efbdd1-ef1a-40c6-ac2d-27d367139d20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b902ca3b-88e7-4ccd-ae42-54fd37157ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1af658f5-3255-4bfb-93ea-05de03e79987">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d5e9708-d4db-4e19-aae8-90f09cd7929c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd656c03-02f2-49d2-8ac6-ad27bab92a22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf134a58-533c-41d9-9b3d-064ea328e676">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_36b31222-5177-44b2-8c7e-386051e7f428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0f32ce7-ec0d-45f2-83f0-a0de0b3f6667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36e242c4-596e-4412-9920-1ca45dfd68d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8cddec43-6655-4716-bf29-100b760b612f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7d2dad33-7520-4b06-bfe3-cebda9ee7513">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9815c625-a36f-4d07-b707-ec66d33859a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d0de5dd-fd98-4de6-bad1-e85580ba0e08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1c91801-83f7-4a77-956a-ca55e5d1e3a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ceaba128-fbcf-4166-9394-68d7f0ca3752">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b15b72d6-5cdb-4d59-9668-79ef523ce4f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8e480977-b24c-4952-a093-809cb4d24763">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5c1c711c-85e7-4fd5-be4a-ccff8eb4b5ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbb9371f-1a37-4003-b48a-8988d30d076c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5b42e1f-179a-4c97-bcee-364d1ff170ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ff6fe352-30e8-47cc-9b3f-0616a04687a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f677199a-7a7e-45a6-8b95-8237f459bc82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02e3ac29-d97f-43d1-b090-d6a871b884dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_601283cb-11d9-4caf-87c7-fdaed3433b0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_654a5c27-2a08-4691-8295-275e8d822171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77f5430e-044c-47e4-817b-bb82a39203cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00ecf5a0-0f32-4b79-8e19-ea08c4983582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af84eb50-6345-4236-85e1-0ec2f50a2809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dcbbc1f4-df6f-4356-a98d-e3b93cb2e392">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d404e4c-8304-4c93-8b97-ed2d89c816a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ca824ca-5d7f-41ff-a5ac-f3de76328507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e7f5a4b7-165d-4279-9faa-59831ac0e6a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f1c65454-d63d-47d1-ab82-933a498abc9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853b1603-5024-4c08-bca0-8e16defc3084">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_950ce21d-3058-4a86-8fc5-5c6da09dfd7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_087cf93a-9ea4-4c8a-9e45-9fc42acee0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92dd2c93-1279-472f-8d40-7e64631b28c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_84fe57a7-bdaa-4724-b43f-d941fb289764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e098bffa-f41b-4b69-a028-c4feab4acf86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4bac56f-597b-479b-b57b-b2aac2d58bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cac11f7-d0bf-44d0-8b8c-a10afa30e275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e44de395-9fb0-4220-ac41-10c9c37f6b98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea85bc90-6724-4580-b1e9-bc7626750460">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed8ba83b-973a-43bc-a272-e96e8cdf3621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e19b554-54eb-4aab-a6d2-7a770a88753a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736eee20-3b0c-44b1-b424-ab399710d6c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_010e4f03-e0d7-4cb8-bac6-98ac3f8de025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_042c4356-75cf-4e9b-891d-aa5d10db05cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_208fa1ec-4809-4807-9ec4-23588a1fb467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f657ecda-9d23-4a5a-9c0b-4fdf40cacee5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_523f1059-be27-4b98-818c-62a820e334d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a29f47d7-80e9-4691-8ada-76fc5c2f6bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53f12aec-e862-46fa-8bc0-4d0d0cfda200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69205394-a998-48be-b6b9-371c49e07ba0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d0b9c19-7f40-45d3-9f15-b20a17310fca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82888fdf-f683-41d7-a848-5279ecc53dcd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63289c77-5071-4fbb-ab73-7b68d4ab818f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8725834-bc02-4f24-a7d1-29c293e23121">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a226cea4-b1cf-4320-a67b-3bce18909a0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5ffb8a8d-d3c4-45db-97bf-b76c935dc4ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c8f602-8ba4-4b42-a483-280414838fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9634de15-4459-4e22-b5c5-17c70fde0999">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdec0538-30f7-4067-8987-308455db1f8c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a77b59ef-a76f-476c-babd-80ad5708e843">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0666e484-9392-43de-83ac-819c383b3a55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b81a42b8-e4e7-478e-ba0a-50a6e0d60e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3bb2f1c1-4602-4b78-b837-bb503c6934dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c551043-5d5a-4968-8a63-7f6a3b7132f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4637e379-f30c-4a31-84bd-ffd62fd2e46f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c03176f-cf7d-421f-9fa6-a1d8c92c4fe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aeb7f15-4f3d-4387-8586-53359e2c0bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c9b0c3f-561c-47b2-9629-81810731b547">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10641ef0-825e-4819-a601-f845fd541f49">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4649cd4e-eb8e-44c4-8cf4-8b52de8527b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cdc2941-1a71-46b8-a3f4-022f1702baab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5b696508-e2ab-434a-8d1b-b5f5cf48933d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1377b5e7-b31a-411f-a56d-254840d49146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5af16294-f0ff-4adc-9a35-fe26c735a205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7086329f-c75e-4401-bf18-c12448d0599c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da05ed8f-45bc-48dc-93a8-aaaea133cc93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_249cc69e-c3bf-4569-98df-982eb0b02755">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_519ff774-dfc3-4080-874f-8c6dffd4c9db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c12f960-6db8-403d-adc7-63d01d1f7b05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cda35508-43fc-4439-ab19-434bb3f04372">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acfad03-f47a-4c03-aae3-33bfb6afefe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a638d024-ed4a-41e5-929e-cb4854c84eee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fa30b0a-0b40-4e75-9fcf-a2cb760bdd7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1248a6-fecf-454c-967c-b71aeb1e0089">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_681ff111-c345-4c75-969a-1eb7a391a4e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_207f8550-12ba-4999-b92e-624be0b8dda4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f167c3c9-799a-4e7f-8bb7-32cf1b7b4f11">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a07ffd7-8004-4de8-9250-9c6429d6f865">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2875bd0e-b8e6-4ecb-a19f-cb48be23d6d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0c7a8c2c-1ae0-41ef-8239-2c3104922d12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83705ed0-b3f1-4918-9fbd-c8cc40df7d22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74e6e7cb-dc2a-4415-ae20-1573ff8836b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90663f13-bdea-49ae-9480-f45efa86e5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0eac8aa6-0f09-436a-8629-5f7028184b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65fa9ac4-a534-448f-8cd0-c38ac7424048">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ff2d05a-6222-4638-9733-1eef61762494">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6820822a-c4d6-4729-90de-29b9def7cf36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a93a36f6-3a25-4c76-9cd9-78c3d42fbdde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e472adfe-10a1-4a92-b3bd-7b5b5ed2486b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83cf789e-d6e9-41de-b519-aa03739f45f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6d58856-e665-4d79-98f5-afd84db54f69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784d6612-2600-4426-92e4-7027acffd95f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13896b4e-3e41-420f-b862-a0a3d21ceb96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_666c7a62-6e20-490a-a1c0-cbfb3c7436a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ff7ed84-33d3-43ab-8376-70a048059152">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14854eba-847f-49b3-8e20-ca94a2f5b9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a9b204ab-1f6e-425f-90cf-898fcd1a7407">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed504220-d7be-48d7-9805-32d3e3c0e5d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c227f1c0-e34a-4741-8d9f-fac803867ef7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb64a662-23fa-4075-9a28-e41e6adf1d71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2d83d0ac-c4b2-47de-a28e-ab512147e83d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7cda8444-ab66-4c14-87f1-12402e45c61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c737ad7-aec2-4180-a72f-d72e244d844a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_133ac243-cbba-47fe-9390-45cbdb008ccb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_872f7b3c-5276-4ce6-b962-0d8b25432d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_189e8e34-f99f-4574-9f08-b8b440464c4b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67cb191e-4133-42e0-add2-607ec93ac3bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb848d85-ce2a-4998-bc42-c56e2faaa553">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_992ea9eb-ce43-4464-a1d3-194fbc6b4ba3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677076a2-8d3d-4f6b-a22d-43b9d496a2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60eb085-3818-4f34-93dc-e7c38e532bfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c0b212b-ce81-4c15-929a-40cc841586ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc7d3b4-6640-49a4-bebd-48161c16bf96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_287c3a3a-9ab4-42be-abe8-142a3b70bf16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_277a94a1-0bcc-44ec-8db1-eb5021c13cab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5a7c9d0-d63d-4e0e-9bf5-95a77cf9cc84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e70d7203-74eb-4383-8a46-da218ed8dce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0614cd6-77e6-463b-98ec-e93ffcba4e75">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e905378-e9c1-4fca-b4a0-c5acf1066973">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99e9719d-ed7b-49f5-b9ed-f4ed85e139ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_37e88aeb-098a-41fc-9e1a-52baadb16798">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd243800-375f-4158-9a2e-e99a8b0a8977">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffc28114-bb4e-476b-9411-5930ed3c523d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acbd5f5d-d985-46d8-9b39-51c1ec77654c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a8f2b10-d625-4291-bbb2-c1fc90c3d4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f23c38bc-87bc-4431-9393-a0cc4d3170c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fa31a3b-1cdd-4926-98eb-7e35a81b18bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f3c2261-ef07-49ba-b884-bebd1494fb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b045d88-1984-4a69-bbf1-f50f6b1ed6ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38fd34c-89a5-4c12-84f2-09fbd8009033">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edbf147e-3aa0-4d6f-b4e9-39601d31597e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a58f4ab-dc05-48bb-9b39-3cb5f45fd2e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8bf36f7-97e0-42ad-864f-2f2edcb88bfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2323e83d-47dc-40de-a144-16eb4e03305b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3c11ea-49cb-4716-9818-5c12949903b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87f4fdd0-5e5d-42bf-97b2-4cff37d86182">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb9b8e19-399f-4574-822d-52b132b2a422">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02522a83-995b-4bcd-b3e9-375364be6b0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_798b3459-1bef-4fc3-8355-fdf9bf179a3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43a027cb-d98c-4ca4-9d54-5af8fe884f01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7c12a36-2bc3-4fab-9d03-d242fdc47304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95306b19-c314-4249-9726-7ef3f94e0d01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ca2305f-ff10-4b1d-b5ac-044bb4c10f74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_78b67db8-75de-4d10-a3d3-fd218675b991">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c76d6e4-2822-44a0-a623-695a0e7f9d3a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e202178-e806-4523-a1bd-f93869911a50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfe9440b-926f-4cce-bf8c-a8f6d487a36f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33626ba5-36b3-474a-a6c7-2c281ff87ec4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e6e2210-e273-4be6-95f9-5688af27f518">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ee8789c-7502-4fe5-90a1-6e73dc9c505e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6133f8b6-0bde-45e5-8f0f-028ebdcf5e51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ad218d74-0a8e-4012-8e2f-0e4b7a336d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c1e52ca-76a7-4811-a892-befb669f3507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_18fd6434-e78f-46b5-82c2-d3ebc9a988de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e648bb24-7214-4a6a-b0a5-a9fe6b8b61b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94d3e68e-9865-4ec2-b05e-248a8bdc3d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_101f17cf-add4-42aa-b827-9fcee3063868">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_93711071-4cf8-4adf-86ec-c6a32d98f266">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64cca2a6-8c18-4f0e-a042-fee853c9f2fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_180895e9-b096-458c-8c97-9c4a72ce7baf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f9420713-0860-41dd-8ba4-9afeb786243f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61f2d29b-5e0d-45e1-8dd8-d0420e496f28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71cfb5dc-ba9d-408e-b18a-81f2094e2f7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17ee7463-034c-4288-8bc7-137ac0a633f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1322195a-a94f-471d-97a1-36aaa5291e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01b1f9cb-d4c6-49b9-8308-a4fe08646434">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab4438b3-f56e-46e0-8d20-4e4129be3372">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f297db3a-e6df-4def-8490-9c3a9b21c27b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_890cc6c9-ad70-4730-a9b0-cdf9c5cac5ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8c6fcf8-d0e6-4535-a745-c08a0054f3ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dcba6d8b-5108-43ce-a5fc-b36e4b065d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52753638-c365-4f1c-81f0-f9fb6fb0d58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ba74212-2d31-402a-b2b0-f3634b0fb61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c87a5c7-5bef-41a5-962c-12bd1cf3d6a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2bf5b977-f2d6-46aa-a673-2f66e395b78b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef3a0e9c-40ac-4a1e-a041-86f72e7d5b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5e0a7a8-420f-4cff-b55b-e6e139165aa5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13ed373b-2943-4988-ad54-980c97b6289f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d6452b62-9209-4e95-b4c8-b3f87293609d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e679a526-99fb-4b23-b39c-566137ce3f75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8a4eb8a9-a1a9-4251-bf2b-4f8c975cf86e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a9bf8bd-6672-4e21-b8bb-e9e91f34e994">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_294557d1-3730-4819-8d03-96456f3fb912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e2daf53-4341-4911-980f-3022b8066b06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7fc0c8a-db70-4c61-b04e-6169c45e6742">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b83a5d31-4ee4-4219-98c9-aaf54ed1f572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_16af6b93-4e31-4e18-a77a-e4539fbbc6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_766b42c3-ce28-41e3-bbfc-786e84c88654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18029036-faee-43a5-8a1c-6439d7404892">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2d90918a-2664-43ab-ba72-50862a4cba1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5fc88920-3f1a-4427-8110-f4bc8a88aaf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1768cfd7-5909-4887-8b25-fc3e38b59dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0147f1f9-332e-4e9d-a8d9-e49d4605f776">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_866002ce-f7f8-46ce-921d-f83f33ee8d46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9226ad6a-e864-4c79-a107-ac6669389ece">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3fa8af05-471c-4f84-9804-2364ab4d0142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f8e378-97b4-4f9d-9b3f-be0fa08c737b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6abb7518-e189-477e-bebd-3b47fbf2925f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08dbcd9f-0cb1-478b-9d54-9251d09fd380">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6c00c6b-4fb8-42b9-aa43-be4aedf68d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395ebb43-da61-4761-9bd9-015b17860fc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b177b6cc-2918-4ee8-a5f2-bd619448a2ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c167ce0a-7228-4516-973a-d0267c640bbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9224a58f-f44c-4dad-95f9-d57b2f19fdfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_009bd855-5a73-40a8-b2db-4147028f51e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d617fbd2-7202-4dd8-8747-bcef9c2c5304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b667f9d-2ac9-4b00-b8ec-120472c203a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39552eb2-2347-493b-a342-36112dd61761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca73dc61-46db-48cd-b6ac-020490792c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12e678-c7ef-46bb-93dc-bd6c4fae421e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3635c9b3-b303-457e-8e50-6af4bf971c81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ed3d1d8-306c-4634-9e74-e55ce4231da4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5431f42a-4340-4948-81f8-b6dc1d46bd85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a549c145-0195-47ab-9ea4-77c6d452a452">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e8510213-3fae-44cd-8c15-4af0efd3142f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff76ff5b-f84d-4bfc-b06f-19f833592c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b52eaa-13cb-4ac3-a2e7-fced09e07ce7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9de60e0d-f60f-4269-b79b-392086bc26e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7954e8ef-e8fa-45c9-a1ed-cc05cb0e38a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11316af2-1bf8-40c3-a347-97344c20ad02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50f7ffe9-6211-4a14-a182-778413891848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_87540be5-5b92-4ea2-bc7d-5b3a26a87c91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f97ece6f-a45e-4473-8e6a-44a98b809134">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c02fc72-0dd4-4386-9b66-933757038c0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_867a6bed-e19c-48e8-a2f3-1926d9616bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02bf56b6-a3a2-4fab-bf0b-44e24794fd3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ecf22d39-597b-4818-b5a8-c31e0720bfc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ced36e4b-41e8-4728-b496-b75bab9931a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34ba3909-aa3e-4d0b-a427-063609b352eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf9be7ff-0016-4672-9459-a0b1516a2101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3227f4eb-27db-4eb2-969a-3af0b573b8be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_22693f43-01c5-4cc4-87d4-61d6b5fc763d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cd4e84e-7059-4b13-9285-4e8f4c356a2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6640ed22-d3ed-4ece-8619-61a1d5d51798">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e7ea311-332e-47d7-b933-6c6df5c31f77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bca5d88c-41fb-4e64-ae21-d1cc14551a8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ab93ba3-8eef-4341-82ab-71ab7e39fa30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e6e188b5-450f-4a43-86af-ba5bcfd661ee">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2bcad28-b999-4f20-bacd-724c9f78c298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cdca876b-026f-48e4-8bef-c9b1dcf12eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9c318374-62a4-4ff7-9cb1-d9a784db08dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca11ec26-3b01-4bf9-84db-24ac4f0248d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8705133d-cdf1-4be9-b24f-e9b2e676a388">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b540bd1e-385f-4dbb-9e2b-56ddb1eb21d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a47fb97d-2d7b-4251-9f17-312b1e07eac5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18a57444-1e35-48a3-a599-55c7a6e7af15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebe2f330-1adb-431a-aeee-4a6a21167603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4c70b357-5014-42b6-a0ee-fec1c2469a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a01662c5-96de-418f-91a5-b16db1b66c81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_87c006b7-bb18-4a80-80da-0eb053d7b15a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f276409-96e1-405c-9e75-4d9fccc8bf87">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_034ec4b5-bd8c-4a92-99a2-1f730be3f002">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bfc273d8-d57c-4ca6-a117-69a5e0ecb2d6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_392cef6c-b0ef-4cb7-a61b-d92b77e1f8b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82bd5ada-01e6-4702-b2bc-43685a564dca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0203b79-c207-44ec-a455-1076786151ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2957eef7-ef17-4284-8b72-885290a5d4c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb554827-e2b3-4174-8618-2fac9fb13cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68ca1c46-e3bc-4281-a44c-882106869b58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_081ff2d8-2c7f-4dea-b78a-d67d6abc4db8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d02ad0d1-25fe-4737-9c11-d7409abb063b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8be185ca-2d62-4f9c-8e1e-caab88cc2025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9664ae2d-68fa-4059-9ffb-473fe2c0cd86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9284884-794f-4ee0-8ef3-402a142e0bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857587f3-78c0-4084-ad11-e09272976390">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_432d7e6b-c2e8-444f-b028-b234d1ef1e88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a5b57d1-932a-4f96-8583-89781b773ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf0a0c29-48a3-41b7-bf37-d440fd41eba2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a7e0964-17b7-46d6-8d1a-268c8cdf3e64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23d6d5b0-ace1-4f4b-865e-5a827364f543">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ef890e7-a6b1-4294-85e1-3fb193760bde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb9c11-e256-4e10-8312-fdfe2385c71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc21f7b2-afe6-482f-af4f-92fd14b5abfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad6c979f-657b-4e73-ba68-257d15d08a72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9990ad7d-38f1-4620-b15c-019273d58f41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c87e7e5-b2a7-40c8-98fb-101f3db6c73e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b79df498-dcfe-4fa8-b694-04d76cfe87b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a676aa7-4dd9-446d-986d-794ce499f297">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f1f0e9e5-3f7f-4a7a-b8e0-3dad27794a06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e9770c9-db90-45bf-84af-be3839c382c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7565f8a-903e-4b04-91ee-dce04a6097a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2eb48637-02e4-4857-bf33-7421a2bd903e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5cbe4d57-0c5a-4e3d-8104-c43f35f3b8c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe00b674-5c44-4794-9a2b-525f35f7f13a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_038e4bd6-fe6e-48cd-8b3b-8617fcf53b16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b8f4ab56-0cae-479f-b994-a089285bf453">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fc5009-d32e-48a7-8fa4-0a892b95543d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f170f287-d4c0-4aa8-bb8a-be6a691759fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1173766-06ad-455b-8adf-663574665ef2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbde89f5-f08e-478a-8a73-f1203842d380">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26c96fbe-07bb-454b-bafe-0b66e0d91779">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66f5f987-6746-4ddf-8291-e079aae6f88f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d1abd8a-4a75-450b-9814-efee70c1f00e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7203f60-7692-4edd-919e-212721c83323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_314d2ba4-7d01-4433-866f-7ed52d8c266f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e1c9ddf7-9f1e-46a2-b210-fcc7a90dd361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e781a75-395c-4675-b1c9-8090f7136a9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d88cc96-bf93-4569-aaa9-b85447f5d6b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5e012982-8c5b-49fe-a915-9984a9844629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99f7bda1-69e0-474c-b2ef-27c28b95a477">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21a9a1e4-817d-4f3c-a06a-88c050bd8a01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a461b809-62d4-448d-8596-070fbc82bcd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88c1f50f-7065-428a-a48e-3955c95e0a83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3633500c-289a-447f-84ea-ee2adf5d8f06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0fb79a27-0296-460e-96bf-344c9748e998">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_320e4ca8-bc24-41ca-89e8-88fb69a20780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d52c596-f3b5-4ce2-ad1f-c662b2590caf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0c87d80-0936-4412-8a9b-c023ac69a7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46f656f6-4f2e-402e-93de-2f4de8fe6b6b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_86fe6bb9-d204-429d-8827-606b790a951a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65a6018d-1102-48c8-bad8-c5a8effaff81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fb4c745-f703-47ce-8de2-bfbbcaeaafc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc383940-5969-4abf-92be-59f7730681f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a02474-3467-4c31-80c7-4c1d43af0cbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1e7c81ed-90ef-4fff-9d64-df1dbba18891">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_270bc494-7c22-455b-a3e0-e1c31732dfc0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0da6b145-a096-4b6a-8359-91e83a938787">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ef5af20-1c4b-49a2-8110-1d688fa10a75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b698233d-7707-4afc-a8c4-ef3860860220">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2d5eb8c-d2e4-461a-a3c6-af74b86875b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_067b340d-de06-4c93-b738-322c9e63f326">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_884b6d2f-b17f-47ab-b894-29709041ea27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_175d59cd-5dbb-4625-981c-cb434b49c02e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7701a0d-bdd9-4f72-b55d-db2c6b054614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b1fe23e9-b568-46d1-9b05-3976637f31cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aab9f87e-3481-4ad1-9af4-85bab1baad21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc158be9-9c3d-46f8-894a-bfda40b4e8d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a8f056b-8c01-4df9-9819-6fb78eee91e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d3637a3-ce8e-4969-a955-19e3a93f2460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb458537-8f24-43a4-9114-692c0daec131">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e806f44d-97f4-44e3-8726-a61f5883335b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a7c0188-4d39-4dd3-8004-9b473b22b3b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f71a10a7-44bc-463d-abb6-e483dc630541">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2e8ced2-7ebb-4a01-a1e4-55f059b92fa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2f6cea0-e313-41ad-96f5-87800121a518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ad72c6b-d938-497c-8618-859b5d3e5884">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f1cf396-8d86-4e6f-a52d-e1af86772ceb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3251f608-0688-4dc4-9dc8-e3091bdac7ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8fd3fc61-31a0-43bd-b0c6-cafdd829679a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fbbd787-319f-444d-a059-3a5536c03ff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b7f797d-4bd2-4df1-9cc2-a888aec7662d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d2eb25c9-57ff-4877-a01d-57ad4b5ad6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f8d3ac3-bcdf-4d13-afbf-63bf24e38d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1342fe65-f28a-4ae6-97ac-46ffc8b6ea76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b546ffa7-d00d-44d4-b9b0-f2a6dc043c97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486326b9-4614-40ef-b499-57360c1454e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65e01f10-db8a-405d-96f2-ecb2436ea1bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173fb145-6c85-4837-8c26-642a031183cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39748ac4-8994-41ef-86ad-aa593876e300">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8feab797-7f0e-4657-8282-79c8b499523a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5838d0b-841c-4085-876f-1356e29461b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66238552-d9de-4b1b-9b46-7f3d2f028039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce8a387e-0ea0-425c-ac7a-1e5dbe93e6f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_28e4a7ba-04a3-4c8e-9d98-9b47f86b7ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dff8a9f5-f6be-4746-a6cf-9e0fb46ef3a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dd48faee-7455-4f0f-8f4a-77e7491becc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50ef0e35-d57a-446f-a4d2-2c9554e2d57e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e0f1d46-62c3-4360-90a8-bff00e7cf60e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b424c2b7-3a7f-497f-80c7-0a30f96676fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a833d30d-19f5-4e6b-9f91-19343a3ef516">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95506cd3-1c3d-4793-89f9-65cb4c8dbe8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3991ca5b-3c5e-4b1e-a604-17fc2269d13b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0b6e1d-6cc9-4cc1-91eb-2548f3a71765">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df182f4d-e0de-492d-a328-0043b36cc033">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21bf0113-445f-4a34-9358-bf53c533c485">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80a0e5c9-61fa-4204-b743-9351bb56ed69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_632eb5a9-9e2d-4eaa-a7b2-00d881f0b85a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b386a96a-0e25-40f1-acd0-e6db2ead045b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10196086-9e19-44bb-b597-102575b853e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b6bb26-e66c-4d36-b242-8da8298dfbcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_40fa729e-1cbc-40e8-9150-07e62aeff0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b2ae2b3-068b-4f40-b89c-183060300298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_233b7c4f-1118-4246-b7b4-8ffb83cea2d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47c6c1b2-0598-4985-ac70-ea6696ec5bc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec420356-2092-46dd-bd46-319011559d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffdebe6f-5731-427d-a69f-bb6a72a5842c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b6b8c7a-4fe0-488e-a01a-1e14170230d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_516c7e02-238e-4cd1-9e09-495bdeb37206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ca2a83-900c-40db-b703-573ca798e017">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2026e7a-6ae4-4e02-9429-3d7c0044c104">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_16daa926-0bcb-48ee-9fbd-f92fda0d41f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0d4db3-6da2-4152-bef0-416b2d5b0f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c08f3b3b-a1c8-409a-90e4-8a48873e7d62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c9829-f820-487d-9ff7-f9d743f2bc6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01815773-3d66-4ea9-a4b5-7e3bc5e21bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11eb003e-8feb-491c-aab0-f4290351e574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3fc6d901-d47c-45b8-932c-9503f5e191e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_346ad448-e260-4eb5-ad22-909cf41d55e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0aa15e9b-4db7-4647-80f3-6faffbbed9af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e186c8cf-20ad-49f0-8181-cebfb9de7644">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2695dfad-50df-46b7-a2f9-455baf0a39eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ccb801e0-67da-49ea-9ae8-eb6b74fd3796">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_518c2ad8-6722-49fb-aeba-027b9834fa12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_768736df-6aba-4013-a7fe-5a4d2415efc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c98ae667-4b00-438c-a4e8-11eaac1449fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aa48cfef-d128-4b07-a145-71146779f621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dad66b7c-ead5-4597-b4bf-97239b0854d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_571e8263-08c1-4586-a8e7-327d1f5ff2be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c344c2f7-1f7a-485e-ba0d-980abab192a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac2bbd87-5d42-4fff-967c-30d4052d4a0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d381ddfa-6e11-4efa-b898-c5d0ecdda246">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a14bcea2-8848-4ed2-8671-6e9c1db7b38f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7eee8ba0-c290-4cc6-9b99-cc978ad4a55f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b660b46b-f89e-44ba-a2f2-5f7ce2e38699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f5a225e-9d00-494d-90ec-44352d98d4e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ba7b635c-3031-40ea-8907-63881e80b42c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c94e6b68-da6c-43d1-94fd-09ad60c74134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6fc20583-c9d8-48f1-833c-e332515ccb72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ff1d968-f352-433c-91e4-2086b875b068">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f57e0ec-227b-48ba-8a55-8b1792a44c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4caf17b-3b80-4f50-84cf-3c9800262e53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_750abbc2-9c8f-478b-967e-5bca6ccb6649">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d877c8a9-ebf3-4468-9bf5-bd35e802914d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dbdb1b4-0575-43d8-ac61-faf72cb621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1b858452-c35d-428a-8b4b-90f21ad07836">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa7083b1-1a9b-4973-84b9-df7487d7f4aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4462db5-e42e-40fb-827a-196a16d123c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df2d3e44-0edf-416c-98ab-3efbaf98a66c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_64b2c7d7-d7b7-4c1c-9f86-b1adea0698d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2f1d3e-8f67-47c6-8e9a-dbd477da2acb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b75cd36a-7f05-4fe3-af88-ff32fe39e6dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0897b098-e2d5-483b-a708-28f47c435413">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc31b2ff-8ba5-43f8-947a-2f11dd26492b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69d4e272-32f2-46ff-a0ee-95358129563a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe46cdb5-2ea1-4fcb-b508-6ca5aa09db3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69d1ccd2-3730-4278-99bf-9ca956be4401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa397ea5-dffe-475a-86f9-d00d21ac01e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25cee9f9-9bef-42be-b860-ab3beead7814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f441e1ff-6bae-4314-98bd-5b1689de1b2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ada9951-1e02-4889-8745-f13dc4148ad6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed408729-5a92-4002-8a8f-ae384ce3620a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_688fc72b-057d-4a98-98c3-f962aeaa22d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_347aaee1-bd55-40a5-99e9-fa9bdc3a9ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3e50ea0b-e624-4ac7-8e6a-29876963b392">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6f1e5e9-d979-47a3-83d4-817003628745">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5318967-afcc-4fcc-b0de-d5f2522a95a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8082da6f-11ee-4cba-96f9-5258414b720d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e704656-b276-46da-b8cc-b757bc42fabb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e9f91b69-a29b-44ea-aa0f-cff86ee80320">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5adebd33-20e8-4c94-b02c-d9033c3a891a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad86e83d-6334-4dd8-b642-b4c16d65329a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c96e50b9-ea15-4421-b6c8-bd9c9158a69a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f43dae36-6df4-46ba-9dc2-01543e80e0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b8b0b9a9-af8b-41d2-a4f8-940637e63f70">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b345e74a-9570-4cb9-9a59-928390e3dc44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17abdb92-0180-4bcf-8ae7-dd923630f360">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0b78ffaa-9859-4658-af17-c8d355633556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9acb676e-054f-4e61-b60d-3371c3320b52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9315b98-af75-40bb-bf8e-05bd03d43db5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9dfeeaef-5c49-4c2c-97b1-03876970bee4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36d76f23-8e75-492b-8f9d-4d68d2dab71c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6a076be-4135-4592-85cf-1f22fb0528a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6fcfb68-394c-4c29-9cef-9e41fdeeee26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_420cad1e-e8fd-47fc-a747-b9032181f6c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b664adb-6099-4a04-a498-dc33ba0fd5b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39cf2a82-5f62-4cef-9bd1-1af4f783291a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7eaeea7-ce64-4a47-86ac-0eec8c65c8aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fa594a2-56ff-41fa-aaf3-c9491755b684">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00865800-7a32-4d63-91f6-88217af4743d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0b0cafd-9ee4-41aa-ad86-965a7e4a00bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_287ea6e7-a365-4038-b8d7-d7f01677255b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd5768e1-dc34-4e62-b9ed-bc8ffcdc0000">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f383c35-5d1f-410b-a60d-d67e1f48f646">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_679919d3-fc46-4791-b7d8-8a87d0bfbb91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_835c00ee-21be-46df-98ff-e6cc1cfabd3c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0434708a-79d9-4740-b697-2bfbd525260d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed1043ac-f6fb-4f30-8a2f-177e4fdcb26b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cafaa7fd-26d1-4609-8186-f9af8022be4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d43e0f0a-5253-41b4-9e43-ef864af5b857">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3d02781-552d-4bbd-952c-f753034b5ece">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46c8e67a-37d6-4498-a6e1-148ad0fcf682">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74a95e4a-dc88-479c-8aa2-fc194cc595ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d27fc6e-5da0-4d89-8d93-8bbee127638d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_17cb9e95-1fb1-4fad-95bc-9cb4cb1eabd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a6b0d1-4103-414f-98f3-14009ce91e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1286c4ed-c414-4282-af59-91af27cb856c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b591b30-bfd2-49b3-9bd5-4eb808638a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38733a74-2927-4247-8fe6-065cd9fdf7de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abe5f6b0-6e09-41d8-b326-685828bb5fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57e7e6c3-e0a6-4ac3-a0e3-392e749b3dd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40d166e5-8a94-461c-96be-c7b40c9b0c26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_159904f5-dc85-438e-adb2-0f7accdab22e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2eb9abb5-9566-4c1c-9e11-c2f6ee115cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba08c29-26cc-4706-ac27-26692aac8c88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c7d6536-ea8d-4b7b-be12-6be542b1db2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d62d7e5-64c4-4d08-8a84-543433b71491">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff03ac62-f2e0-4beb-a79e-447a8dbcf53c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b729ff6-e8d4-40a8-a250-8546f9d43ff9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d917556d-7af8-4d62-912f-cee8779b78ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57df35dc-cdbf-498c-a3d5-7f5da2618ba2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3e47bb0d-8a7d-4e68-bab4-e4b55c2be04c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_09b5337b-759c-4cda-b09e-fc2131692bfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6554fd18-1d49-48eb-88d8-289134c6e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1baf8007-34b4-410a-bd34-21ba83f132e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ea887338-df13-41c6-81c8-10ddf6501626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dbf3737-7c17-4e23-b698-a6231fc95c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cf25bb9-e5be-466a-9eda-76d00e20aead">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_181c1a17-a777-4729-8e13-5d427ad49c94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7bad0622-8a66-4e8c-ad40-dc0a25bf0123">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73e5d2d1-d756-4b50-8069-e663130f1816">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6296a5-b265-47cf-b634-c8e0e8fff1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90364382-c1c6-4471-850f-7ebf7e718070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3ba7162-1168-4478-97a5-1f522aab0b8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34818fdb-09a6-4567-be70-0bfe57e6cba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dea346f3-01e8-4b63-bbe3-5aeea6ea9129">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0e08d7a-7d6a-4cb3-8a77-447b121443cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d8569a51-3dcb-49ee-95e1-193d570db5be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ccffd22-4277-4a42-9dc9-86b270a0f291">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e8f404b-ad7e-4684-bc52-e3464e34ee79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fa3678ca-1dd0-4be0-aac6-a5cf857e7d60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19bb3455-dba7-4049-8350-9fc3c29ff4cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4274888e-6e49-4d9e-9563-b483331f8424">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80fa1756-f607-4448-ad06-dd7b5e69ec38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ac383d2-d853-4b4e-b0af-171813d0b7aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff8e4c1c-ad07-489e-ba11-43217dd68dad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8d3d915-6065-4890-943e-4cf5c69a97a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_563b8841-aa4b-4bf2-a54f-8f069829f070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f1203b6-43c0-44bf-ba48-25564bbefef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57a42edc-5e05-4604-b596-f01ab114f5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd023497-58d7-4396-8f9d-a9bd364f8c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45d740ad-e86f-40d0-9008-fd671acbef6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33c8f510-825b-4689-a374-f96650937c33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe2c5d47-fa92-41ec-b454-3cb1c878437e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9f2dc0-6618-4f8f-a284-22aa15d23fb7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cfe03e9-7d00-4eb7-be53-4b443d69703a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a26ae26e-b636-4503-ab26-2f5946d511a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0759a425-647a-4247-b66b-26357a147542">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6ae1641-50f7-45be-9833-bf04ddcf7697">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6cc414f9-05d7-45a2-a19e-958faed12395">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eda4be62-674c-4d62-bec3-33bf3bdd6294">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a241b4fe-ce93-46b3-ba20-126ed4574adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fdad08-fd5a-4f4a-8ae4-296ea3184087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0d653c1-85b7-4edb-b412-90836f207efd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a897e54e-1f4e-49f0-a8b8-d1b79c28413a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b3d8eb66-45fc-4b9c-9206-5b87bd362315">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bffd0293-189f-4b46-9e82-f8951326d01d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bda2a584-06ba-4aa3-8af1-945d6ad9829d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b37c45-5751-4c50-862e-d2f811623bd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e9f123e-b540-4391-833f-84e5f9b7e63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8911f118-6ed7-4424-b8e1-a6885482ddbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3da39f62-762a-4533-9485-f1849e5f8812">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dffdb415-95a8-496a-ad1a-93cdeb444fae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7ed6624-d332-4a9a-a96b-b31bcb1ef24c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccb6edb-253e-4e1d-85da-c68ef40f59a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa063f2e-1205-4d1a-a549-3ccc5b31e65d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_443775ac-c8ba-4e4d-a91f-d1926ba21744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ef85f09-3622-4a12-87bf-fefcecc01e4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28b3e895-483c-478d-a5a3-7b9d7c9e11f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a0244ab3-80e5-4c20-b201-a142d50e6ec1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c8e0d41-008e-48dc-af1e-e988941e71ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0ba9bc8-9cb8-41f9-be4e-a8f6184e1432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4e958ea-f50c-472b-8c35-9b2a606d4310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d0edeee-fb82-46ff-9ad7-8937813fd4a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf4393c0-21c2-4e35-b330-c1acda2647ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_72627757-688f-4752-a751-c9e2bd554d2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3d5e8cc-be34-4d4a-a586-ce582737826b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10180352-5b41-43e5-8bab-bbd40fc3053b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10313794-08ff-4455-90e6-a439d474d0ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_22ac1bc2-c0f8-4d04-897f-c24e25f28f4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aad73b40-3e9c-40ac-834d-4c0243a5c334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f492ecb1-1a65-4013-99f8-49edc9d7d556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_307df982-5918-4ad2-8c83-1cbc9b7906ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31cfec00-6695-4126-b60a-98c4cd7132e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cf36442f-8f07-4110-aecd-1c7124608dd2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53e398ff-d48d-4e1b-acf0-be0965777d35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4615f36c-51ee-4eb0-945c-d57636d7fbb3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_db7be977-a065-4bb0-8b27-d44e0a6cac16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c3bbfbe-faab-4429-8c29-799f941f9add">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed71bbb4-203f-42dc-8a01-e3b144ea8ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_54cc9d2a-325e-4545-a35c-d322e006a8d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5731482a-7053-4716-866b-ab26f39cad97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aea5de0b-5724-497a-b712-f813e6c55462">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_350e99eb-81c8-4938-9014-f14d16cc0989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a83373ad-d7a8-400b-9d4d-cf7a0dac3d73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_030a749a-f8db-4c51-a67f-571efd180ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fe0f5c1-8319-4dc7-ac10-643c4d4ac0c4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3105ff97-c823-4905-b049-f467bc8e0810">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d4658ae-163f-40e5-ab58-754de44a9565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f655fe14-241f-462d-9fb3-a58dd791a31b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_97da8dc3-3290-45e8-92ae-a01611dc0b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_513211dc-4e13-49b8-b8f9-8a062e6136e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bdb83ed-36d7-4e74-9e77-1237f7695622">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f605145-f6fd-4665-9672-8fef199d1592">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e8c477a-837a-416a-8283-44318182f678">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47b201ba-930a-423f-b4be-a71805471077">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4bae3a8-84d1-40fd-b83c-a9bf8c206d9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c6145b2-effe-4953-9f32-2e49388dca38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fbbaea94-c6b8-4492-99c4-08893180b6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4decc4c0-9950-4fdc-8682-dca579e200cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f851b27-33f3-45f3-aefb-2c134479e2ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b061adbe-26eb-4721-a6c9-e78026e0f915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b79434bc-5187-4184-a806-7a39037a7640">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b395e7f-bd27-41ce-a590-eeb60a5f502b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee96be74-4d86-4eb1-9150-2d594bfcfe1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d08a684-cdcb-484a-a767-03b10f4ada7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb24cba-8dff-4ef9-9ba5-dbdb086e77e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_706e83b8-c1de-43d0-bafd-57766513c62e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f468d841-1bf6-470e-85d4-55d34fab8bff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a78dbd51-f64b-4abf-9154-3c138316e279">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90c04b95-703a-4bae-82b8-7edf3075aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f193bd8f-badf-4600-82ac-f212d1f33534">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_340082f1-db9c-446d-97df-80e45aa0058b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e33fc23-0e6a-411e-b0eb-67b1271cf383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89c3d444-cf42-4e48-9825-96160ba9895f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71f8df70-c805-42fc-9a09-c9527e6f8175">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_09c871ac-e7a9-40ac-9580-ed616b994397">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6a25879-018d-46a3-82a7-81b9b99b609c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf08be5d-b85e-46be-9378-6eb35540e070">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6398ff9b-368e-4aa0-9a7b-8d9a2d095835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a94e93-5272-46b4-85ed-7a173200852f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e87b2c5-e7b5-428a-b836-5e55a23693a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05d6e5c3-2268-437e-829c-9e9107a18dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7951c520-ccd7-46b8-a3a5-fd879cd12257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6adbd31d-0c80-48ec-84d6-000aac8d9a85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:ControlArea rdf:about="#_1f9ecd81-e069-4040-bd64-f34b0fac3a60">
+    <cim:ControlArea.netInterchange>210</cim:ControlArea.netInterchange>
+  </cim:ControlArea>
+    <cim:Terminal rdf:about="#_65a95678-1819-43cd-94d2-a03756822725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c96df9d-39fa-46fe-a424-7b3e50184f79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c6a1e49-17b2-46fc-8e32-c95dec33eba8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_unexpected_inverter/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_unexpected_inverter/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
@@ -1,0 +1,12953 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:5bc75f63-85bc-d020-02d8-1d9358dae159">
+    <md:Model.scenarioTime>2030-01-02T09:00:00</md:Model.scenarioTime>
+    <md:Model.created>2014-10-22T09:01:25.830</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment: Small Grid HVDC Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E "as it is". To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.version>4</md:Model.version>
+	<md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://GB/Planning/ENTSOE/2</md:Model.modelingAuthoritySet>
+    <md:Model.DependentOn rdf:resource="urn:uuid:a97cec76-42cc-bf53-2269-4f5abcce7244" />
+	<md:Model.Supersedes rdf:resource="urn:uuid:2fea4dd9-083b-f2b0-7b57-568efb25ccf9"/>
+  </md:FullModel>
+  <cim:ACDCConverterDCTerminal rdf:about="#_7780ec9e-6743-4c53-aac2-f123637d5274">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_c4af08e0-9608-4654-b74f-e359a7a29dfc">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_0193405c-4f37-421a-b7e6-9c4a8904eaf8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_9b40dc62-2c36-4b70-b931-db436ddb3fad">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_412aed14-a85f-4828-a751-221172c48263">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_61a0a556-ae4c-42a0-bda3-7423cea7e6ff">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_e4b9540a-1a8c-4f8b-a8a5-b7c0dc0d1df8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_3844652e-cd36-43e8-9e90-a1bbe2d85dfa">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:DCTerminal rdf:about="#_a03cc8fb-fe85-4a7e-b96e-5c074abed705">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_e768024e-1c0c-4c0f-b023-5deb11d64dfc">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_5be89c2c-b370-46ce-8844-338414489fb3">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_d2dac22c-7798-4a59-b5db-3e4fd307abda">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_6bc9072c-735e-4016-9ae8-acc2d37f1fba">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_02d46e89-85fe-4756-aeb5-4869950f8776">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_bbc66594-69da-46d5-9a1b-2f4a706fb6a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_600ea926-a53e-4f42-92b1-aa10bfeb79a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:Terminal rdf:about="#_0471bd25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04682030-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe868-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0470d2c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0237-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667281-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0234-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c4474-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a1673-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc79-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500450-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bfb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640186-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04776270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04619088-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d8a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce94-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d86-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465fd54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e431-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d851-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893cc3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c6b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b148-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453add6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459a142-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801509-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04597a34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464289a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c633-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc426-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0661-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465af34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04860874-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500454-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505274-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472a784-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452c378-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2b7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b5fa2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e12-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd35-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0447c6f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812675-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e2a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04773b69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b092-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc82-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459c855-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483706b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4da-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04507980-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481514-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f00-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab84b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c33-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452ea84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b202-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046cb413-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801506-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454e651-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046735d6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492681-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662461-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865694-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e193a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1184-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745537-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472f5a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837060-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c8772-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0450798a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684744-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea71-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455347a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479ac63-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04636547-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea76-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b47-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b978a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828601-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b207-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2947-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725960-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b55-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2ba-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481517-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a3c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046030f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04605808-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a2194-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae80-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048badc2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf53-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04795e46-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04719611-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047abdd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04885261-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04878f1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044bbe98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e224-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531190-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a4e31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed161-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04686e5b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b366-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f94b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b095-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c906-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0467f924-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837069-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cdb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468e383-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500455-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f01-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04675ce4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04656113-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9786-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04845acb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04880440-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e227-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745535-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a7548-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793738-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460f444-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2949-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453fbf5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487b620-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a6a26-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04854522-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549834-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb43-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837066-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2ea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e13a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725965-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9785-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7600-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b44-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457f391-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531198-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0475188b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04561ed6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c877a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b066b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047ae4e0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614262-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04834957-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765105-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d379-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046205b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485452a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f8f24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ef879-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04887972-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492680-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477feb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab848-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4040-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e436-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0233-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c17d3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479102b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d645-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04670ec2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d7a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449e9d9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b5484-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04798557-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed164-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8348-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bf2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642899-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a6fbb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466e7b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b4ef6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045386c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046f4c22-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe865-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461697a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04742e24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0668-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d856-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e91a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d5054-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f0395-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04483c21-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0238-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fbbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bf65b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04806320-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f4103-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b5a14-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1180-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044974a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04616975-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04723258-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482860a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789af1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044778d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492688-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047cb9a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f017-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047120e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486336-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f51b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04558294-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471bd29-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04529c66-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04753f92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d910-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667287-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04518afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048ac362-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d294a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662468-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6817-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640181-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047df222-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9139-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3895-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04817494-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d2ed5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448d862-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e225-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531196-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b792-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4317-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a623-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf49-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048915b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc78-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812676-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a2722-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570934-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044be5a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453d4e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b36a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d83-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745533-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046eafe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b2254-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c1c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b364-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c7110-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452755a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e8e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840ca7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489d905-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04633e38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7606-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab846-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4316-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522732-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047eb572-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a627-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd36-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840caa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cd594-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fe2d8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047147f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc428-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8340-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04736ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b86b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c638-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044aad27-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b209-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893ccc-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8346-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf48-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047084aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04607f19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500452-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a754b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480ff6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04542305-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d7cf3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474553a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e75-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481749a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614268-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e3ab3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9138-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e88d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4693-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b27e3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d71d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04731cb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047da403-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b140-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e6758-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c1240-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486334-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f70-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480150a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448ff77-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522737-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cd2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570939-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046476b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b62-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492686-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04590500-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486337-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631ccc1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474f17b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0488eeab-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d376-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765100-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3307-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04767811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3303-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d5-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ecbda-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04622cc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b205-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e432-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d4536-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b799-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483e592-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482ad17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047fc6e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531191-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0486cbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454983a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc88-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048433b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549830-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c902-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4047-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d641-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045163e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474ca6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478c20a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f018-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476ed4b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466c0a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c8d06-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b094-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04494d96-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489b1f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04513cd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045dbff8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e64-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04851e16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048481d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:about="#_0448d86a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044bbe92-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>16</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044d1e22-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04819ba4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>46</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048433b6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ca8f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854525-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f08-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047fedf2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476781a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0477627b-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04697fc9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>90</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0481c2b3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448d863-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>61</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>28</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04747c44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>130</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047e1936-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cae82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>48</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045b00d5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>62</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046efe03-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>71</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b89-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0447ee05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94b4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048bfbe0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ea4c0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>52</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e4a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046205b5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>7</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048b5fa5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>70</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b7b95-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>15</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04716f06-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0483be82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>31</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046d0232-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>6</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453d4e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>113</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044aad24-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a219a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0489b1f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04798556-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>277</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>113</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047abdd7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04791028-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04817492-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94ba-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ecbd1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>2</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0463da70-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047b0bf0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0461b790-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b0665-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04689566-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04547126-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>77</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>14</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>54</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04812679-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04742e27-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2257-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0466246a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04488a49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048740f1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047d7cf6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2251-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047dcb12-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046adf5a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476ed42-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>13</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045c8777-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>85</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854520-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04778989-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>27</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cfca7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0479fa87-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>45</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0449e9d7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>53</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0451d918-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>42</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0482fb36-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>66</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>20</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0484cffb-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448b150-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04867dab-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04481515-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>36</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048a9c51-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e46-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0485e168-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>21</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046c3ee3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f6da2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>60</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>34</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c0cb3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>5</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>65</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04682035-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04887973-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045645e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>51</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0474f170-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046a4319-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>19</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>2</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045d4ac9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>17</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0462c904-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045163e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>87</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046dc585-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453add4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0450a093-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>84</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044974a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>63</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EquivalentInjection rdf:about="#_5631ccc0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>184</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d4-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>6</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>20</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>8</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:ThermalGeneratingUnit rdf:about="#_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044ca8f0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-85</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_668eb671-5c36-4351-a95d-53ca850581db">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.680008</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_f26d4eb3-ebdb-4025-8080-f856ce656b42">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-450</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_7566f2a7-61eb-42fe-a59a-8276257fdbc6">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>230.999985</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e5a479a8-ab8d-4a54-bb52-376874ae2784">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04856c34-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-7</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b55d80d5-720f-46f9-897f-ff8c5eaf8b44">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.644</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_9a6bdb3c-346d-4426-8127-5f6cbf0150b2">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047fc6e6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-4</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_98f667da-02d1-4a31-b826-44314a1fbbfe">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>33.495</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_fec62959-21c5-4921-90b2-7c85e9f3bfab">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0452ea80-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-36</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_9db08c95-4586-4a2b-87e3-5a17c944b43a">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.36</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e54b499b-436c-4b89-9803-b1d75e2fa364">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044cd00a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-252</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.243988</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_27799004-aa1e-4889-ba95-ee6fdae64895">
+    <cim:GeneratingUnit.normalPF>1</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_048aea70-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-513.437439</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>62.1325531</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_827a9c80-183d-4e33-9e73-ef0aab3dfb13">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>136.62</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0458ddf1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-391</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_12b01822-ca11-4cf8-a6b4-2f8ff805ca20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>221.1</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e3753d6d-b894-4cce-b6fa-307c50dc107f">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04859346-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-204</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_dff93c01-9c84-4c1f-8529-66c054ed9e37">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>135.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d9948603-709f-41dd-a0ff-2ebda091255a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047f0391-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-392</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_23727856-fd9b-4124-a981-4e862148f3bb">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_56975783-9739-40fc-8ec1-e1de8cb06c9a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045ab2b0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-220</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b8449cd9-5a17-497e-bf04-70f728b0f9f2">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e56da2eb-bb6a-4133-953c-40073c5bc5f4">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046bf0c4-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-40</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_d41be6b4-155e-4c8f-b46b-16b50c49f0f4">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.319992</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_83fae784-1da1-4055-8108-ba978276d1b6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04633e31-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-19</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5f711f63-f631-45d3-b26c-33821ab2ee56">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_a6ec9760-88da-48df-a23f-7877e7c85ccd">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-477</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_e6131af8-c298-413b-84e3-4e21c3b6b06f">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>137.28</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_2621b09a-22e3-4630-b3bd-32c102e36741">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0489b1fa-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-607</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b0d662e5-64c9-4d59-b8e0-9b1ed175769b">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_05df66ba-3f64-40cb-8b18-c66d26c4e2c1">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0483224a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-314</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_c1d29442-5f57-41d1-bb60-4b74b4994c20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>223.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04839777-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-155</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_29df1e0b-36ca-4536-97b4-6f98b84d49d8">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.02</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_17852426-f663-4add-9a2b-0a635d51f101">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0472a789-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-160</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.34</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_b97aee41-3115-4cfd-9071-b52fb44d0b66">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046c3ee7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-48</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5005c073-28d1-4a7d-b257-649dec43ec73">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.06</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:RatioTapChanger rdf:about="#_047df228-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_047d2ed8-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044974a0-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_045eaa55-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0488797a-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044b4964-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0447c6f3-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+    <cim:RatioTapChanger rdf:about="#_04682034-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>31</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0487dd39-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_04549831-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:LinearShuntCompensator rdf:about="#_04553478-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_f4cdc674-4a66-4ab8-8d4f-552cb066e259">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.935</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0475dbd6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_a7768441-642e-48a2-b4a8-0ae06bebf676">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.419</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0447c6f6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_c701959a-91c1-4a35-9a37-71fb790426ca">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.676</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_048b5fa9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99c6c4ad-5247-4058-96d4-ee8495103e85">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.723</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045b00d9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_be267a3c-f7a7-4bdf-bb17-71b773247fbf">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0460cd38-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_069d84c6-bd26-4c26-ac6c-e801a0202a00">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.814</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0489d903-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.423</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0450eeb7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6c36f421-303e-4932-93a9-5b0ff86cb7d4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.565</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045c6067-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2d222dd9-7306-4afd-baa5-fd303b0eeb40">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.066</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04558293-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>124.763</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0466c0a0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99931a87-ee15-4fd0-b251-9556df7fe598">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.002</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0449e9d5-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6cc38790-c6a6-4309-99f4-a3258e24e785">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.403</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_047825c8-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2a6c1dcd-201b-4911-83b2-c16acc50a0f4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.212</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04684741-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_eae61817-d3cb-488f-a1f3-13bc8e31431b">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.323</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:CsConverter rdf:about="#_7393a68e-c4e6-48dd-9347-543858363fdb">
+	<cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>480</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.unexpected" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.dcVoltage" />
+    <cim:CsConverter.targetAlpha>13</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>0</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:CsConverter rdf:about="#_9793118d-5ba1-4a9c-b2e0-db1d15be5913">
+    <cim:ACDCConverter.p>-63.8</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>55</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-63.8</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.inverter" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.activePower" />
+    <cim:CsConverter.targetAlpha>0</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>17</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:RatioTapChanger rdf:about="#_ee9505e1-96d7-49b3-9d1a-924397ffb27e">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_a5bf9702-545a-437d-9663-773550202828">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_739658a7-e08b-4395-8d79-93e87b7855e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:RatioTapChanger rdf:about="#_ea8cd467-31f0-40dc-95d7-4064463724c4">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_c089eb25-9f67-4d82-88a8-635dd4808bae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_453bdc57-5855-4eb5-8712-d6a0255e0da8">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:VsConverter rdf:about="#_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd">
+	<cim:ACDCConverter.p>-153.5</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-153.5</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.pPcc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>213.54</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:VsConverter rdf:about="#_b46bfb8e-7af6-459e-acf3-53a42c943a7c">
+    <cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>360</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.udc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>218.47</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:Terminal rdf:about="#_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe0e60b-3870-44fb-ba93-a056228f9636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_071bb138-ff00-4874-8acc-a884aa5cf4a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a168e701-bd48-4f66-8f0b-0f69b2545530">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8cac1e7-4826-4ecd-bac1-f4085fc15956">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dda862d5-7727-420c-be3a-a6a30e0b4c65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f72bfe50-f1ae-4f21-a477-f62e75a636af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfe1e320-861b-4d31-a076-5ddc474e4a05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14d37503-25e4-40e2-b20f-4de429a0dd00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c7f5674c-44a0-42d6-a701-4706b14c3eac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_21e25548-adca-48b3-b2a4-c000485222ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb3e09c9-fee1-4407-935d-ce2d342dbd7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e141e4b7-12e4-4b78-ae07-e8ab741ef9cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5de34198-471c-48af-a0b2-e5ae14970738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b862807c-b874-4b47-ae4e-59e4479bfac6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d88d693-242f-459c-bf12-267c22ba7809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d1cfe9e-3f42-4b3a-af90-111257354f8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41a94bfb-c430-4007-b29f-b89204ec913f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42ee39f4-ef6a-421c-a581-5da2682980ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_43724816-f5f6-4374-8ac4-96565bd5aa59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f1e8a6-8e32-479b-b73b-79823a3e1a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c37e51b5-c01e-45e9-88dd-957334a720ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe09b58a-7b27-4460-b596-c5886b3645ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8219d169-b5c2-467f-acbe-b04e0d39a7ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bff67964-ffa7-4243-943a-07c911e18dcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f4d752a-acee-4ad4-93fe-ad3cb6722d51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88d448f2-1777-46d4-840c-f64a7bea8a12">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c5dcb2-81f9-4076-b9d6-fb43a1a76d9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8e16607-1e6a-482b-8b4e-e5d990b93a4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cd484cd-37a9-4454-88e4-ab538b00a7da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3184d830-8702-40c1-9f52-c8e23eb3feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e68e5c02-683e-409e-8371-bb2e5f947c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b97c5dc2-7cd3-4a6d-9f6c-d18ca2229ea8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb5279-2c55-4531-b91d-3b71fa7f1674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a90f437c-e33f-4571-baa4-14f6e6a5be19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b64e6a0-436c-4389-be48-9dd120beb218">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe9cbbd7-a68e-4a3f-950d-3b1c2278b0fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b5a3e17-a13b-4158-8b91-a4303fe7e433">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f472e138-541e-429e-aeed-e632232888b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1e00a228-c452-418b-9db5-0a0ffbc5a5d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_26698a8c-a280-406e-b882-9037efe6a03a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145597a6-9fde-4bf2-b2fe-8a4c6c5f4774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd76d8e2-4515-4964-af8e-67885c73ad5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_883bebaa-0b47-45b9-8d4e-75f8784dbabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9145eb98-9d67-4793-b83a-967c6ff56e1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7c10087-4ab2-44cf-9362-3ead8a066326">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a5780b7-5e74-4532-b3c1-d1617bc090b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aeb3fe0-66f5-4f34-a79b-14f777313348">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b60203f-42be-4959-8f9f-10aa7e6812f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca41ef76-12a4-45d9-8665-946b5d46b7f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8de12885-e525-4726-a2a9-80a9eaf637f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef70c25a-ab63-467c-a0c5-c0d5ecf22f82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_79ae9e2d-942f-4878-be1b-a9e7e2971740">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a22db682-0414-4fda-ae6e-9e48d11a5565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5578e708-945c-468c-b7ac-56a738f7701f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4820525-8b5e-4f46-9a5d-7b93cadc813b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b95964af-8fe3-44e0-91ea-d1d71c7bf25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c58d4a-2ad5-4eb5-abe7-e79c1cde9d71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9bc8d338-1940-419e-98f6-8ae664bde365">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e5bfa23b-0c58-4ef8-a317-bc7a65457ba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e64d1ea0-1cc8-4317-9d6e-ec2fce5eeb77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d5377df-3bb0-4d2d-b6e7-e08f369a28df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f2156a1-b0c1-4bd7-aff8-17e4acfb98f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e030a6dd-e9c9-4aba-bb6e-8ed4b7add9e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae1f9fe4-1234-4ec7-b2a9-c6077a19d401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9385a5d5-0ce1-4218-ad3d-2645077a1bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cf89592-6284-4711-a283-848c6e97203b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91291202-267f-4ca0-b8a0-0ef3cd7b0d3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eb152b46-922a-48eb-a401-854a48d592dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a74688c8-f01f-4419-91e1-790b7d8637e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b85df60f-96a8-4187-b01f-018879647feb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_730d18de-6962-40b1-94cc-b1175fc098f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca3640a9-b054-4d3a-879b-8ed41d028ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fd6a4b6-c0ec-44b7-9ab9-b8ec781850d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c23c7c69-c302-4315-ad2e-4d5389140def">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c801bf-3eb3-46f5-8295-4c816d9bb318">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d3c4d8e1-11c8-4876-b4b0-906e5b7a73a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c06fc0e0-1893-4e97-b465-e24f6a934e84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_085ccbba-fa65-4793-82ac-f8d599966ced">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4c27dbc-6761-4286-9c91-debd13ac59a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_11f29b11-5932-4ba4-9a4d-7295d9ded126">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d64d90c-e2bc-416e-bc3b-75cb2866b13f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7097128-535f-4435-ac2d-dc1f01b38b72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43252980-acea-46e9-a46f-0b8d923cb4fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a9bc577-2923-4546-9c2e-a28d8a2bb2d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4de6e42-ee62-432a-a8f9-311154ca4545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1e250b6-b8c0-4b8f-86af-d654b592efe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77171614-596f-4d4c-8f88-9603a8225203">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_800fb8b4-0209-40bd-9a5c-098a9d5bd46a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_599a8732-3d99-4067-b506-3fcef610c47b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b90d47e8-e306-4b82-b7de-071f8ba139a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_50413d47-3ac4-4933-8d6d-6136134d1cd1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_51ff9c76-7b34-490d-af24-56521461f98e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0a4f-8817-40ed-b729-55c92d171c5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ca5e61b-bce8-4488-9a89-a13faf616146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_07aeceff-a2da-441f-9c1f-65f5bea46ddd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60dbae27-1064-4d48-8b63-60969b90b01c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1d5b0f7-a631-4cb6-be6f-ff459dafede2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3a46f9cc-a382-49d4-a2e0-5353e7f09803">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fb1a0d9e-d78a-4f35-b1a7-4e77ea9cab61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_974090ae-7987-43d6-8dfd-965bf0b8c7b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed826093-243b-43c6-9cba-b5487b34d56b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_987874b2-d6b4-40ae-84c2-09d47aa16fe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c11374d8-1dfc-4494-8c10-8ee6e792dd41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_baca14fe-c74f-453a-88ed-bbcbd0aa5a6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10fba6d2-bc82-493b-b4fa-928668273f68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a02c16bd-ad21-47c2-a34c-c1cff1e19015">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3de5af1e-30d0-4503-b58d-b4fe3a1e084c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01c6db55-d351-46fb-9f2d-13c1de997349">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e46cfed7-5361-44e6-9ea2-0be51afe2287">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_53feaad1-74b3-4cdd-98c6-045d45061593">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c5c6689-a80f-488a-b9cc-23667dd2e923">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b2ee2f-b05b-4c5d-a1f6-addff43e7070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_745264ab-02d8-4377-971d-38e58d86f3cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_902e06e1-e0cc-408f-987e-4483dcf5a4eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_39019b70-09ba-470e-8dd8-e35080b2b090">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf0d0769-33ed-4bab-b86a-a34f6fa059d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_066fe35b-8e2d-4bdd-97e2-b66d2d6a1147">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0f32dc6-eeed-4c00-98dd-22b8191b674b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da140b84-888f-4608-8a2a-b355ff10e175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1dd52921-a7ba-4bd6-ab24-1240f2f30301">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9809db90-fa03-4ea9-a507-c327adb29ec7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_349a9ac5-71b8-442b-ad95-93d514881b07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449ad8d-0b1e-483c-a333-adadb108d264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83cf2f18-0417-4b5f-915a-a8610df259b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17901350-2daa-4c42-a4e5-3a39dd813f13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8c102c6-1217-40c3-b05f-bda872504328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b557b2a5-2259-46ca-9681-73ed8578bb64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_85c693ac-04b6-4bcc-a3bc-1a47837f5c51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12e9d7c1-ec4a-435a-9f87-af7519f81d19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c2feb87e-acf9-42af-b093-c69ca64b0282">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc64ae88-ea38-4e5e-a850-c965ad4811e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_205ce345-8ff3-4f47-97d7-0c00c0f51259">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_110d1aa8-d200-4684-8266-26b5f69ab5f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57bea695-1bcb-4abf-9a2a-a2270d257a2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b687f746-a11b-4250-9a2b-92fb615faca3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff90c538-e532-4da1-85fd-f966a3e6cfd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c9aabb45-f6be-49f5-81c3-6a6fff595b20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b10eb7dd-58cd-4846-92e3-4371938950e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbee05eb-f6ec-48ac-8f45-6e801f352b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24b4767f-a3ac-45e4-9c9e-1e6f63c13e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10f7b85d-f7a2-4346-93f3-d026b3437ae4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_120699d4-88c2-48e3-a094-737b515cb65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_47f09825-70f4-4225-9a99-167a37ed724d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d95135a6-a2f3-42f6-ac01-44e9459fea02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_32b22d72-0891-4711-b2bb-7cb89e348e00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_360c39c1-9801-4f23-858c-459a2eb08725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_298e3c2c-e3fd-4cd7-b38e-a5cc7790dd05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ce1d70e-9fdb-4110-829d-d3f0e2144b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a59ae689-2f80-4159-9641-7a9286868f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_62f6a018-d394-47f3-9f1d-66303cc80a53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7c55b814-99a0-412a-b837-150f33b099c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f280c3c-7c31-4233-8845-42d0290431dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a5f2d-17cd-4194-a8eb-ee4f3cb5b22c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2afa6c27-acaa-4d28-a6cf-3283b98c8fe5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac4c08a2-5201-4366-b7f1-d86fae43245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_308169e1-3f4a-4bec-b3ea-0ebc76d5bc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fd08ae73-ab6a-46a2-9cd7-4316852a4604">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ee5fdbd-b7db-4e3f-bdd3-b5de81dba6f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07bd6984-102c-4162-9555-858f90689d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34e5d3b4-7e84-4389-a389-b1e799c1e2f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7796b60-d57a-4401-91d9-fdbcabab4dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1fb6f240-a6c7-4597-ba87-ab70943b397e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae668ec-5d22-4cc9-aa65-749a4098cfcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13521110-8ae1-4f60-b218-5e8b75bfd923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3368d4b-4206-4671-91ea-350fba2e9039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45ddc3e8-863f-4519-8fe7-a4f746cbe9aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_20705efc-e9d4-4664-b3d0-095d62ff29d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_822fd5ed-1f12-4abc-9487-8e98657da101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_201811a2-df0c-4ff5-ac68-2956151d94c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8103baed-0e59-45ae-b521-6118cbe2da01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe1856-7c93-4b98-bee2-9dabc7b62fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_708aaaa8-e7c6-443b-8285-91504fe45b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8cc8b9c-5b5b-4b4a-8610-03d974c74739">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9a1601-96ee-495f-9f88-e5b1e439d9d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b3ae708b-6f42-425e-8dd5-00d6daadb551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c0edefe-d42e-4966-ad5a-f120620ea284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8345da91-c150-4265-922d-5308fdc44671">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6df484-0741-4f53-81e2-6e70cfd5a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67785dbe-ab63-4618-8737-6150fce2c56c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39312527-1286-4662-9cf5-c5e3cae10de6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3f499c2-f337-43b0-9b6f-5849b58eb1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4d1a84b-45c6-410c-b4c0-e74399ba3f6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35414171-4c4d-4f95-9580-9fba40cfbc2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2be79109-4947-48be-9f48-587e8cfdaf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db602221-867c-4da7-8f29-8ce8ac7dcdce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6651b16c-1772-4788-b21a-93531b87e488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6d3c05da-fa71-4424-8c56-8400c9528908">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_98dd0655-72b5-44f8-8950-70ba30e70bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd1daa5c-eefb-4712-89b0-a81967839921">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7bfef0f0-3061-4827-b75b-29bb615a2586">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7706ff68-778e-47fd-afb2-a9b19a1021df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422336f-9b82-4511-8613-997ecb41c564">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_919ef501-e345-48f4-92f6-f3f9917d961d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38d1ea1-2686-480d-a8e0-70c6f7c4a6f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb56fda5-c1ce-46dd-91ec-73fc396a6ec0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f85a3a47-79fc-408c-a671-6dae0a3fd2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2af82b02-99ad-4353-95d9-8933f1f03ed8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_90bdf796-f9f8-439e-88c4-2aed057f8728">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acb6cbec-a463-4186-816c-13d6f9e8f8f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2671dcd-4825-469d-92a4-11a7c1168e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f199ee7d-42c2-4eea-b369-8605bb280c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db969abf-2a57-4780-a11e-d100009e1c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853c07ea-f383-48c1-86f3-88e38fb111b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d74efa59-9559-467d-847f-20c752ef7a0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71f3eff0-c211-475d-bfc7-5761e3d51925">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2083790-f439-4a1a-be0b-3d40dc6bd591">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_830f9eba-407e-4c21-b958-58c1c566bdc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5c932ecc-c9fd-407f-ab7c-bc6bf6d37c42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c16a8f4c-9b2e-443f-b642-9e425306592c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_516714e5-4f88-4718-976d-98699566123e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_731906a3-3e0d-4904-9226-5bce546bf1be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6bba47d-244a-47dd-8cf5-f9ce2d619482">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c299175-5b93-4a5d-98e3-1e0d98759953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac9424f2-22d1-41ba-b520-0674ebae6a33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0bed41a7-c52e-44a9-a378-8ee6057a60c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f45c35c5-e0b7-4a4a-a7e5-065f2cc79a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92e84348-2aad-427e-8224-863e9c987476">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_42abf657-9f60-4bda-b557-ea055a58f606">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a88a858f-a4f9-4a7c-a7a1-599aa2a98bd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c82ed1a8-5ed9-463f-87e9-21df6f621661">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c754faaa-23fb-4cd8-b9f8-64a692c467e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c548e424-3e91-469d-8d41-c15924cc0735">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e79f20f-77d1-440c-9517-b03244fcb642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbdf8582-a8e4-467c-ae4f-6bc08aba7057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_352fef36-0467-4ec6-8b85-d38af06da2f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_71a7543b-d3e6-4c6b-a724-4d34681cffc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c2f7966-0719-4ede-ac47-c93bcec328ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cda62ce-a773-418a-8562-975eff37d6ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf038e04-bf8c-4655-85c0-657b65fda472">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f91ff24b-4608-42bc-8165-3845d9d89a3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c57369e1-70f0-4ab7-ab95-0ca6d1d20b00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f05307b2-779f-4931-ab27-1c812eec0e09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10cb7e56-91ea-41b4-9698-9ed591d4a610">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b54615f-86ab-42fd-a7b6-091f420c6185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159809cd-32b7-4d81-bdc3-f4521a5611dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40021451-2f6c-4c08-8206-0f9577efbc02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53df2bde-0065-4e2a-8f79-8b9887289cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da880e10-59e4-42f9-88ad-bb19fd0995df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ffb2763c-86ee-422c-ad01-19a27c2f5d95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82d50004-0240-44a0-946b-1136ce73ca33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddd3b955-2005-4764-9bb2-94f1a0b57ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1072268-4956-4f91-999b-829a5160c6a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3f6df38-eaa2-4ba8-8267-2ea812b5b730">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4808825-dec5-4d4e-a575-d6b617e60f4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a243601a-7f53-42f8-9e0c-7d3ddda35309">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8713048a-be6c-4fbe-af8a-018305cb793e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7508d369-6037-4398-a0f5-85136d240f10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_215eef72-26d5-43d5-9728-b716a6eb398b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cf45286-0bc4-4244-9187-d90880603533">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4dd81da8-8ce2-4aed-81fd-54b4ee4566ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2edf2c26-ba96-42a7-bbca-bdce425dc719">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_37451d52-ada3-4155-9718-f2cbac55ea7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bb72b3a9-db44-4120-b8d2-ceae058fc3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e20cebb-95f4-46a1-86f5-30706c326241">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c5cd262a-00eb-4b1e-aa14-af39769452f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f41b17b5-937f-41ee-9be3-6582238dfde8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e39b164c-e8d1-4120-92c2-d51ef5331858">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c794fbfb-111e-4bd4-bc4f-22539cf5a14b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_481b6412-4dd5-43ec-a4f3-fd0cceb8fbd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_75da10ab-1e91-4b8d-94a6-022e3a31020a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35b12500-941e-433a-a80e-43850be4aa09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e2e8adb4-e6ae-4d8d-b946-bc510782ffb8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f8d2d0c-a59b-43c9-9c09-0d5ab82e3b3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cf6338c-83dc-4336-a40e-396191812535">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_19c6f61e-b720-454a-a47f-7f2c51dd0de1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9de4515a-0b24-405f-9920-6beff64f39fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35fa07b6-905a-43fd-aa2c-c1b6ba8c2738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a74196-8d0c-4d96-9eff-1db74605a665">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572e87e4-428f-4ba0-8148-585a3ad489c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53cb22fe-b2b8-4b42-9c90-c46f4b52e32a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b61be02-219e-401a-84ab-137d8a522a31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49649668-8e65-46b9-a759-ed5b1c2f3475">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_12b661c8-e048-4af8-8e1b-6fcaa75e0a27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8967ed7e-f69e-49de-87c5-3e424ff043ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6c92e2ed-107b-45a8-8618-4bbe372d15af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1ff47f6-e080-4f99-bfe0-0d44e36ed6af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f13674a-e4d9-432a-931f-7e823ccf41ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_569d3c0b-1dd9-4175-afa1-b4a43a0f768c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c51731eb-388b-471e-84ab-39c64b56d1f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159e2c73-99e7-4c61-84cb-8b56e8703a78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d4a77b1-cf38-4213-9584-62d8813b8e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c3cb471-aab3-4d54-a738-d6deb20a22b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92c4d859-708f-440a-b6bc-cbbdfd0c6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8500b6e8-3687-4c94-b665-b84ee822b1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a8407c09-50cf-42be-a06a-3ffb9affbea3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9552f175-d04f-4789-94a1-8cab3ce656da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1a64602-04ae-4adf-be2e-03f2f6f8d1a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1693cc70-297a-4d11-8f9a-6da05e8afabe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b40a4b1a-6ec4-4eb0-b09e-274f28a19e10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d50ed217-8664-4101-a79c-02e1b5753702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6022dd0-29a4-4921-8b60-dc855a2794a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ea3ac4b-c6c8-4d96-b1bf-47d064be4317">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ffc5985-1458-44fd-85eb-755b32fa5b9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_32b4075c-eb28-480f-9770-c79c28617f2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26970c44-1c28-45a4-8327-f9d544822995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45ba6338-e010-4c7b-bb0c-22c9bfc0e435">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_326c6626-3a7d-4415-b9ab-8a2a4f0ada10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_388c280e-dcc7-45f3-98e1-587260e1b369">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ba14b260-4f8b-437f-9464-3aaf7d17ebd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fa746ea-521c-4ebb-ab9a-961099f261c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_333cb385-6e3d-48ae-9653-e6ca5835a27f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_609f5d51-8bad-46ea-a50d-cb2725642283">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e09087b9-1874-4158-910a-a468d445f4e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c8def7d-c9c6-469b-8115-d832ecd100e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acda9192-b001-4925-99a2-7ea65a81b267">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_178dfb1a-7c01-459e-805c-2e2046495275">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203eb441-0e19-4f62-804a-582232ecb670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e44585ef-eaea-423e-8531-d641e8826802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c6dc912-1aad-4cdd-a31e-73d43122e59a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d057d3c-d61a-41e0-9737-432b5ada155c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab849915-3e6b-4677-991d-e447a4db0f5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_041d24f9-1f82-4572-b813-ef4155a06173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23f9448d-9c57-4843-b921-aa60104ed2fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_96016276-135f-47a4-8755-188a64bb58d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27429877-cb1a-4b4b-85c7-92ae6726c79f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b39b22f8-b659-4550-9084-67aa7f7f0ffc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7fadc3a7-981a-4da8-a7eb-7085ca13e62f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_24e5c55d-e28b-45c9-a430-c9726b2914c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1043f8f9-8018-4203-8ec3-5fb793a1aa65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd347645-1c88-4697-9cc2-3e4abee5489a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a675d01-61ef-416f-9ded-1e5f734fce59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fccb783a-2f63-428c-b673-df05f116a386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23dc57ad-b8f9-462e-bb07-e2a7b879e944">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70cddb78-0926-4f3d-9f04-d0f2992a53e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_91c5b0ca-964c-4e71-85ce-3e4c34c39c62">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a330abcb-4a34-4ccd-9608-a09ca5e660d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc62a2c3-2da0-400c-98cd-1b8c3d1e1851">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_123ee6c9-8eff-4182-a6be-b14ade88b4fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b05826a5-4010-46c7-8cc1-2a4e588b911a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e52c2f08-e57b-4336-ad61-e315ddd425d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdff05a2-d002-4be8-a815-794b6a1f4025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_08cb8736-36b3-4225-997b-9e9d8b24398e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_664735e6-7c6d-4483-bb17-1b04b78187bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be1c75ee-d6ef-4c9f-a1f6-1e0f57d8aa6c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f91f072-ee1c-4484-8d13-5beacf3327b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8216652-9e1d-41ce-a916-e3087ea5b445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4569417d-00a0-413e-a233-981ee337f5ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d38f0bfa-be3d-4373-b90d-25b44a3a5da7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbab36af-ad99-42dc-a330-7631cf62d18e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_198ffc44-f46d-4f3c-9d2b-b00564f56603">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_785b252c-70a9-4f1c-bb8b-0144e0c34393">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7ee4f1cc-2ec3-487b-be5f-448ba1098364">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1dc6a8-5807-4b72-8352-aa38b7ef65c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47f462e0-6cc8-4085-b44d-a737dcfc58a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3698d996-dbcd-4ca1-a37b-ccee8e5dd75d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebf4e82b-8581-49d3-af44-466ad5ea5beb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88fc4b51-b403-4d0e-ad17-53a083adf8d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_67dc16f2-6949-47e1-b0fe-24ea05e11bed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d802a3bb-92c9-4fd2-872c-8ea459589526">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2769e0a4-1dd7-4690-a2d4-c2a4e877d6ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fbe8ded1-d7f0-4670-b721-ee137eccc9f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a07a7054-1160-4fe1-8753-18700a3178a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21084cc5-b2fb-49fd-b186-93bcf6b7cacd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0e40411-5b47-43c6-bd1f-f26ef82c761c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4322f8ba-4c64-48d6-85f7-7feb029e02ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8152d58-e869-4e34-ba72-e6a0250f09d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de2baf32-b5d9-4bbf-a286-ee7ad91c29ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d6d8c290-8ac9-4364-8e20-50201070dd1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cb3d25-f7a4-464a-9530-c0f6f2b11aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ee4ec5b-6b89-4d91-ae82-fa24d7d9e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2de64646-e09b-4942-ba68-2162bb1d979f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0945558c-d1dd-46ef-bfd3-6d0cdd75b650">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d98fdbd5-ddbe-49ce-bcfc-259d2c399282">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_da23cbf5-92fc-402d-9e75-2007112a3f65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca3b225a-2b14-4324-a2dd-00ff96571ecf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ea2d464-a933-4e76-8c57-df5e29dd0948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72dff77f-fc9f-4ef2-b366-9aed8d81046a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e461b2-8712-4afa-b271-2132865b1341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816c2a66-edc1-46f4-bd0d-4e699b823836">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2aa0739-9784-4743-814d-ad6a586a59c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_480e9cf2-a17d-453d-8f6a-013c28fcf0f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8feb73e1-4390-443c-ac47-834bde0ea038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c7e854-bf10-4c96-8f26-2ae14a703e31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e4e2100-c19c-400b-9b6f-2333e3808b98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_359a47c4-a101-430b-9db8-7408d78f8461">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76475b35-db74-44f3-abff-712442eb405a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba94349-afaa-48c8-bfee-61910d7d1d3c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3885f06d-f07b-4cad-92c4-0f8080c30303">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f69ab1b-604d-4ae4-ab51-9cd0d53c37a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5e8a806-f0b1-4bf6-9b57-929d670efd58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c338198-266d-44fd-8764-ff2a3268a067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1f7e1e82-5754-4fa6-8940-937f91087a25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8ca6df3e-0210-4e88-9620-4bee4bbe7072">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ea84499-a970-45ee-8be2-8cc9ab5dc2c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7993d16-c661-40a6-be19-d4fa0622950f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52870298-2d98-4bdf-ae81-2e477350eb87">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8389405d-9280-4803-bace-2ee38355fafa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e75b0fc3-f421-4ffc-b561-fc9ee5815972">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9128d5db-cbf5-4234-bd30-22c604210b35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a64ecd0-d2b8-4bac-beb1-bc8c8c451a4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2973b3c1-7d40-4ce0-bc30-b8bbc9245641">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a061825-baae-4496-8f93-6c3283ca85dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d662cb35-3827-44a5-a3df-576e423d7f32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b254ac83-1713-4c0c-950e-e82a7202e4d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43473fa2-f081-4f68-9b5f-69d2a75f5e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c43f06b7-fa8c-4aa1-bdd3-6e194480695e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a789d5-207a-4059-9cf4-0d8c5c0bb4a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4b8a765-2040-4572-a6e1-26c29549a549">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_865773df-833a-4310-a335-9e014d4e4d79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_abce531c-5509-4558-a719-7e01a9ac9005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1162fbcd-0df3-4aeb-b5f9-0d8fe58c55eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b22ddb30-b0d8-4a03-bed3-36ad77a3c2d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ec9d5e7-5de2-4792-9a86-03be2cb1838b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24630e95-086d-4fb7-ab52-0c8f447b4010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75e6fea8-348a-43f4-81c6-c5c1410ad595">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_825b65e2-24f7-4b23-adac-ad62053e0323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e1293a1-22ce-491f-a2f3-35e030a88667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d658fe4-38bb-4b80-89eb-d8f550a95fa2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e10d1db8-788a-44de-ba42-57edc9539967">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b554668f-bfb9-48f1-9bae-7d23e0f421ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beab0b69-1a8a-4d32-a111-6129bd8e468f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bee5c82a-500b-4921-8166-d664da1fdb2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_584dde80-3141-4bf2-99e9-cfee485d38af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df108430-9a62-4d23-ae3f-411cfbabd93a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03564f3b-c300-43ef-81d5-5f32696ca734">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0d79f3b-ad55-4f76-8d1c-e1b086da71ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20a90dba-1a5c-4f63-94a6-4bdc9a797602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6616d5e-edaa-4a8f-80c4-ee8ce85b31e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_065b6429-bfb7-4474-8500-887ec059494e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afa75dae-3ef6-4a83-95f4-1ed757b73580">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7974968-25a3-4664-bfd6-eb4e57880faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b7f411f0-e6f4-435b-a618-b1801a393d7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cacb34e5-35e0-4430-8c83-3ba4662fe7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76de976d-9edd-41e0-a14a-9c3bf5b509c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a8f004-7214-4a5b-89a8-fb99d5ed06d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dba29713-3989-41b0-89f9-a00883e9ddaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e685a6c7-06ef-4810-b74b-02c66aaa2f40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e458bc3c-51da-4496-9872-65d448af1133">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_870a57ae-f39d-45a0-9a9f-8402539c2c44">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd06f193-5870-4dd1-b594-b3e3b0ed6c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f02ee40c-f678-4ffd-b9f9-25285e43451f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d989ccb9-8582-41ba-8028-96a149e9402c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bc00a444-0894-4316-9fcb-508834ba9c38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd28ef43-261d-4dc5-afb6-8af0e9b6a2ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_142dec8c-d69e-4dc5-99a7-77ec0eb1dc03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef5f45e8-622c-49d5-a98a-71d47862d0ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b3d29cd-0a79-4315-af49-9d8c938ed76d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cc9423f-d622-43ad-bae1-77352fec565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a86fda-ad55-4b0a-b89c-2249a3d87c62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfcf9a1c-9418-4f53-b867-ecf7a735786f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b066d371-c699-42ce-aa1f-9262e331dd58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa0532a1-f44c-4447-936b-5241f29b4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cd198483-e657-460e-a753-771668b6455e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b0697f6-9428-422d-9bc5-3c95eb881ed4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b0e4433-ebd5-4af9-96da-62c2120aaccc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8cd999d-efb3-4d33-8565-1ff34a512572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e5e024a-be13-4ed4-b298-cbd85e03eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b04bbd4-394c-4fd2-a57c-5b0ce7b8328d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c82c6f0c-0683-453c-be75-9d1292c7b04a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f770f7d-f55f-40a9-b77b-2249a6771467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_add69c46-4996-4189-b8c5-496dd7f98a9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d255438d-d4f1-4e0e-b09a-ac843779dac7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4cac272-ef4d-4576-b391-284439f9c285">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58193dca-5bac-436a-9292-9ce96ba22418">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed897479-dbe9-4fde-93dc-15e7e0ff68e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_964dece9-6c0b-47df-9d43-e9b422360913">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67877821-e62a-4526-8b36-3115e852e88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29f5c6f6-b2ad-4aa7-96a1-cc8d2ff4b614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_81a13e90-2b4b-4a09-9ee2-eeafd9e00bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cab260bf-1740-4f3e-8882-f4cbba442795">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_46e90e7e-887f-4771-8caf-07f3ddf5b3e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a8e8f80-5d6c-4b17-904b-64dc2fff2262">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa77f9ed-8a3f-4d87-98ac-0a7375a86fb6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4374bc16-61ca-4b5a-9d9f-798fa48b665f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd77817-e562-4b18-928e-a519da1f2124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac14aa5b-4fde-4251-b311-33015973af60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5131569-0960-445b-8cf0-340c24986c0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6744f681-5c6f-4566-826e-524754bf8a1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4173c4e7-f582-40c2-b317-fa1d8edeb448">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cf483c45-14a3-419e-91df-689c1dffe6d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce3cebcb-219c-4426-a7b9-a174401a66c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aeb54478-bfea-4787-b466-90df885b1c33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4a408d5-2c11-49a8-b0e1-fb4e7b4545f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebfeab9-b411-4d19-a937-e3e9c4ea19ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b367e89a-724c-4a9a-a2de-a7d44de2c1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac672323-d104-419f-a71f-4ce30e297d82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_91dab2ee-b23a-4591-88be-d0020bf6ca9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_51f3b44f-e443-401d-84ae-b8e86c4b270b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4725e87-14c3-431a-814b-d7e174e12658">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_76f12467-9fe0-47f8-9c3a-79c8075d0c39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88fd8c00-aa5d-4bba-9d81-40538478b744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fdb1052-84a7-4bc2-9e00-b6c03e26adca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c8707e87-05c6-4f12-97be-5c71b626e8b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e0d1edb-a714-487e-85d0-0023872faf7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bda506a-f6b5-4f4a-b8ee-1d4957f48cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2851ba40-fad5-4db5-b45b-481d141f197f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f14bee3a-c4ad-4778-95c2-0211fc182eb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91899442-8c02-44d8-8b35-c512b257104e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4eba8816-da7b-4a57-8825-62061d59eb8a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a30fa62-5391-43eb-9ef9-81d417b7d445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55bc9730-8c40-451b-8199-cdd4170be47a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_187cb72e-9561-44b9-9624-a40a68adf40c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaf25965-83e7-470f-9207-e8729d4bd007">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003c3228-ae26-4e1e-b2ba-173885fa9f5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba63da6f-556b-47f5-9e8f-90f8b8e7fab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03e26ee9-a3fc-4c22-b0ec-5b56c9659504">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b5cbc4c-3b65-4de1-960c-20cbb7a93c23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f9f8103-498e-48dd-a025-031b7a357d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4876f051-8bdb-4900-9acd-a5ccfefc9732">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6ca903-3d8e-4566-8497-69c094b27fdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8c2d0e3-0b5f-4fa2-ae70-769bc1e229ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97528f91-9197-4833-a0ef-509553c108ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af52cd86-fb78-4aae-a5e4-899bbb32afad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_844c3edc-a332-4684-bd75-d2dfd5f3bb0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79e5c665-133a-40c0-b624-24695482f6b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6dddc74-a83d-4295-aee3-81685a166f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba1543ba-b338-437f-b377-c21d79b8f66a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0ab92b74-70d0-4546-abc9-4ebe526966fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_188dd9c9-8052-41a6-918f-dad2f04072e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c03b674c-609f-4376-8ef6-e5c8cbc8a37e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51cdcacb-8528-415e-96c6-d5ce8b2ef440">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c38b13a2-fdfe-4efe-952d-66ddf616d722">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a66aa870-a14d-4ebe-98fb-56dadc7cad89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7bfbf56-b417-4d5d-969e-2dc60af24f55">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aaa9f9d2-61a4-48c4-8b74-9f1cea3dcf19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7eb7cd9-22bc-4182-9ace-4a7283dee574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59a28b95-3bb8-45b4-a0dc-93bf57a4621a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53fd4b3d-190c-44fa-a4da-a06af831ee73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4442b941-d4d5-4ca7-bb8d-5a427f0e3821">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7ba9ee4-7854-4f0a-8527-e67110d01ca7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_83bd7a12-4fbd-4219-b9f2-8a70e5d36a69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5fcf6744-b487-434f-8a95-531fb0ebeb65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2e562797-dba0-4f5a-9c34-5bd39c9d4694">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c864bd86-d942-42e1-ab35-ac890c49f5de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ded25e34-2f5b-45bf-b847-b9f87b9de7ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_412cb19b-097c-4378-b3f3-cf5b731e677d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1b501608-150d-4e0e-a33d-403a1ddd70de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f849bf17-7777-4aac-a443-f34aef90c1c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea9a9a67-57b3-4e54-8850-9634c88b0fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07cdd920-0989-4add-afb5-de33f3e28212">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af78f809-0fca-4913-8e81-0bf6d1836582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_721fb0fa-b655-4188-9fe8-639356861427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_280c464a-a4ec-46ed-8a3b-b18e807ea7cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d578c1f8-6516-415e-a1b1-18a592ca45ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3bcafc5d-6dc8-4de5-b4d5-eb468c889fd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c1fa00fc-fedb-41f0-8a45-09c6856a38cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7289d742-f3ca-4b60-9e58-b6da7497219c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_219cf87c-2e4d-4254-ad89-9ee4bce93e99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b04a6c9b-435d-45e2-8e43-d7b159a64e6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f145836d-2f92-4563-90ff-55f68863c206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d824f3c2-f6b4-460b-8875-8e822ef5d542">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45101256-dc1d-41ee-aeef-65ef96bddfe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9e3c9fe9-71e6-4a25-b457-8fdade0cf6d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2925711a-ecfe-4584-95fa-216a76889e0e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbe15b06-0197-471d-a3bd-08a22b40e4e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_53a237e7-aee3-4680-b1e0-3204ddaa07a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e6ea76c8-471f-4d7f-afd7-df09fec29637">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19490fb3-067e-4068-bcea-4a2ee8a27fb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56d744cc-18d1-42a8-b559-be005071f72a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5540a41a-7beb-456b-ab92-d6e9bac08adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d15ece-a13a-4f72-a22c-d0df5b4d42e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa27116c-d2fd-4d60-ad61-0bba8bf76d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0570db62-851b-4096-89b3-306a830f9d08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7b243c85-0fcd-43e7-9caa-16aef19823e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a2d7e12d-d6ad-4b3a-afd5-1259bf58612d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0afde8ea-487c-4f36-8090-f72727664eef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8aa5a02d-03c8-4aea-829a-ae2aae86f897">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba870de3-4f01-4c36-a70a-836982d78be2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b712d454-cc47-4381-a23b-83696157c215">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40872517-e212-4794-ba82-e587fedd9a57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1122014a-cc7a-46e2-a3de-4b03c23b43f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d3d8bd1-1bd8-4b9b-aa6a-d3057c751e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c1fdd5a1-0341-4524-aca5-6b77f18930c2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30b48ec4-7a67-46d8-927f-f135edf85da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce183715-8db9-44a3-b4ff-c224869d4f5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a29c607-c616-4405-a680-f472693b6c02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f872969d-a939-45c4-9254-acf26f5d05b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6788a97-75e7-4609-806a-927f5ab7b097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fc04519-665e-4785-adf1-846f1bbc4bab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8c8eaa7-f1a5-49ff-b392-8eeafc898658">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f99fb43c-62c5-4639-8053-66758542a7fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b6fc7aa-035f-4630-9048-7dba8d02450b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33c4b2d1-1210-4147-b097-77dbc9bb672e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac04fce3-ee20-4127-a581-50bc78421887">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f49f8d8-32b1-4522-92d4-19c3a726e0bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5cdcb762-8802-4370-ade2-f2cb1ff713c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ee50c6a-92c6-4446-ab9d-f18863a55bcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e81b0bc8-2b54-4ea9-b9b3-1f0bbe7afbba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_859c4ebc-14bb-432d-829f-70f94d346847">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e317ddfd-c060-46a5-8279-74abf6b28979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad1e1809-32f2-4cf7-b9f4-3eae73b294c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36c4cd74-a5e8-4ae8-826d-7a82578086a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2436005-f7ba-4729-b7ce-4c62da0adf39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92d4a147-300d-4b06-85b6-741b6700f71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a706fcf4-819a-4598-96f7-c9647368a248">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6e3ad789-b748-46a5-9c80-1b60f334e802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50679c3e-cfb5-4a11-a9e1-e578f88371ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddb0e6eb-82a8-4246-b77a-2155477ebdd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fcc31e9f-277e-462f-bc16-0330cd3163af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e25f3ef4-5c5e-4546-ac7d-53ecf70aa9ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea847c13-d0be-4616-ad58-1769b7d799ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fcefe6a-7bd6-488f-8dd1-26b7e23b55a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5c51845-f008-4108-9e64-1a913591741e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3334eb38-fe2d-48f2-978c-c7088acf1e7b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8f4e9bf-7c05-46e5-accf-e021501658e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6bbc18a0-9898-4620-9dea-8a547b996fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4927304-e6d5-41d4-b669-d0ddf7d05853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5909fee3-e912-47ac-ac18-990aa009f211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b0d4c18-9941-4d4c-865c-88b1a8c0dc12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b8877ec-b6e4-4f9f-b1e5-18ea5e1b35e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_507de8fe-a640-43aa-94b3-8be6dabe22b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5d4c518-715d-4049-aac9-002f60e13bbb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_390d1cea-c5b7-49db-9a04-226290e027ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9ab11de-1ca8-476d-8c7c-7364b4bc3bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3cb7a299-166a-4ec6-98c4-21c0708e92bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_716eb523-8ac1-4154-b7da-92242b3b61ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb7a7e2-47e8-47b1-9f51-ac53838a652e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6a85b772-385e-4c24-b4c3-e16d66dc1603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb7bc05a-c1be-492f-80da-4eace7ca08cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7c5c0d1-9a22-4edd-8bdc-386f781bce15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_daba953d-958b-4002-a3d8-ee9944bfd07d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57a5e5f7-befc-4422-8f0e-26335a11c5ae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f3318d5-eccc-45de-9579-2f989e144c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96cdf652-f2ac-4e90-b56f-1cfdd4c21cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a21110ce-7fe9-4dc1-b2d3-cf4704ca6c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c94db8fe-c4a3-4178-af77-d688d8a64408">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89fe4a5c-784c-484c-8337-9768c6689f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc8b7ccf-7888-4967-aed6-eb5d343179f2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29113799-f271-4951-a18f-ac987e0e09a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7c3c200-930b-4a90-8dfa-9f839cebf79d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a464cdf-d261-4c53-a320-9be8618fa0d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24ea3acf-ec02-4609-b9e6-da4f477b7a60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ce04a2f-8e18-4bae-9267-07ade5132cb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ebfcf35-fa99-4bb7-8204-0c94fccdaff4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d6c972a-8fb2-4dbf-aa6a-ed82e0c0b3be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dccf116d-491e-4e69-9ea8-8101ad6ec043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66e91c22-b40e-4e8b-8502-27007d0accc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d2bdda8-6ba3-4fbd-acac-7a14cfd8552d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d80d39f-69f1-4dc5-946b-cc151ecda5ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12ba20-35c6-48dd-9694-bdfa799fce94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_167c8171-868d-4aea-a0ee-46d2620d07ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b888c561-d178-45ad-a230-1e5addfe2106">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c344ba5-2ccc-4a21-be2c-aeebe2b6483c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95fd436e-f77a-473c-91d7-6aa7715a985d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb51de1d-6ca3-4a05-a78b-aca3707e3fa0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b295e329-a5ba-405a-8300-6eb7751d5f42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8667e660-8674-45c6-beb5-7a8c5016497c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37a461fb-e8ae-40e8-ba2d-04176c0fc86a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_990bab29-8285-4d4f-9568-8d76adf2e329">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7615cd28-6642-4ed4-aa07-41fcf005901c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70fbecbd-a570-40b0-b924-9dee18a0033c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ceab391-9b32-40ae-a4ca-a1876f5c77d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36783286-75df-4d91-8996-b28c539c0af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25834ef0-16fb-4334-bb5d-f4573046692b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b78831ec-6458-4f71-83df-dc4911f17fe2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c8111a2-d58c-4cd6-ac92-65b5016ab9b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_049942ff-eb3c-47b7-8037-dbe0742de940">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41484357-f128-4be7-8ae7-27bdc4b86019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d612c351-c679-4e42-929d-30dabcf165ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06343fcd-f7cd-463d-9be4-e945953fd82e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e983c04-7dae-4061-9233-f5654965744b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_547bd475-13fe-483a-8458-71d3c783493c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1f1508-11df-4d70-82af-061d2ca91351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e03205d7-a924-40f9-a3de-2b83f1e37bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fb84e7-ad1f-4124-8c51-051ac93c5a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c1fa02e8-02f0-456a-b06c-ccd75879889a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9fa2e723-ed6d-4a1f-858b-423dabe74184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af9a95ae-eb9a-4491-a957-2829445d67a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2406d38e-44d5-4ed7-af86-823636e9a488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2c6b929-0196-4434-88f1-a805d4c48986">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6db42efe-97eb-43c5-bc1b-c47c564f3066">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1d6ce52-59f2-416d-a8fc-10fe7e19096c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_560bf83d-89b1-49c8-b344-48c32eaffeac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f38de7a-9d74-4d51-b1ab-5da7b960ffc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c88a1ec0-0fd6-4ba2-81e2-be367d0f4df2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca498289-9312-4a5e-8dd2-23cef664abb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9fd6394-daeb-4698-b348-275e808d6afa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86d88bbb-ea78-4904-b49f-53fd2bb4d191">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31accc74-faad-4484-b101-f73ef44a6936">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41526c5e-6b58-416e-8b3c-6424b0acb3fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11cf92b2-84a0-47fe-a195-f0e64010f8dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe7369-d00f-473d-8b0f-691d98291bb2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85c2b8e8-79c3-4ef8-8c1e-d6827a6d718c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81228225-5cb8-46cb-ae11-d29586a1e2ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d6f3a82-2659-40d8-ab95-8a2bd5fc6265">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a960f0-930e-4403-97ad-3691fb54d700">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc031930-2fef-4625-8e81-5e393e3ae979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8d28d23-305d-4634-9eab-d844d194e774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84f4f334-5f2c-4c88-8d1e-28203511eca2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd1091dc-e3a1-4166-9ec9-dc1722819f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7801660b-310a-46ec-be58-28a687126bec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a4c90d8-4c22-4948-8791-53f8ca5d4622">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27d75556-9ede-437c-b23e-d79dc1dc96ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c51a0cdb-d467-4d24-877a-7775e82b53c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_86c18cb1-3611-4361-8a20-4b8fe0384de6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15a078c8-16a6-459c-8f79-40a9ca4a6572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c4d4d990-9de9-471e-b1e4-694e37b7b9ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37502de3-cfc1-4b05-bd5b-ed9030f8f189">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4e417d1-226a-4b14-bd6d-28351e5628ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54ba944-901e-40df-840a-d23df6f7a88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d318d295-ccfd-47d3-8f1a-043d208aceab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a68248c1-14fb-4dda-b56f-e13a5aa7f527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b135ab26-112f-420d-85f0-80758a7585db">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_31101594-c7f5-45a2-ba6b-27e8f669cefb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd1b6f49-5364-40a3-bdbe-2d82edd1437b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_55cbfc96-cde3-435a-a7f9-ba18fcd0638e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b67b401a-51a7-4330-9d7c-943ffec2f6a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b749a48c-ebf1-40f5-a322-68053428edc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c4f9c0c-1a4b-442f-a4bf-406aeefcc4c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90c30a29-5734-4a13-aad2-5797a77639d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d0a545b-ea46-4ed8-a24f-40c92b051ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b81fa63a-0bc7-4b07-a18e-659a715bcc1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_762575f8-bbb2-4377-bad1-861be802222a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dbad50ed-ffe1-4f0b-b052-2d78375b5463">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e782e39-34a0-4f10-8569-f499394ff261">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1657588a-9956-4af9-ba4f-5b748460b57f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f61f229-a94e-4cfd-9fc1-0399486ffc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c221c69-bd4b-47e5-a647-7f1159e00af0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f53e5a2-d64a-4f0f-8c2a-a443eb46ca6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5a83883-e82c-4672-8b1b-1f636ef7e8e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ea96345-5a97-4a05-b4b2-310f4d0afd29">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f84a5f8-b9a7-4872-9053-b1ef88e2d05d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8819d649-f8e2-4e89-a972-a50bc9c9fcff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01cb8d57-9bad-4964-88e1-b30f590fb4c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7a1d0c9-9b78-4278-af7a-b2b1231cad51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a74a4aec-0927-4239-9575-0cb091400067">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee9adf37-e0a5-4e76-9283-7f1724ad6853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68cc2320-f052-4f83-bb13-d1f4fba57eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38c9825c-4892-4cd6-b9e0-c4adad69a028">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_210557c6-8c1e-46fa-9045-fe56f0c89153">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c1d4660-f77d-452e-8aad-55c5eb44d24f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98b17987-57ae-48d2-8676-f875506d5927">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1b979e7b-cfae-4605-b8e4-9a5fc3be5cfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37f05fac-fd02-4322-9f59-d7defa1c9c2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01df9095-b5fb-4e49-a1a5-1aeedb85f23f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08675ad1-6474-40b2-97c3-0a52b7663139">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7dca1366-a6a6-4577-bd7d-d653e9739366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_25539bb9-f941-43fd-b933-79a889e1038f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203587d3-1f66-4dce-bdbb-222273112bf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e31e4207-59a8-4219-8cd9-900e92f76717">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ba58280-2b98-4ba2-9e29-94e847ae6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64485f9e-8a5e-4388-92fa-f558d6b90e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95bbe69a-d4d6-4ab2-836a-1008b8caffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_479ea762-732a-4eb9-915c-2b88c78fabe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e835c60a-dc97-4554-9544-fcabed551f58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0c82da2-3dea-43d9-9cc1-4d39c9a43b78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_342803ad-2a21-431e-859e-5ee83a93cc91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_93c8c2ee-ca43-4e2b-84a0-2f1bfec243ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_84e84bc3-3fc5-4759-8a09-3bac5643687d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e83af75-d5fc-49f9-82f5-4dff21fbbeae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_315a215e-faf9-4824-9446-b23a5fbc46f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1822bb-61f2-41e3-9f6f-2803fb0e53f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e859328e-c8cb-48ba-81a8-c3d69072787f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bb1238d-127f-482f-b129-003cafd854cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00d4de7f-97a1-4ee1-affd-236e5ca7669a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_06cf8848-6457-458a-8535-40f3b914107a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b2a2428-1a4d-46f3-85de-fb147e11f451">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90836758-b0f5-4d95-8b21-a6c1003de8ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_feebd7e5-b054-4c98-a96b-b28c48f82243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b097aa4-01e9-4d1a-8f1e-c63c4131ad9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_771f6532-a3aa-43ac-b1ce-0882c959f109">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acbc514-341a-4d18-ac85-8e4cfe2f382b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea41c901-8756-447c-bf4d-2d335b26ca9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77fa6aae-4ad7-4b72-b051-e6f28d5b142e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_76d4e8f2-3f11-44e1-9f63-8c2be3ec5162">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99da10c6-16c3-4dbd-99d6-83f1e0842025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd575cc-c1f8-4bdc-a62f-ef6220a31456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72cc6651-81f7-46ef-b37c-7fc46aec73e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62b9e7fb-d6f3-49ac-9a42-d77ee831eee9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07aa0735-959a-42b2-b4f3-6074067aafec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ae60514-69c6-4288-8e65-a598a25c9c90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3cf6bc3a-337d-4393-9090-f9060f0eb182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_129bf6e2-5b6b-4bfc-87e2-fe9b5212a467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80972da9-13cc-4b7f-9e1e-6343fa94224d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5316a4bf-19be-49e9-98e9-e7509b4a2a23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45e90f13-81c0-49fa-8677-5b58fa5ffd80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2234ba5-52c8-40a2-acd4-9a57460b3d57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4427f2f-4949-4d59-a3e0-79721efd6e71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e599f57-e8ba-4a78-a8de-93389bc0e6e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c931db7-c9c1-4d7c-8659-a78594c06d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3edbfddb-96c5-4997-a24f-d7a1006a01f0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5406d33f-9fca-4c3f-b933-88d01f6f3bad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7b8d64a-03f2-47cb-a62b-4f6a877e7f7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38ab5d22-589a-4032-863f-ba589156bbf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af8788c6-83ab-4c1a-b888-97f10d25ae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df6de0f5-def4-4f68-a871-8ad85b2376a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0020cf33-6189-424f-ada2-6c74c3ef22c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e3b7333-bcb7-4fdb-bda2-0947a573ea26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7602d239-dfe6-41fa-b6af-2ef200468081">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ca892ebc-e51d-46dd-95dc-a78a20f8626e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7438269e-b295-4183-9b94-7417d16c8b14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d382ea-800f-4f9d-80c3-8bef6e8a5dc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7085f2a2-88d6-43f3-b486-d8fee1e75218">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99134582-5a8c-4bcc-bebf-da4676e7a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7133333-4a33-46f6-aca2-bc7c432aa30a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f47a5586-ebe9-41b1-9844-44ed52052550">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_724e7034-65d0-4d26-995d-2cc45736495e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10ff5cf5-d7d1-439a-848d-788d77dbd40a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5b8f1c43-e90c-4587-8669-bf331953a643">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d35a277-c55f-4836-b36c-14fcb66f8f77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_593d0b12-0c6f-46f3-a675-5bc320b23e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c8577d7-eab5-453a-b5ec-3e88c1f69a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01fb6448-cd88-4c99-a93a-ce66fdf0b9ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a1e5cb-d60d-49bd-94b5-ae5ed77d95e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fead62ca-3226-4feb-94aa-7ef14946dabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bcb2d8c8-abb4-4b80-9e8c-4fc8d169dc6d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef66a335-fc26-4701-9790-79f6dd980150">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe0d6475-e165-45c0-8a0a-def79cf38182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0f65e91-5055-49e6-bcf6-9f607dd0ffa2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8fd01294-d5fb-4478-aab0-0c6b11eb195f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e7791f3-2f85-4c7c-87fe-f530bc9c34b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_055f6a1c-d9c4-4ec7-b72d-c385976c9b2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5adae9e3-7054-455b-8e44-93c55e875bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_717e37b0-3fcb-4c83-8c61-6f3bb9b305da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4490fe16-8b5a-4687-a603-3873c45cfb86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abc18a4c-d871-4631-a190-ec032f93d5df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74fca12b-d271-4fbc-82ff-70cf20e508a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d4a0b0-a444-4a06-8929-ae495a0f2399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59f4b07a-765a-4139-ab24-2040c49e6fef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1a3d91f-fcd8-45d9-9068-17367aabe864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aa8d0b3-7c00-4d3a-bc74-c2b2e6b93bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da927dcc-2cf1-405f-80d4-f7dd92117518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_66f28d02-03ca-4604-bfb5-31ab54d621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7848a48-ec4c-4aef-88d9-a75acc3eb65e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0f4a0f9-4c5d-4893-98c2-19b42e6ec40d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea7cda5f-7955-441d-a706-62050000be98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d4de290-a5a6-4525-888c-67cb8386065a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_658c5fbc-8d6d-40aa-a7a5-a2c5101bdb02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13119acb-18fa-4ac9-9d96-0a98c69b66e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e3c1c910-6fec-48e6-a071-f1bc05bff568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43709e36-106a-4bf0-94a0-67e433f9d58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_29d86cfe-511b-4b0e-886f-d808af28ac00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_58ce1bb1-e8fb-44c8-ba47-2325967e7140">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b67afef-e077-4f0c-8754-e862f2be799e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca6d3234-c045-4487-a1f2-023eda3c6b48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13db0e89-518f-422c-8ee0-bebcda57c914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37085430-1118-460f-86d8-a58274c29368">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6cb1b71-d49d-4b44-a7ee-8f8379ca6c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b876ab67-4bdd-45bd-a5b8-02c3b9e6492f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0975e90-01cf-440f-ab2c-1cbda073793e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c2797fb1-b15d-492c-a86f-900dc054eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c15a8b9c-87c5-4765-a698-bd3a743ea0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e900d4f0-88a0-4f10-b450-ecc7289fe172">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2fa583a9-e27a-445f-b11a-3cf60a6c096a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62b2ccb4-0d9c-4592-b19d-d21ac06c6bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9343a5e6-3fff-4379-b4b2-88ac2b9d5e30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fd34c6da-f9b4-4edb-abbb-229e9c0e6507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4576d17-b9dd-481e-a99a-9b2e86fe2c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5659175d-91c4-4e77-b2e3-de41cfee7a61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_88f90584-8048-4836-aed8-557a1be25574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4425d538-82c3-45f4-a79f-468ce22b1277">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c15e468-811f-493c-8431-c78323ee7261">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ef86e14-8dd5-4f53-b834-3693fd04025d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41a92499-948f-42e0-99d4-4c81b1763be6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aceea622-96cc-4cc0-a4ef-c0985a14aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef55c6e2-1559-4898-ae94-bf5aec5eee35">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c1066bc-6435-4370-adbf-6e5e9dca8a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b46e9d4f-f807-442d-b48e-25f59c33a0fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7a197074-f6dd-496d-98d8-ece105892059">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_afdda05b-9fda-4c5e-b67f-5a8835a9f019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6c15186-72d3-4946-a857-f709eddf838f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b63e438-cf9f-4456-a2e4-1d1600bc4943">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99c5da9f-56a9-4126-8ec8-27c0ffa69c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a721d8e-f3b7-4d26-8044-ff5e90d0cd32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd52bbb8-eb82-4bb2-8c14-37ae895d7f14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_021c9ae9-3d30-4a67-aa98-7c86f9f2669f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4db08985-bfd7-4f60-ae09-e3044e1143c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dd33081-800e-46fd-ab6d-3688e6d05155">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5d4dc3e3-1d65-421d-9995-ae5fe9b9ae99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_12e40f94-2cdc-4991-8c72-28352ab765ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b26843e-a219-44a3-8b10-e755dd65cc50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2b84dd51-5672-4c25-9b6c-eda83c8e6aef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8dce3f98-5a3f-47b6-8671-6264edb60f38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eef57a7f-1b38-43a9-a2a1-88d1d43c41ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2e8d3533-e650-41e8-ba9b-36b5ec94aadc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4957a875-6ba5-46ca-9ebc-5842f66e92f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b51b1dc-b52b-4d98-ae80-713d27ba53bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_571fbb8c-c22f-464a-a009-75887e5265cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f02a089b-51ec-46fe-ae11-2aab8b340bd4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b9574069-9cdb-498c-80b6-bacf8e33d6d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f67e88-6aa3-4155-953d-51300aefea7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54015ba-0d13-4c36-861e-13d092f9307d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4190d3e0-bea8-4b68-a705-a1359a5b8022">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97917706-3686-4103-bed3-0588a7169e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7536f1d-7c3f-45d7-8a79-842bf0992eec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61ef9abc-a0f9-4c1d-ad7d-cc9d81ca9b68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dba72ef-c7a8-4f5a-9b83-2d8dccecea7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aff8a4f6-0ddc-49cc-b04f-492336fb78ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7a42f18-f442-49bd-809f-5af6909a5bb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f11a1291-627d-47f6-8d13-d122d2907fa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a7027d7-d811-4bbb-9fbd-ea325624dac3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c354d477-f0f6-491b-af74-faf74282d996">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a1d8cdf-7ea7-4554-ac6b-d7755614ea93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b906ef20-f829-41ea-a58b-bee609b03812">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab799eb1-046f-4efa-a790-46f648e33aab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c44198e5-abbc-49d9-9b4e-8d5c545425fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5728316b-1343-42ef-a0dc-2582ddfce4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01957b23-1950-4ef7-9f12-e88028223835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aaf9837e-648a-4328-a7f2-1e524528ec4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2a8261e-43de-421d-a8cf-d18e51356b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_745a62ff-fa7b-415e-a80d-58499bd979a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfd66150-92b7-4637-96a1-10bf16bad932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19709704-48f5-4360-b6bc-454dabb4a91a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc0bebe2-35b8-4d32-a5dd-c866e110519d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ade4e44-a1a3-47c7-96f7-58ef549c8881">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ce1137e-97af-4f0c-8e97-d8362f9a6681">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_704bca7a-a16b-44af-a3cd-63ef88281c92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_771f698d-78d2-45f4-be66-2d71d49dab8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f86c5a9c-3aaa-4913-8c02-8ad29f83cda3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0371a00-0b14-46f1-b09c-25eefe811e0a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b541a7b-677b-4452-ba63-04630664276d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28cd2978-aafe-4b1d-a72b-800c2057fc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9114bea2-7789-40e9-b181-5c37526bff09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46d738cb-d6df-44ea-b946-4d780d06ceb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_625e468b-920d-4c28-805b-434508aafc60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f76818f-5a86-44b6-9f8e-2fa8425cf4ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c00a6123-f67a-4394-b0a2-9703b6fe7c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46a60d8c-5ee6-4b88-9d77-bf14dbd42e13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_842f35d2-8bc4-422e-9c6f-482c3319c75e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_223736f3-2dd8-400a-ae21-23490dceb5a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e7184e6-b0eb-4071-8f5b-ce9d3575ebd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d990be00-2c1a-4878-91fe-9d411db99e7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14de64f5-2498-4d4a-93fd-07ddc4faf4da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_248960f7-2bb3-4e4d-8ef5-9e4b5256e242">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc787984-7965-4911-874d-63951b71c9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_beef0f3c-1063-47c8-8c01-980f9d0ace04">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_efefc590-7ccf-4e2a-b1eb-29ce71bac7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2851c207-d0f0-4afa-8459-93e67ab046b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc647ca6-b570-44c6-9a95-9017a0d9a6c1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f69a138-dd10-4d1a-b4fb-bdaebbdf6bb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb12c256-e1e0-40f4-8409-f632dd91a567">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_197813ee-99dd-4dd7-8c7d-953125010823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad326602-7990-4820-b11e-d30fe8712f1e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c7f1716-7a9a-41f1-bbe3-a0c786036aee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e5e210cb-1713-4b5c-ba13-a23753fc6357">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6947b0e4-2183-40fc-bc41-71fb9826a566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ed6be82-6f0e-4e3a-9290-5440ac0e3210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f2ef388-bb24-45de-ad9e-e1d81b0a70e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d34ee87b-12ea-4264-be1d-77523cba6664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96509c69-be8a-41c3-aecd-cfe5a78a347d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fc8b50-beba-4f1b-9b37-44be779b4008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d93a35c6-2778-4e43-ab3a-949e0ba70465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5812071d-a8e9-43ca-8ccc-b51bad61713c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b8883d7-bfd7-440c-8b70-b542def33958">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7f4e2cc7-9c7e-4591-b673-e15674599f33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_69312939-c515-43c2-9907-6f7a9b4c2844">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5feef99d-86e6-42dc-9c15-685a70a1f1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88aa5ed7-9987-4bde-ba31-fb3b30f70285">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c18d4158-7fc8-4153-ae44-3b69c9326167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb77820f-64bd-4d5a-8a1a-a712fd8c3dd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8185f40d-99c0-494a-8fb6-1c2c1e36d884">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d843d9d-ad4a-4ceb-9ffb-1f9b8b2a892d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2ac50ab-cc63-4365-8bc8-5a0a2ec32143">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70091785-81cb-45d4-a120-97a3784b6f40">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f82c11fe-c49c-4676-98df-a97998557859">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b24f203-4333-4e3b-a822-f022244e1d92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cde6c0e-e554-4167-b71f-62b67afc85cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4e1a8fe-b9e8-42da-acd6-6ccec8014bb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e045e99-8d68-4ed8-9391-4309be949fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52120d04-2b1b-47b1-9581-72ba5a43d32e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c5d7ca3-84b6-4bf3-8e80-a725069ff9fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_877e8141-40e2-4022-81d0-7ca6b91fcfb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a36a24-459e-4f26-ba5f-5da5af49a4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_eca88a11-bf8b-4a75-ade9-2de5bea4877c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d827f489-f33e-4019-87af-4414e8baf08b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff3ff395-0043-4d1b-b7be-f7a978500713">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74b2a3b7-700d-4d2d-a24b-de95f780984f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d3b9648-41fd-46c5-a65e-4770c2379091">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38bd0277-d889-46cc-a57f-4dce84db3179">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac35b9f6-9769-4ea2-b7b7-a39fa5afe1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6487111-119f-4c04-b03a-4f358ad555ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a3956a79-3d90-444e-b18b-babe0a24c7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0886d513-eb42-4bfe-a1d1-91dd552d985f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3ef6f07-77db-4073-9b75-8c884a8227b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fe67305-2b8c-4275-b395-ab7968cd0272">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ad26464-ac9c-4a4d-9367-9adb3cc20cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac0b47a3-728f-4a27-8c82-47187058245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ae765c-598e-4e7a-a7e8-7ec76be26ff0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14440212-9e9c-4a98-ae20-bd02c0389b11">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b558016f-c443-4453-a846-56cb92195255">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9f1df3e-d035-4107-8c1a-ae630c1dd0b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6891853-d085-4539-87e5-a3b8c0a18445">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74abf6b5-ec41-47bc-bcd7-ead4aa9b4d4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a024617b-feac-4a5b-a1c7-5ceec0238f98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_053ae80c-2f62-4b2b-87ae-759d2bbafe48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_72caf4ce-0392-4a83-b9ef-66c1bf18cd42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_618b6fb8-cf30-49ec-98a0-16a816909cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6869cbe8-5336-4075-850d-5689210ea8b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5efa4008-dc17-4aec-8c9c-d3d19f2be5cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71b4a9b6-82e0-4375-805b-2116c6402f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4698229d-cd6e-4c86-8cca-e6d2005f3fa8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f83db32-bf0c-4cae-b788-13c0365c7c20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a97f14b-bc34-47b2-8772-22c5879d1cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1fdfb51f-2996-4790-b046-72e240d1e0ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f253934-45a9-4b3e-ab30-7e2ce8327ed1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_132e5e39-3f2f-418d-b826-1376ee0c715a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2db62614-6569-4e78-94a3-0006780692ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e3da9b20-f585-4c9c-93e5-14c19f2b6399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dffd3c04-567a-483b-bd21-95a2c659040a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f622f73b-4f50-45e7-a314-dd7abc1fbf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fafe1dfc-054b-4ed7-91ee-8d379326eec6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_835c90d6-b524-4dfc-baa2-91154554bb3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af61f0bd-2d4f-41a5-8108-5d6bbb9ceac5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62aee4c7-b396-4790-a96b-58735a58099e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8543a6eb-0473-4bcb-8ab0-59ba2fc58b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13c4e177-274f-4c6c-8a54-1666fa02f5cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b4f2a4b5-de1b-46e6-9caf-819d0d5f7756">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec6c71c-fbd3-47b3-a7df-259f8fcf18fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9cf81c-329a-40a9-b846-02b92c38b584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45d1f6db-a578-4885-86c4-fff085855ffd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60d8d59-4416-4646-a1cc-0f85a3ac109f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_63c4a7de-7676-4226-901b-6e8a9e63491b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27f1ae3b-e45d-4997-9a2f-af8fccfc9c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ede0ad83-2917-45a9-a53d-17dbf251a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2d6aa302-62c8-40ae-b6d7-4872d0a2c81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9187f8f4-cb9f-4497-954c-4e9470855a9a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b023345-3d98-4426-8967-f6be81e1828d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ae07a8e-253a-45de-a576-a70bd5668d58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1d3ead1-3f0f-40ee-943f-f1dee312b0a3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3b3ede6-1f39-4cf6-8970-363427783803">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e58009b8-1f83-4974-83fa-f2044fb95808">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5022d2fa-b3fb-4a51-9b0e-65566f9d8473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddad94f4-3682-4c83-839b-0aae8dde7bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be420f6b-ced7-44a1-ae07-7c136bfb1e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e65535d4-bfcd-41b3-96dd-2a50f50ab590">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5f92fe6e-b0e2-41ee-a046-28611580b915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87635d3c-7a14-4f8c-952e-6ee385bb6d83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4052ff8-e2da-4b60-b80c-c68fc1a60619">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ed5519f6-7ead-4c66-bd34-fb76ff46cafc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ceea3926-ece0-4b7f-a7d9-909e150d3d84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_29c7f86f-dcfa-4ff4-bce0-b1d88b129da2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_32467b45-4242-40f6-ae90-399a071e765c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c229d207-3189-4df5-85e1-37b21b353674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34394c63-2e6d-4553-ade0-bf94a78e4382">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f84f5c00-f7e2-404f-b646-fbab051c5d78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6d3aa49-e3d2-46b1-8d53-3f1f75e8aa4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d8d3d57-7ca8-4460-b92e-0970be0092aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f792f6d0-fe8a-4439-9e46-e461869601cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52b96eec-0446-40bc-818e-dc037aca27d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b92b26-84f9-428c-b42e-767cde1ee485">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c1572f8-54e9-4f58-b58e-4be8dcb49b80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddc2ea92-8895-4269-9512-fe42270e9a5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6904c68-be16-4784-a554-5e37a8906992">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_893b7d03-19c8-47d2-898d-eacffd52b8c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1285083e-4048-4afa-a315-b3cb3fd4781c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4ffcd89-c4be-4992-88b2-db12df2fc476">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a862cbfd-9088-49a4-a91a-4e32c22e9e43">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d015a1-51d9-46ff-aba2-2a10b7abc94d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b88e545f-683d-454e-bf38-a4b4a11c66e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df0b8e73-382d-4260-9489-8114c52cb9f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0d88a48-c7e1-46d7-a314-85c4f870919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f95ea0c-7967-4cc2-88dd-62ba25802230">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0cca45f1-e599-4046-bca2-f221f2fd0d69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7df41223-5692-4dbc-a02c-d0d7c1576298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1bcd4be-f73b-4aa8-9b0a-7514c7c50bc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e93dd0e3-db03-4ae7-bb2a-30ea502339da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_145e4229-0762-4f9e-95cb-fed99ad79e9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e360b1-fd0c-4c11-bbe3-c543d1af1a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_513d4e03-731e-4486-853e-49ec395312a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45a4646a-3dda-4a59-855a-ecd1fb44263f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_08aeec0c-32d0-40db-82e8-cff84194afd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b59d6e2-48d0-44d8-9a67-0106c94f0142">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45aee435-3966-4bd7-a2df-ccc5ed886045">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_20f86f62-6dcb-4b55-94fb-3f3e6de5521a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad48cbcc-0af7-4f32-9433-2fcbad64670b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_27ac5033-50ba-4225-9d50-ef7282186c0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74c4fed9-ccd6-4a23-abbe-a8d0d429460a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca797025-3a0e-46c3-92bb-00c36c229c63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed8e5966-f137-439f-aa01-b1cc7d49e74b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33b677a7-46fc-43c4-85ea-ad1351da9c4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2070290-3e27-42f5-80f9-8f6035aeb75c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cc431a-3e19-4339-851c-f5b1c6f85d36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9878ef4a-3f92-4c4f-8b67-6eaca87fc58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1163857-e5df-4f81-adb5-de5b3f4b13b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d94d4a5-e15b-4126-b4f1-c774996c1587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6f592ab-96ec-44c9-8837-3fa9668144a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94e72f33-d0b1-45eb-b58c-abc95358f80e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8cf22fc6-6d20-4aa0-81f0-3f34586cde7e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ff9c845-5984-4ddf-83c5-cb948ea978dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9cb09ce-880f-44da-8356-5e62c28e9556">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87db2dcf-7381-4bd1-af56-900c29170284">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d0c504a0-1dc1-4a84-a77c-dd4356d9c45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62836935-2777-43a9-b6b1-2d8ce915e99b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_301306f5-441d-42c4-a85b-b4dd619b1d54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d98d033-219a-4647-8ef3-214a241ceba0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_649ff81e-a994-439c-a3e1-79ca4b97f467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ee3600e-761d-444e-a54c-3b231bf6b0c6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_651d7211-bcfb-47c6-a62e-546f97cbdf31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d660b3a2-36f4-46af-965e-9ccf63921b99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06ef8f5f-ced4-44b1-89fe-636fde5295f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de006bd6-6239-4d9b-b431-975fc883ef69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2409fcc-0d8a-491c-a8ad-caf94d44c866">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8953b98f-b6ac-4fd9-b382-280dd9f83848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51c81d09-778d-4eb7-a792-b13cd11990e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_030fd25e-8a7c-4067-956b-95de2e43ca1b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eea0f6ae-4a78-41b2-8fc1-9b24e9bb1b2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_799401b5-7bad-4628-936c-272a47afe701">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b30e5c53-c685-4975-9ff7-395f24f94933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfdcd1a6-2100-459f-801d-cffdecc34978">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ac17236-8641-4330-acc4-a3546fa3be0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c2b5717d-14ab-4735-84c7-f08eec3c5151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92093091-9def-4b01-a1f4-97281f352dd7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_457739f8-564c-4260-a9b3-6e7ab51f19a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_29f45a6a-1c54-4cf0-82c7-18f8a94aa832">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b59ca157-0966-4c44-b922-2203edb1b072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12b76adb-53b7-4746-81e9-b6b66f3b395c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677cf6a1-0bef-416f-97a0-cfae59065c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e11c9d8-c96d-45de-bf98-be3f0191af7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b085e19-fd8b-4a19-8ef7-75a2a1b340e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_14b9ba51-ca52-4687-8618-aa9a4680a7fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3f25543-e935-456b-bc76-6fa1074135df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_09448cec-6754-4734-a17f-dfad905c44a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a3baf0e-2dbf-411b-b020-a2de9b0020df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_547408ac-ad5a-4f0c-b307-254a70440a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5862bea5-3fec-4d62-8c22-91f359b85c16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb76ec3-366c-44c5-8d38-728ed54ff389">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a8ab2f4-2478-432f-8c9e-8f2cb5f5d630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82e14c8-843c-4eb1-9432-72391eabdc02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03284608-2cac-46a1-9ff5-fe40d306eec9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc5b8041-f904-4ed5-8244-e97962a5caac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9489f62f-c3ab-4790-8054-ad01c5b0d5e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ecef8e03-2ae5-4c33-ace4-eb88a1ddd005">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_063f483b-b293-4c29-bd55-d372d3f4a341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17042f33-0046-48aa-ad84-d9efbde7078e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395a61b8-006a-4196-bb79-5cb27b25eab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9239f57a-e9c5-4fad-89a4-b8ea2bb28e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fcfd5cfc-f4e9-4a3c-acf7-ca2702751185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff76a3ee-bcfb-4db4-9bb2-974d6c21c42a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00e7942a-8a44-4f31-b35b-6c88bd506e89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72e10721-4709-4f0d-b005-2572bb18c770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2362f3c-d255-4610-958d-0e10053bc77c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f7c9d871-1586-4d82-bacf-c192bc284e34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145bc878-e3d0-4a68-999f-86ea26ae1990">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea6d0cf2-bf23-43f7-8409-991f9ae05b48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_337e83fa-bd65-4743-8321-42b10816e5fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676e07d5-62ab-4f73-8081-8f032b081774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f58dafd0-b948-4a63-bdc5-4ede3acb6afd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5afccff9-daca-4c68-8816-fb0044885a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7134e652-abe4-43ba-a026-b7e9d691a8ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3f60a0e0-4a65-44b0-ac9a-ecaaff0568f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d79d96-ba63-41a9-9ce0-85a38c48b050">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f14d84b1-2685-4ccc-a131-7dc23a20cad0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08e585b5-f18b-48b8-890e-b58b94cbf885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b9bf5836-6dbc-41ff-9ff1-0d01024ba9be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_52ec1e35-44c6-4fcd-a770-aa08f88d7795">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4dfb00b6-e3bb-424a-8e2a-3dc0e75138b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27b64a1b-ef39-463d-9343-1468c0720811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_992ca25e-c4db-43d8-8de3-7d4236242e8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7ecc7d69-bfd5-4fb5-8431-2b10b70edd88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4ea322a-da37-4bd3-b3f6-0e78ff502bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c40abacc-9e8b-489d-8671-de0b37aa8636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7a85746b-e339-4d05-972e-ff0e3eac549f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef89fef9-47bd-4286-b6ea-a99a281f039a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c24582-f9d5-4bbf-b7d6-b61f103a44fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_efed0d03-d7cc-4f26-8ea0-45848fe13aa9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_967d5338-3df4-486c-afa3-b5e88ac715d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd19b3b6-f6d1-45a4-8dc4-0fae74d2c3a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e919a839-3083-4a1c-b235-9336097753f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7fe68b1-6ed0-4ca7-9ade-c169c8374eed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14085fc9-b39f-419e-83e5-e2cab1d55160">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c821c5d-c3f3-4c50-b6db-ac35e16b97c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ce0efe1-62bb-4a5e-9733-f1cbdf080af5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3d8e9855-b1b8-40ef-ab65-b3c547a83cba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e308ac0-5c77-4bc6-a8b5-5ec33f548691">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d75db8c-3edc-4746-bc88-43066fc4ceb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6db6bdf1-075a-4fe6-9fde-b9591bc20d23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29fdda51-879b-4420-9d67-a14259902e2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bcae2b91-06e3-4f90-a51c-142614f8d6ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b539dc50-2b2d-42cc-af9e-8edcec28839c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3210626d-f10a-4215-a19c-6e68ee613be0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05e16d9e-15b8-449a-9037-b399ae6087a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c629896-e4df-4b62-bc96-f1258ec5c947">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f6e0ab3-52d0-46dc-b58e-93c5f22bd0f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_265e5d25-3027-4f0a-8a18-975067551770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26a6c4f6-6c52-4721-82b6-3c78f69b0ee4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d317588e-e08f-4292-8aef-6be6170c335b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ace3fb1-ff34-4a2e-bef3-e579c91380f0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cfa32d7-a521-4c3d-bb3c-265306a0320d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_272e6f11-15a5-4195-8a44-ecb091d1500d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b5baf11-9a74-40d5-900b-7352ec34da1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a85f927c-7844-4f5e-9391-108fa014f96e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d281e9c5-8246-4cd1-b81e-e8ff1b538a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab98a3b9-d124-440c-9f3d-4a4884dfb95d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f451588-ac24-4bbf-b20e-8cb3da0f0c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e441009-4aca-4646-b423-3b43c9fa7d68">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a281b9f5-89f0-4a22-8d46-b194d9bb411b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be3aced-f45f-4110-b799-7588f844f08e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d38dadbb-5707-41a9-b85e-66dc8b70f583">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d937e822-cd68-4dcf-8832-87c36ed4c7cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d492ddf4-a60e-4fb6-abe4-821fd2501932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca7cfc2c-1aa8-48c8-85ad-b0a1ac53495f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5bee6c3-edef-487c-abc4-66038a4fc79a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43e6fa8b-1193-43d7-9292-dd54a91e29e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f692ed1-d190-466a-b31d-138e71b9d2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ee620ab6-e452-4ca0-9e44-9133cd745cb4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b68fda8f-bd7b-4a4c-8983-fa5e733d294e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f51bca0-95ce-4cdf-baab-e02610175e71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1f96919-4686-42c5-b11d-80413fbf695c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1175e53-6cca-43ef-9550-4f088dfd2c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44975eb4-b7c7-4098-bf5d-076229b9598a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59fb8ddf-dbac-416d-b576-ff27c78f97ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3425cd4c-f477-4c35-9414-a074fcda03b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dbb3127d-13b6-4b18-a82d-429d7a661cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff1b53e1-3ba7-4331-b32a-431fcbe569c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48d3cfe4-1850-45cf-a38f-2463e84bbf4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_132a6e57-05b7-40f7-936d-8ad215faa067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec22b841-2d09-4c40-9094-2910f9d18f47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69dee46-8d4d-4321-bfb5-695e8cafc361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784648ac-b7c7-45b9-8b04-cd52657911de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16a4890e-2299-43aa-85aa-60d568a6f55b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c85bb9e-b82c-4148-9151-33ae459b1ea5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_31d058e1-7999-4900-8304-e699855178b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f055a8-4a29-4f1d-afe4-0a6255d8fbef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bd353fe8-a348-4ac3-93ae-173919e4b699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b0262344-289d-4b5c-89fe-a2ed32b4ca12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6ea1e1a-dbe8-4939-b05c-809b216ad452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02aa59e2-99d3-4957-b768-41f796d55d31">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b1c55cf-a01c-4f0c-a008-0f4c3f91f1b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6611048-9b76-4265-b03c-75500718c097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9024f22-f8e8-447b-875b-4ca9b01d799b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e3ba0a3-59cf-4d02-8c5d-e5a6846a0eb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fad1e6b7-5f14-4853-a74b-6677b5c0719e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6b142fa1-1890-4e15-9044-a1c3910f6538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27c3357b-8a1b-4130-bad2-fc753b66ec3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a94aefe0-21b4-462d-aff6-7aa79d6af0ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_255ca98c-c55c-4369-8358-031e6aae3279">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b627ac26-6fab-4f5b-b08a-f0bc8281227a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dfeaa24-c478-40bb-aacb-337c3ba958c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_533a0fb7-2cac-45af-b21b-6bc5e424689e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7e3c55c3-c306-4bad-86dd-f8cd84a7adac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8010fb5a-ccd3-46e8-bf62-76ddb2c39d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20c7a56a-a0b5-42fc-b168-b4256f98459d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d7307f8f-a895-4152-9146-3dff1dae3a45">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a42b677d-a545-4739-ab21-0906bc5547bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fb41ff7-7704-473d-a4d0-051663aaa078">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c26a2a3-27ed-4b94-83cd-17e4c607df1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_343e6a5b-fbe6-4747-8c53-1eb52d084263">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a640bd3f-ea54-40dc-a069-ae10b7b98e8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b63f3186-9667-4c33-871a-7e97ca96d072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0d68b555-1b95-423b-821a-2d321b2e53af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_090e9885-ef0d-40e5-abb6-e43fb1b8f24a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9fb9ad9-e629-46b4-850b-445a76ca39cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0acb4c9e-f5c0-4ab1-b811-10d8c74c7e95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a54a35ca-7b80-4008-af79-e44cca11d323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dc30822-bc18-4884-bc98-f167564638bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebd0ef2a-c759-42e5-bd7b-6bedcf57e560">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0b2aa62-3d71-41fc-a067-bcdaf1bdb2ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d02435-6273-4736-8568-3ac72f70d876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9365ce5d-c4b7-46f5-b929-259b1c0acd25">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dd5b60f-7c8e-4cdb-8e48-e1f8e14d54b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c854969b-0dc0-4d52-8549-20b433c77a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2dff895c-7df3-43b1-9d6f-371d946ceb94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a85cbe00-e62d-4fdc-a20f-7a5f3429f811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7e9c7d6-aaae-4c63-80a4-c463d4186c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1550bc6d-0c38-4f43-8aa5-d2ee7fb75810">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e269512-714c-4f4b-bea4-0ec09ad3c5c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_108759a7-92be-4837-a459-530d3d469d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3f15ee8-97f9-484c-bd1e-5497a0d3695a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_581aafca-3016-492f-a1f6-1dccbe761b20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eecb8405-190d-4db7-87d2-c00a985010b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a166efd4-dc5d-4c8c-b621-be5ae04ee995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_658e17f5-93f0-4cd9-a55f-bee355ab6427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97265ab7-cedf-49ee-a787-73b89c0bea8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cff70ad0-2745-4c83-92b0-9d2674884e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8144362d-e099-434f-98e0-5c5956d76c50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ecd98a2f-c81b-4ba8-80dd-c5e870ae5a8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b462b4-2e7e-4314-b5c7-a982f303dde4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf6cbd2f-5987-4ebc-b776-19232cd670d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2149a1d5-743e-4433-b55d-4ea03cb9d96d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b0bee1d-f5c8-41f8-a196-e0055949116f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d516a33-6095-49c5-91b1-7897d6d4af68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34608c0b-a18b-441e-9131-bd56073e45d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd94ebd3-d19e-4a18-9765-6701c33c17b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2166479e-4319-434c-b484-21ef1be759eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0101d57-44da-4395-9bc3-ec5770bb993f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5eecedbf-d6e1-4a37-afb2-ca148b34a874">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b353f73-ab00-437f-a2d4-9eb81e2b9298">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1e1fb9d-607d-4053-9be3-c699b18bb749">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c9559fff-bf85-4c78-b609-8673ac1ac5b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e8b6bc49-dcc6-451a-a59a-bbb38cbe4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_62ecfa5d-20ad-4605-951f-1b1ee85fc9cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2dcdd11f-f143-4f62-bac3-2648ed438d44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72933c8a-6d75-4fd6-a111-3912cdca4993">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5707f101-1574-4ac9-b315-76e8d0bdea8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fc51695-79d7-447d-b7d0-2d441a615dbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6eac4e6-904b-49e5-8643-fa10dde8dee3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6367f18b-da16-451f-9398-4dcae9461dfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d2353b1-df8a-4d93-aca0-e4755108539b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_62bf7bf9-411d-4e21-b3a9-598f88e52265">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71909016-4df2-4de9-9017-0af613c378a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72c8d946-969b-4911-9ef6-98c84304e8fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f86f8992-c397-4968-b61b-5d1ee0be135e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0bb4e66-8e2c-4258-b9bb-9d5f6fdb68b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b641ad1d-8f25-400d-8d06-0ee76124ce9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_06da1fb2-d197-4746-8669-418acdd11ef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f0b74cf-101a-4fcc-8b7f-5dfb37885d42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61d59f3d-dd4b-4488-b6dd-eef9d4cdb561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e91a7605-459b-4d91-bef4-eca132a0fe79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_60fa5a5b-8d4d-44b0-abc2-c2c9805035d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6604084-2693-4dde-a853-88ca9da67a80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_330ca30b-c80f-48fa-8bf7-1be251e000a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4d9534a5-0e6e-4bd8-8537-bd4919ff95d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_282c0f6b-a099-4c0d-80da-497535cf380f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db5668b-6269-42dc-8cf0-4d5f1edd75bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec70b485-7a69-4fb3-afc7-ff87095266f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_063a6c89-83de-45d6-b507-d333070c2f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9dab1799-adaa-4517-977c-ebe6a16d2549">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bf0fb38a-3e9f-4346-9366-6875ce97be73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a568e818-3e12-4ef1-b0d9-5bd46fd927eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b814bc8b-78d9-4faa-afd7-8ab401b6340f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff01ab24-a8a2-4a7f-9c5b-47940f37410a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db4eff7-f3a7-4b86-9c3e-414ab37d6771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57802d22-bf06-4f03-a7ca-3c8ef8b8d251">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_048330d9-3bbb-4b3d-9923-9a39eaead778">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e79f72e-ea6d-4cfe-aa54-d9261d98436e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d30f340-85c7-4d92-9577-cd96cc2f5d1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac74c520-a4ed-478d-92a7-4f485a50822c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_820e4f42-5173-4d16-b4b6-979e62ae9f35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f491bbb-1277-4229-a3e1-f8f10ba1b923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4796e0b3-1a9c-486e-bf68-fcdf5eb1bd64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7af55883-cbd1-4b4e-a1f3-ec6a28f641e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10c65879-6984-4e77-9fa6-34c3640edd5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb403c1c-7c91-46bf-b50b-424f2bc0cfd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97c4755c-1514-4404-ba19-5e804bba3b5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c339a2b9-fb0e-4670-b01b-0bc99c288d38">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_36ca438c-ccc1-4d35-949f-54817dc7d31c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec171de2-3ee8-4f73-96b8-bafd19f04677">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4b578fe6-79bb-4f4e-9a6f-4ac9b840d579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a456902d-0412-4ee4-b228-8a714ae36878">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315b18a-8654-4766-971f-dc5ddfac8ce7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9858fd9b-b96b-4df8-b153-e34219045db2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7419c7c5-a3e9-40c7-99db-621c91281ebb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfb0ee89-1778-48e7-aa6e-c2e0e042d331">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ea1abc7-2de0-4679-8e7f-631374e6a83a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fb07bd1b-bacb-4795-9c75-8cb1c5fa83a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9151fb81-9550-45d4-bd07-4683d29009aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83940b4e-267c-4c4c-b9a9-0d9027a52d67">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9372795f-ca2e-48b3-b41d-0880ae5d7991">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b7cbc2c-e5b4-4e1c-80e7-8de1fba51664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5fdfe70-9a41-492b-9f27-da15ebba8a72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7166895f-1edf-46f1-b802-40c4c0f7ede2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f2d5b22-dc04-4ed2-9638-317a3a8499d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ad8b9f-65df-462c-a914-26b406488a65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_450e1f78-108b-42f4-875d-bdb70269e9b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c831d6a-b29c-46bb-9ec0-e8e1a95f3ea9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c4a824a-2713-459d-a73f-ea5de799b0fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd3db492-87dd-4b09-8170-de53b4ab0249">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f2cded8-25d1-4851-9d10-76805fbf0350">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_432654df-26ec-4b72-bf22-d2ed67081a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a5c821d-15ab-4aad-b751-c9b46bd2fb53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a6652b1-3a02-467a-9ac4-07e00c70450f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b023ed9-5451-4e72-ad37-cf8ed02ce876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d69413cb-36c4-45b9-96a5-197a238a21d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50bbc7b2-6b08-4a8d-a9c2-d375ef380e6f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffe8f414-26b1-49eb-bc04-f72708ab201f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf7ffbfa-817e-4a65-a0ab-2c237a4ec04e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40abf24a-4c0e-4c70-91d3-a07e95c560d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e0e0d2d2-3a63-4684-a023-2daa39568822">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef5fc63f-d2c3-40e5-a1a3-092327cf3a5f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2733bcd5-5171-4254-9b71-d7d4822da04e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce699638-1fd6-4cc8-b5e7-da5014317b9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6dd43f1f-50a8-41ae-b7ed-ce110f47260e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_19f9acc1-d6cc-4cba-ab1a-39bc6330c6bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d58c01-2816-42b4-9026-b4a864be5971">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab88280f-88ae-4d19-9293-87d20c9555f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4c1ce33-8835-4644-85bd-df6b5d895e97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfb91ec8-3c9e-43b3-b0eb-2d8d432ff514">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2c2ebdb-c362-4dbd-8cdc-106859815a67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4512872-e0b0-49c0-a886-abcec20ed4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92d457d4-5831-4817-8dd0-252285238b17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11586e77-2f1b-48ef-a43d-3c3ccee74e9d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0ffc407-f68e-47c7-ae3d-e0357444b057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_488812d8-5ebf-42e9-a429-6e647b84fa5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf5edb31-3e2a-4b1c-824b-623eda6f0d49">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34d7c069-adc0-41a7-b8b6-2031ce11ef40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4736319-8c40-4ba2-9349-388c6e2231f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_feb099cd-62e8-4b2c-9a35-31961fa7f751">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfa33102-fb3c-40b6-b982-16f1db6cabdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f158ee-3379-452f-b5c4-3e6a6e9869e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e571827-4bcd-4f9c-a4ca-8f43fc1bf1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fcb52fed-20b5-48de-9187-a5bcc4b4bc55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e556c88-b5e0-46c7-9acc-cee3f394c3d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9993779b-feea-486a-ae35-2b21258ad63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be7c3e94-4419-4fed-aacc-75ff147f2a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b834a45-5de1-47ed-bb11-411d4631e322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_783ea7ca-a48e-474c-b2ac-d904da9ca09a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e96c03c-3d23-45ee-aca5-4dc6260b00b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66399c4d-6f60-4c2c-9275-23fc994898b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86670c41-42da-4ce3-8823-8c140a50621c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_846aed1a-7886-42e1-bff0-9c1d20867b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ac9a23a-c7b7-4368-9495-6a79740ccdd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ecc55ff-bf91-4ae1-a6b3-ae84c0f5a1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e04f8a12-64bc-402d-8135-fde49c9456a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2532ec3c-b602-428b-add3-c397c469e629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8747ee4-c3fa-4da8-9f95-523edc656e56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70e32c10-3c2b-439a-80a8-67794b3a501f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd59329e-ae4c-4ea7-a16c-1ed5ae6986c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6a44534-92c5-41c4-8e55-f21f2746c102">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39113052-5b6c-414f-8b14-c45da77d0961">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4becd58-5c0c-4842-98cc-22eb03b299d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c1270b9-bac0-4dc8-8577-5e54ccace42d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736d9926-2933-4786-b3f9-d831a26d493f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea268416-1911-411a-9871-a5e4e0d8532d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_810a4f75-02f8-47f8-a59b-bbe4a9e9fd32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_645391ee-b5b0-4663-a5a9-219880d387d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac44bb69-b7c8-4510-8e7d-27713ec34d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_617803ce-c01a-419e-bdc2-8ad91881204b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5a4dbd71-77ca-4909-a368-d4199225e92f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d0caaa59-77cf-4704-a71a-5771f0f65948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2dadea34-e273-4d47-bddd-e5811a5f3060">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de945cfb-1c19-454a-a288-3631d0d33d82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91a822b7-c670-4873-8a6c-60b180b100ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4c9a7e6-05c0-4b9d-bfb7-f0df1a033d94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8db43a7-acd3-42a5-a4f9-31bb793ebc41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec950292-2658-44d0-94e1-7ab461b27707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd883edc-c0de-417b-b378-06b106f94a05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_abcf9ee5-7753-4307-9a56-b119fdd62d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9feceb23-85e1-43cc-b4a2-c3e2465caa9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_15685edb-292c-4afd-ae2a-40d35a35ed21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a8c3fd-df2f-4963-8b4b-a55141d2956d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17092b96-3f07-4c32-add1-f029ffa6a018">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4dd4bcd-df20-47ad-b0d0-994799f393b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_734f6749-fc85-4447-b206-97e1b9a6da60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2ba4c89-a65b-4ff0-8ec2-1cfc6ba62415">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe36402a-ceef-4899-8e68-563a5528ef41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18ce150f-356e-449a-81f3-c71920e26569">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7575bc2-040d-43f4-8b66-98a8736a20e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b49bd25a-dae8-4ee3-8034-79541d1f2b19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ed6cdf6-03b4-4d44-bd05-cf1415e2e538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7367cd2c-ab45-48ae-b600-1b361ed30b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6204fe90-8afe-44b9-9daf-b27d4d1e054f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc1cbce3-d371-40e6-b379-af34f2e14c8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_070caf31-fafe-4ad3-bb49-81f0d801fe0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fa8b508-ef32-436d-a22d-2f1566b4c571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c6db05-c475-4b69-bf7d-98b2f77d0c30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0b69b9b8-0a43-4693-a724-ee34791e2049">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd7e3f-68ca-40bb-a4ec-bc4d38416f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51441483-9728-461b-ac63-30e57f41518e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be873af8-4dd3-40c5-8167-d27d925e3573">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc2cd4e1-70fe-44f1-a685-6439199241fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e9f43430-6b51-4306-99fa-e543c431f3f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f63b05d6-b2e1-439e-952c-63767d0ca702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4438e97-ec0d-4908-9114-7d6c48f89284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25b2d034-7d7a-4db4-a467-987c5b19b4cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_24b6307d-23d2-44a2-95f2-4f8d39d70e0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06334274-246c-4230-893a-302a747331ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_193894af-6766-4066-8dea-9fb9ffcedd4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c5785d7f-56da-4e61-83d5-2f18adb7b233">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66c811f7-adff-4a4e-94a1-b8038daf18d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b21b057b-e4f5-4cd2-90b1-32617e981260">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2fa674ab-5a22-48f8-aec0-6fae8dfed969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bdafb8c8-a619-4936-9f6f-79d0767617eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bdaefda6-56c3-4fee-832a-c7b1abfebfd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a74705c-5bbb-49e1-926d-d4aa5c52ab36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3becd1c-277c-4d5b-88f4-9c355ee975e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d486dc1a-d28a-4880-be97-4814c9a25b7a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2943a5be-cb31-4d8c-ad96-227e0193ace1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0853d553-a35d-45ec-a9a0-0d8184f76a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76b45095-2687-4271-805a-7bf60ed3551c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ec6b68d-ba61-4c55-b09c-bfbdb80ebcf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85214598-6383-438e-a4d2-ab029b7530e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc5543ec-b224-4bc7-9eba-a827e3058465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f733246b-e52f-4ed1-88c7-aced475bbee2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d86a131f-8960-4881-9ff7-7ae1a6d6d354">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0177aba7-d4b4-4e75-8e40-62222b87bf6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7742836c-da33-49fd-a00a-cc7e0321277b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d4c4a91-3ac3-4e24-903e-8ed844e5dcb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_512335a8-1004-4cfe-b462-f7ac341eef60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b4df3c1-a13b-40a4-82f5-66f82deb2cbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ec66737-2300-4657-9389-6282cbfed896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_710e51f5-0e13-41aa-ad39-0e6e38c4c5c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8e247e25-f821-4e40-bcc2-84579384b6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a36c16-7af8-49e7-bcf6-503669668780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d296778-ac03-4544-9620-df7302d93702">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ce08e898-8a0c-4b22-b375-651840464974">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8f229ad-ca28-4a4a-8277-eae642c78a9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5a98d74b-051b-45b8-864c-5bc17b868079">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_935533c4-c8b4-4d12-91d1-e357e32bb1cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee8c3a5c-d53b-42a6-84a6-d109057f66f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6e4f67c-da26-43bc-81e1-d91efef4bc0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_985a89c4-0962-4b76-9685-1cbb1b755fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e181c7ce-9b27-447d-b60c-7bf20fb74fd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7ca85a2-5dec-4379-924a-7bebfcab592b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b87135b-9de3-4278-936b-77fc18f47f98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaea47ae-5e05-40b3-9f34-6f857dfe9902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d4f4a91-6e54-42b2-8f8e-0b9c478cfc4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a799f946-7cb8-4538-a661-ebc68828235d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a5d488cb-2a2a-4f74-bf60-4a7c2afe5167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ab32114-c60b-49e4-b16d-59f43ae9b429">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d9ceb6d1-ef81-4fb4-999a-5c4a09bbda2b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_79a6ad94-a07b-447e-85c6-61dc4e3f2c41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c072731-8b09-473e-b65f-5d1c595f7d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f8545bf7-29e8-488e-8f7a-27d45dd27584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_001e3e3f-9f35-4adf-ae09-beaf7310f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76f3cd08-a9cf-442c-b664-7ffae80f34e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c8477581-f647-4fd1-bc0f-38da40a5c34b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_941ef755-9542-4b5e-bf50-bcc38e4e3e0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f65b7928-e759-4f20-96d0-03563432dcd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3c9d70ef-69b7-4294-888c-a1db7a6cd16e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84e2fb08-9c7c-468d-99da-88aef49b8955">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c6209ae-c301-44d9-a9f4-39e503aeeea6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_35d6a3fa-41cb-4def-a6f0-02242f07cc8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af3599f4-876f-413a-9e2f-61e4f97cd772">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_925cb008-fbf8-41b5-bccf-a9ba0207496d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3544d101-9166-48bf-8d7a-9830f8bd7e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c4961b0-db79-44fd-b894-3e3ca701e148">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_751f3c0b-38fd-4d93-92c2-210d657c929d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ad3d6235-3931-404e-96c9-eefea6cc2a51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_15f6523a-a6ca-4929-b2a6-797fe5165942">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_607ee7c9-c194-4980-bbeb-4871d045b117">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d595630a-5c38-41ca-8d89-e6de86401784">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4879caa-544c-436a-b481-ca7782fa14ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d468b176-1c1b-4e70-b89c-cfdb358d12c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39e8728a-cf2e-40ee-a6f3-60eeeb2b3bed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99a7243e-cd1c-4944-878f-353803f16173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f579bce8-a5a5-4af5-843f-b6774ebdc50e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e7e06c9e-85ac-467d-95a1-dee3fba2db7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2efd19a3-19a9-453b-8a62-1358a678e54f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_50cb2407-1a48-4d05-b50d-0eb7d0fe0d5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_59921408-ed5f-4010-8874-8c7cfc9cb99d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a6832ef0-2d40-4b67-81ec-7a22195700d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d14c5eb-de52-47c4-8527-6c2d90f6ba09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4257e0c0-571b-465c-bd0d-e6dd32b83599">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0fd26d9c-7a97-4480-a4c9-5927169899b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce509f30-fa28-4fb8-b93d-2e7d0753e01a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06be5c7a-6d6d-4bda-989c-3de94c0ad642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39381952-7a93-4505-b431-38b454ddf896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d75cbc77-7b81-46f7-a818-c80eb0b51a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2aed15b5-05d0-46a5-bfde-aa18a6e58bca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff83925e-7032-4d39-808f-131c849e3c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ad21880-4865-4369-a402-af2fe2d06469">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_823e97d4-6e60-4330-a062-2dc6dbd6aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7de33c3c-f761-4510-833e-4e658bb155ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bd21b61-bdd0-4bf4-baec-1df6fb7aba04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e097cc96-68b0-4776-9baa-0e05ac6d2079">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8f842892-67fe-404e-bb86-ec52099e76bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_369c7b20-7a1f-4e27-b826-b22fd852f92b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d3f27b3-8901-4993-a783-1c5cc360e39e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cc984ae-ba96-45d2-ae4e-36e988202551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85b55d99-54a0-44c9-be12-73aa01d85025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9438622-ec39-4de8-8bfe-8b7a7acb728e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2020f19d-8579-4c6a-bb85-33cbcf9c80fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2512e2f-f697-49c5-88ed-472ce66102d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ebfb91ff-e57a-4c99-82de-0f5c7bb20361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77f21387-12a9-4a66-a13f-3650ea2a0626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be648bd2-646f-465f-82d8-fc18fff2565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0d9d1f9-ac28-42fb-a3bd-873d848c0bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c1eff410-da05-4ed2-8a83-6d72a5b1ed9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f36d52fd-a011-4d3f-9886-ef1558392dd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b130e0c5-4e18-4c5e-9630-96c1e8523961">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3d60d422-5a45-4fde-b96e-83fcc351399a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71dde336-035e-4993-bf5e-ff65d982884a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5fc7015-c249-4da2-b59a-fda46e003a21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c25e18f8-ca13-4e18-8e6e-106713a05817">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003ae024-12b6-41bd-afb8-dbff8fc0716f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1fd2a69-ab09-4a4f-8e0f-1b3b2a7ed8ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4b5ce0e-676b-4e14-952f-0e70e5eec005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cabaaf52-7fc2-4375-b423-17217e547d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bc43aea-edf5-40ea-bb93-360747aaa871">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_35f390d0-fc3f-4dae-a334-b28e27ecd4cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d09ce77-c1a0-49c5-9da4-1743097d6b5e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2f12e17b-a03e-40bc-9633-3b062f903a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_befafd88-9e45-4aeb-bc91-72989f037361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4642aa0-952f-4c0d-a380-67e9ca5798c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_19ff8aa3-4c9a-41fd-8b5c-fb88ea00d914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23992233-1625-467a-afb5-7c7db2154274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d18c73c5-9283-456d-88a2-ed56c52068f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40db0b6a-2fed-42ff-b3fd-4146ac3a6b9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab9dcac3-38d2-4998-ae2e-743e9e93dbf7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87844dc5-0f00-4fdb-83bf-4df6a5a66c00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_397a5ac6-c21c-41e8-8bc3-37030f7791e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_46777efc-f783-4fc1-91de-03444ae43579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cac650bd-26a7-4597-8d04-f5210c60e5d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c7661b-773d-4e82-a011-20182f0d879f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72eb8f4f-06a8-4acb-8749-7c2c83001667">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0591bf58-eb3c-4ea5-9379-1dc6ff597412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a6ea8c7-7bb1-41ac-98c8-ecf05ba41d55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e35d55cb-7309-4c84-b62c-24c5701faed7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f22fc970-4d7c-4dac-94e9-f52e0faac4e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e70d3d1a-6c78-418c-97d1-03544787f442">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de1d2205-000f-412c-a692-27e23e6cb8ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d7a2c8d-6bdf-4432-ba34-64126abef849">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_14dde051-a9ec-4ec5-9832-422934488527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13f572fd-94dd-4eed-8ef3-ace0e748a2af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de08189c-2421-4654-b7cb-107162c73d63">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3a29e1c-911f-4564-a654-c6fa2f73900c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b0a3b7e5-2272-4789-b17d-9fc98ce6b190">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676d9d34-6500-4af6-b5b0-a64590ebdc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28831048-7986-4d83-9322-ad7b45aa6979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02c24ba5-c256-4bb1-8aca-18aaf5a4119d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cda097e5-c55f-4370-8046-a22566d23aa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3db309f7-b0f0-438a-9619-158dcf92e77e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7f5cd2a-e199-4fe4-8a07-000b61f6b849">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3559ab6-f11f-4163-9018-fd2d381786b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7080f5dd-d253-41a3-8978-1acb7fb725c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec4106bc-ce58-4d3b-8e92-880efd0b1664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10977b32-fdb7-43a9-ae61-93d4bf8d7afe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904d3954-8cda-412c-9749-e8bb17d66a92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0111008-7282-4c97-885c-7fab48bd8436">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_876454d7-7628-4133-9422-2ca5424ca361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9ff15473-2981-407b-a9c4-b2fb35aa3674">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_55ef1165-5526-42a2-b3bb-e8ec92717df8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c28c5416-4d5e-4bb5-abab-96a1565edfa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d927603-3d20-40ce-82ad-83b83ee19f72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_229408e4-2c2b-4574-a315-b735a27c779d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68082b8f-1b58-448c-b179-bb3cf663ae68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70edef45-f5a6-4dcc-8ac3-0ddabf759635">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ad9b069-1fed-4ad2-8270-2d803e8bb18a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdf583c1-b367-4df4-aa13-61564d6ab6d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92c79159-1d7a-40df-9703-3a5db5829183">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dae057b6-7b1a-426e-8e5d-2acbe7a43672">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd8175-e9d4-4ea7-ad36-55850bf37124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fa57a151-cb4b-467d-a0e5-025f0e879340">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29fa0b37-8927-4e2e-ad4e-fe8ace32f522">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372fb999-5a14-474c-a762-df4ec45be325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59a4afca-74e7-42f7-8568-57ad4f7f5a7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eb5af546-4e64-4615-b4be-c5f84c5afc69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e2e577d-945f-428e-96c0-85a30ddfb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc4aa6d8-c784-42b1-bd46-b5a7b0fbee37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ab4e7e3-cffd-4fb4-9903-775b019afed0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e958a796-f688-4058-ac62-e7ff354a8b2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba240b0-4442-4e3c-9b12-92037859dc8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58cefcd1-4074-4f65-b238-c8bd2807bb62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b7e5f911-cc7f-4035-b405-dce36c696979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b105dbf7-08b4-44f2-a809-7659b9b0c0f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dc8c8d-842c-4d37-9ddd-729767e27b17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a87b7beb-c39c-4b09-81e9-5ac4e5d6dca6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c5a9d89-ddb0-44bf-bc81-169851dcd038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ae060b4c-d898-4866-8934-72ad68a61d2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ff2d666-0eca-4c6b-909d-de8c8dcd5ff5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2416d8d-eb9f-4c0d-992e-584910dc95fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13563e1b-bc67-4100-a744-0b15bdcbc8f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b50e0e0-9880-458b-8ec1-df2b45b77707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3003a0e9-678d-4407-8d92-8ef9f603d17f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8927687e-896b-4610-9f61-0ff4ee7f0355">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_836cc85a-d634-47ce-9f91-cad257677a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9185dc-ee0f-48c3-be9b-0999eccbbe09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2608e084-b64a-419d-ae01-4b6cc1e71585">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_167d679d-7fd9-41f8-9d06-caa39dba4d17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f458e59-de2f-4f0e-b34c-3964259cb7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e60f6916-d41b-4f3e-9e12-d053db17fe84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d5f4047-8216-4d31-ac16-4a9a054c9322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a3bcd38-457d-4fb3-8e07-3bbd70861a2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_208ee53c-3823-49b8-a07e-4c96709a6290">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_132fabf0-f06c-484e-88e6-745ec73dc90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d366858-cfa5-4734-ada5-a1d4e1de96bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73ae19d9-1ac3-4fed-99c6-6a4638bb06fd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dbff479-ccd2-4bd7-9d0d-d7699ee4f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3af795-f0ef-42e6-bdcf-5998074e2330">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec7efa15-a618-44c1-9777-6d7d98c12e77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_105b771b-417b-4b18-9aae-2edb5c322c6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e02995be-5319-4997-89c6-0baa13af4633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c61435e-e1f9-4541-89e2-6263603b3b69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dff476e-df06-42c9-9efb-b4090eccb100">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1efff4-9a22-42b3-91df-2c842ef69d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_23c32af9-38b9-4c72-a024-eaacce4cd25a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67c313c3-0537-41d9-bf5a-0ce46862778e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c78abdb-f124-4796-b624-ca207adf405d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6df2135-d56f-4ede-ab61-32537752244b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bc5c2ec-af4a-49b9-8349-b9267dbb909b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4f648f4-68bf-4e8d-a158-24c7ff934d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b9a43ab-5f04-4a70-8105-4d1d6dea5cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07d9c908-2ca6-47f5-9b54-23668c13aea1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_188820ff-ff28-4597-8755-16e1f383ac16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92ae4c05-9849-413f-9950-08e73b719f53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3e291d07-59ff-4e54-9816-99637c944ce5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e993253d-fa2e-425e-8a54-ab9d59eceeb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bb91660-0de2-4d77-8dc0-b2dd97689d06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0be57c-dc2c-4fb6-83c3-f9dbb5bedcf9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe303d5b-825b-4378-83a0-91aad62189bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97347a26-0a57-438d-8632-a5da61335545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc4d10a6-b3e1-4e1a-9417-a6a54c099ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53554a66-e2ec-4121-a84f-bc5f58c3a39c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81767925-5b0d-4258-9684-c3609914ad4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_190cac75-5579-4ffe-844d-db8817b5c500">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8714d145-9c20-4532-852d-751b41958aac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904f003e-1ce9-4007-aa9f-00aac3c62a98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_214096b4-1ddd-4b94-a7c5-67cb764c0a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cdcc05e-df32-4ee8-b7a5-cb1f696db621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e32b1e8a-316f-47e4-a283-9b8dd0642e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3aece19d-4dd7-402b-a8d2-5d26d7ee3b39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db8c2187-33e2-4116-ab89-78beab00ea57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_78ead1cc-f404-4ee7-9fdf-ef48535800a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_22055254-fa36-47e3-a1a2-155d0a0cc771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_557a2416-503f-4222-9308-f18bccbd1d01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2470f09f-6853-4749-9034-4f203dd05145">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71fccfe4-5391-44df-b2df-5d66fde7db4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c091e57-8b19-4353-8d4c-313ee3863561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3cefb57d-57e1-4e3f-903f-69749aa540e3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f2d8a7d-95b2-4973-bef9-175379b439ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7f34bf2-27c1-481c-b244-d5bf555288ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_072343f7-33d8-44c6-bfb3-86f4b517797d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f53ca695-3ad2-436f-b57b-a0d82976e489">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b72db782-c1e2-47a6-bfee-76d98a50ed7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285196f-6ba9-482f-84b9-7bd3923b8e05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9c86c4c-2491-4427-ba0f-710ebde97af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec3d8a3-15ad-479d-a33f-5c01230dfc8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7d59712-1642-4092-9ee5-f67caca03a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f4c0f5d-b870-41b8-b34e-293e4d986355">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dbdc2b2-f9a3-4c59-b067-f65e01e1c62a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_74ea36c6-2edf-4166-96d0-d0d8e03ee4aa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c8effe0-03d0-48cb-a537-7a5e9e2809a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90803e77-364e-4047-8ac4-d4d18032eed9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_82adc907-8d3a-4b68-bb4e-6a74b4c9e7f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7306d11-ce28-4c9b-ad6f-e38fd8311161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5f35c9b-8ba6-4cc9-a4a7-30b3c05f361d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d94625fd-9209-448e-ba9a-d9419e7c7184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8621c35-abc4-4aea-8aa1-7c4f318308e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afadb174-03ee-420e-85b7-2cc1b03b5fc9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b9f9fa5c-16be-4030-ab78-85df203a3689">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ba01acea-929c-4066-b7f9-8a44679d7278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_868bdae4-132f-4de9-80a9-235a2f7649b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c93f0b0e-710f-45df-b479-efe99898bc58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4d7cdc2-47c4-4d81-8813-1307da791074">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c182723-b6c8-469f-8368-664cbe6c5ae9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a826a3e-f47f-4547-bc86-8d5c29802073">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71d7fc82-41ba-4769-aec6-c28a028c24f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6f20f8e-1d3b-463d-bcbb-74e286d08e4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e3de8b-6459-4ecc-9a7a-f07ad5e41dad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51015e38-eafb-4bea-8fda-d7254a752591">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7f865691-09f3-49ed-a046-6a9f927b88f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb298e3f-8717-47ae-8c74-0352837ea9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e34a8420-47f1-45d5-8a93-1a88750c93ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cc228ed-7b17-4a46-98c9-9b6dab5ecdab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0e39-4dd1-488c-9f42-261213615c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3fc35f4-afb3-4be8-9042-80c22938c1da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7fae11c-5433-4dea-8daa-573036118c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f8d7f2b5-d937-4798-8f49-2f9d6d366a37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_61654344-ea9d-47f6-bc0f-4c1f512f6460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71e972be-0b67-4baa-b9aa-d2af29f81dd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b836030e-56ce-4bda-a621-1cd3898f7a3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8905b57b-c2f5-4004-a604-898087cacd6e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c31d0b56-0d49-4611-bb21-4da3c47be957">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e12d10a0-1652-43b7-acff-b94dd8e81d99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285cad5-6de7-4403-b3f2-3cc8618a8428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62f45f9b-4214-4227-8a3d-8ec5bf11c1bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27857a57-dc46-46b3-be78-4a3e508faa27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_97ef7eea-fbed-4cca-8155-059d768bd25e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aad83482-c91c-4404-b6c5-2e4b0cf2c430">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_741b144a-92be-4316-a667-6d77127a3c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e783a6c6-9325-45bf-ae94-3e58253dcb28">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb5e5403-2a79-44a4-9175-3e0c6cde1a7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6ee4820-527a-4806-9ce4-2f0d42f31276">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dd1d63-111d-4dcb-a900-09f637cb1718">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70cd53c9-69bc-4bcf-a3ac-4e7ac464b1e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f3ff468-9121-48f9-8210-265dc8d4bdc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56f4ed47-0029-4843-ac3d-c989194a4f6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f57fe36c-18fc-40f7-8f07-d908b0a444e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec5c7335-88e4-4853-80bc-bff5cc1fec3f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c90725bd-093b-456b-b293-35b3d24e93e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b8b82bc-e378-430a-8d32-a757dbac9654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315475b-5bda-49ee-857d-d4909e35ac00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8605a6ae-08aa-4247-a681-37bfa08ddcab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_947b0817-ebfb-4448-9e46-1b205c39cb36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06dc1e7f-54a1-4ca4-9bae-106fa4fc0b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_34fba600-df3c-4444-92e6-44820bb53700">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d5b75fd-ef40-4687-9465-b9813bff0c55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12f3da88-6382-4ee0-9944-8ee455b9d12d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b80ba0c-7c2c-4247-9376-4d6c8150fe09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b246ab5-1854-4074-a138-ced059858bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9088e061-ab8e-4b2b-9c0b-b84ff5986524">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58ac5024-a283-465d-96e4-3958b4e5d587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_113e04bc-404b-4a53-ba47-2aae867c3bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_025d8e4f-7965-45cf-98c4-7cfaefcc2b38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06847793-4f82-43ea-9d81-98aa1e2596dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77a92fc5-b352-4ac4-9526-2c325a319aa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f575e4-4d82-41ad-a7e6-0c4a89a7846d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74525261-c7ef-4d31-9b26-15b564328d3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c95a00b3-90f7-4ae0-94c2-50696538217c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_707a27cd-6e44-4b2b-aeac-ec7fe86c87a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_acde90a6-1736-4d99-996f-f94f40387275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0de56081-b8f4-46b2-a104-342f7c06f81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06b6e45c-cf6e-49e4-85ed-66b9519391e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ade7d271-d264-48f8-9f66-84ae1e80ef77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35fd6ed3-a06a-41de-8588-3d779ab51fb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c861879-751f-4428-a068-75a4aa42e588">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_220d4678-9c77-48ce-aa02-b302549280a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_235615be-43b8-4c5b-b4cb-14db7ee8d61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5226f2b8-6339-4e7a-b351-7b464c9fcd25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31e9896f-9c68-4f37-8acf-d2c43cb44200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bccf7bb5-9fcf-41a4-8cf5-b5cf08d878c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a07fd55-9727-4c3b-aab0-14051933c782">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf5a4f02-dffe-4020-a13a-e045e31e4aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2efd1a7b-4bc5-4856-b2de-bcc27f4a2cde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0a9a1b03-c9e8-4187-956c-bac2bf1926d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_353093f4-bcf3-4890-85da-8c4aa9d6d6d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b6d2fa48-1a37-474f-990d-10d2d794bce6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_13574538-536b-4538-8e26-c6241ee2d5ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27efc09c-a8ce-4383-b44b-a4400909f8fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8b00173-49f3-42b9-bcdc-567771ef26ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c24f1de0-8b83-4a10-b680-d7cd903045b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e12f605-dc64-4ca7-bbe2-8b1a99b0e82b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acc178ac-8fb0-4df7-a38b-28fe75a170d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_49ef34e8-d89c-478e-806c-58fdfff64426">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6c25f839-f61c-4929-8ed2-75621b54683a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24a54926-5757-44e2-b82e-671a97a4246d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3419e66e-ddd7-49e3-8c10-6ad6c5f5c49d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d0a4264-7e61-4421-a1e6-90882ba91d0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95d6b06f-a866-4954-98d2-4e1f36a7d499">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5f288ec-4c79-4843-ad2a-10afd29f69e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4946888b-0e94-4c37-9f66-56b71e7e256a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a30cb194-1934-4fc5-b1f4-a49039bf46a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f58e858c-6f20-495e-9732-36ccfd05cf5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d61dc199-1ebe-4435-bbb3-8701fbb7df76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0acdfc8-d22b-44e5-b98a-e3beb4bc431d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_517ca612-cfe1-4358-ae6d-b05efa7f5171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6893ad1-b526-45a1-9b4b-82de55b52fcf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7618e19-9e6c-4a93-a8e5-7c0a3ec3f2b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4838ab73-e852-4a4f-8e14-d36cc6dde894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e64818e2-9253-4d51-ae0c-81d112e2cd5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c3a36588-a846-4a37-b181-afe3af3cf915">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_714070e7-1af3-4863-8885-8920f896f2f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_05372493-820b-4768-b6b3-b06cf4c88040">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2e0649e8-ae5f-4146-b539-55df36ed26f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dbb7f413-9cbd-468a-b57c-023e980826b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f829759-3787-4e7b-9c49-51fb44f490de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6586012-dd0f-4349-81ef-057a9818e91f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0551774b-ab93-4cf6-9afc-3f49ff2e5339">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d90700a-b751-46d6-9883-1afa754ca728">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ee00881-e663-4ef8-8e61-5a9d373b60eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_029a4186-6f37-475f-b0b2-d4888ec78456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7417b3f0-f39a-4da3-ad99-a0c5acd31dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7bf60b21-3cfd-4c15-92be-de3bf3987969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebe2830-5530-45ee-bca1-03f80a144de1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6857768a-9ce5-4491-856d-121d10953832">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45b979e1-6499-4853-8bae-ee72dab68308">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cd8ac52d-b2f1-42be-a279-de43a535b633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_318892f0-18d1-415a-8a4f-12e16802ed01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3896d698-274c-4aa2-b2dc-85550339e7e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0586ae6a-a2dd-42a2-8280-def5212f1885">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe7d3d87-0991-43d4-982c-3bfd6eabac43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67fb0682-a5a6-4906-a36d-cfa2097397a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d83d8c12-075f-48b0-b5f8-38259d641027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d886ae8-6347-4a11-965d-4486a842b72b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c1ec08c-6b4c-48a8-bf02-006c60e178a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37d7a305-3c5e-45e3-9792-0aa39d89a087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b89a5862-62ee-448a-adfc-b98dc77a6c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_466e04fa-ecf7-4c12-a305-5264e60badfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e4ab9e7-323b-4168-af5d-6cfe6914e92a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_782b4c70-97ca-4ac2-a57d-c1e49802e962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47c94546-4aca-4eac-b3e2-0f6ae04baba5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bfa323-d130-4b02-af40-1743043ef9a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_365b45e5-9725-4467-992c-44a30aa3aeb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02fde0e5-c682-4a0f-9691-475fb76be114">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5a0d3ee-b330-420c-85ff-dc7216fafbd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_370ed0c9-995f-45bc-91e7-b340199efb75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97f67aae-d210-4862-8d2e-78e4ee1057e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae5e385f-d5a6-4333-9bcd-13f60268cafe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5559d554-2049-48cd-8104-20ceed7b4686">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ba7f2c25-8fa2-41f5-8355-8beac83b5a65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_408d47b3-1f97-42f6-b331-0d61e5f90670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_965d13f4-485b-425b-8dfe-c897500fdf2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5b6d87d-a141-4762-80fb-6ade51c8d259">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a63b1ae8-cf67-4f81-913c-0470719183fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d01c2bb4-c8ab-4007-861b-449bb235e3f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b221fecc-3f56-466d-a7e0-7ede7a1aff0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_42d8d499-e591-46c3-96b0-0fa80adbf923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_18c74b81-234f-4bf6-9d2b-38816c082d78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed2cda40-9e01-4b05-a44c-17e790367156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63c6dbd4-a478-4642-b02a-ec6a5bd2d82d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c05a0e46-1a0a-42a7-8033-274b947fad1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_49ffe632-11ab-4d04-b22e-1a7de4ca7746">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c0115ef7-fd26-4d5e-b841-07d14b72b16a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_beb12705-81f2-4cba-8b89-321726c2ba08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_808645ff-087e-45ef-940e-26389858902e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_236ea25a-9487-490f-9886-1854ecb7dd5d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de290528-0feb-4427-a306-11c0789ad3a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c31e8fd-473d-4142-b1ef-a7741eaa41eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea5970d0-fe70-4953-8353-e1f908f04833">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cb01ec5b-3693-4d3a-9bbc-7433afe2c562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b906c8fe-3028-436c-a6e9-ebe0aa0bd0e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc43effe-3bcc-45c6-addc-8790363e2e81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4bcb575-87ea-4553-9bb2-c6114aea6ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_574d3b76-05e7-4206-b43a-2406be300e73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e809161f-b94e-40e1-aa05-c26b5db8319a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90532d5c-51b7-42e8-b997-7cd3aacb3b01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89ed2c1b-8753-49f4-a90c-1469a1db2d6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c321ce94-d20a-4ca1-ae56-0e345f8d8f39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d1b4265-e043-4df1-94d8-c9b3b2a2d74c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6ef71c8-d16f-43a2-a67e-c3f882aa5898">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d291384e-072c-4e36-ada9-1d78743a5f17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb70152-e11a-4835-b3b8-9607ee61012f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b347ac3-f5b9-47b8-a5be-86112eb518ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a1af822-b372-4f65-8a5a-fb7c2bc9fa46">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70bc8a62-4b3f-471c-8f26-4de6dcb587c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f47ee7a-dab5-437e-928d-f5fa1a931021">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_37259d03-2688-4269-b724-a019708c03c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ae7edf1-44ca-45bf-bdcc-b9f2db3d3383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a629244-1958-4b39-8124-9299af3f90ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25d6bfbc-0406-4021-a7a3-eaf27c8bf87b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbaa2b91-19f6-4276-a1a5-bd29c05847a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92cb244c-751d-45a3-a4df-744118e58171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34f3366a-08b6-4ff2-8d8d-25bd186e23d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88ad481f-2dc4-4bed-b6ad-4eb45eff8c85">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_073bf8d7-6f1c-4bdf-8589-f3e7118b1419">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15de3a48-a951-4860-bf45-0a7d3e496232">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40f29c78-d193-4938-964f-009a195cfcce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cfd8928d-63f2-491b-8f99-7f12bc865a43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a21eb818-fb97-4531-8b5f-fb94643421b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0bceaa1a-cde7-4481-a6ec-fc1f00e4d173">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dee9f7f-ab45-4ad1-97a5-1ed775bc0a1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d87472d-343d-4508-af27-99ba0013009d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76ca6183-d22f-4b08-90f6-608c23ae01e0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89fd8582-7f8a-4635-9309-c36ab173d8d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e54502c-3e0d-4961-a3f2-e1a19f9f15be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bbdd559e-0803-4e99-b9d6-73d9343ea7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0568054d-a321-41c7-8ae0-7f3e4e6d6efe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae5c783-5004-4cb5-902f-6c2e49f16d2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e65738a1-a385-46d9-bfb5-a85aa03dd1af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db28d434-76f8-4140-b103-101d760da602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64e9f5fc-90f4-4b7a-aaf9-87364ee47047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2fa69bc-0690-4b00-b689-0c313b529130">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2310d678-df3f-4460-9315-9346518888c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42a60441-ee00-4407-bd69-61ce56d08585">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_999e6491-6e9e-41fd-bd90-90ea018661cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0d8bf12-31cc-4ab3-a046-31a57efa5aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f192d0c1-711e-4760-8b00-fc1b798d7a02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc53a16a-a3c2-4f8a-8b0f-fd3ee7701b92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0d478a92-27c8-4122-8f65-e89167e50c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be723ea-f9a9-460f-88f6-f6ce88b9adc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3707ae37-c9f8-4bed-9e83-767995f2904a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f748d44b-1f22-4a0d-aac6-e9abfcd344d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a040a884-edb3-440e-8118-8473a3c88c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_12360317-55cf-4c68-86ac-bb6d7454dc66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_792975a0-5c5b-4c55-ac56-01684e17cb4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21034b29-0370-4459-ab1d-d54d10337173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cae54e92-78b6-443c-a94e-3808610aa607">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877f697-fbf0-411b-8b70-de015b64ed2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cefd7b3b-3bc8-414c-af54-efef4551a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80564bd9-c46d-48a3-9ee0-fe1d044715b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_470d84cc-b496-47b1-997a-3bc5b2898568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4b700d6-4419-4e60-96d4-f054f596ebb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f829f61b-477f-45d8-b5a4-cb19a3097682">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a700bfb5-accf-4acc-aef6-75b5b4b9d283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c319766-eb32-4975-8ef4-5ec8b325c3d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6572c581-24a4-47a9-a39e-74085116d4f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bfdb9f7f-01ce-4490-b1ff-42b5e2cc0317">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebdae831-2ebe-4c64-96e1-7b91aa2db64a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2acc7925-5dc1-4c32-a264-f384326d40b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67d15e4f-3211-47ca-a162-20bc863f456a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c17ac3-19ad-4a74-8105-be69ace57902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d447f6d1-7ced-4a18-b489-a848ecdd8f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_82a2c0de-02c4-48cf-a2bc-43c3b43f70c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a799c07-5afc-43ce-b6e5-07bf3ed01299">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23e5c5af-5021-486f-9313-ced0a3c0f78e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a54d4bb-318a-4594-accd-f73e0717c332">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30418a78-e345-4166-be71-c6811a5139a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c5983df-c5d5-4543-aa10-8c9d879a6374">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67dc3e00-7773-4b9a-af3a-8078a00423ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0c34f271-4f47-410e-a4d5-e6f3c8be9d05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_715f00f3-4358-445d-9f13-346e0ef19af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_493944a5-fdaf-4639-a919-4c5e720a062e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c822e6e-dbec-41ef-87fb-3d352bf3b4d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9fc9618-b87a-4744-9548-0d53ca4522fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bff94f8e-926e-467d-a828-c9f16173009c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edfb58f9-6d6a-4008-946e-e5b27b49797b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b7e37f7-ad7c-49a3-be0d-d7ac833b23cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aef1682a-ad01-4e95-8f68-29f223e6f177">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3d42bd6-cd90-44f7-839f-9c7d6dfe9649">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b68c57c2-3f55-438b-8c6a-3b9dc7666ef0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1be73187-7c73-4469-a943-23ea7399b3cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_967043a8-1caf-4faf-918e-70fb1864c57f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7dbcb3f2-427d-491a-a73f-b8eab7746d5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa6059d4-f302-448b-b6fd-62d762a2997c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_19697a59-ebbe-422b-b0d1-4a07469d2c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3009951e-b1d4-4b82-a877-470a516b3361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1221a04-19b6-4b6f-9cb6-06bed845b81e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f70cdd53-344d-4c70-a11b-c4bb7c9fea2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbe11006-c06f-4120-a209-0ac2fa08164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_755105c1-f410-4e09-87d0-5ef15746ff1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_034f40e3-2783-4202-8189-fe8b6e11bcdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c605939-9b97-448a-8051-6de0d751931b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3415f772-e20d-4104-ac5c-44683fffe2a2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bf36e9c-2d4c-4d3b-aaad-b21e7e3085ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd408c9-e801-423f-97a1-a5857d1ad4af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0e75e28c-718e-410b-b2d6-1539bc5e017d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d2dc1dfb-bedb-4a06-aef6-073ba5573610">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3e57554-31bf-4fba-9fcf-72fbcf3c24c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48b08358-167a-4ba5-8716-c7c79c76f989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_440d5403-5712-430b-871c-f1449bc683fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07f052be-64dd-4fca-907d-6852e038a6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3b04fb0a-9cc9-4ca4-9603-38b983258538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_475b64aa-d502-4417-8208-594fa2af4bf7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aff9e12b-a0cc-40ff-ad4c-21354b0de88f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1a973e3-96be-4a6f-a7ec-2f2862e2ffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53fe31c7-898e-427a-866d-f9d639564156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fafbfd-5596-4044-8d74-0992f06c8c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_233d686d-90e4-49df-91ed-b5ee6fbd0cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_598db54f-b81f-40f4-84b3-d92f72daaeb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e61eb85c-b7b0-4336-8e32-6a5c2a7145a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1d98bf9c-8243-4f7b-84eb-ec54a4b21b90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eee51978-7250-423f-9dbe-827906d8c019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_466b004f-e572-4666-84a1-2a772ee0b5e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_026dedc8-5998-4752-926e-f2cc48db14e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0df05e46-9c77-4f7c-9c28-38b92d66e07f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_85ab2be6-50f3-4381-9947-70df840ac3a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb8a4d63-989d-445b-b112-1e304b518cc1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd353504-cb09-44f5-8b25-f1e3e8801e61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_058f2f86-c3f2-4ba3-97d1-9f6906004cfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dcc4cbb-f0a3-4b73-9079-8d7c8c4941ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_342151b7-663b-47f7-8b53-2fa6224c2828">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f0bc0c2-c9e7-4e8f-b803-28c6f5b6548d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395651fa-2b08-485c-95e1-17a893d7d3b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2ac23bb-09bd-4ea7-b41a-5bf5ece19009">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee8c7797-c83e-44d7-93d5-cc60b64290bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b935634-82bc-4212-a612-3d84f1ca3962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d5bcf04-bd8d-4514-95dd-e69f13c19274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1c01a24c-a208-4b22-9903-79a2ec531d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6637d54a-210d-4025-92c6-4995da491520">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_264c6f54-7b73-4d1d-b95b-aa94cc0c0648">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b87edfe8-d64d-45c7-a4d5-5f6ade3ed928">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fab46ba-9cce-4e10-8989-9b54974aad69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2bf00d-7b46-40be-b277-a0840a5c63d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2569cf1b-e90a-4497-a949-7c29fb699a7c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0be40f90-cbc9-4369-94b5-2601506fc161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edfc8def-f6fa-4677-89aa-538653292967">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_020f3c9f-49b5-414c-b4da-8a181c4aef4a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a7038c54-b029-4d0f-b91a-a528c0603ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8ff51ca-83d8-4277-acc1-b260d7d222e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6149b0c5-3cdc-4fa3-8743-c97d0b1f1d09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efeffccf-a6c4-4517-9821-d938ee8fa3af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca2de83b-7f42-4e32-8d5a-0ece354dda71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_94e6073c-06ab-4928-bd4a-16d8bfcc85c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01d168e6-ade5-4828-9749-c9cedd71eebe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_606a464d-cb9c-4a42-b5a9-6bd5ebbb6595">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bc2c3508-b5d9-49b8-a05f-570e28feddc3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_83795781-3114-4144-a04d-4c0218a2526b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b6d0b90-ac02-4a7a-9af1-fdf9ac0d1968">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_829d7f0f-f7f6-48b3-9fe9-40f3e80ee793">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_556c4014-05ce-4318-9c92-92047428cef3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cee22e6-3110-4e02-bed4-8ca368110b4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d64beee8-381e-4dd4-867a-de9eb2a66310">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e49c05e0-c6bc-4d7e-960c-d3fa31a486b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ba5019-26cb-47d3-a5de-6ae0d1ef25b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9963b957-2de8-4a05-af6d-0661f387330f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_268f36ab-f34d-4460-887a-0dbc24dd712b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b443e54e-315f-477b-84d6-6d83a39f6582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d8011e8-c7b6-4240-b4e6-c084fcc656f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ae136d0-afbe-4cd3-8706-8d321ad21e77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c56bbb1a-8c33-4ac7-808b-5e5d608cf875">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4109393-e03b-4c7b-a1fb-68f16c5a7cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb22b97b-0a84-4bb9-a4b6-5ee546825505">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9305c134-9be1-4026-a7be-325c101808c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c44701df-674b-48c0-94e7-2c620ae5942c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52bce418-da4c-4366-9147-90f23d9ee414">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a611e83-5034-4d03-b49d-c2259085480b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2fd42f2-672e-49cb-89aa-ac029b972620">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a04b87c-e6be-43d4-8deb-64099c5ca9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c5eeef0-5d1e-4edf-9502-650fd596cb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fea85a80-5dad-4838-afcf-75cd6d1fb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_713b3db6-d6ea-4a82-b06f-41b9783f69a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bd036bf-ba6e-4988-ad02-c1aa6666ac71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9552d0dd-3606-49fa-9aff-3dabc358798a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26940964-aea6-404e-8941-bdef013c8cdb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1adf3588-5d2b-4eab-b7d2-30a16cee0515">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65930981-025c-4bdd-b596-7f62dd2561d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dfb9aa9f-a159-4fba-92b1-6699c5351725">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6498579-f6c9-456f-902c-9d19b549b62f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26f0578a-c48c-4ed3-9405-7136aa508830">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_124f89df-1b77-4379-9104-99b98925be65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7fe7db13-1783-4d2a-a28d-5f544b258215">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7865f19-c83d-4d89-83a1-c97ffb796b50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f232587-ef4e-458a-ba35-ef158ef922b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7e35b494-953f-4999-bfdb-bbd338329e40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d1b5735f-c0de-4f92-b6d5-ef48cbf3acae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cd4c469-6355-43a9-a5e0-ce8c00e18dab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_49de03bf-9e1e-422e-a69e-992d88da11b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_582c7383-519e-4e95-9adf-d9f4682eb24d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f563d686-694c-45b3-b865-a4cd8600efdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b25096d-00f9-493c-9281-086f23040240">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2729e62d-154b-493f-8d64-5be7d09e89f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7303683-4312-4b4f-b006-f19d2bdb4a53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4698552-6cf7-4edc-bd48-63f44e816764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_733c06d2-d42b-433a-9896-e0d6fcf9f32d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8d144de-e131-4d9d-8c7e-5bf07887df32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf630364-e744-49bd-95e8-ef6d2aa4a7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_158a8112-d449-451c-8048-c6f0a9ccc502">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56365e0e-6d39-4996-a813-c06ce027b7f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9154b45-62d9-4cec-bb90-8b7da0fe72ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ab1a7a4-b512-406b-bd86-e321a39b3c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee320934-b8e9-4ada-9357-7eaee8eb3086">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1410e2a5-1a0c-494f-9145-13ae508493ab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_06741fd3-bdac-4576-8d99-ce74f8873229">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10371938-cce5-4d1c-b82d-62a4e06bb278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a82616f9-19ad-4009-812a-a4242ea9216d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a3f956b-efc6-4e70-923d-9029413a0f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e81259a-44ee-43e0-90ef-ff3b7230fc06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77c54f25-f344-4794-b5ae-abc64a604c19">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_65928fe7-3119-4e0f-93c4-0efcb16c9889">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d09255f-8e8c-4e03-a33b-be6fc2d42cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a2b9d6d3-d281-42c5-b456-e3774492b58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cc24ef5-3e02-490c-aad5-eab050a7a09b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d16de56f-7bd6-444d-9033-50ad12a2dd17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49e72d64-61bc-49e4-a565-03efa5d1acac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6cc99e3b-ca3f-48f3-8bfb-3568f4bd8d3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12968947-f95c-4b8f-83b2-5f0be6468cd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b754364b-ed30-47a2-a7da-9e4d6b03e0b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a13b69a6-56b1-4302-b0aa-3e0d081eecc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8eca3ce7-0b31-4a9d-b32f-c3950b6a566b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e27937e7-537c-4e95-a726-226798fad970">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ad17838-e54a-4c82-8a76-e0fcf5c2164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e698365-e833-4996-9473-f06a71d5589d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dacf7f3b-2ff5-44ee-a2b9-2aa57613a8da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bf6e629-c40b-403d-a645-d75c413c1eb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71c7c564-e605-412d-b6c0-23bbd162ad74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9c399c4b-5712-4062-ae0f-b688af0abf8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82b12011-cf89-478c-a37f-7641faed076f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_622cc0c0-28c8-44df-b59f-442849dc17d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f50b0d66-c542-4520-82d6-cf362ae23dd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_981f8d40-cca6-4b14-a267-a52df3e27e28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d39fcc1-e4e8-416a-a1b8-23bb62b77122">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72e08efd-5a8c-4c2f-b168-945b4c3186fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f47a4f9b-2995-48d9-b4b2-15c179da2be0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e1969e-aa96-4aff-af51-289b2f5f6184">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_68762a18-5f8d-4758-81bd-9239b9599167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b12a945-b2bb-4f02-82cd-4b59978c2b6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55c94c33-048f-4560-bb89-1a7ee27877be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f2b990d0-4495-443b-850f-d159ff7b487d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ee9f380d-06d6-4eeb-b07f-74433ee23ef5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a0063-77eb-48c7-8a3a-108717a1e342">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_471d2814-6487-4a03-8f1a-20fc685d4574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4f45b63f-e24a-4d36-b81d-35a032a7f094">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69246fd4-e827-4c4e-814f-937e24af9cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857769c9-5ae7-4e03-b421-b496cd37e421">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0188ffa8-b7d9-419d-be90-546712bd99d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0caddb83-6772-48c8-8392-b8592da29ce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b030c208-5e93-4339-a4df-49716f2f7ca0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_665fc7dd-b3d6-48af-9489-a931ec2d728c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae9ad4b4-9db4-45ee-bc7c-507982451c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73bb8f1b-7fbb-4501-b6a6-2d62532da861">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69ebf4e7-8f76-484e-bfec-e17f43ca4fcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4770649-3999-4da1-aafa-f310796bfb38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cd6bd8f-b186-4bda-83d9-9978919a34d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6de1c0f1-63e1-4838-9ee5-50fa9c7b441f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9d29ca-490f-4343-a83a-e789adae5850">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48ee110a-0ae2-43e8-bc1b-7abd771bffa7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9fb29ff6-0f14-4848-815f-df067a483b21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b40a5b9-55e1-4e8e-a264-d6a2bc01bee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c693cbf3-a4e0-453b-adda-4025e954d286">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6eb2ea9e-ae8e-4f15-8a8e-256d297537a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fde71d0a-4cd8-4273-bc10-76dd1fd19e66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d2d2a00-7af0-40a7-9847-bc28c0c1ea23">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e83e957-0488-4692-88e3-8bbb2a691173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cd9e84b-d0d0-4f34-8381-a7b6f7c03ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44020251-68c0-42b1-a413-3a748a1ab55a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57c0a3a8-7306-47e3-9934-a50251ef5bba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_971c083b-37d3-4e4e-a1aa-cfaecacf5562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_712d9aa7-73f9-4897-8147-a85039c14211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a9e577e-ad31-49f4-8389-4ca6efa6181b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8453e888-4f01-4fa8-83cb-972ee72535dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91cbbb58-6fdb-4496-93c3-bbb3fa994bd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90c5968f-502f-4af4-a99b-500f99be089e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b748562-c7fa-4923-8e6a-4427939ab97d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_31215c2b-0e3d-4bdd-88dc-45dd0d473877">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_03388553-ce12-4a8e-9cfe-74622fe2d729">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91c214fb-62d2-430e-bc9a-76d136d1b683">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7b97d0b-2cab-4ff6-91a0-ec87303b18d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc8f845-7da1-477b-a7c6-418956ac6e80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b46d5c4-0bc9-4057-b52a-b3ce593eae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9b90290-a864-4599-8c79-4638611ba5de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e50dfb35-302a-4194-affa-eb06048ced86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_565f7f95-7442-4d72-82bf-cf99d732e17d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_884f8d38-b876-4ad6-b4c2-5ed16c445a58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5070e00b-3d37-47b2-97d3-5950de3bda10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3154beab-9876-4812-828c-aee1690971ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_508d06fb-a64b-4e4a-a836-e866b64db8c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_885fff4b-dc0a-4883-bb41-faeef51ebca5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0db9c722-ba04-452f-af36-e304d10c09fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_23a2a4e9-dc99-4a8d-9add-3ca0c97933f6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c02a9d5-d136-481b-997e-0dbb22363151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5653476c-dbd0-459f-b3d0-d2ad9975dbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d3dbad17-c193-4f54-b0df-c903d58903d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b288691-206e-4af0-8daf-e9a2dd7030f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27025919-dfe6-46d6-8488-095eb2927d08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec1df18b-3e04-4dfe-b264-82b497dace66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b1e30c4-d9ef-4c9c-a476-ce98100f35c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e579b00f-7530-407c-a998-3dec9b484ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_105bc9ed-8b9c-4aaa-b534-174d2f8126b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebcc901d-16ff-471f-9893-98de344c8277">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a096101-135f-4769-a102-be67822c8b8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10bb5ba5-7e15-4c5d-af9e-a947afbcde01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1ff25a54-512b-4914-a35d-98ca1342ae4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac6351d2-74a1-4f8c-8406-4d39c66676a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1e98c83-9051-49f4-8f9d-8e5203f765f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00933292-540a-4140-afeb-a6d0921a1994">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7aabdc4a-f063-48af-9976-cd6d5698db14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2de76924-7d29-4ac1-aa0e-cbe05c315c21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4842c5b-2bcf-4b09-bbd1-530fc01bf44e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad91ff76-5a92-451a-b74f-438c17d16665">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56feff01-9529-43ca-992c-b9f7ed0df41c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39ddeef7-8343-4da5-9c9b-283f25344dbd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5d7a62e9-15fe-4fcf-8a5e-c18e280317ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cb38a95-411a-4892-815e-6f272a1fe602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_22ffe2f8-2c9c-4d97-b486-5f92260163c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_96ab21dc-4b8b-4149-8a04-a61050c092a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdfaab97-2d5b-4a29-984f-e8e221b59ae1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e875bb6f-949a-431b-8199-7b2eeb3c7f14">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_84efe136-ee31-43dd-88af-ffd1637858fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a55355e3-2084-4438-8018-10d3755a97ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1899ca-0520-4a4c-8045-faf978e483a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37a31de5-f6f0-4ee5-b7d8-386f81866e35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b7a9125-651e-4392-9214-d4ddbdb52247">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2f0b9923-7398-4564-ad82-4bafa9778688">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_624525b5-e21c-4305-9ac5-ff7388b1001f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d37217f6-9cec-4c6f-805d-deca7c019fbb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9461a04e-4368-4f49-b3b6-2f05deb219bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae0b6a0d-a5eb-4f61-8b2c-a02e751e84d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04c8a74-9253-46b9-b6bd-9701dc35eab2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be945639-e526-4e91-a7df-a51110b91db0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1dfc97c0-c7b9-4c31-8f4a-a6d6ab182d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed9ad61e-b067-4f4c-bbb2-c41dc385d6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79603aaf-2a57-4463-8db1-671b1a2e220f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efabaf18-727b-4c00-a40c-f17833ed29dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe002e4a-1ec7-4895-86ac-558b453b515f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_20262ba5-86c1-47f2-932b-e0127e4f76d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1f99cde-ae8e-4ba1-9d73-01d49a79cb15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f86804b-4b7d-44a5-aa8c-8be0a817dcba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18f5c8ef-7b91-4ff1-ad12-25013fb2261c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b10151b-bb1c-42d3-a1d4-2405ed3692b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd81079-c54c-4362-a512-99e1574343ec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_46326a22-e670-4bea-b1cf-9c254602f2fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_671ff075-93d9-4eec-9954-3d1615290aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bfde40f-72b0-449c-8d42-637fbc9fd2b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9cfe9126-4dc0-4fe7-b98b-211301ed1b99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_706882f5-592d-4dbf-8de3-c5573164ff4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82267948-83d9-48d3-b8bd-a253eda0320b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86674381-d6d0-4318-88ff-c1894543ae67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bfcb49f7-6405-44d7-8045-14aea9e30b6d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9009bf32-48af-45a1-9d21-011ed8761328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1826f25c-9775-4f4f-b2b1-ae473c49e3b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7a71e962-82ea-4db6-a0fb-4975df482e2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fed39c-b567-4583-b5e7-b7b55af29412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b17a4fe-7e52-4091-8ed0-3aaeb20bad36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f5e9ea3-87cc-4bb8-9367-89a722729922">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5273405-4204-4386-a10f-f7c54e4f4238">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4bf260bd-da56-40ac-b0a9-aa914db52552">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0308fee4-f4a4-42a9-a181-5a87b1d39278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cb7100ed-7dcd-4b33-83d3-d2a0c4f3d3d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_356e63d0-5646-4a7b-8572-342dd3328f76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bef3a4e-f3ae-4cb1-835d-0e5d9f063ad8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c9e7d8-6d56-48b4-b8dc-a71f2d4b224e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1bb11d6a-188e-42e8-9304-e8a4ee0872a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7e54d3a-d5aa-4f53-afd7-6549180a071c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c78dc3b-842d-45a6-a8c7-430b2ba7b894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_520c328d-8cdc-425a-a674-f704abb85b1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_511860b2-8d73-404f-ac31-3690c0941043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd8849fd-c520-4587-9a6c-18d0f987bfaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4001dee1-5a46-480b-bee2-4f49f8336ed5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173717d5-e642-457d-9561-712c94fe0c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4c221fa-68a4-4b6a-a352-bb79f98caa60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2bdfd341-8eb2-4212-8f13-d86974a0d2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8f7de386-3c11-4fbf-b624-23fd3c1c562e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8e1bdcf-845f-499e-ae37-18f99362ad08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c797ea5-c893-4c9d-9e67-c90e8e199411">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1c420df-1842-41ad-819e-009e2c6b9a29">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ebf6639-df4d-4202-835e-d9a6be726cf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71632e7a-40a5-49e8-9ddf-b674a3cd0aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_849161e7-454d-4c72-a0af-047c5336f94e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89d54c89-fac5-4820-9e7c-2bfe46e356b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7f2ab18-b44f-4ff0-ae23-624e27b84d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4986ee49-2f30-4ac6-86a0-753bc271c311">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17b41316-5349-4bc1-8cf0-478a08f5b456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9b0f671-71a8-4cef-9ec7-8e98fbc6ae19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18b0b238-e39e-46d1-8b44-c343c305efde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_73c9270e-8671-4fdb-9c60-e5adcb17e72d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43cca838-8ddd-409c-b337-2e67b51a1d4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b1289ea-c81a-4e41-adeb-e00ddfa67bbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877c860-1f30-404b-bcc2-973e5eb01818">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3fed168-71e5-4be1-ad94-9cab9c37daa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5b81bb78-faaf-4c79-acd9-dee20dc0c61b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bd400616-4892-4133-be8b-398ae2219c89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d654b4a2-619d-472f-ad7a-f6da11cf4d4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc89f01e-591c-46f7-b57a-88b2deb6f051">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_734d06cc-67f7-4711-9fd6-fbdf778ab26c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b7472e2-0209-480d-afea-3cdaa1f3b566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f419035-11a2-4fb2-9aaf-9dd5d2f68558">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_868cbe39-38ec-4502-87c3-89c675fd01d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c59826ec-f49a-4f2e-9bff-450f400089f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d29eddf-8a9f-437b-915d-a171ba75e4d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b8f651fe-90c8-4acf-935b-3a28bbda1010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12d4f8ef-1503-435d-a08d-1172f0e8d4a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b4d225b7-cae1-4c84-a2cc-ec8d86545530">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3851fa4-a3e6-4620-9d84-e5f2e223d882">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0201cee2-9ba3-469a-a163-ff4d8f90339c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4a1bc43b-f726-47b9-af5c-c555b9460663">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e7c03dfa-74bb-4ae7-aae2-e3b13867e39e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22893df4-f066-4d77-9b20-41996fada264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713eb8dc-b3b6-40fb-ad61-4d88de8074cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a425377d-6338-4a06-ae87-a353daba71e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_234cf63c-93ab-46d8-a942-c61871c6c1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96120813-56ab-4482-a890-46d757bc9053">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_895c4d4b-23c3-4aaf-869a-84176c9c5ed6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5215b7c1-8498-4aa2-b3b5-d35d65fc4432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_540d8499-d8a6-4731-aa87-d0ac791ded2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88906a21-f574-4aef-915d-859acd1e22d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70afba82-3536-4952-b226-a329a794c7e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2090b49-5a3b-4f65-bf81-6fb949c6e77b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69b76bd-7138-45bd-bef8-e6a69172e021">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41196d74-dde1-470e-a114-485ebdbf53a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e80cb5-a4bb-4fb0-8754-25a61418b53b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67dfd7f9-e5a9-446f-aca5-9480722e279d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f1c9764d-7a62-4b2e-976d-8eceb473c52c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e8c1bf-b50c-4089-8ec2-7fede6310b5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cc8a469-7e37-44f6-895b-a38e53ba8c61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ce44f7a-e1fc-4554-8a26-2532ad150716">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_216b5db8-fd97-4534-8794-ef399bba9f06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_274432a3-9f3f-4229-a3ac-ac465ad8834c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86385e2b-890f-41fe-a051-ce32d787268e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c5d1874-528f-4b5d-b918-1808616d7d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_756d2942-df77-419e-b7c3-e43b68db0205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bed2fb-0f11-4f6b-b3e6-54108ce9f48e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb29035-f491-4bb4-85d1-a52b9731a61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e93ad931-1622-4890-99f5-1a0b86bb5cc8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8140af2b-d5f3-42e9-a3b2-b00593fe86be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ffc6a17-e0e8-4922-8d3a-6e5eb7c98cb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_402cd84e-9864-43f4-8dbb-63bf7cd1a0c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f41d01a5-a611-4390-a26b-18fa617aa345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713ca869-bea8-42c1-89c9-748ac1a2a210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_55fc5e5b-0d1f-4bcc-bf93-c8b921aed1fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d84ef8be-1d52-4db0-8f0f-982228b08963">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b740b750-4224-4059-b382-78942d33d819">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4971b9b-47da-4d2d-a33f-aca6a40ebb5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6fcf9d44-0aa0-4601-acec-32f45ad7d508">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82f01d0-3f3a-4fbd-9a3f-98a1e954e09d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c3cd7e7-115d-4869-91a6-70bd2e8a0879">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b134ce8-e167-4933-b483-9abc85f82a68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bcc360a4-e0de-4270-b3e3-2c0729527a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0de34ed6-5f54-4d96-b85c-f9cef605702a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3231c97c-9430-4350-8fa2-291f9293ff8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36da5543-1c92-4034-9537-b7236c3523f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4aa7d6c9-5036-4a5c-bafb-8aacb7e07fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da489a8-37d1-42fa-b44a-5ca3ec46da01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c597a409-1d5d-4f8b-85f1-afc3b592df8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_995c307a-76a6-4c64-8cb2-e814cbfb12fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5693ab73-76c1-422a-af9d-4b3bcd6d3a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f644f1c-6ed3-47c9-a38e-08a9485b207f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9bc005-cb3f-409f-820c-a5e040ed86e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fd822661-fd79-443e-b070-216e9012562e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_251ff7a5-1ad4-4805-a523-f27406ba6d79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce12731c-2b18-4e1f-aae9-29964c988cc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c161c630-05f7-4404-9947-055080df59a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_54136fba-4c59-45e0-95da-af7801dc09d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8734587b-a66e-445a-bd1f-6cb940b51c00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e6d45e9e-66db-4bb9-8d38-86c61edab12a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42e6c5ff-2a1f-423b-a9e3-9664e6627f4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2af328b-5185-4c38-b82f-0c4efcbd4ec5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67450fc0-6b2a-44ab-9128-d96d9676f9eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3aaff381-983e-4c90-a188-21ecb252229b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9041fe38-9715-48d6-8f4b-00ab3676a859">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8a2be9b-a47a-4ac6-8746-2c90af9e406f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb0e8f84-c639-49a9-a371-e1853cc9c701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9b24d9c-36c5-4858-87d6-2d837c4230bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7b028d2-f6ab-4e46-86f1-9afc8ef4aada">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16c68725-79d7-4807-aecc-018c600ca5d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_068cba16-15d4-458d-8d1e-14680f6a0841">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a442a01-9c9c-4edb-805d-fc3b45f89e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c8d0fb8-e4e7-4e8d-bb20-179996e179b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7bf7ffc-0480-4a79-a24d-b2d6601acb16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e46b1d1-347c-445b-a227-48aea8b8e2ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ba5d05a-ea6e-4f08-92de-61331f4b7ce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2e5fbe0-2c25-416f-bd5b-e04d9aa999f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ccefb321-71a9-4304-b680-6cd833613598">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc84b185-167b-4586-83b2-d6caac6cb45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68f575ef-5627-4282-9c58-c1e41eba70d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb56196f-75b4-4eeb-83a6-10e82c03a842">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_821c5870-ece1-4e61-9ff7-55588a7550b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6e6c67c-a057-4fe9-a74b-bde8f770bb4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cac2fa32-b7b9-489c-bd7c-a6db746f42d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fc8453e-ef8c-4bb4-9294-2a4e227544ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65e5a63f-cd9d-4a6b-81c9-8297e8add12b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb6439c8-04f0-407d-93ff-be80b9fda84d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3444efea-71a8-4c63-ba38-2ed9a6bfacaa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bc73643-70cd-496c-a6c0-55f2a679ef50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8599188e-23be-49ef-8aaa-2bfe07131eba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_51d5398f-d2cd-40f5-943a-48c008f0cd91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4b1710b-5144-49f7-aa16-78538eb731c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0026b68a-d9ca-4f76-8bed-993b99226fdd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_034d70b1-92d5-4259-a101-27f795ef79e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9b2f023-60c6-4246-bae8-1f304d7c046a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6065275-b0ba-4fe1-8c93-51befb9431a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_824a0775-e3d3-4af9-9950-5ad9c0f2acb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c3ecb7-c758-481d-af0a-85b852631da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fdfdeae9-a5ac-48dc-9b36-7779d7c45b07">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef7f8f3a-7613-4529-bf6a-4beb89a652e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0dffafff-ba7c-4bf2-8345-b32936bb7d86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b375a1eb-4e15-40e6-8931-21f756370ad8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a17eaf05-1e9d-47d9-84bb-52098403ebf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccf1734-7ea4-4030-b8ee-7a82d958edc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a878ee53-c51e-4a70-a80a-fb13a8db928b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8657f8e9-55a2-4388-a722-de31eec99cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42fbeebc-27b3-457f-b780-23328d760a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2ef59be7-e550-41c2-ad9f-a4e7fae6d3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ec6ef57-cfcb-47d1-b38b-6ca3220c5e02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20979194-0a0e-4f2f-8f25-8612d79fb907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c4ee866-a65f-4f9e-8d76-0a085de8e748">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0cb1e098-2473-44ba-8ace-88063372e452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ff52ade-2687-43e4-8fcc-5f099a77ae41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_568590c3-5871-4f14-ba81-c7895686ce80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0769e266-9d4a-4af6-b15a-89f29e34da03">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c16aff2-0a52-4ef9-a47b-8542e0c753ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd8422e1-afb2-4d1f-8ebb-931b8458508d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9d9b5953-6a6b-4b2d-8776-8f0a554bacf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c308372-aefd-4a3f-a694-4f9269fa5587">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4055725-3496-4afd-9eed-220b29535c3d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25d44ccc-4df7-4ae4-8c71-c7b06699a507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e984b7b-5485-47b0-b49a-043ae3aacbd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e6cfa0-aae4-4c01-8062-3dbe496f4574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87b48993-4fff-409e-8fac-71ac7496438e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60f5fdfb-bb99-48bf-8281-1a716d1e9cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c49006c-db19-4e93-a62f-4f74ce7b5671">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd9d62f0-ad1c-47e8-ab65-be18b6eecbae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_032e8c7b-951c-4471-bc78-04fa2abc164b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5400d815-e041-4be6-8e24-f4b4a55ea557">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6403f818-0982-411f-8685-1a954d578710">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab41767f-a4c3-4501-8fe6-2c53b0b29faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_518b887a-c883-4f6d-96bf-fefd70874c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5937e65-8f83-4221-a7ea-1b171d13f761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2964a972-3a4f-4f4d-bb34-2a87fbb7209c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_803e8c65-63e0-44e4-95b9-4a68587c9ebf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_28a90dc5-c31b-479c-8bd0-36ae75d91886">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7b5b4d52-a9b7-437d-b626-5013d30b573a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8809330-10c9-45a1-ba8e-56983312a283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15a8e6b-dff9-4599-a3f4-cc992e64a5eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_da85e8dd-137f-436d-8551-4c667949a953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c990151a-be6c-4ab6-bea5-3fa861d3f487">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c68683c3-4c6d-41e7-910a-f8fb69106e2d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9cd6b6e3-2fe6-4b21-a527-04ee4da982fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea51ec29-12dd-4c22-bd1c-f8b4d6c88c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d73ee5a1-22bd-479a-b8c2-cfac03997d0b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_00d337e1-f715-40b3-ba0d-330107be943a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e35079e-d21c-42b9-a71a-bd371ef325be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba54f75-4322-4260-a3ea-5c8a1fd8da22">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02cced8e-b04a-4c14-99eb-effab66cbbfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f499942-c1d7-47e2-b0c3-94f2db7b5d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db50e30-5d8c-41fc-92ae-ce10b51c1142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c76a037-c8f3-43f0-809f-c2d22fdc7c61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_942009fe-1099-46ff-8dfd-39bb6c8db838">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8330d965-e14a-4069-9ba5-af9cee313c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9a94a356-74e9-46df-97fb-5bb574ce5aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74896b7f-2442-4b14-9fd4-a345f81988ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80d06191-1b0a-44ba-8966-72b2cb09552f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_721cb49b-421d-4b7b-9009-5e492dc2fff2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cf5789-1e9f-49d3-bca8-81720d2a2e85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_042500b2-456e-440a-a299-70b68697b78e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61d12870-7112-4a95-9fdf-bb0548490252">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3f46115-af74-4aa6-86ae-154180f55b59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_766c7c0e-c479-4fb3-b381-e2664ad819a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_184724c2-9322-472e-ad84-f3d5ed3e8ab3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1a75e146-4a56-451c-9165-17ea4fb4a25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_effcbaaf-8216-43cc-b073-cfe772572506">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_44dbb378-126a-4790-98a5-6e6b6da2c8d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f4a76a-d81a-490a-85c0-8f01b63ab5ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2edeaf8b-6707-40c9-9fe2-ccf1f8eb347e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e3c8c14-3636-4f67-918b-08d3187d513d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ad35ae9-afda-4659-ac88-72a2bb9fe44e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f77d3121-7cef-4297-bc8d-745375d989c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_63e90e7a-e502-43a3-9128-eb540c6c00c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e510fe3f-7d44-4d7a-9f1f-3388843068d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01d20bb2-a8dd-407a-a54f-f4d90f2206f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc0eb440-7432-4aa2-8900-5a7646660733">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dafcd693-b165-4b36-88f9-6bd171a206ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47dcc68b-7686-488f-b77e-cbedaf655b09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a44d56b-3af4-4d12-831e-161bdb3b7217">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de415489-e0f2-4512-b73a-135b3e345a95">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4a169528-7bec-471a-8892-3f66276e37d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74ef52d5-c88f-4177-9d50-2a6e408bc8a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cef415e9-2e4d-41ec-8d65-54f834f290e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4df8a044-9965-4a70-91ad-3e0dab7ccc17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb6166e-1b65-4c55-94c3-b2157ed3517f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e19eba57-e9c1-47cf-ad50-59fe6b08c01e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_346a5319-3ec2-40a2-aefd-38dfacbbe97c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63c7ea9b-23ae-480c-b27b-f7764ef9d5a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_168c2329-960b-4f86-91db-ef94ad8f7dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_686e884a-a0b1-454e-b7d1-33c7ad46f89f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ec1f350c-c2ae-4665-8e68-45edcf92d1fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4edf081-2fb2-4da4-94db-98a2a596247f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_312f25f3-55bc-4417-848c-236d31d823f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f359893-b7c5-41b0-ada8-8df06cf7a8e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db1a4a3-7c77-4e7c-8a3b-65499a81fb30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc4c311e-d167-4d5f-8a36-c7c1c915bc04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ddcf7aac-e7c3-45e9-bd81-6146e951addd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af420f53-37ae-44db-abdd-79138f483c56">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13b3e3a3-d932-4e97-83f4-d63c4e1c8527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2463ff2c-7690-4dd6-bf44-039f9f475bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df6b50ee-af5a-4e61-9bda-0752ef238e3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d67568e7-c48d-479f-a4ef-51e35b018f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3be2355e-0065-43df-a264-57a295042faa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd875ee0-a6ef-4ca0-87ef-f6b5b079308b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41386a39-3f57-424b-a8b5-8d3b5a32bd79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eaf7e467-44ab-42e3-bcd7-70692bebbd62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aeb672ee-e2c9-4172-b7c6-3d3915821c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbbbea53-8f92-48c7-8cdc-a3fbd920c43b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bae580a2-0dcb-4ed6-86b1-f5f603b937dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4eb83445-5e74-42a9-9b92-e1cb3c6ba13e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33f8b01b-0fde-4257-bf74-20588be588ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_876a178a-7474-45e5-abc8-d9e3eb0d231c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2f24cd6-459c-49a4-b93d-9c6817cb1488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84507e60-680a-4b67-a596-c214ae0b8c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56715438-6a4b-49f6-bc4d-605136e0a3e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f46a611-ff04-4bda-a0be-9d29131f4b4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b1a2061-0ac8-49a9-9954-847d9862df0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec63eedd-ad1e-45d6-bae8-c797162a1e4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3971a8d-94bc-4b4e-973b-16844ffdbf18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8526a3ae-9742-4e33-ad46-dcb5e89af11b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f31a7a93-b405-47bc-82e0-5862c71ef7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1bdcf5ed-4a96-4d08-93db-65c2d5dd908f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90ffc2e4-3f7f-4b32-81e6-c4c2a792b458">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73487593-2e52-4172-9f55-c27fb539b609">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f7eb4e4-8de9-4352-8986-c31fbf58723a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6137d3e5-4586-417f-93c1-dc9e2b46adff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_696dc02a-5cfa-4723-913e-a5885b3e5885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_843f4407-c335-4824-8f2b-7f2ed4094014">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_947cb703-a50e-4602-b5a1-60cbeb8832c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f8860a6-75f7-44b6-94e5-01dbf0aa3de8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0220034a-1a6c-46b3-bfbf-a984702d3c1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4f54cbe-fc62-4410-bffb-0521959fc2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d3a0ccf-17a2-4beb-ac9b-7be3dcb0fb73">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc80f782-5c36-4239-8442-fb25c5d61c4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c216355b-0f57-4118-89bb-b2780f146bc2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6d75d35-3089-4dda-b69f-ff471b24aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ab9cfc0c-b194-4af0-9fa2-77978e43c0c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_63a8f42a-c8a8-4e9b-81c8-001bed4d2a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7f09426-095c-459e-8e0b-e38500fab1b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed7f9c93-a8e7-4999-9d18-f5bd01b65933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aa3a3f9-c86b-4641-b368-a099f8583656">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0fd18f1-856f-461f-bdd7-997115ef1044">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c78936d7-acfd-4a0d-aaae-0153ebc7d768">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_09e0f824-f92f-4e4e-92ec-7d6770b9d243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70993686-256c-46bd-a2fc-674f52ac59dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_65b03961-f9f6-420d-8f61-f44ba99fc4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de9a7b88-6748-4089-9d89-911dd957bee7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec4cad68-f17a-445d-922f-8a419d3fec9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7850bffe-8b78-4551-8f92-d52ef0addadb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c912ed7-2d69-4118-ac02-b9035f0d9e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_43b6fcd3-4a29-4e9f-b597-518117e3f111">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_009a7bac-59fd-4b36-a39c-a635cdf04418">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b0739c1-a932-452f-b10c-356d293b82a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec5176ac-a1d1-4f5c-9546-e9e47f6ad8e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ef8ecc8-7d0b-4507-9877-9f640b323ef2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b6c251a0-7f4c-4930-8e39-7a91fce144e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66e59497-02ee-4f54-ad5f-4f399b2eaab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_891c0f42-fb9f-4390-ae0f-307bc6cbfc64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04a2dbc5-819d-41de-a987-8d334031c175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc5d543b-bfcd-46be-8fea-1b2490b1ea9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9f5d49d-922f-44b2-9d78-ba41b47542a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41955f1e-f88d-4160-8879-ade4e9d027f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d97bfa8-9abe-4275-a2b0-1acbaa779613">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dfc5b8f-fecb-4041-ae98-3c2b1f96feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8dfa0c60-9696-4870-87d5-ec7d3e2b72a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15c0d9e-956d-4afe-9654-9ae5cbeae473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0a4153e-156d-4852-9921-6d1a1c1064e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df7dc1b3-5ad3-4697-b808-103a9b2e22a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d69e028f-ecb0-477b-9fdb-36594afce196">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c04f249c-6bbe-4db7-9637-a3bef2cd6599">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04b9b246-5df3-43be-a733-5aec27fd9be1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_00fbdcfb-3d3b-4378-8dcb-5608f6eaa51b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef59a32a-bc5c-4512-9437-86fdef2ac2d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a208f474-056d-48b6-a271-a7123684f108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a20e1cae-0b90-4139-b87d-9ce76e6219f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23db024a-d255-4402-b2cd-e7e0052f6e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816a0247-2a88-43d5-8de0-d4709dbffe98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9749f3a4-64c5-482c-87c6-37322d113948">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_580de0e9-f8c1-4969-811f-46712414524e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20f43d84-963d-41ca-8548-86be349e8471">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2bd46877-a632-4ddd-b880-1940461fb45d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_02f193ba-e746-4eda-ad79-9999ef27fe47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b569c39-9301-424f-959e-c45e0fd99f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91e9275d-053a-4d88-9d20-c094f2ccc85b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69f112ef-9f4c-42f3-9ac8-472698d68257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e47741b-e0d0-4985-913c-d95c500b7e48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1178ee67-c92b-4568-bdd2-101440661e16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8960c67-75b6-4aff-8b83-05fffd558dc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc81403a-372f-4310-824b-112e7bfcb323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1d717e38-50cc-44ad-a538-cea12eb5e1b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5465ff43-da95-44ae-b8e2-7f3b590e6c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9e6cf153-1255-4a4e-a3cb-8931792c077b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a29bb72-2f86-4d29-affe-b2391894c13d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d58201c-4d98-41ba-beb2-ff5d742fcb66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98fdd615-f480-4b42-9bb3-cea3b7c2fda8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0a978e78-aa93-426e-9765-368315bb94e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c873a17-42f2-4abf-8c47-e47021e0e3f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a5a6dfce-8298-4b76-8289-9e3fee8a8583">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0df7090c-0218-49e1-a3f7-cf30c8f9f8b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_177bf3c3-c744-4321-836a-a2fae0b0bbb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a551b9c1-3d7d-449a-84ee-1743fd7f9366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38a5688b-b7c0-45c5-9243-0293e2e48b94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad56fb97-89e8-4c97-84fe-98d7049617bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee95150b-76fc-4ba3-a9e3-8aa2a41479b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3304e735-d4f2-43dd-bb3a-22e720aa6d7d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2869b4e-01d4-4787-a309-e5c09b2214e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45bfc964-e77c-4912-993c-6ed38877d6a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d598576e-9992-4e55-ab22-7ac5e336c167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0387494e-d16b-44b8-903d-3aae7c4b2d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ea8cb0d-f908-40e8-8be5-f6cf397fc6c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47badf30-a042-4cbd-b2e5-027b03e98eca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a2503c0-15d6-484c-9d50-dcaf87e40afd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ac3075d-b630-4f72-9637-9e0d639eea21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a73abc8-c136-4d48-8b72-ccf7c89b569e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_443d1b23-9393-4b67-9596-b24170a7715e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2003d398-4989-457f-96d2-1d171aaa3496">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_467e0941-4ce6-41ca-9c73-fc30a3a465d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_434f488b-72ac-43d7-ad91-7397a8d1064f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e39401b-8a3e-45f5-9b9a-b23d200ded9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7396260-dcb7-4643-8440-4c22300245ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c6c8c-c3eb-4c10-9ed8-60b192b7e93d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10d7ad43-0c5a-4691-af6f-b2784e71188f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5169785-0581-44f2-ab10-12791b566cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa81dcb5-3516-4f66-8384-f28ec6470452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84b7f2f0-27e0-479f-93ac-7e5575559334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9da5e21a-cedc-4d7f-975e-b895d61a5b4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8b07eabb-e9c1-45a8-854a-b0e19382565c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d7048bf-1d51-442d-a7c5-42af545b53b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_667943d8-8735-412d-b993-d7f49ec6ec56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_78ab02ba-6e28-40f3-ad7c-e904efb2dce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f55d08b5-1ce5-462f-b19d-7e59303c7055">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0adb0e5d-57dd-4b49-9fb6-4b542a78e281">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fc722a0a-b5d9-4c9d-b2c6-aa57aa347267">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f46dacd-ec53-47a3-9ad0-e69d01af2a32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47e98763-4205-4c3f-9fca-580e6716eb93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7c51871b-8c97-4823-8108-47c7d756d416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422d93f-8f56-4ece-b98d-d6bfdacfbced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73252c52-15f1-4024-8dd3-b7f5c081e5b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c7306cd-aaf6-4452-bf95-aa1b65184654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a90aba9-d586-422e-8011-ee94ca4fa7c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bcf3d63-4745-4934-a4db-6c7e999c6cc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_acdd21e9-23fa-4c1f-adce-ec12996b7bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec2c9742-eb7a-4c04-84e9-7ff3c8cb7325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ddaae786-f86a-49d4-ab4e-8f62cf002977">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0b79f1c-045c-4a78-b3b6-8646f10b3864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39ac3d07-5ad3-4af4-85ed-08bd818a9c57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_febc165c-7c90-4f43-afb5-b99fcd6d0ae5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e8d3745-e50a-4068-91e4-fe628f09b912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b72232-5245-4b60-be58-4f5e8ac5fbfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_27f3ab55-1b69-46a2-817a-20f140d8cd91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dbcfdcc-7bc5-4654-bfd5-0eb2a6764f4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9985dadd-4bc9-4c0a-9952-68e4674633d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eeb5e115-4fd3-465d-846f-a8b94662e138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a93a0ae-8c5b-4578-aee6-66d0adaa0034">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ed23ba9-347c-4522-ab04-d6987fff54a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3321c52-80b8-43a6-ba29-433ed615fb9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e7079d-f268-4eb7-ab0d-986277db80ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd245486-24f1-4bd9-a5a0-8566fb209f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4585259-822e-4a6f-b0de-a7c1df729d57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d66a7f2a-ec30-4686-bfa9-5804598b7f1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e0a586e-4363-4731-9ebb-852e63184386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b2993f37-953a-4fc6-95df-364a30765e93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_879b6ec0-699e-4c45-95e1-8ec2b6f0b1ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_75e908a2-18b0-47cf-92ef-1c6e2d0b87ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af84240f-9aed-44db-b2fa-e1e428b93e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b675fdd4-61f1-4375-accd-7b6aa01e61a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d19a72c-2062-448c-8aec-ef4299deaef9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_85657dc2-b4a9-4900-90bd-9841b7283960">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0b1f34a-3695-4717-ab24-afd7b7f2a4c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_278a371e-c8a3-443c-9812-da6d05023804">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea4a6b35-dcbc-4dd1-a1c3-41af5b692519">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_387649d4-7c09-476e-8f8a-88778b3433f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1108f037-931a-4c97-ba81-1d3945e8a108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2796ac28-9104-41f1-a0f7-8c2b2b8c7e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6d589299-a69a-4252-af49-c04675260ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c00ff0c-aaad-4bd1-a28e-b2814d8544a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8045156f-db54-4b51-ba78-c03b95abc2a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a34bc6-1275-48c0-9620-13d697e84771">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6978d4dc-db26-4438-b821-7dc2d6de928f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_293a7321-4d59-4ac2-a737-ecf77e9722e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2e2ad7f0-44f4-4af2-82e3-77bc37ef1f54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d8ac7a7f-ddbc-407f-9405-dc3215bc0b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b09fc32-acb9-4459-877e-24322a0a83f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c41c99-9bf7-4d09-8101-027de2575f03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572a2fa4-34a0-449e-9795-578123117344">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_959ae440-87a5-461a-8c69-d91c6be97d4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_373278fc-18a1-4abd-b048-691670efb49c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc776d4c-f4e1-40d8-89a2-218707466d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2bab2b3-e4e7-4ef4-9ed8-fe3468bd5127">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c260bc-94c7-4cfd-a4d9-f2539e71b7fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10b57bad-d28a-40cf-8f33-3c48cf7fb4f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48680022-5b7b-4547-9e96-7fb49bb638fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8095e658-d0bb-43dd-845b-f036a180d704">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e90719ac-9754-4a36-bbf9-fb321ace6d2d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88b36e46-3e08-4a9c-86c8-a35e0556771a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1305bd82-d13f-463f-b23b-0a7beff54c8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27490d8b-7f83-437c-90e2-38655ae49692">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5812ba09-aecd-452f-ba1f-37c16d76b2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_83030d83-d89a-4ba8-92fa-3a20313fdd4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_38c2fb13-f108-471c-ab65-5731a64b6cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_109ddaba-7a47-45ac-877e-b4d0edefd18c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25c10f11-aad4-4271-9b83-6f26879a49b2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90193171-e667-46cb-a5f8-a79f5fb9a047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c4024fb-6fa3-45d1-bf4a-1a1c9e967701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75034b3f-0566-4bc4-9e77-4589ec5a3529">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ee4a0c2-7707-486d-b061-60cb3639131a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0cbf76-5e70-4ac1-a14e-1aeb435db65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3debb7b8-d827-48c8-827f-6dceae6c47fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1bf7aaf1-e4f6-4795-abd1-863d1c5e481a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6799f164-6554-4fc2-8c0e-83c42fea4ced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b3e639e9-c7a1-4eac-9134-b7ae9a1019d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_108be304-cf43-4c5a-8bf3-94fa3e8d74fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372e32b1-1aab-432b-9c3e-bc1b489d9e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dac4a438-5467-461a-87f3-b7a53957f069">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eebbadab-e107-4699-8e8c-fa9c1f93e384">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04be338c-4123-4d3c-907d-cfe7e46e082a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dc3386cd-4655-4bdc-97fa-b6d42a53a6dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df932d23-c0fc-424d-b8c2-f3e6599fa319">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1cf568f6-4c0b-4a61-918e-d6ff3351b8cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cb029e5b-97a2-4f2a-abcd-e6e0fdefc53f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f455767-aa17-45df-8151-164007b94c58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe42c63-3b53-41e3-b839-0f65d0069446">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1eb2294-922e-4794-8a02-65e81ca3371c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee5a5db3-c2b3-479e-80db-614dd45941e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44a01d28-5f0f-433d-9765-93694bb03814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_91c721ce-fd9d-42b6-85d7-574a9f1ac063">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35eb4da6-136b-4bca-8604-47e75286e65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4044b56c-de8a-49b2-9a24-8d72190aa272">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da881031-0b0d-40b6-86a5-aafdbfa81931">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a94c14fa-0352-43d6-8f52-27d7ed31fbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_982d9d6c-a0b3-4977-9ac7-6542cc61f4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2e1acf0-3a18-4654-b0c6-1f49191aa7f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac2f8368-74fa-4e99-9ecc-00d828bae587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db7e5d95-3bcb-4838-8615-e20786189b81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2c8b805-99c5-4822-a5e0-8b7715404d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39133449-53e6-450a-bbb9-2a9f492816ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52cf4172-5261-4ed2-b0f2-153da4661c73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_759a9435-a21e-4f99-a560-85da57a1d290">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0ab7585f-f58b-4966-873c-f67bb20f6b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4406299b-b743-49fb-aaf9-da8a976adf9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_149e05ed-ded0-4b52-9f8b-a74fd2961737">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d81de1fd-80d7-46f9-ab23-eb276e288ee6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da192a0-4748-4919-af6c-739d407d0d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d3e78a-4c0d-4af9-91b7-ad6b70ac9a08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4de32c8f-fbec-44e8-b08c-4b1f7f0ebaff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_247f2ed6-5a4f-477e-b5de-c71d021f919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0b877750-4384-4ec3-bb38-08ee5ccf16d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9c8c518-9a45-4371-bd8d-47e5a3520e74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be89e92c-bdaf-4807-acb6-4025d0a88244">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee9c1f11-acf2-44de-905d-5f284b2f2e99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7540f357-0df7-4c75-930f-21d4e0cf46b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7948fd33-023b-4cba-b871-f34288cdd5e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56081645-b0f9-492d-a015-67797a891d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7eacae3-b893-4773-8a15-c0c58eded027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aa5ddeac-c8e9-40cb-a1d1-9f7ea09b3630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12af6be9-e7c9-48ed-94ec-5d6f90db8dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a34654ae-5aee-4fc6-bdc2-5ec098a6a2e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_60196fc6-3c06-45c7-ad3a-d58ffcea6351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d6ffcf6-4c89-431e-8efe-472592c985d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c4fe896-13ef-487f-8ff9-2dfedad5b2b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8cd607f-df0e-4528-8b90-5b4718af222f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7fda72c2-1863-4339-a7a4-f6b3e2b6fbef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6d1299a0-430a-4b38-892a-45af9c3963b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea273147-7151-4e4f-9db9-1fcb630b401b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e24c6d73-f009-4bd6-8a3f-55799db87823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_018b9ff1-6444-4689-b68c-97b463b09946">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6a79ce6f-d266-4de9-a41c-650ab243444e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70a7cf98-4c62-4403-b08e-76c9392f56eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c4f817-3a34-431f-a6fe-db0ca3ad14b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_242be4f0-4ccc-4c64-8ca8-285c5f801e05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1747a54e-2f1b-460a-96e9-f1e004c0fc50">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1cf3a401-e334-4e2b-b888-747c70fcee33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5923661-1d0c-4844-b6d1-4ee4c6953345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dbd09afc-8674-45f5-a0ec-f55886cf9441">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f120ca0e-d965-4061-ba03-9ddd552b5aae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd539541-75e6-4ca8-9f8d-b27aef8a0d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cf00de-bf8e-4a71-a89e-ba65c7d70449">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_21bb583a-c74f-4282-8144-3cf309cc0088">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a65ee9f-719f-4f47-9dfa-ba9ff879cdd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9d9a73b9-313a-4e9b-8fa0-cbba3d566d96">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_585ae3c4-d76b-4fb1-bc52-cc2665b7bff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a471487-7727-4db6-ac27-ea7374e03907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc862be6-abcf-4e48-b9bd-d1865d75558e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_df93daff-7fbf-4ba9-9486-40503806d1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bc441fb3-f4a0-4696-9076-82679a508d59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c3d8d60b-befc-4d71-a319-22ba6e25bb74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1d980b-aaf8-4ee7-b7b1-bbce95a7748e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486d1e9b-549a-42df-ad67-29d2016f4571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fe878612-3cd3-4f69-8d54-6f4fd236cda8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dcd0ebfe-3623-4fc3-89df-ad719955b5f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4446022-9134-45c6-bb58-b7a27696b416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24f3e454-8e14-4307-af4c-b8767213f69f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c57189dd-499b-42a1-b6fb-40bc90d3a310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_804162b3-4b87-423b-9dad-13464536caea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1eff0e72-3247-4107-9993-1298d21ecee5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bc82a1c-068d-4239-b014-3e770cd1c98f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e61e1ae-4fb7-4b1c-bf38-bb156bdb052b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_abc4c98f-3c84-4a3c-a195-03f724cce1e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53d5747b-9ebd-469e-a3e4-df8d5abb2c28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad5a88de-f5bf-4fa2-b3fc-510e9e8d3c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_64d83d6d-d0cd-4903-8112-392b2344dfb9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e85227f9-582b-468f-ae33-3c98845cd6db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a53cb408-2e26-4fa5-b28d-20627309624e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_86b5e424-cfe9-4df4-a2e0-2c9029f68f74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6137780-8fde-4ca3-91f1-64a5945e332b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_520b33bf-bad6-407f-a1a9-6f9105538d74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29d5088a-c14a-4618-ba86-5567efa2066b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7579990-1de5-4ca6-9653-82ccc5732f00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_095d7783-c130-45ad-917a-c2dd3768cb3e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c9b6315-c3b1-4e8e-a21f-67f978c07c5b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57779485-dd57-4100-859b-10cacc1c835f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_240ef7c2-1e73-4fcb-a83b-0d111cbf2e37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd5f3cad-2a76-4762-94ec-98a3c293daf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfdd1c93-6dfd-46b6-813b-0a5845e15134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a5be388-1f63-4417-9d57-f6a8d7f6c174">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0fa19015-6980-4456-aa50-cf912583bbcd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ab6db68-d9ef-4fab-9e9a-3375d6ecce58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9327214-7ce2-4fcb-8be7-d157202b62a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395280f8-b83c-4445-8d46-c5e5796fd2c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1cd39a2-57f4-477f-b935-966f5a9b061d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f20a0e2f-0b05-403c-981a-8b622394964e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f60585d4-e1ef-457a-85d5-a0cc458b1138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4f6fa4a-f388-4aca-a526-4034b8eaa0f6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fc3f67-b589-46aa-9a14-df1c38f536bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b901fad0-2935-4ad2-8c60-ca6f514d7ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c82adf2-700c-4e2d-8783-691c7eb0739e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a18a8468-b108-467a-865a-cc01df943616">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2c51b1a-fe39-428c-8e64-d34cca938997">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afe375c5-fa11-4fff-8684-c4c3797d88aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b864d96c-56d9-456e-abbc-339fb8a509a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e788d4bc-4664-4c67-bbbf-1e2b9efa5a73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad243881-6037-440f-9c2d-b0a9e64c6a64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0832547-0582-43c4-aec9-e5c9f203a373">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3edfd931-7c3a-46eb-aafd-7dd35d41352a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6efbdd1-ef1a-40c6-ac2d-27d367139d20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b902ca3b-88e7-4ccd-ae42-54fd37157ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1af658f5-3255-4bfb-93ea-05de03e79987">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d5e9708-d4db-4e19-aae8-90f09cd7929c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd656c03-02f2-49d2-8ac6-ad27bab92a22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf134a58-533c-41d9-9b3d-064ea328e676">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_36b31222-5177-44b2-8c7e-386051e7f428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0f32ce7-ec0d-45f2-83f0-a0de0b3f6667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36e242c4-596e-4412-9920-1ca45dfd68d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8cddec43-6655-4716-bf29-100b760b612f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7d2dad33-7520-4b06-bfe3-cebda9ee7513">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9815c625-a36f-4d07-b707-ec66d33859a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d0de5dd-fd98-4de6-bad1-e85580ba0e08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1c91801-83f7-4a77-956a-ca55e5d1e3a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ceaba128-fbcf-4166-9394-68d7f0ca3752">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b15b72d6-5cdb-4d59-9668-79ef523ce4f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8e480977-b24c-4952-a093-809cb4d24763">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5c1c711c-85e7-4fd5-be4a-ccff8eb4b5ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbb9371f-1a37-4003-b48a-8988d30d076c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5b42e1f-179a-4c97-bcee-364d1ff170ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ff6fe352-30e8-47cc-9b3f-0616a04687a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f677199a-7a7e-45a6-8b95-8237f459bc82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02e3ac29-d97f-43d1-b090-d6a871b884dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_601283cb-11d9-4caf-87c7-fdaed3433b0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_654a5c27-2a08-4691-8295-275e8d822171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77f5430e-044c-47e4-817b-bb82a39203cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00ecf5a0-0f32-4b79-8e19-ea08c4983582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af84eb50-6345-4236-85e1-0ec2f50a2809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dcbbc1f4-df6f-4356-a98d-e3b93cb2e392">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d404e4c-8304-4c93-8b97-ed2d89c816a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ca824ca-5d7f-41ff-a5ac-f3de76328507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e7f5a4b7-165d-4279-9faa-59831ac0e6a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f1c65454-d63d-47d1-ab82-933a498abc9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853b1603-5024-4c08-bca0-8e16defc3084">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_950ce21d-3058-4a86-8fc5-5c6da09dfd7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_087cf93a-9ea4-4c8a-9e45-9fc42acee0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92dd2c93-1279-472f-8d40-7e64631b28c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_84fe57a7-bdaa-4724-b43f-d941fb289764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e098bffa-f41b-4b69-a028-c4feab4acf86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4bac56f-597b-479b-b57b-b2aac2d58bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cac11f7-d0bf-44d0-8b8c-a10afa30e275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e44de395-9fb0-4220-ac41-10c9c37f6b98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea85bc90-6724-4580-b1e9-bc7626750460">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed8ba83b-973a-43bc-a272-e96e8cdf3621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e19b554-54eb-4aab-a6d2-7a770a88753a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736eee20-3b0c-44b1-b424-ab399710d6c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_010e4f03-e0d7-4cb8-bac6-98ac3f8de025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_042c4356-75cf-4e9b-891d-aa5d10db05cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_208fa1ec-4809-4807-9ec4-23588a1fb467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f657ecda-9d23-4a5a-9c0b-4fdf40cacee5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_523f1059-be27-4b98-818c-62a820e334d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a29f47d7-80e9-4691-8ada-76fc5c2f6bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53f12aec-e862-46fa-8bc0-4d0d0cfda200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69205394-a998-48be-b6b9-371c49e07ba0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d0b9c19-7f40-45d3-9f15-b20a17310fca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82888fdf-f683-41d7-a848-5279ecc53dcd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63289c77-5071-4fbb-ab73-7b68d4ab818f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8725834-bc02-4f24-a7d1-29c293e23121">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a226cea4-b1cf-4320-a67b-3bce18909a0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5ffb8a8d-d3c4-45db-97bf-b76c935dc4ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c8f602-8ba4-4b42-a483-280414838fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9634de15-4459-4e22-b5c5-17c70fde0999">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdec0538-30f7-4067-8987-308455db1f8c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a77b59ef-a76f-476c-babd-80ad5708e843">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0666e484-9392-43de-83ac-819c383b3a55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b81a42b8-e4e7-478e-ba0a-50a6e0d60e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3bb2f1c1-4602-4b78-b837-bb503c6934dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c551043-5d5a-4968-8a63-7f6a3b7132f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4637e379-f30c-4a31-84bd-ffd62fd2e46f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c03176f-cf7d-421f-9fa6-a1d8c92c4fe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aeb7f15-4f3d-4387-8586-53359e2c0bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c9b0c3f-561c-47b2-9629-81810731b547">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10641ef0-825e-4819-a601-f845fd541f49">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4649cd4e-eb8e-44c4-8cf4-8b52de8527b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cdc2941-1a71-46b8-a3f4-022f1702baab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5b696508-e2ab-434a-8d1b-b5f5cf48933d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1377b5e7-b31a-411f-a56d-254840d49146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5af16294-f0ff-4adc-9a35-fe26c735a205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7086329f-c75e-4401-bf18-c12448d0599c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da05ed8f-45bc-48dc-93a8-aaaea133cc93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_249cc69e-c3bf-4569-98df-982eb0b02755">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_519ff774-dfc3-4080-874f-8c6dffd4c9db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c12f960-6db8-403d-adc7-63d01d1f7b05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cda35508-43fc-4439-ab19-434bb3f04372">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acfad03-f47a-4c03-aae3-33bfb6afefe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a638d024-ed4a-41e5-929e-cb4854c84eee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fa30b0a-0b40-4e75-9fcf-a2cb760bdd7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1248a6-fecf-454c-967c-b71aeb1e0089">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_681ff111-c345-4c75-969a-1eb7a391a4e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_207f8550-12ba-4999-b92e-624be0b8dda4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f167c3c9-799a-4e7f-8bb7-32cf1b7b4f11">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a07ffd7-8004-4de8-9250-9c6429d6f865">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2875bd0e-b8e6-4ecb-a19f-cb48be23d6d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0c7a8c2c-1ae0-41ef-8239-2c3104922d12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83705ed0-b3f1-4918-9fbd-c8cc40df7d22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74e6e7cb-dc2a-4415-ae20-1573ff8836b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90663f13-bdea-49ae-9480-f45efa86e5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0eac8aa6-0f09-436a-8629-5f7028184b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65fa9ac4-a534-448f-8cd0-c38ac7424048">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ff2d05a-6222-4638-9733-1eef61762494">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6820822a-c4d6-4729-90de-29b9def7cf36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a93a36f6-3a25-4c76-9cd9-78c3d42fbdde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e472adfe-10a1-4a92-b3bd-7b5b5ed2486b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83cf789e-d6e9-41de-b519-aa03739f45f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6d58856-e665-4d79-98f5-afd84db54f69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784d6612-2600-4426-92e4-7027acffd95f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13896b4e-3e41-420f-b862-a0a3d21ceb96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_666c7a62-6e20-490a-a1c0-cbfb3c7436a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ff7ed84-33d3-43ab-8376-70a048059152">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14854eba-847f-49b3-8e20-ca94a2f5b9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a9b204ab-1f6e-425f-90cf-898fcd1a7407">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed504220-d7be-48d7-9805-32d3e3c0e5d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c227f1c0-e34a-4741-8d9f-fac803867ef7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb64a662-23fa-4075-9a28-e41e6adf1d71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2d83d0ac-c4b2-47de-a28e-ab512147e83d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7cda8444-ab66-4c14-87f1-12402e45c61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c737ad7-aec2-4180-a72f-d72e244d844a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_133ac243-cbba-47fe-9390-45cbdb008ccb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_872f7b3c-5276-4ce6-b962-0d8b25432d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_189e8e34-f99f-4574-9f08-b8b440464c4b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67cb191e-4133-42e0-add2-607ec93ac3bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb848d85-ce2a-4998-bc42-c56e2faaa553">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_992ea9eb-ce43-4464-a1d3-194fbc6b4ba3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677076a2-8d3d-4f6b-a22d-43b9d496a2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60eb085-3818-4f34-93dc-e7c38e532bfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c0b212b-ce81-4c15-929a-40cc841586ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc7d3b4-6640-49a4-bebd-48161c16bf96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_287c3a3a-9ab4-42be-abe8-142a3b70bf16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_277a94a1-0bcc-44ec-8db1-eb5021c13cab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5a7c9d0-d63d-4e0e-9bf5-95a77cf9cc84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e70d7203-74eb-4383-8a46-da218ed8dce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0614cd6-77e6-463b-98ec-e93ffcba4e75">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e905378-e9c1-4fca-b4a0-c5acf1066973">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99e9719d-ed7b-49f5-b9ed-f4ed85e139ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_37e88aeb-098a-41fc-9e1a-52baadb16798">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd243800-375f-4158-9a2e-e99a8b0a8977">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffc28114-bb4e-476b-9411-5930ed3c523d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acbd5f5d-d985-46d8-9b39-51c1ec77654c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a8f2b10-d625-4291-bbb2-c1fc90c3d4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f23c38bc-87bc-4431-9393-a0cc4d3170c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fa31a3b-1cdd-4926-98eb-7e35a81b18bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f3c2261-ef07-49ba-b884-bebd1494fb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b045d88-1984-4a69-bbf1-f50f6b1ed6ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38fd34c-89a5-4c12-84f2-09fbd8009033">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edbf147e-3aa0-4d6f-b4e9-39601d31597e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a58f4ab-dc05-48bb-9b39-3cb5f45fd2e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8bf36f7-97e0-42ad-864f-2f2edcb88bfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2323e83d-47dc-40de-a144-16eb4e03305b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3c11ea-49cb-4716-9818-5c12949903b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87f4fdd0-5e5d-42bf-97b2-4cff37d86182">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb9b8e19-399f-4574-822d-52b132b2a422">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02522a83-995b-4bcd-b3e9-375364be6b0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_798b3459-1bef-4fc3-8355-fdf9bf179a3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43a027cb-d98c-4ca4-9d54-5af8fe884f01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7c12a36-2bc3-4fab-9d03-d242fdc47304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95306b19-c314-4249-9726-7ef3f94e0d01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ca2305f-ff10-4b1d-b5ac-044bb4c10f74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_78b67db8-75de-4d10-a3d3-fd218675b991">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c76d6e4-2822-44a0-a623-695a0e7f9d3a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e202178-e806-4523-a1bd-f93869911a50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfe9440b-926f-4cce-bf8c-a8f6d487a36f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33626ba5-36b3-474a-a6c7-2c281ff87ec4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e6e2210-e273-4be6-95f9-5688af27f518">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ee8789c-7502-4fe5-90a1-6e73dc9c505e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6133f8b6-0bde-45e5-8f0f-028ebdcf5e51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ad218d74-0a8e-4012-8e2f-0e4b7a336d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c1e52ca-76a7-4811-a892-befb669f3507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_18fd6434-e78f-46b5-82c2-d3ebc9a988de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e648bb24-7214-4a6a-b0a5-a9fe6b8b61b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94d3e68e-9865-4ec2-b05e-248a8bdc3d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_101f17cf-add4-42aa-b827-9fcee3063868">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_93711071-4cf8-4adf-86ec-c6a32d98f266">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64cca2a6-8c18-4f0e-a042-fee853c9f2fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_180895e9-b096-458c-8c97-9c4a72ce7baf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f9420713-0860-41dd-8ba4-9afeb786243f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61f2d29b-5e0d-45e1-8dd8-d0420e496f28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71cfb5dc-ba9d-408e-b18a-81f2094e2f7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17ee7463-034c-4288-8bc7-137ac0a633f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1322195a-a94f-471d-97a1-36aaa5291e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01b1f9cb-d4c6-49b9-8308-a4fe08646434">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab4438b3-f56e-46e0-8d20-4e4129be3372">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f297db3a-e6df-4def-8490-9c3a9b21c27b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_890cc6c9-ad70-4730-a9b0-cdf9c5cac5ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8c6fcf8-d0e6-4535-a745-c08a0054f3ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dcba6d8b-5108-43ce-a5fc-b36e4b065d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52753638-c365-4f1c-81f0-f9fb6fb0d58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ba74212-2d31-402a-b2b0-f3634b0fb61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c87a5c7-5bef-41a5-962c-12bd1cf3d6a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2bf5b977-f2d6-46aa-a673-2f66e395b78b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef3a0e9c-40ac-4a1e-a041-86f72e7d5b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5e0a7a8-420f-4cff-b55b-e6e139165aa5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13ed373b-2943-4988-ad54-980c97b6289f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d6452b62-9209-4e95-b4c8-b3f87293609d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e679a526-99fb-4b23-b39c-566137ce3f75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8a4eb8a9-a1a9-4251-bf2b-4f8c975cf86e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a9bf8bd-6672-4e21-b8bb-e9e91f34e994">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_294557d1-3730-4819-8d03-96456f3fb912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e2daf53-4341-4911-980f-3022b8066b06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7fc0c8a-db70-4c61-b04e-6169c45e6742">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b83a5d31-4ee4-4219-98c9-aaf54ed1f572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_16af6b93-4e31-4e18-a77a-e4539fbbc6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_766b42c3-ce28-41e3-bbfc-786e84c88654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18029036-faee-43a5-8a1c-6439d7404892">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2d90918a-2664-43ab-ba72-50862a4cba1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5fc88920-3f1a-4427-8110-f4bc8a88aaf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1768cfd7-5909-4887-8b25-fc3e38b59dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0147f1f9-332e-4e9d-a8d9-e49d4605f776">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_866002ce-f7f8-46ce-921d-f83f33ee8d46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9226ad6a-e864-4c79-a107-ac6669389ece">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3fa8af05-471c-4f84-9804-2364ab4d0142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f8e378-97b4-4f9d-9b3f-be0fa08c737b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6abb7518-e189-477e-bebd-3b47fbf2925f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08dbcd9f-0cb1-478b-9d54-9251d09fd380">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6c00c6b-4fb8-42b9-aa43-be4aedf68d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395ebb43-da61-4761-9bd9-015b17860fc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b177b6cc-2918-4ee8-a5f2-bd619448a2ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c167ce0a-7228-4516-973a-d0267c640bbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9224a58f-f44c-4dad-95f9-d57b2f19fdfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_009bd855-5a73-40a8-b2db-4147028f51e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d617fbd2-7202-4dd8-8747-bcef9c2c5304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b667f9d-2ac9-4b00-b8ec-120472c203a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39552eb2-2347-493b-a342-36112dd61761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca73dc61-46db-48cd-b6ac-020490792c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12e678-c7ef-46bb-93dc-bd6c4fae421e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3635c9b3-b303-457e-8e50-6af4bf971c81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ed3d1d8-306c-4634-9e74-e55ce4231da4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5431f42a-4340-4948-81f8-b6dc1d46bd85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a549c145-0195-47ab-9ea4-77c6d452a452">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e8510213-3fae-44cd-8c15-4af0efd3142f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff76ff5b-f84d-4bfc-b06f-19f833592c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b52eaa-13cb-4ac3-a2e7-fced09e07ce7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9de60e0d-f60f-4269-b79b-392086bc26e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7954e8ef-e8fa-45c9-a1ed-cc05cb0e38a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11316af2-1bf8-40c3-a347-97344c20ad02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50f7ffe9-6211-4a14-a182-778413891848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_87540be5-5b92-4ea2-bc7d-5b3a26a87c91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f97ece6f-a45e-4473-8e6a-44a98b809134">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c02fc72-0dd4-4386-9b66-933757038c0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_867a6bed-e19c-48e8-a2f3-1926d9616bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02bf56b6-a3a2-4fab-bf0b-44e24794fd3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ecf22d39-597b-4818-b5a8-c31e0720bfc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ced36e4b-41e8-4728-b496-b75bab9931a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34ba3909-aa3e-4d0b-a427-063609b352eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf9be7ff-0016-4672-9459-a0b1516a2101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3227f4eb-27db-4eb2-969a-3af0b573b8be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_22693f43-01c5-4cc4-87d4-61d6b5fc763d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cd4e84e-7059-4b13-9285-4e8f4c356a2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6640ed22-d3ed-4ece-8619-61a1d5d51798">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e7ea311-332e-47d7-b933-6c6df5c31f77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bca5d88c-41fb-4e64-ae21-d1cc14551a8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ab93ba3-8eef-4341-82ab-71ab7e39fa30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e6e188b5-450f-4a43-86af-ba5bcfd661ee">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2bcad28-b999-4f20-bacd-724c9f78c298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cdca876b-026f-48e4-8bef-c9b1dcf12eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9c318374-62a4-4ff7-9cb1-d9a784db08dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca11ec26-3b01-4bf9-84db-24ac4f0248d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8705133d-cdf1-4be9-b24f-e9b2e676a388">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b540bd1e-385f-4dbb-9e2b-56ddb1eb21d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a47fb97d-2d7b-4251-9f17-312b1e07eac5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18a57444-1e35-48a3-a599-55c7a6e7af15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebe2f330-1adb-431a-aeee-4a6a21167603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4c70b357-5014-42b6-a0ee-fec1c2469a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a01662c5-96de-418f-91a5-b16db1b66c81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_87c006b7-bb18-4a80-80da-0eb053d7b15a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f276409-96e1-405c-9e75-4d9fccc8bf87">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_034ec4b5-bd8c-4a92-99a2-1f730be3f002">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bfc273d8-d57c-4ca6-a117-69a5e0ecb2d6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_392cef6c-b0ef-4cb7-a61b-d92b77e1f8b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82bd5ada-01e6-4702-b2bc-43685a564dca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0203b79-c207-44ec-a455-1076786151ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2957eef7-ef17-4284-8b72-885290a5d4c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb554827-e2b3-4174-8618-2fac9fb13cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68ca1c46-e3bc-4281-a44c-882106869b58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_081ff2d8-2c7f-4dea-b78a-d67d6abc4db8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d02ad0d1-25fe-4737-9c11-d7409abb063b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8be185ca-2d62-4f9c-8e1e-caab88cc2025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9664ae2d-68fa-4059-9ffb-473fe2c0cd86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9284884-794f-4ee0-8ef3-402a142e0bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857587f3-78c0-4084-ad11-e09272976390">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_432d7e6b-c2e8-444f-b028-b234d1ef1e88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a5b57d1-932a-4f96-8583-89781b773ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf0a0c29-48a3-41b7-bf37-d440fd41eba2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a7e0964-17b7-46d6-8d1a-268c8cdf3e64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23d6d5b0-ace1-4f4b-865e-5a827364f543">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ef890e7-a6b1-4294-85e1-3fb193760bde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb9c11-e256-4e10-8312-fdfe2385c71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc21f7b2-afe6-482f-af4f-92fd14b5abfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad6c979f-657b-4e73-ba68-257d15d08a72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9990ad7d-38f1-4620-b15c-019273d58f41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c87e7e5-b2a7-40c8-98fb-101f3db6c73e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b79df498-dcfe-4fa8-b694-04d76cfe87b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a676aa7-4dd9-446d-986d-794ce499f297">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f1f0e9e5-3f7f-4a7a-b8e0-3dad27794a06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e9770c9-db90-45bf-84af-be3839c382c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7565f8a-903e-4b04-91ee-dce04a6097a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2eb48637-02e4-4857-bf33-7421a2bd903e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5cbe4d57-0c5a-4e3d-8104-c43f35f3b8c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe00b674-5c44-4794-9a2b-525f35f7f13a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_038e4bd6-fe6e-48cd-8b3b-8617fcf53b16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b8f4ab56-0cae-479f-b994-a089285bf453">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fc5009-d32e-48a7-8fa4-0a892b95543d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f170f287-d4c0-4aa8-bb8a-be6a691759fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1173766-06ad-455b-8adf-663574665ef2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbde89f5-f08e-478a-8a73-f1203842d380">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26c96fbe-07bb-454b-bafe-0b66e0d91779">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66f5f987-6746-4ddf-8291-e079aae6f88f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d1abd8a-4a75-450b-9814-efee70c1f00e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7203f60-7692-4edd-919e-212721c83323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_314d2ba4-7d01-4433-866f-7ed52d8c266f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e1c9ddf7-9f1e-46a2-b210-fcc7a90dd361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e781a75-395c-4675-b1c9-8090f7136a9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d88cc96-bf93-4569-aaa9-b85447f5d6b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5e012982-8c5b-49fe-a915-9984a9844629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99f7bda1-69e0-474c-b2ef-27c28b95a477">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21a9a1e4-817d-4f3c-a06a-88c050bd8a01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a461b809-62d4-448d-8596-070fbc82bcd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88c1f50f-7065-428a-a48e-3955c95e0a83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3633500c-289a-447f-84ea-ee2adf5d8f06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0fb79a27-0296-460e-96bf-344c9748e998">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_320e4ca8-bc24-41ca-89e8-88fb69a20780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d52c596-f3b5-4ce2-ad1f-c662b2590caf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0c87d80-0936-4412-8a9b-c023ac69a7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46f656f6-4f2e-402e-93de-2f4de8fe6b6b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_86fe6bb9-d204-429d-8827-606b790a951a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65a6018d-1102-48c8-bad8-c5a8effaff81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fb4c745-f703-47ce-8de2-bfbbcaeaafc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc383940-5969-4abf-92be-59f7730681f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a02474-3467-4c31-80c7-4c1d43af0cbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1e7c81ed-90ef-4fff-9d64-df1dbba18891">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_270bc494-7c22-455b-a3e0-e1c31732dfc0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0da6b145-a096-4b6a-8359-91e83a938787">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ef5af20-1c4b-49a2-8110-1d688fa10a75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b698233d-7707-4afc-a8c4-ef3860860220">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2d5eb8c-d2e4-461a-a3c6-af74b86875b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_067b340d-de06-4c93-b738-322c9e63f326">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_884b6d2f-b17f-47ab-b894-29709041ea27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_175d59cd-5dbb-4625-981c-cb434b49c02e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7701a0d-bdd9-4f72-b55d-db2c6b054614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b1fe23e9-b568-46d1-9b05-3976637f31cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aab9f87e-3481-4ad1-9af4-85bab1baad21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc158be9-9c3d-46f8-894a-bfda40b4e8d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a8f056b-8c01-4df9-9819-6fb78eee91e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d3637a3-ce8e-4969-a955-19e3a93f2460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb458537-8f24-43a4-9114-692c0daec131">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e806f44d-97f4-44e3-8726-a61f5883335b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a7c0188-4d39-4dd3-8004-9b473b22b3b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f71a10a7-44bc-463d-abb6-e483dc630541">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2e8ced2-7ebb-4a01-a1e4-55f059b92fa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2f6cea0-e313-41ad-96f5-87800121a518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ad72c6b-d938-497c-8618-859b5d3e5884">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f1cf396-8d86-4e6f-a52d-e1af86772ceb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3251f608-0688-4dc4-9dc8-e3091bdac7ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8fd3fc61-31a0-43bd-b0c6-cafdd829679a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fbbd787-319f-444d-a059-3a5536c03ff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b7f797d-4bd2-4df1-9cc2-a888aec7662d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d2eb25c9-57ff-4877-a01d-57ad4b5ad6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f8d3ac3-bcdf-4d13-afbf-63bf24e38d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1342fe65-f28a-4ae6-97ac-46ffc8b6ea76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b546ffa7-d00d-44d4-b9b0-f2a6dc043c97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486326b9-4614-40ef-b499-57360c1454e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65e01f10-db8a-405d-96f2-ecb2436ea1bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173fb145-6c85-4837-8c26-642a031183cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39748ac4-8994-41ef-86ad-aa593876e300">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8feab797-7f0e-4657-8282-79c8b499523a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5838d0b-841c-4085-876f-1356e29461b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66238552-d9de-4b1b-9b46-7f3d2f028039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce8a387e-0ea0-425c-ac7a-1e5dbe93e6f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_28e4a7ba-04a3-4c8e-9d98-9b47f86b7ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dff8a9f5-f6be-4746-a6cf-9e0fb46ef3a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dd48faee-7455-4f0f-8f4a-77e7491becc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50ef0e35-d57a-446f-a4d2-2c9554e2d57e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e0f1d46-62c3-4360-90a8-bff00e7cf60e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b424c2b7-3a7f-497f-80c7-0a30f96676fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a833d30d-19f5-4e6b-9f91-19343a3ef516">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95506cd3-1c3d-4793-89f9-65cb4c8dbe8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3991ca5b-3c5e-4b1e-a604-17fc2269d13b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0b6e1d-6cc9-4cc1-91eb-2548f3a71765">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df182f4d-e0de-492d-a328-0043b36cc033">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21bf0113-445f-4a34-9358-bf53c533c485">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80a0e5c9-61fa-4204-b743-9351bb56ed69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_632eb5a9-9e2d-4eaa-a7b2-00d881f0b85a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b386a96a-0e25-40f1-acd0-e6db2ead045b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10196086-9e19-44bb-b597-102575b853e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b6bb26-e66c-4d36-b242-8da8298dfbcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_40fa729e-1cbc-40e8-9150-07e62aeff0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b2ae2b3-068b-4f40-b89c-183060300298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_233b7c4f-1118-4246-b7b4-8ffb83cea2d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47c6c1b2-0598-4985-ac70-ea6696ec5bc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec420356-2092-46dd-bd46-319011559d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffdebe6f-5731-427d-a69f-bb6a72a5842c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b6b8c7a-4fe0-488e-a01a-1e14170230d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_516c7e02-238e-4cd1-9e09-495bdeb37206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ca2a83-900c-40db-b703-573ca798e017">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2026e7a-6ae4-4e02-9429-3d7c0044c104">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_16daa926-0bcb-48ee-9fbd-f92fda0d41f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0d4db3-6da2-4152-bef0-416b2d5b0f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c08f3b3b-a1c8-409a-90e4-8a48873e7d62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c9829-f820-487d-9ff7-f9d743f2bc6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01815773-3d66-4ea9-a4b5-7e3bc5e21bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11eb003e-8feb-491c-aab0-f4290351e574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3fc6d901-d47c-45b8-932c-9503f5e191e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_346ad448-e260-4eb5-ad22-909cf41d55e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0aa15e9b-4db7-4647-80f3-6faffbbed9af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e186c8cf-20ad-49f0-8181-cebfb9de7644">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2695dfad-50df-46b7-a2f9-455baf0a39eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ccb801e0-67da-49ea-9ae8-eb6b74fd3796">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_518c2ad8-6722-49fb-aeba-027b9834fa12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_768736df-6aba-4013-a7fe-5a4d2415efc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c98ae667-4b00-438c-a4e8-11eaac1449fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aa48cfef-d128-4b07-a145-71146779f621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dad66b7c-ead5-4597-b4bf-97239b0854d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_571e8263-08c1-4586-a8e7-327d1f5ff2be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c344c2f7-1f7a-485e-ba0d-980abab192a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac2bbd87-5d42-4fff-967c-30d4052d4a0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d381ddfa-6e11-4efa-b898-c5d0ecdda246">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a14bcea2-8848-4ed2-8671-6e9c1db7b38f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7eee8ba0-c290-4cc6-9b99-cc978ad4a55f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b660b46b-f89e-44ba-a2f2-5f7ce2e38699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f5a225e-9d00-494d-90ec-44352d98d4e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ba7b635c-3031-40ea-8907-63881e80b42c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c94e6b68-da6c-43d1-94fd-09ad60c74134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6fc20583-c9d8-48f1-833c-e332515ccb72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ff1d968-f352-433c-91e4-2086b875b068">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f57e0ec-227b-48ba-8a55-8b1792a44c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4caf17b-3b80-4f50-84cf-3c9800262e53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_750abbc2-9c8f-478b-967e-5bca6ccb6649">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d877c8a9-ebf3-4468-9bf5-bd35e802914d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dbdb1b4-0575-43d8-ac61-faf72cb621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1b858452-c35d-428a-8b4b-90f21ad07836">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa7083b1-1a9b-4973-84b9-df7487d7f4aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4462db5-e42e-40fb-827a-196a16d123c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df2d3e44-0edf-416c-98ab-3efbaf98a66c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_64b2c7d7-d7b7-4c1c-9f86-b1adea0698d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2f1d3e-8f67-47c6-8e9a-dbd477da2acb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b75cd36a-7f05-4fe3-af88-ff32fe39e6dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0897b098-e2d5-483b-a708-28f47c435413">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc31b2ff-8ba5-43f8-947a-2f11dd26492b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69d4e272-32f2-46ff-a0ee-95358129563a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe46cdb5-2ea1-4fcb-b508-6ca5aa09db3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69d1ccd2-3730-4278-99bf-9ca956be4401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa397ea5-dffe-475a-86f9-d00d21ac01e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25cee9f9-9bef-42be-b860-ab3beead7814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f441e1ff-6bae-4314-98bd-5b1689de1b2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ada9951-1e02-4889-8745-f13dc4148ad6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed408729-5a92-4002-8a8f-ae384ce3620a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_688fc72b-057d-4a98-98c3-f962aeaa22d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_347aaee1-bd55-40a5-99e9-fa9bdc3a9ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3e50ea0b-e624-4ac7-8e6a-29876963b392">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6f1e5e9-d979-47a3-83d4-817003628745">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5318967-afcc-4fcc-b0de-d5f2522a95a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8082da6f-11ee-4cba-96f9-5258414b720d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e704656-b276-46da-b8cc-b757bc42fabb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e9f91b69-a29b-44ea-aa0f-cff86ee80320">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5adebd33-20e8-4c94-b02c-d9033c3a891a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad86e83d-6334-4dd8-b642-b4c16d65329a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c96e50b9-ea15-4421-b6c8-bd9c9158a69a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f43dae36-6df4-46ba-9dc2-01543e80e0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b8b0b9a9-af8b-41d2-a4f8-940637e63f70">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b345e74a-9570-4cb9-9a59-928390e3dc44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17abdb92-0180-4bcf-8ae7-dd923630f360">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0b78ffaa-9859-4658-af17-c8d355633556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9acb676e-054f-4e61-b60d-3371c3320b52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9315b98-af75-40bb-bf8e-05bd03d43db5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9dfeeaef-5c49-4c2c-97b1-03876970bee4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36d76f23-8e75-492b-8f9d-4d68d2dab71c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6a076be-4135-4592-85cf-1f22fb0528a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6fcfb68-394c-4c29-9cef-9e41fdeeee26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_420cad1e-e8fd-47fc-a747-b9032181f6c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b664adb-6099-4a04-a498-dc33ba0fd5b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39cf2a82-5f62-4cef-9bd1-1af4f783291a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7eaeea7-ce64-4a47-86ac-0eec8c65c8aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fa594a2-56ff-41fa-aaf3-c9491755b684">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00865800-7a32-4d63-91f6-88217af4743d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0b0cafd-9ee4-41aa-ad86-965a7e4a00bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_287ea6e7-a365-4038-b8d7-d7f01677255b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd5768e1-dc34-4e62-b9ed-bc8ffcdc0000">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f383c35-5d1f-410b-a60d-d67e1f48f646">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_679919d3-fc46-4791-b7d8-8a87d0bfbb91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_835c00ee-21be-46df-98ff-e6cc1cfabd3c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0434708a-79d9-4740-b697-2bfbd525260d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed1043ac-f6fb-4f30-8a2f-177e4fdcb26b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cafaa7fd-26d1-4609-8186-f9af8022be4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d43e0f0a-5253-41b4-9e43-ef864af5b857">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3d02781-552d-4bbd-952c-f753034b5ece">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46c8e67a-37d6-4498-a6e1-148ad0fcf682">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74a95e4a-dc88-479c-8aa2-fc194cc595ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d27fc6e-5da0-4d89-8d93-8bbee127638d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_17cb9e95-1fb1-4fad-95bc-9cb4cb1eabd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a6b0d1-4103-414f-98f3-14009ce91e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1286c4ed-c414-4282-af59-91af27cb856c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b591b30-bfd2-49b3-9bd5-4eb808638a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38733a74-2927-4247-8fe6-065cd9fdf7de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abe5f6b0-6e09-41d8-b326-685828bb5fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57e7e6c3-e0a6-4ac3-a0e3-392e749b3dd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40d166e5-8a94-461c-96be-c7b40c9b0c26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_159904f5-dc85-438e-adb2-0f7accdab22e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2eb9abb5-9566-4c1c-9e11-c2f6ee115cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba08c29-26cc-4706-ac27-26692aac8c88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c7d6536-ea8d-4b7b-be12-6be542b1db2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d62d7e5-64c4-4d08-8a84-543433b71491">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff03ac62-f2e0-4beb-a79e-447a8dbcf53c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b729ff6-e8d4-40a8-a250-8546f9d43ff9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d917556d-7af8-4d62-912f-cee8779b78ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57df35dc-cdbf-498c-a3d5-7f5da2618ba2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3e47bb0d-8a7d-4e68-bab4-e4b55c2be04c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_09b5337b-759c-4cda-b09e-fc2131692bfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6554fd18-1d49-48eb-88d8-289134c6e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1baf8007-34b4-410a-bd34-21ba83f132e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ea887338-df13-41c6-81c8-10ddf6501626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dbf3737-7c17-4e23-b698-a6231fc95c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cf25bb9-e5be-466a-9eda-76d00e20aead">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_181c1a17-a777-4729-8e13-5d427ad49c94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7bad0622-8a66-4e8c-ad40-dc0a25bf0123">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73e5d2d1-d756-4b50-8069-e663130f1816">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6296a5-b265-47cf-b634-c8e0e8fff1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90364382-c1c6-4471-850f-7ebf7e718070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3ba7162-1168-4478-97a5-1f522aab0b8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34818fdb-09a6-4567-be70-0bfe57e6cba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dea346f3-01e8-4b63-bbe3-5aeea6ea9129">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0e08d7a-7d6a-4cb3-8a77-447b121443cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d8569a51-3dcb-49ee-95e1-193d570db5be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ccffd22-4277-4a42-9dc9-86b270a0f291">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e8f404b-ad7e-4684-bc52-e3464e34ee79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fa3678ca-1dd0-4be0-aac6-a5cf857e7d60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19bb3455-dba7-4049-8350-9fc3c29ff4cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4274888e-6e49-4d9e-9563-b483331f8424">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80fa1756-f607-4448-ad06-dd7b5e69ec38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ac383d2-d853-4b4e-b0af-171813d0b7aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff8e4c1c-ad07-489e-ba11-43217dd68dad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8d3d915-6065-4890-943e-4cf5c69a97a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_563b8841-aa4b-4bf2-a54f-8f069829f070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f1203b6-43c0-44bf-ba48-25564bbefef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57a42edc-5e05-4604-b596-f01ab114f5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd023497-58d7-4396-8f9d-a9bd364f8c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45d740ad-e86f-40d0-9008-fd671acbef6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33c8f510-825b-4689-a374-f96650937c33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe2c5d47-fa92-41ec-b454-3cb1c878437e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9f2dc0-6618-4f8f-a284-22aa15d23fb7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cfe03e9-7d00-4eb7-be53-4b443d69703a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a26ae26e-b636-4503-ab26-2f5946d511a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0759a425-647a-4247-b66b-26357a147542">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6ae1641-50f7-45be-9833-bf04ddcf7697">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6cc414f9-05d7-45a2-a19e-958faed12395">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eda4be62-674c-4d62-bec3-33bf3bdd6294">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a241b4fe-ce93-46b3-ba20-126ed4574adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fdad08-fd5a-4f4a-8ae4-296ea3184087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0d653c1-85b7-4edb-b412-90836f207efd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a897e54e-1f4e-49f0-a8b8-d1b79c28413a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b3d8eb66-45fc-4b9c-9206-5b87bd362315">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bffd0293-189f-4b46-9e82-f8951326d01d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bda2a584-06ba-4aa3-8af1-945d6ad9829d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b37c45-5751-4c50-862e-d2f811623bd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e9f123e-b540-4391-833f-84e5f9b7e63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8911f118-6ed7-4424-b8e1-a6885482ddbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3da39f62-762a-4533-9485-f1849e5f8812">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dffdb415-95a8-496a-ad1a-93cdeb444fae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7ed6624-d332-4a9a-a96b-b31bcb1ef24c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccb6edb-253e-4e1d-85da-c68ef40f59a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa063f2e-1205-4d1a-a549-3ccc5b31e65d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_443775ac-c8ba-4e4d-a91f-d1926ba21744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ef85f09-3622-4a12-87bf-fefcecc01e4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28b3e895-483c-478d-a5a3-7b9d7c9e11f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a0244ab3-80e5-4c20-b201-a142d50e6ec1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c8e0d41-008e-48dc-af1e-e988941e71ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0ba9bc8-9cb8-41f9-be4e-a8f6184e1432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4e958ea-f50c-472b-8c35-9b2a606d4310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d0edeee-fb82-46ff-9ad7-8937813fd4a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf4393c0-21c2-4e35-b330-c1acda2647ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_72627757-688f-4752-a751-c9e2bd554d2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3d5e8cc-be34-4d4a-a586-ce582737826b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10180352-5b41-43e5-8bab-bbd40fc3053b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10313794-08ff-4455-90e6-a439d474d0ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_22ac1bc2-c0f8-4d04-897f-c24e25f28f4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aad73b40-3e9c-40ac-834d-4c0243a5c334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f492ecb1-1a65-4013-99f8-49edc9d7d556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_307df982-5918-4ad2-8c83-1cbc9b7906ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31cfec00-6695-4126-b60a-98c4cd7132e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cf36442f-8f07-4110-aecd-1c7124608dd2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53e398ff-d48d-4e1b-acf0-be0965777d35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4615f36c-51ee-4eb0-945c-d57636d7fbb3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_db7be977-a065-4bb0-8b27-d44e0a6cac16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c3bbfbe-faab-4429-8c29-799f941f9add">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed71bbb4-203f-42dc-8a01-e3b144ea8ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_54cc9d2a-325e-4545-a35c-d322e006a8d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5731482a-7053-4716-866b-ab26f39cad97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aea5de0b-5724-497a-b712-f813e6c55462">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_350e99eb-81c8-4938-9014-f14d16cc0989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a83373ad-d7a8-400b-9d4d-cf7a0dac3d73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_030a749a-f8db-4c51-a67f-571efd180ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fe0f5c1-8319-4dc7-ac10-643c4d4ac0c4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3105ff97-c823-4905-b049-f467bc8e0810">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d4658ae-163f-40e5-ab58-754de44a9565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f655fe14-241f-462d-9fb3-a58dd791a31b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_97da8dc3-3290-45e8-92ae-a01611dc0b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_513211dc-4e13-49b8-b8f9-8a062e6136e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bdb83ed-36d7-4e74-9e77-1237f7695622">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f605145-f6fd-4665-9672-8fef199d1592">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e8c477a-837a-416a-8283-44318182f678">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47b201ba-930a-423f-b4be-a71805471077">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4bae3a8-84d1-40fd-b83c-a9bf8c206d9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c6145b2-effe-4953-9f32-2e49388dca38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fbbaea94-c6b8-4492-99c4-08893180b6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4decc4c0-9950-4fdc-8682-dca579e200cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f851b27-33f3-45f3-aefb-2c134479e2ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b061adbe-26eb-4721-a6c9-e78026e0f915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b79434bc-5187-4184-a806-7a39037a7640">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b395e7f-bd27-41ce-a590-eeb60a5f502b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee96be74-4d86-4eb1-9150-2d594bfcfe1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d08a684-cdcb-484a-a767-03b10f4ada7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb24cba-8dff-4ef9-9ba5-dbdb086e77e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_706e83b8-c1de-43d0-bafd-57766513c62e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f468d841-1bf6-470e-85d4-55d34fab8bff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a78dbd51-f64b-4abf-9154-3c138316e279">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90c04b95-703a-4bae-82b8-7edf3075aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f193bd8f-badf-4600-82ac-f212d1f33534">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_340082f1-db9c-446d-97df-80e45aa0058b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e33fc23-0e6a-411e-b0eb-67b1271cf383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89c3d444-cf42-4e48-9825-96160ba9895f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71f8df70-c805-42fc-9a09-c9527e6f8175">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_09c871ac-e7a9-40ac-9580-ed616b994397">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6a25879-018d-46a3-82a7-81b9b99b609c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf08be5d-b85e-46be-9378-6eb35540e070">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6398ff9b-368e-4aa0-9a7b-8d9a2d095835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a94e93-5272-46b4-85ed-7a173200852f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e87b2c5-e7b5-428a-b836-5e55a23693a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05d6e5c3-2268-437e-829c-9e9107a18dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7951c520-ccd7-46b8-a3a5-fd879cd12257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6adbd31d-0c80-48ec-84d6-000aac8d9a85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:ControlArea rdf:about="#_1f9ecd81-e069-4040-bd64-f34b0fac3a60">
+    <cim:ControlArea.netInterchange>210</cim:ControlArea.netInterchange>
+  </cim:ControlArea>
+    <cim:Terminal rdf:about="#_65a95678-1819-43cd-94d2-a03756822725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c96df9d-39fa-46fe-a424-7b3e50184f79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c6a1e49-17b2-46fc-8e32-c95dec33eba8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_unexpected_rectifier/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_unexpected_rectifier/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
@@ -1,0 +1,12953 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:5bc75f63-85bc-d020-02d8-1d9358dae159">
+    <md:Model.scenarioTime>2030-01-02T09:00:00</md:Model.scenarioTime>
+    <md:Model.created>2014-10-22T09:01:25.830</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment: Small Grid HVDC Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E "as it is". To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.version>4</md:Model.version>
+	<md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://GB/Planning/ENTSOE/2</md:Model.modelingAuthoritySet>
+    <md:Model.DependentOn rdf:resource="urn:uuid:a97cec76-42cc-bf53-2269-4f5abcce7244" />
+	<md:Model.Supersedes rdf:resource="urn:uuid:2fea4dd9-083b-f2b0-7b57-568efb25ccf9"/>
+  </md:FullModel>
+  <cim:ACDCConverterDCTerminal rdf:about="#_7780ec9e-6743-4c53-aac2-f123637d5274">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_c4af08e0-9608-4654-b74f-e359a7a29dfc">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_0193405c-4f37-421a-b7e6-9c4a8904eaf8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_9b40dc62-2c36-4b70-b931-db436ddb3fad">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_412aed14-a85f-4828-a751-221172c48263">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_61a0a556-ae4c-42a0-bda3-7423cea7e6ff">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_e4b9540a-1a8c-4f8b-a8a5-b7c0dc0d1df8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_3844652e-cd36-43e8-9e90-a1bbe2d85dfa">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:DCTerminal rdf:about="#_a03cc8fb-fe85-4a7e-b96e-5c074abed705">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_e768024e-1c0c-4c0f-b023-5deb11d64dfc">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_5be89c2c-b370-46ce-8844-338414489fb3">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_d2dac22c-7798-4a59-b5db-3e4fd307abda">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_6bc9072c-735e-4016-9ae8-acc2d37f1fba">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_02d46e89-85fe-4756-aeb5-4869950f8776">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_bbc66594-69da-46d5-9a1b-2f4a706fb6a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_600ea926-a53e-4f42-92b1-aa10bfeb79a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:Terminal rdf:about="#_0471bd25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04682030-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe868-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0470d2c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0237-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667281-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0234-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c4474-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a1673-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc79-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500450-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bfb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640186-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04776270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04619088-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d8a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce94-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d86-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465fd54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e431-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d851-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893cc3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c6b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b148-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453add6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459a142-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801509-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04597a34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464289a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c633-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc426-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0661-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465af34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04860874-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500454-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505274-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472a784-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452c378-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2b7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b5fa2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e12-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd35-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0447c6f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812675-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e2a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04773b69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b092-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc82-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459c855-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483706b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4da-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04507980-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481514-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f00-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab84b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c33-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452ea84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b202-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046cb413-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801506-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454e651-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046735d6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492681-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662461-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865694-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e193a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1184-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745537-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472f5a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837060-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c8772-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0450798a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684744-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea71-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455347a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479ac63-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04636547-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea76-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b47-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b978a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828601-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b207-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2947-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725960-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b55-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2ba-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481517-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a3c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046030f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04605808-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a2194-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae80-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048badc2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf53-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04795e46-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04719611-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047abdd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04885261-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04878f1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044bbe98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e224-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531190-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a4e31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed161-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04686e5b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b366-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f94b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b095-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c906-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0467f924-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837069-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cdb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468e383-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500455-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f01-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04675ce4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04656113-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9786-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04845acb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04880440-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e227-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745535-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a7548-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793738-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460f444-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2949-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453fbf5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487b620-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a6a26-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04854522-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549834-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb43-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837066-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2ea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e13a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725965-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9785-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7600-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b44-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457f391-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531198-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0475188b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04561ed6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c877a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b066b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047ae4e0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614262-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04834957-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765105-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d379-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046205b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485452a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f8f24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ef879-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04887972-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492680-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477feb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab848-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4040-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e436-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0233-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c17d3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479102b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d645-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04670ec2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d7a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449e9d9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b5484-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04798557-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed164-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8348-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bf2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642899-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a6fbb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466e7b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b4ef6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045386c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046f4c22-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe865-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461697a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04742e24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0668-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d856-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e91a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d5054-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f0395-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04483c21-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0238-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fbbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bf65b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04806320-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f4103-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b5a14-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1180-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044974a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04616975-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04723258-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482860a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789af1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044778d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492688-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047cb9a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f017-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047120e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486336-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f51b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04558294-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471bd29-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04529c66-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04753f92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d910-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667287-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04518afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048ac362-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d294a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662468-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6817-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640181-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047df222-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9139-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3895-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04817494-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d2ed5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448d862-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e225-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531196-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b792-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4317-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a623-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf49-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048915b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc78-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812676-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a2722-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570934-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044be5a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453d4e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b36a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d83-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745533-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046eafe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b2254-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c1c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b364-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c7110-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452755a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e8e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840ca7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489d905-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04633e38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7606-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab846-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4316-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522732-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047eb572-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a627-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd36-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840caa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cd594-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fe2d8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047147f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc428-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8340-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04736ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b86b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c638-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044aad27-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b209-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893ccc-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8346-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf48-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047084aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04607f19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500452-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a754b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480ff6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04542305-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d7cf3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474553a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e75-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481749a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614268-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e3ab3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9138-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e88d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4693-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b27e3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d71d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04731cb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047da403-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b140-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e6758-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c1240-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486334-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f70-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480150a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448ff77-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522737-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cd2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570939-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046476b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b62-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492686-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04590500-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486337-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631ccc1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474f17b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0488eeab-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d376-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765100-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3307-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04767811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3303-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d5-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ecbda-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04622cc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b205-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e432-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d4536-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b799-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483e592-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482ad17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047fc6e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531191-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0486cbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454983a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc88-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048433b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549830-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c902-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4047-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d641-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045163e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474ca6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478c20a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f018-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476ed4b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466c0a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c8d06-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b094-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04494d96-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489b1f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04513cd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045dbff8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e64-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04851e16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048481d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:about="#_0448d86a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044bbe92-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>16</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044d1e22-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04819ba4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>46</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048433b6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ca8f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854525-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f08-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047fedf2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476781a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0477627b-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04697fc9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>90</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0481c2b3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448d863-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>61</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>28</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04747c44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>130</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047e1936-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cae82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>48</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045b00d5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>62</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046efe03-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>71</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b89-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0447ee05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94b4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048bfbe0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ea4c0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>52</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e4a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046205b5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>7</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048b5fa5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>70</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b7b95-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>15</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04716f06-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0483be82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>31</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046d0232-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>6</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453d4e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>113</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044aad24-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a219a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0489b1f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04798556-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>277</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>113</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047abdd7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04791028-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04817492-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94ba-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ecbd1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>2</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0463da70-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047b0bf0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0461b790-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b0665-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04689566-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04547126-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>77</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>14</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>54</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04812679-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04742e27-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2257-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0466246a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04488a49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048740f1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047d7cf6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2251-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047dcb12-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046adf5a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476ed42-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>13</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045c8777-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>85</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854520-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04778989-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>27</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cfca7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0479fa87-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>45</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0449e9d7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>53</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0451d918-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>42</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0482fb36-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>66</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>20</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0484cffb-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448b150-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04867dab-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04481515-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>36</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048a9c51-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e46-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0485e168-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>21</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046c3ee3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f6da2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>60</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>34</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c0cb3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>5</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>65</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04682035-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04887973-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045645e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>51</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0474f170-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046a4319-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>19</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>2</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045d4ac9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>17</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0462c904-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045163e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>87</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046dc585-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453add4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0450a093-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>84</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044974a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>63</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EquivalentInjection rdf:about="#_5631ccc0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>184</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d4-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>6</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>20</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>8</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:ThermalGeneratingUnit rdf:about="#_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044ca8f0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-85</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_668eb671-5c36-4351-a95d-53ca850581db">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.680008</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_f26d4eb3-ebdb-4025-8080-f856ce656b42">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-450</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_7566f2a7-61eb-42fe-a59a-8276257fdbc6">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>230.999985</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e5a479a8-ab8d-4a54-bb52-376874ae2784">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04856c34-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-7</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b55d80d5-720f-46f9-897f-ff8c5eaf8b44">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.644</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_9a6bdb3c-346d-4426-8127-5f6cbf0150b2">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047fc6e6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-4</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_98f667da-02d1-4a31-b826-44314a1fbbfe">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>33.495</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_fec62959-21c5-4921-90b2-7c85e9f3bfab">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0452ea80-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-36</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_9db08c95-4586-4a2b-87e3-5a17c944b43a">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.36</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e54b499b-436c-4b89-9803-b1d75e2fa364">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044cd00a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-252</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.243988</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_27799004-aa1e-4889-ba95-ee6fdae64895">
+    <cim:GeneratingUnit.normalPF>1</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_048aea70-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-513.437439</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>62.1325531</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_827a9c80-183d-4e33-9e73-ef0aab3dfb13">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>136.62</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0458ddf1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-391</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_12b01822-ca11-4cf8-a6b4-2f8ff805ca20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>221.1</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e3753d6d-b894-4cce-b6fa-307c50dc107f">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04859346-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-204</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_dff93c01-9c84-4c1f-8529-66c054ed9e37">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>135.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d9948603-709f-41dd-a0ff-2ebda091255a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047f0391-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-392</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_23727856-fd9b-4124-a981-4e862148f3bb">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_56975783-9739-40fc-8ec1-e1de8cb06c9a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045ab2b0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-220</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b8449cd9-5a17-497e-bf04-70f728b0f9f2">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e56da2eb-bb6a-4133-953c-40073c5bc5f4">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046bf0c4-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-40</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_d41be6b4-155e-4c8f-b46b-16b50c49f0f4">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.319992</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_83fae784-1da1-4055-8108-ba978276d1b6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04633e31-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-19</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5f711f63-f631-45d3-b26c-33821ab2ee56">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_a6ec9760-88da-48df-a23f-7877e7c85ccd">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-477</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_e6131af8-c298-413b-84e3-4e21c3b6b06f">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>137.28</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_2621b09a-22e3-4630-b3bd-32c102e36741">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0489b1fa-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-607</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b0d662e5-64c9-4d59-b8e0-9b1ed175769b">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_05df66ba-3f64-40cb-8b18-c66d26c4e2c1">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0483224a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-314</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_c1d29442-5f57-41d1-bb60-4b74b4994c20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>223.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04839777-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-155</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_29df1e0b-36ca-4536-97b4-6f98b84d49d8">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.02</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_17852426-f663-4add-9a2b-0a635d51f101">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0472a789-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-160</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.34</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_b97aee41-3115-4cfd-9071-b52fb44d0b66">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046c3ee7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-48</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5005c073-28d1-4a7d-b257-649dec43ec73">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.06</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:RatioTapChanger rdf:about="#_047df228-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_047d2ed8-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044974a0-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_045eaa55-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0488797a-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044b4964-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0447c6f3-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+    <cim:RatioTapChanger rdf:about="#_04682034-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>31</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0487dd39-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_04549831-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:LinearShuntCompensator rdf:about="#_04553478-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_f4cdc674-4a66-4ab8-8d4f-552cb066e259">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.935</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0475dbd6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_a7768441-642e-48a2-b4a8-0ae06bebf676">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.419</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0447c6f6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_c701959a-91c1-4a35-9a37-71fb790426ca">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.676</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_048b5fa9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99c6c4ad-5247-4058-96d4-ee8495103e85">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.723</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045b00d9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_be267a3c-f7a7-4bdf-bb17-71b773247fbf">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0460cd38-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_069d84c6-bd26-4c26-ac6c-e801a0202a00">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.814</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0489d903-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.423</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0450eeb7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6c36f421-303e-4932-93a9-5b0ff86cb7d4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.565</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045c6067-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2d222dd9-7306-4afd-baa5-fd303b0eeb40">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.066</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04558293-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>124.763</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0466c0a0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99931a87-ee15-4fd0-b251-9556df7fe598">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.002</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0449e9d5-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6cc38790-c6a6-4309-99f4-a3258e24e785">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.403</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_047825c8-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2a6c1dcd-201b-4911-83b2-c16acc50a0f4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.212</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04684741-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_eae61817-d3cb-488f-a1f3-13bc8e31431b">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.323</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:CsConverter rdf:about="#_7393a68e-c4e6-48dd-9347-543858363fdb">
+	<cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>480</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.unexpected" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.dcVoltage" />
+    <cim:CsConverter.targetAlpha>13</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>0</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:CsConverter rdf:about="#_9793118d-5ba1-4a9c-b2e0-db1d15be5913">
+    <cim:ACDCConverter.p>-63.8</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>55</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-63.8</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.rectifier" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.activePower" />
+    <cim:CsConverter.targetAlpha>0</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>17</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:RatioTapChanger rdf:about="#_ee9505e1-96d7-49b3-9d1a-924397ffb27e">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_a5bf9702-545a-437d-9663-773550202828">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_739658a7-e08b-4395-8d79-93e87b7855e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:RatioTapChanger rdf:about="#_ea8cd467-31f0-40dc-95d7-4064463724c4">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_c089eb25-9f67-4d82-88a8-635dd4808bae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_453bdc57-5855-4eb5-8712-d6a0255e0da8">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:VsConverter rdf:about="#_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd">
+	<cim:ACDCConverter.p>-153.5</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-153.5</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.pPcc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>213.54</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:VsConverter rdf:about="#_b46bfb8e-7af6-459e-acf3-53a42c943a7c">
+    <cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>360</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.udc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>218.47</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:Terminal rdf:about="#_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe0e60b-3870-44fb-ba93-a056228f9636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_071bb138-ff00-4874-8acc-a884aa5cf4a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a168e701-bd48-4f66-8f0b-0f69b2545530">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8cac1e7-4826-4ecd-bac1-f4085fc15956">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dda862d5-7727-420c-be3a-a6a30e0b4c65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f72bfe50-f1ae-4f21-a477-f62e75a636af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfe1e320-861b-4d31-a076-5ddc474e4a05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14d37503-25e4-40e2-b20f-4de429a0dd00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c7f5674c-44a0-42d6-a701-4706b14c3eac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_21e25548-adca-48b3-b2a4-c000485222ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb3e09c9-fee1-4407-935d-ce2d342dbd7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e141e4b7-12e4-4b78-ae07-e8ab741ef9cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5de34198-471c-48af-a0b2-e5ae14970738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b862807c-b874-4b47-ae4e-59e4479bfac6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d88d693-242f-459c-bf12-267c22ba7809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d1cfe9e-3f42-4b3a-af90-111257354f8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41a94bfb-c430-4007-b29f-b89204ec913f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42ee39f4-ef6a-421c-a581-5da2682980ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_43724816-f5f6-4374-8ac4-96565bd5aa59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f1e8a6-8e32-479b-b73b-79823a3e1a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c37e51b5-c01e-45e9-88dd-957334a720ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe09b58a-7b27-4460-b596-c5886b3645ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8219d169-b5c2-467f-acbe-b04e0d39a7ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bff67964-ffa7-4243-943a-07c911e18dcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f4d752a-acee-4ad4-93fe-ad3cb6722d51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88d448f2-1777-46d4-840c-f64a7bea8a12">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c5dcb2-81f9-4076-b9d6-fb43a1a76d9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8e16607-1e6a-482b-8b4e-e5d990b93a4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cd484cd-37a9-4454-88e4-ab538b00a7da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3184d830-8702-40c1-9f52-c8e23eb3feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e68e5c02-683e-409e-8371-bb2e5f947c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b97c5dc2-7cd3-4a6d-9f6c-d18ca2229ea8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb5279-2c55-4531-b91d-3b71fa7f1674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a90f437c-e33f-4571-baa4-14f6e6a5be19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b64e6a0-436c-4389-be48-9dd120beb218">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe9cbbd7-a68e-4a3f-950d-3b1c2278b0fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b5a3e17-a13b-4158-8b91-a4303fe7e433">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f472e138-541e-429e-aeed-e632232888b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1e00a228-c452-418b-9db5-0a0ffbc5a5d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_26698a8c-a280-406e-b882-9037efe6a03a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145597a6-9fde-4bf2-b2fe-8a4c6c5f4774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd76d8e2-4515-4964-af8e-67885c73ad5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_883bebaa-0b47-45b9-8d4e-75f8784dbabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9145eb98-9d67-4793-b83a-967c6ff56e1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7c10087-4ab2-44cf-9362-3ead8a066326">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a5780b7-5e74-4532-b3c1-d1617bc090b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aeb3fe0-66f5-4f34-a79b-14f777313348">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b60203f-42be-4959-8f9f-10aa7e6812f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca41ef76-12a4-45d9-8665-946b5d46b7f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8de12885-e525-4726-a2a9-80a9eaf637f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef70c25a-ab63-467c-a0c5-c0d5ecf22f82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_79ae9e2d-942f-4878-be1b-a9e7e2971740">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a22db682-0414-4fda-ae6e-9e48d11a5565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5578e708-945c-468c-b7ac-56a738f7701f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4820525-8b5e-4f46-9a5d-7b93cadc813b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b95964af-8fe3-44e0-91ea-d1d71c7bf25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c58d4a-2ad5-4eb5-abe7-e79c1cde9d71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9bc8d338-1940-419e-98f6-8ae664bde365">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e5bfa23b-0c58-4ef8-a317-bc7a65457ba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e64d1ea0-1cc8-4317-9d6e-ec2fce5eeb77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d5377df-3bb0-4d2d-b6e7-e08f369a28df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f2156a1-b0c1-4bd7-aff8-17e4acfb98f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e030a6dd-e9c9-4aba-bb6e-8ed4b7add9e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae1f9fe4-1234-4ec7-b2a9-c6077a19d401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9385a5d5-0ce1-4218-ad3d-2645077a1bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cf89592-6284-4711-a283-848c6e97203b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91291202-267f-4ca0-b8a0-0ef3cd7b0d3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eb152b46-922a-48eb-a401-854a48d592dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a74688c8-f01f-4419-91e1-790b7d8637e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b85df60f-96a8-4187-b01f-018879647feb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_730d18de-6962-40b1-94cc-b1175fc098f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca3640a9-b054-4d3a-879b-8ed41d028ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fd6a4b6-c0ec-44b7-9ab9-b8ec781850d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c23c7c69-c302-4315-ad2e-4d5389140def">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c801bf-3eb3-46f5-8295-4c816d9bb318">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d3c4d8e1-11c8-4876-b4b0-906e5b7a73a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c06fc0e0-1893-4e97-b465-e24f6a934e84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_085ccbba-fa65-4793-82ac-f8d599966ced">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4c27dbc-6761-4286-9c91-debd13ac59a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_11f29b11-5932-4ba4-9a4d-7295d9ded126">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d64d90c-e2bc-416e-bc3b-75cb2866b13f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7097128-535f-4435-ac2d-dc1f01b38b72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43252980-acea-46e9-a46f-0b8d923cb4fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a9bc577-2923-4546-9c2e-a28d8a2bb2d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4de6e42-ee62-432a-a8f9-311154ca4545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1e250b6-b8c0-4b8f-86af-d654b592efe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77171614-596f-4d4c-8f88-9603a8225203">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_800fb8b4-0209-40bd-9a5c-098a9d5bd46a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_599a8732-3d99-4067-b506-3fcef610c47b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b90d47e8-e306-4b82-b7de-071f8ba139a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_50413d47-3ac4-4933-8d6d-6136134d1cd1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_51ff9c76-7b34-490d-af24-56521461f98e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0a4f-8817-40ed-b729-55c92d171c5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ca5e61b-bce8-4488-9a89-a13faf616146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_07aeceff-a2da-441f-9c1f-65f5bea46ddd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60dbae27-1064-4d48-8b63-60969b90b01c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1d5b0f7-a631-4cb6-be6f-ff459dafede2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3a46f9cc-a382-49d4-a2e0-5353e7f09803">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fb1a0d9e-d78a-4f35-b1a7-4e77ea9cab61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_974090ae-7987-43d6-8dfd-965bf0b8c7b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed826093-243b-43c6-9cba-b5487b34d56b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_987874b2-d6b4-40ae-84c2-09d47aa16fe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c11374d8-1dfc-4494-8c10-8ee6e792dd41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_baca14fe-c74f-453a-88ed-bbcbd0aa5a6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10fba6d2-bc82-493b-b4fa-928668273f68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a02c16bd-ad21-47c2-a34c-c1cff1e19015">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3de5af1e-30d0-4503-b58d-b4fe3a1e084c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01c6db55-d351-46fb-9f2d-13c1de997349">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e46cfed7-5361-44e6-9ea2-0be51afe2287">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_53feaad1-74b3-4cdd-98c6-045d45061593">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c5c6689-a80f-488a-b9cc-23667dd2e923">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b2ee2f-b05b-4c5d-a1f6-addff43e7070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_745264ab-02d8-4377-971d-38e58d86f3cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_902e06e1-e0cc-408f-987e-4483dcf5a4eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_39019b70-09ba-470e-8dd8-e35080b2b090">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf0d0769-33ed-4bab-b86a-a34f6fa059d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_066fe35b-8e2d-4bdd-97e2-b66d2d6a1147">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0f32dc6-eeed-4c00-98dd-22b8191b674b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da140b84-888f-4608-8a2a-b355ff10e175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1dd52921-a7ba-4bd6-ab24-1240f2f30301">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9809db90-fa03-4ea9-a507-c327adb29ec7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_349a9ac5-71b8-442b-ad95-93d514881b07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449ad8d-0b1e-483c-a333-adadb108d264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83cf2f18-0417-4b5f-915a-a8610df259b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17901350-2daa-4c42-a4e5-3a39dd813f13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8c102c6-1217-40c3-b05f-bda872504328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b557b2a5-2259-46ca-9681-73ed8578bb64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_85c693ac-04b6-4bcc-a3bc-1a47837f5c51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12e9d7c1-ec4a-435a-9f87-af7519f81d19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c2feb87e-acf9-42af-b093-c69ca64b0282">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc64ae88-ea38-4e5e-a850-c965ad4811e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_205ce345-8ff3-4f47-97d7-0c00c0f51259">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_110d1aa8-d200-4684-8266-26b5f69ab5f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57bea695-1bcb-4abf-9a2a-a2270d257a2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b687f746-a11b-4250-9a2b-92fb615faca3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff90c538-e532-4da1-85fd-f966a3e6cfd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c9aabb45-f6be-49f5-81c3-6a6fff595b20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b10eb7dd-58cd-4846-92e3-4371938950e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbee05eb-f6ec-48ac-8f45-6e801f352b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24b4767f-a3ac-45e4-9c9e-1e6f63c13e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10f7b85d-f7a2-4346-93f3-d026b3437ae4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_120699d4-88c2-48e3-a094-737b515cb65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_47f09825-70f4-4225-9a99-167a37ed724d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d95135a6-a2f3-42f6-ac01-44e9459fea02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_32b22d72-0891-4711-b2bb-7cb89e348e00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_360c39c1-9801-4f23-858c-459a2eb08725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_298e3c2c-e3fd-4cd7-b38e-a5cc7790dd05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ce1d70e-9fdb-4110-829d-d3f0e2144b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a59ae689-2f80-4159-9641-7a9286868f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_62f6a018-d394-47f3-9f1d-66303cc80a53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7c55b814-99a0-412a-b837-150f33b099c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f280c3c-7c31-4233-8845-42d0290431dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a5f2d-17cd-4194-a8eb-ee4f3cb5b22c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2afa6c27-acaa-4d28-a6cf-3283b98c8fe5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac4c08a2-5201-4366-b7f1-d86fae43245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_308169e1-3f4a-4bec-b3ea-0ebc76d5bc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fd08ae73-ab6a-46a2-9cd7-4316852a4604">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ee5fdbd-b7db-4e3f-bdd3-b5de81dba6f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07bd6984-102c-4162-9555-858f90689d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34e5d3b4-7e84-4389-a389-b1e799c1e2f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7796b60-d57a-4401-91d9-fdbcabab4dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1fb6f240-a6c7-4597-ba87-ab70943b397e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae668ec-5d22-4cc9-aa65-749a4098cfcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13521110-8ae1-4f60-b218-5e8b75bfd923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3368d4b-4206-4671-91ea-350fba2e9039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45ddc3e8-863f-4519-8fe7-a4f746cbe9aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_20705efc-e9d4-4664-b3d0-095d62ff29d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_822fd5ed-1f12-4abc-9487-8e98657da101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_201811a2-df0c-4ff5-ac68-2956151d94c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8103baed-0e59-45ae-b521-6118cbe2da01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe1856-7c93-4b98-bee2-9dabc7b62fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_708aaaa8-e7c6-443b-8285-91504fe45b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8cc8b9c-5b5b-4b4a-8610-03d974c74739">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9a1601-96ee-495f-9f88-e5b1e439d9d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b3ae708b-6f42-425e-8dd5-00d6daadb551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c0edefe-d42e-4966-ad5a-f120620ea284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8345da91-c150-4265-922d-5308fdc44671">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6df484-0741-4f53-81e2-6e70cfd5a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67785dbe-ab63-4618-8737-6150fce2c56c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39312527-1286-4662-9cf5-c5e3cae10de6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3f499c2-f337-43b0-9b6f-5849b58eb1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4d1a84b-45c6-410c-b4c0-e74399ba3f6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35414171-4c4d-4f95-9580-9fba40cfbc2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2be79109-4947-48be-9f48-587e8cfdaf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db602221-867c-4da7-8f29-8ce8ac7dcdce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6651b16c-1772-4788-b21a-93531b87e488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6d3c05da-fa71-4424-8c56-8400c9528908">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_98dd0655-72b5-44f8-8950-70ba30e70bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd1daa5c-eefb-4712-89b0-a81967839921">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7bfef0f0-3061-4827-b75b-29bb615a2586">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7706ff68-778e-47fd-afb2-a9b19a1021df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422336f-9b82-4511-8613-997ecb41c564">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_919ef501-e345-48f4-92f6-f3f9917d961d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38d1ea1-2686-480d-a8e0-70c6f7c4a6f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb56fda5-c1ce-46dd-91ec-73fc396a6ec0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f85a3a47-79fc-408c-a671-6dae0a3fd2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2af82b02-99ad-4353-95d9-8933f1f03ed8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_90bdf796-f9f8-439e-88c4-2aed057f8728">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acb6cbec-a463-4186-816c-13d6f9e8f8f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2671dcd-4825-469d-92a4-11a7c1168e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f199ee7d-42c2-4eea-b369-8605bb280c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db969abf-2a57-4780-a11e-d100009e1c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853c07ea-f383-48c1-86f3-88e38fb111b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d74efa59-9559-467d-847f-20c752ef7a0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71f3eff0-c211-475d-bfc7-5761e3d51925">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2083790-f439-4a1a-be0b-3d40dc6bd591">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_830f9eba-407e-4c21-b958-58c1c566bdc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5c932ecc-c9fd-407f-ab7c-bc6bf6d37c42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c16a8f4c-9b2e-443f-b642-9e425306592c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_516714e5-4f88-4718-976d-98699566123e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_731906a3-3e0d-4904-9226-5bce546bf1be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6bba47d-244a-47dd-8cf5-f9ce2d619482">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c299175-5b93-4a5d-98e3-1e0d98759953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac9424f2-22d1-41ba-b520-0674ebae6a33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0bed41a7-c52e-44a9-a378-8ee6057a60c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f45c35c5-e0b7-4a4a-a7e5-065f2cc79a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92e84348-2aad-427e-8224-863e9c987476">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_42abf657-9f60-4bda-b557-ea055a58f606">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a88a858f-a4f9-4a7c-a7a1-599aa2a98bd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c82ed1a8-5ed9-463f-87e9-21df6f621661">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c754faaa-23fb-4cd8-b9f8-64a692c467e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c548e424-3e91-469d-8d41-c15924cc0735">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e79f20f-77d1-440c-9517-b03244fcb642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbdf8582-a8e4-467c-ae4f-6bc08aba7057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_352fef36-0467-4ec6-8b85-d38af06da2f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_71a7543b-d3e6-4c6b-a724-4d34681cffc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c2f7966-0719-4ede-ac47-c93bcec328ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cda62ce-a773-418a-8562-975eff37d6ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf038e04-bf8c-4655-85c0-657b65fda472">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f91ff24b-4608-42bc-8165-3845d9d89a3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c57369e1-70f0-4ab7-ab95-0ca6d1d20b00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f05307b2-779f-4931-ab27-1c812eec0e09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10cb7e56-91ea-41b4-9698-9ed591d4a610">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b54615f-86ab-42fd-a7b6-091f420c6185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159809cd-32b7-4d81-bdc3-f4521a5611dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40021451-2f6c-4c08-8206-0f9577efbc02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53df2bde-0065-4e2a-8f79-8b9887289cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da880e10-59e4-42f9-88ad-bb19fd0995df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ffb2763c-86ee-422c-ad01-19a27c2f5d95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82d50004-0240-44a0-946b-1136ce73ca33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddd3b955-2005-4764-9bb2-94f1a0b57ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1072268-4956-4f91-999b-829a5160c6a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3f6df38-eaa2-4ba8-8267-2ea812b5b730">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4808825-dec5-4d4e-a575-d6b617e60f4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a243601a-7f53-42f8-9e0c-7d3ddda35309">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8713048a-be6c-4fbe-af8a-018305cb793e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7508d369-6037-4398-a0f5-85136d240f10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_215eef72-26d5-43d5-9728-b716a6eb398b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cf45286-0bc4-4244-9187-d90880603533">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4dd81da8-8ce2-4aed-81fd-54b4ee4566ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2edf2c26-ba96-42a7-bbca-bdce425dc719">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_37451d52-ada3-4155-9718-f2cbac55ea7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bb72b3a9-db44-4120-b8d2-ceae058fc3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e20cebb-95f4-46a1-86f5-30706c326241">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c5cd262a-00eb-4b1e-aa14-af39769452f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f41b17b5-937f-41ee-9be3-6582238dfde8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e39b164c-e8d1-4120-92c2-d51ef5331858">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c794fbfb-111e-4bd4-bc4f-22539cf5a14b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_481b6412-4dd5-43ec-a4f3-fd0cceb8fbd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_75da10ab-1e91-4b8d-94a6-022e3a31020a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35b12500-941e-433a-a80e-43850be4aa09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e2e8adb4-e6ae-4d8d-b946-bc510782ffb8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f8d2d0c-a59b-43c9-9c09-0d5ab82e3b3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cf6338c-83dc-4336-a40e-396191812535">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_19c6f61e-b720-454a-a47f-7f2c51dd0de1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9de4515a-0b24-405f-9920-6beff64f39fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35fa07b6-905a-43fd-aa2c-c1b6ba8c2738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a74196-8d0c-4d96-9eff-1db74605a665">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572e87e4-428f-4ba0-8148-585a3ad489c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53cb22fe-b2b8-4b42-9c90-c46f4b52e32a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b61be02-219e-401a-84ab-137d8a522a31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49649668-8e65-46b9-a759-ed5b1c2f3475">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_12b661c8-e048-4af8-8e1b-6fcaa75e0a27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8967ed7e-f69e-49de-87c5-3e424ff043ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6c92e2ed-107b-45a8-8618-4bbe372d15af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1ff47f6-e080-4f99-bfe0-0d44e36ed6af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f13674a-e4d9-432a-931f-7e823ccf41ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_569d3c0b-1dd9-4175-afa1-b4a43a0f768c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c51731eb-388b-471e-84ab-39c64b56d1f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159e2c73-99e7-4c61-84cb-8b56e8703a78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d4a77b1-cf38-4213-9584-62d8813b8e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c3cb471-aab3-4d54-a738-d6deb20a22b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92c4d859-708f-440a-b6bc-cbbdfd0c6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8500b6e8-3687-4c94-b665-b84ee822b1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a8407c09-50cf-42be-a06a-3ffb9affbea3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9552f175-d04f-4789-94a1-8cab3ce656da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1a64602-04ae-4adf-be2e-03f2f6f8d1a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1693cc70-297a-4d11-8f9a-6da05e8afabe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b40a4b1a-6ec4-4eb0-b09e-274f28a19e10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d50ed217-8664-4101-a79c-02e1b5753702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6022dd0-29a4-4921-8b60-dc855a2794a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ea3ac4b-c6c8-4d96-b1bf-47d064be4317">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ffc5985-1458-44fd-85eb-755b32fa5b9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_32b4075c-eb28-480f-9770-c79c28617f2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26970c44-1c28-45a4-8327-f9d544822995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45ba6338-e010-4c7b-bb0c-22c9bfc0e435">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_326c6626-3a7d-4415-b9ab-8a2a4f0ada10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_388c280e-dcc7-45f3-98e1-587260e1b369">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ba14b260-4f8b-437f-9464-3aaf7d17ebd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fa746ea-521c-4ebb-ab9a-961099f261c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_333cb385-6e3d-48ae-9653-e6ca5835a27f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_609f5d51-8bad-46ea-a50d-cb2725642283">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e09087b9-1874-4158-910a-a468d445f4e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c8def7d-c9c6-469b-8115-d832ecd100e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acda9192-b001-4925-99a2-7ea65a81b267">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_178dfb1a-7c01-459e-805c-2e2046495275">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203eb441-0e19-4f62-804a-582232ecb670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e44585ef-eaea-423e-8531-d641e8826802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c6dc912-1aad-4cdd-a31e-73d43122e59a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d057d3c-d61a-41e0-9737-432b5ada155c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab849915-3e6b-4677-991d-e447a4db0f5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_041d24f9-1f82-4572-b813-ef4155a06173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23f9448d-9c57-4843-b921-aa60104ed2fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_96016276-135f-47a4-8755-188a64bb58d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27429877-cb1a-4b4b-85c7-92ae6726c79f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b39b22f8-b659-4550-9084-67aa7f7f0ffc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7fadc3a7-981a-4da8-a7eb-7085ca13e62f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_24e5c55d-e28b-45c9-a430-c9726b2914c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1043f8f9-8018-4203-8ec3-5fb793a1aa65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd347645-1c88-4697-9cc2-3e4abee5489a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a675d01-61ef-416f-9ded-1e5f734fce59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fccb783a-2f63-428c-b673-df05f116a386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23dc57ad-b8f9-462e-bb07-e2a7b879e944">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70cddb78-0926-4f3d-9f04-d0f2992a53e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_91c5b0ca-964c-4e71-85ce-3e4c34c39c62">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a330abcb-4a34-4ccd-9608-a09ca5e660d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc62a2c3-2da0-400c-98cd-1b8c3d1e1851">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_123ee6c9-8eff-4182-a6be-b14ade88b4fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b05826a5-4010-46c7-8cc1-2a4e588b911a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e52c2f08-e57b-4336-ad61-e315ddd425d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdff05a2-d002-4be8-a815-794b6a1f4025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_08cb8736-36b3-4225-997b-9e9d8b24398e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_664735e6-7c6d-4483-bb17-1b04b78187bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be1c75ee-d6ef-4c9f-a1f6-1e0f57d8aa6c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f91f072-ee1c-4484-8d13-5beacf3327b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8216652-9e1d-41ce-a916-e3087ea5b445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4569417d-00a0-413e-a233-981ee337f5ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d38f0bfa-be3d-4373-b90d-25b44a3a5da7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbab36af-ad99-42dc-a330-7631cf62d18e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_198ffc44-f46d-4f3c-9d2b-b00564f56603">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_785b252c-70a9-4f1c-bb8b-0144e0c34393">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7ee4f1cc-2ec3-487b-be5f-448ba1098364">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1dc6a8-5807-4b72-8352-aa38b7ef65c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47f462e0-6cc8-4085-b44d-a737dcfc58a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3698d996-dbcd-4ca1-a37b-ccee8e5dd75d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebf4e82b-8581-49d3-af44-466ad5ea5beb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88fc4b51-b403-4d0e-ad17-53a083adf8d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_67dc16f2-6949-47e1-b0fe-24ea05e11bed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d802a3bb-92c9-4fd2-872c-8ea459589526">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2769e0a4-1dd7-4690-a2d4-c2a4e877d6ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fbe8ded1-d7f0-4670-b721-ee137eccc9f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a07a7054-1160-4fe1-8753-18700a3178a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21084cc5-b2fb-49fd-b186-93bcf6b7cacd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0e40411-5b47-43c6-bd1f-f26ef82c761c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4322f8ba-4c64-48d6-85f7-7feb029e02ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8152d58-e869-4e34-ba72-e6a0250f09d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de2baf32-b5d9-4bbf-a286-ee7ad91c29ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d6d8c290-8ac9-4364-8e20-50201070dd1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cb3d25-f7a4-464a-9530-c0f6f2b11aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ee4ec5b-6b89-4d91-ae82-fa24d7d9e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2de64646-e09b-4942-ba68-2162bb1d979f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0945558c-d1dd-46ef-bfd3-6d0cdd75b650">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d98fdbd5-ddbe-49ce-bcfc-259d2c399282">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_da23cbf5-92fc-402d-9e75-2007112a3f65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca3b225a-2b14-4324-a2dd-00ff96571ecf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ea2d464-a933-4e76-8c57-df5e29dd0948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72dff77f-fc9f-4ef2-b366-9aed8d81046a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e461b2-8712-4afa-b271-2132865b1341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816c2a66-edc1-46f4-bd0d-4e699b823836">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2aa0739-9784-4743-814d-ad6a586a59c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_480e9cf2-a17d-453d-8f6a-013c28fcf0f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8feb73e1-4390-443c-ac47-834bde0ea038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c7e854-bf10-4c96-8f26-2ae14a703e31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e4e2100-c19c-400b-9b6f-2333e3808b98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_359a47c4-a101-430b-9db8-7408d78f8461">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76475b35-db74-44f3-abff-712442eb405a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba94349-afaa-48c8-bfee-61910d7d1d3c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3885f06d-f07b-4cad-92c4-0f8080c30303">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f69ab1b-604d-4ae4-ab51-9cd0d53c37a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5e8a806-f0b1-4bf6-9b57-929d670efd58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c338198-266d-44fd-8764-ff2a3268a067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1f7e1e82-5754-4fa6-8940-937f91087a25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8ca6df3e-0210-4e88-9620-4bee4bbe7072">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ea84499-a970-45ee-8be2-8cc9ab5dc2c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7993d16-c661-40a6-be19-d4fa0622950f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52870298-2d98-4bdf-ae81-2e477350eb87">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8389405d-9280-4803-bace-2ee38355fafa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e75b0fc3-f421-4ffc-b561-fc9ee5815972">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9128d5db-cbf5-4234-bd30-22c604210b35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a64ecd0-d2b8-4bac-beb1-bc8c8c451a4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2973b3c1-7d40-4ce0-bc30-b8bbc9245641">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a061825-baae-4496-8f93-6c3283ca85dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d662cb35-3827-44a5-a3df-576e423d7f32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b254ac83-1713-4c0c-950e-e82a7202e4d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43473fa2-f081-4f68-9b5f-69d2a75f5e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c43f06b7-fa8c-4aa1-bdd3-6e194480695e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a789d5-207a-4059-9cf4-0d8c5c0bb4a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4b8a765-2040-4572-a6e1-26c29549a549">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_865773df-833a-4310-a335-9e014d4e4d79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_abce531c-5509-4558-a719-7e01a9ac9005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1162fbcd-0df3-4aeb-b5f9-0d8fe58c55eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b22ddb30-b0d8-4a03-bed3-36ad77a3c2d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ec9d5e7-5de2-4792-9a86-03be2cb1838b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24630e95-086d-4fb7-ab52-0c8f447b4010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75e6fea8-348a-43f4-81c6-c5c1410ad595">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_825b65e2-24f7-4b23-adac-ad62053e0323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e1293a1-22ce-491f-a2f3-35e030a88667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d658fe4-38bb-4b80-89eb-d8f550a95fa2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e10d1db8-788a-44de-ba42-57edc9539967">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b554668f-bfb9-48f1-9bae-7d23e0f421ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beab0b69-1a8a-4d32-a111-6129bd8e468f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bee5c82a-500b-4921-8166-d664da1fdb2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_584dde80-3141-4bf2-99e9-cfee485d38af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df108430-9a62-4d23-ae3f-411cfbabd93a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03564f3b-c300-43ef-81d5-5f32696ca734">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0d79f3b-ad55-4f76-8d1c-e1b086da71ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20a90dba-1a5c-4f63-94a6-4bdc9a797602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6616d5e-edaa-4a8f-80c4-ee8ce85b31e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_065b6429-bfb7-4474-8500-887ec059494e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afa75dae-3ef6-4a83-95f4-1ed757b73580">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7974968-25a3-4664-bfd6-eb4e57880faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b7f411f0-e6f4-435b-a618-b1801a393d7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cacb34e5-35e0-4430-8c83-3ba4662fe7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76de976d-9edd-41e0-a14a-9c3bf5b509c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a8f004-7214-4a5b-89a8-fb99d5ed06d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dba29713-3989-41b0-89f9-a00883e9ddaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e685a6c7-06ef-4810-b74b-02c66aaa2f40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e458bc3c-51da-4496-9872-65d448af1133">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_870a57ae-f39d-45a0-9a9f-8402539c2c44">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd06f193-5870-4dd1-b594-b3e3b0ed6c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f02ee40c-f678-4ffd-b9f9-25285e43451f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d989ccb9-8582-41ba-8028-96a149e9402c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bc00a444-0894-4316-9fcb-508834ba9c38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd28ef43-261d-4dc5-afb6-8af0e9b6a2ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_142dec8c-d69e-4dc5-99a7-77ec0eb1dc03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef5f45e8-622c-49d5-a98a-71d47862d0ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b3d29cd-0a79-4315-af49-9d8c938ed76d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cc9423f-d622-43ad-bae1-77352fec565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a86fda-ad55-4b0a-b89c-2249a3d87c62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfcf9a1c-9418-4f53-b867-ecf7a735786f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b066d371-c699-42ce-aa1f-9262e331dd58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa0532a1-f44c-4447-936b-5241f29b4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cd198483-e657-460e-a753-771668b6455e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b0697f6-9428-422d-9bc5-3c95eb881ed4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b0e4433-ebd5-4af9-96da-62c2120aaccc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8cd999d-efb3-4d33-8565-1ff34a512572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e5e024a-be13-4ed4-b298-cbd85e03eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b04bbd4-394c-4fd2-a57c-5b0ce7b8328d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c82c6f0c-0683-453c-be75-9d1292c7b04a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f770f7d-f55f-40a9-b77b-2249a6771467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_add69c46-4996-4189-b8c5-496dd7f98a9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d255438d-d4f1-4e0e-b09a-ac843779dac7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4cac272-ef4d-4576-b391-284439f9c285">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58193dca-5bac-436a-9292-9ce96ba22418">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed897479-dbe9-4fde-93dc-15e7e0ff68e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_964dece9-6c0b-47df-9d43-e9b422360913">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67877821-e62a-4526-8b36-3115e852e88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29f5c6f6-b2ad-4aa7-96a1-cc8d2ff4b614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_81a13e90-2b4b-4a09-9ee2-eeafd9e00bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cab260bf-1740-4f3e-8882-f4cbba442795">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_46e90e7e-887f-4771-8caf-07f3ddf5b3e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a8e8f80-5d6c-4b17-904b-64dc2fff2262">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa77f9ed-8a3f-4d87-98ac-0a7375a86fb6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4374bc16-61ca-4b5a-9d9f-798fa48b665f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd77817-e562-4b18-928e-a519da1f2124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac14aa5b-4fde-4251-b311-33015973af60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5131569-0960-445b-8cf0-340c24986c0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6744f681-5c6f-4566-826e-524754bf8a1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4173c4e7-f582-40c2-b317-fa1d8edeb448">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cf483c45-14a3-419e-91df-689c1dffe6d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce3cebcb-219c-4426-a7b9-a174401a66c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aeb54478-bfea-4787-b466-90df885b1c33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4a408d5-2c11-49a8-b0e1-fb4e7b4545f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebfeab9-b411-4d19-a937-e3e9c4ea19ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b367e89a-724c-4a9a-a2de-a7d44de2c1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac672323-d104-419f-a71f-4ce30e297d82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_91dab2ee-b23a-4591-88be-d0020bf6ca9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_51f3b44f-e443-401d-84ae-b8e86c4b270b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4725e87-14c3-431a-814b-d7e174e12658">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_76f12467-9fe0-47f8-9c3a-79c8075d0c39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88fd8c00-aa5d-4bba-9d81-40538478b744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fdb1052-84a7-4bc2-9e00-b6c03e26adca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c8707e87-05c6-4f12-97be-5c71b626e8b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e0d1edb-a714-487e-85d0-0023872faf7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bda506a-f6b5-4f4a-b8ee-1d4957f48cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2851ba40-fad5-4db5-b45b-481d141f197f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f14bee3a-c4ad-4778-95c2-0211fc182eb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91899442-8c02-44d8-8b35-c512b257104e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4eba8816-da7b-4a57-8825-62061d59eb8a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a30fa62-5391-43eb-9ef9-81d417b7d445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55bc9730-8c40-451b-8199-cdd4170be47a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_187cb72e-9561-44b9-9624-a40a68adf40c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaf25965-83e7-470f-9207-e8729d4bd007">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003c3228-ae26-4e1e-b2ba-173885fa9f5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba63da6f-556b-47f5-9e8f-90f8b8e7fab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03e26ee9-a3fc-4c22-b0ec-5b56c9659504">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b5cbc4c-3b65-4de1-960c-20cbb7a93c23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f9f8103-498e-48dd-a025-031b7a357d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4876f051-8bdb-4900-9acd-a5ccfefc9732">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6ca903-3d8e-4566-8497-69c094b27fdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8c2d0e3-0b5f-4fa2-ae70-769bc1e229ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97528f91-9197-4833-a0ef-509553c108ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af52cd86-fb78-4aae-a5e4-899bbb32afad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_844c3edc-a332-4684-bd75-d2dfd5f3bb0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79e5c665-133a-40c0-b624-24695482f6b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6dddc74-a83d-4295-aee3-81685a166f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba1543ba-b338-437f-b377-c21d79b8f66a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0ab92b74-70d0-4546-abc9-4ebe526966fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_188dd9c9-8052-41a6-918f-dad2f04072e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c03b674c-609f-4376-8ef6-e5c8cbc8a37e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51cdcacb-8528-415e-96c6-d5ce8b2ef440">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c38b13a2-fdfe-4efe-952d-66ddf616d722">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a66aa870-a14d-4ebe-98fb-56dadc7cad89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7bfbf56-b417-4d5d-969e-2dc60af24f55">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aaa9f9d2-61a4-48c4-8b74-9f1cea3dcf19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7eb7cd9-22bc-4182-9ace-4a7283dee574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59a28b95-3bb8-45b4-a0dc-93bf57a4621a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53fd4b3d-190c-44fa-a4da-a06af831ee73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4442b941-d4d5-4ca7-bb8d-5a427f0e3821">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7ba9ee4-7854-4f0a-8527-e67110d01ca7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_83bd7a12-4fbd-4219-b9f2-8a70e5d36a69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5fcf6744-b487-434f-8a95-531fb0ebeb65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2e562797-dba0-4f5a-9c34-5bd39c9d4694">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c864bd86-d942-42e1-ab35-ac890c49f5de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ded25e34-2f5b-45bf-b847-b9f87b9de7ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_412cb19b-097c-4378-b3f3-cf5b731e677d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1b501608-150d-4e0e-a33d-403a1ddd70de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f849bf17-7777-4aac-a443-f34aef90c1c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea9a9a67-57b3-4e54-8850-9634c88b0fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07cdd920-0989-4add-afb5-de33f3e28212">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af78f809-0fca-4913-8e81-0bf6d1836582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_721fb0fa-b655-4188-9fe8-639356861427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_280c464a-a4ec-46ed-8a3b-b18e807ea7cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d578c1f8-6516-415e-a1b1-18a592ca45ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3bcafc5d-6dc8-4de5-b4d5-eb468c889fd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c1fa00fc-fedb-41f0-8a45-09c6856a38cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7289d742-f3ca-4b60-9e58-b6da7497219c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_219cf87c-2e4d-4254-ad89-9ee4bce93e99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b04a6c9b-435d-45e2-8e43-d7b159a64e6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f145836d-2f92-4563-90ff-55f68863c206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d824f3c2-f6b4-460b-8875-8e822ef5d542">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45101256-dc1d-41ee-aeef-65ef96bddfe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9e3c9fe9-71e6-4a25-b457-8fdade0cf6d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2925711a-ecfe-4584-95fa-216a76889e0e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbe15b06-0197-471d-a3bd-08a22b40e4e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_53a237e7-aee3-4680-b1e0-3204ddaa07a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e6ea76c8-471f-4d7f-afd7-df09fec29637">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19490fb3-067e-4068-bcea-4a2ee8a27fb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56d744cc-18d1-42a8-b559-be005071f72a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5540a41a-7beb-456b-ab92-d6e9bac08adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d15ece-a13a-4f72-a22c-d0df5b4d42e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa27116c-d2fd-4d60-ad61-0bba8bf76d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0570db62-851b-4096-89b3-306a830f9d08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7b243c85-0fcd-43e7-9caa-16aef19823e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a2d7e12d-d6ad-4b3a-afd5-1259bf58612d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0afde8ea-487c-4f36-8090-f72727664eef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8aa5a02d-03c8-4aea-829a-ae2aae86f897">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba870de3-4f01-4c36-a70a-836982d78be2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b712d454-cc47-4381-a23b-83696157c215">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40872517-e212-4794-ba82-e587fedd9a57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1122014a-cc7a-46e2-a3de-4b03c23b43f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d3d8bd1-1bd8-4b9b-aa6a-d3057c751e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c1fdd5a1-0341-4524-aca5-6b77f18930c2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30b48ec4-7a67-46d8-927f-f135edf85da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce183715-8db9-44a3-b4ff-c224869d4f5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a29c607-c616-4405-a680-f472693b6c02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f872969d-a939-45c4-9254-acf26f5d05b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6788a97-75e7-4609-806a-927f5ab7b097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fc04519-665e-4785-adf1-846f1bbc4bab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8c8eaa7-f1a5-49ff-b392-8eeafc898658">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f99fb43c-62c5-4639-8053-66758542a7fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b6fc7aa-035f-4630-9048-7dba8d02450b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33c4b2d1-1210-4147-b097-77dbc9bb672e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac04fce3-ee20-4127-a581-50bc78421887">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f49f8d8-32b1-4522-92d4-19c3a726e0bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5cdcb762-8802-4370-ade2-f2cb1ff713c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ee50c6a-92c6-4446-ab9d-f18863a55bcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e81b0bc8-2b54-4ea9-b9b3-1f0bbe7afbba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_859c4ebc-14bb-432d-829f-70f94d346847">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e317ddfd-c060-46a5-8279-74abf6b28979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad1e1809-32f2-4cf7-b9f4-3eae73b294c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36c4cd74-a5e8-4ae8-826d-7a82578086a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2436005-f7ba-4729-b7ce-4c62da0adf39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92d4a147-300d-4b06-85b6-741b6700f71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a706fcf4-819a-4598-96f7-c9647368a248">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6e3ad789-b748-46a5-9c80-1b60f334e802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50679c3e-cfb5-4a11-a9e1-e578f88371ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddb0e6eb-82a8-4246-b77a-2155477ebdd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fcc31e9f-277e-462f-bc16-0330cd3163af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e25f3ef4-5c5e-4546-ac7d-53ecf70aa9ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea847c13-d0be-4616-ad58-1769b7d799ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fcefe6a-7bd6-488f-8dd1-26b7e23b55a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5c51845-f008-4108-9e64-1a913591741e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3334eb38-fe2d-48f2-978c-c7088acf1e7b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8f4e9bf-7c05-46e5-accf-e021501658e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6bbc18a0-9898-4620-9dea-8a547b996fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4927304-e6d5-41d4-b669-d0ddf7d05853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5909fee3-e912-47ac-ac18-990aa009f211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b0d4c18-9941-4d4c-865c-88b1a8c0dc12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b8877ec-b6e4-4f9f-b1e5-18ea5e1b35e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_507de8fe-a640-43aa-94b3-8be6dabe22b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5d4c518-715d-4049-aac9-002f60e13bbb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_390d1cea-c5b7-49db-9a04-226290e027ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9ab11de-1ca8-476d-8c7c-7364b4bc3bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3cb7a299-166a-4ec6-98c4-21c0708e92bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_716eb523-8ac1-4154-b7da-92242b3b61ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb7a7e2-47e8-47b1-9f51-ac53838a652e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6a85b772-385e-4c24-b4c3-e16d66dc1603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb7bc05a-c1be-492f-80da-4eace7ca08cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7c5c0d1-9a22-4edd-8bdc-386f781bce15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_daba953d-958b-4002-a3d8-ee9944bfd07d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57a5e5f7-befc-4422-8f0e-26335a11c5ae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f3318d5-eccc-45de-9579-2f989e144c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96cdf652-f2ac-4e90-b56f-1cfdd4c21cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a21110ce-7fe9-4dc1-b2d3-cf4704ca6c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c94db8fe-c4a3-4178-af77-d688d8a64408">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89fe4a5c-784c-484c-8337-9768c6689f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc8b7ccf-7888-4967-aed6-eb5d343179f2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29113799-f271-4951-a18f-ac987e0e09a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7c3c200-930b-4a90-8dfa-9f839cebf79d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a464cdf-d261-4c53-a320-9be8618fa0d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24ea3acf-ec02-4609-b9e6-da4f477b7a60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ce04a2f-8e18-4bae-9267-07ade5132cb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ebfcf35-fa99-4bb7-8204-0c94fccdaff4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d6c972a-8fb2-4dbf-aa6a-ed82e0c0b3be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dccf116d-491e-4e69-9ea8-8101ad6ec043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66e91c22-b40e-4e8b-8502-27007d0accc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d2bdda8-6ba3-4fbd-acac-7a14cfd8552d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d80d39f-69f1-4dc5-946b-cc151ecda5ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12ba20-35c6-48dd-9694-bdfa799fce94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_167c8171-868d-4aea-a0ee-46d2620d07ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b888c561-d178-45ad-a230-1e5addfe2106">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c344ba5-2ccc-4a21-be2c-aeebe2b6483c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95fd436e-f77a-473c-91d7-6aa7715a985d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb51de1d-6ca3-4a05-a78b-aca3707e3fa0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b295e329-a5ba-405a-8300-6eb7751d5f42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8667e660-8674-45c6-beb5-7a8c5016497c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37a461fb-e8ae-40e8-ba2d-04176c0fc86a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_990bab29-8285-4d4f-9568-8d76adf2e329">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7615cd28-6642-4ed4-aa07-41fcf005901c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70fbecbd-a570-40b0-b924-9dee18a0033c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ceab391-9b32-40ae-a4ca-a1876f5c77d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36783286-75df-4d91-8996-b28c539c0af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25834ef0-16fb-4334-bb5d-f4573046692b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b78831ec-6458-4f71-83df-dc4911f17fe2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c8111a2-d58c-4cd6-ac92-65b5016ab9b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_049942ff-eb3c-47b7-8037-dbe0742de940">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41484357-f128-4be7-8ae7-27bdc4b86019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d612c351-c679-4e42-929d-30dabcf165ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06343fcd-f7cd-463d-9be4-e945953fd82e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e983c04-7dae-4061-9233-f5654965744b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_547bd475-13fe-483a-8458-71d3c783493c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1f1508-11df-4d70-82af-061d2ca91351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e03205d7-a924-40f9-a3de-2b83f1e37bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fb84e7-ad1f-4124-8c51-051ac93c5a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c1fa02e8-02f0-456a-b06c-ccd75879889a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9fa2e723-ed6d-4a1f-858b-423dabe74184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af9a95ae-eb9a-4491-a957-2829445d67a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2406d38e-44d5-4ed7-af86-823636e9a488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2c6b929-0196-4434-88f1-a805d4c48986">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6db42efe-97eb-43c5-bc1b-c47c564f3066">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1d6ce52-59f2-416d-a8fc-10fe7e19096c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_560bf83d-89b1-49c8-b344-48c32eaffeac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f38de7a-9d74-4d51-b1ab-5da7b960ffc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c88a1ec0-0fd6-4ba2-81e2-be367d0f4df2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca498289-9312-4a5e-8dd2-23cef664abb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9fd6394-daeb-4698-b348-275e808d6afa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86d88bbb-ea78-4904-b49f-53fd2bb4d191">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31accc74-faad-4484-b101-f73ef44a6936">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41526c5e-6b58-416e-8b3c-6424b0acb3fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11cf92b2-84a0-47fe-a195-f0e64010f8dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe7369-d00f-473d-8b0f-691d98291bb2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85c2b8e8-79c3-4ef8-8c1e-d6827a6d718c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81228225-5cb8-46cb-ae11-d29586a1e2ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d6f3a82-2659-40d8-ab95-8a2bd5fc6265">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a960f0-930e-4403-97ad-3691fb54d700">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc031930-2fef-4625-8e81-5e393e3ae979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8d28d23-305d-4634-9eab-d844d194e774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84f4f334-5f2c-4c88-8d1e-28203511eca2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd1091dc-e3a1-4166-9ec9-dc1722819f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7801660b-310a-46ec-be58-28a687126bec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a4c90d8-4c22-4948-8791-53f8ca5d4622">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27d75556-9ede-437c-b23e-d79dc1dc96ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c51a0cdb-d467-4d24-877a-7775e82b53c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_86c18cb1-3611-4361-8a20-4b8fe0384de6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15a078c8-16a6-459c-8f79-40a9ca4a6572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c4d4d990-9de9-471e-b1e4-694e37b7b9ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37502de3-cfc1-4b05-bd5b-ed9030f8f189">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4e417d1-226a-4b14-bd6d-28351e5628ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54ba944-901e-40df-840a-d23df6f7a88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d318d295-ccfd-47d3-8f1a-043d208aceab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a68248c1-14fb-4dda-b56f-e13a5aa7f527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b135ab26-112f-420d-85f0-80758a7585db">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_31101594-c7f5-45a2-ba6b-27e8f669cefb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd1b6f49-5364-40a3-bdbe-2d82edd1437b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_55cbfc96-cde3-435a-a7f9-ba18fcd0638e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b67b401a-51a7-4330-9d7c-943ffec2f6a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b749a48c-ebf1-40f5-a322-68053428edc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c4f9c0c-1a4b-442f-a4bf-406aeefcc4c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90c30a29-5734-4a13-aad2-5797a77639d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d0a545b-ea46-4ed8-a24f-40c92b051ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b81fa63a-0bc7-4b07-a18e-659a715bcc1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_762575f8-bbb2-4377-bad1-861be802222a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dbad50ed-ffe1-4f0b-b052-2d78375b5463">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e782e39-34a0-4f10-8569-f499394ff261">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1657588a-9956-4af9-ba4f-5b748460b57f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f61f229-a94e-4cfd-9fc1-0399486ffc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c221c69-bd4b-47e5-a647-7f1159e00af0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f53e5a2-d64a-4f0f-8c2a-a443eb46ca6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5a83883-e82c-4672-8b1b-1f636ef7e8e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ea96345-5a97-4a05-b4b2-310f4d0afd29">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f84a5f8-b9a7-4872-9053-b1ef88e2d05d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8819d649-f8e2-4e89-a972-a50bc9c9fcff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01cb8d57-9bad-4964-88e1-b30f590fb4c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7a1d0c9-9b78-4278-af7a-b2b1231cad51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a74a4aec-0927-4239-9575-0cb091400067">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee9adf37-e0a5-4e76-9283-7f1724ad6853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68cc2320-f052-4f83-bb13-d1f4fba57eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38c9825c-4892-4cd6-b9e0-c4adad69a028">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_210557c6-8c1e-46fa-9045-fe56f0c89153">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c1d4660-f77d-452e-8aad-55c5eb44d24f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98b17987-57ae-48d2-8676-f875506d5927">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1b979e7b-cfae-4605-b8e4-9a5fc3be5cfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37f05fac-fd02-4322-9f59-d7defa1c9c2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01df9095-b5fb-4e49-a1a5-1aeedb85f23f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08675ad1-6474-40b2-97c3-0a52b7663139">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7dca1366-a6a6-4577-bd7d-d653e9739366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_25539bb9-f941-43fd-b933-79a889e1038f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203587d3-1f66-4dce-bdbb-222273112bf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e31e4207-59a8-4219-8cd9-900e92f76717">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ba58280-2b98-4ba2-9e29-94e847ae6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64485f9e-8a5e-4388-92fa-f558d6b90e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95bbe69a-d4d6-4ab2-836a-1008b8caffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_479ea762-732a-4eb9-915c-2b88c78fabe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e835c60a-dc97-4554-9544-fcabed551f58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0c82da2-3dea-43d9-9cc1-4d39c9a43b78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_342803ad-2a21-431e-859e-5ee83a93cc91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_93c8c2ee-ca43-4e2b-84a0-2f1bfec243ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_84e84bc3-3fc5-4759-8a09-3bac5643687d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e83af75-d5fc-49f9-82f5-4dff21fbbeae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_315a215e-faf9-4824-9446-b23a5fbc46f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1822bb-61f2-41e3-9f6f-2803fb0e53f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e859328e-c8cb-48ba-81a8-c3d69072787f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bb1238d-127f-482f-b129-003cafd854cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00d4de7f-97a1-4ee1-affd-236e5ca7669a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_06cf8848-6457-458a-8535-40f3b914107a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b2a2428-1a4d-46f3-85de-fb147e11f451">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90836758-b0f5-4d95-8b21-a6c1003de8ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_feebd7e5-b054-4c98-a96b-b28c48f82243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b097aa4-01e9-4d1a-8f1e-c63c4131ad9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_771f6532-a3aa-43ac-b1ce-0882c959f109">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acbc514-341a-4d18-ac85-8e4cfe2f382b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea41c901-8756-447c-bf4d-2d335b26ca9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77fa6aae-4ad7-4b72-b051-e6f28d5b142e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_76d4e8f2-3f11-44e1-9f63-8c2be3ec5162">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99da10c6-16c3-4dbd-99d6-83f1e0842025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd575cc-c1f8-4bdc-a62f-ef6220a31456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72cc6651-81f7-46ef-b37c-7fc46aec73e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62b9e7fb-d6f3-49ac-9a42-d77ee831eee9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07aa0735-959a-42b2-b4f3-6074067aafec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ae60514-69c6-4288-8e65-a598a25c9c90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3cf6bc3a-337d-4393-9090-f9060f0eb182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_129bf6e2-5b6b-4bfc-87e2-fe9b5212a467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80972da9-13cc-4b7f-9e1e-6343fa94224d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5316a4bf-19be-49e9-98e9-e7509b4a2a23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45e90f13-81c0-49fa-8677-5b58fa5ffd80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2234ba5-52c8-40a2-acd4-9a57460b3d57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4427f2f-4949-4d59-a3e0-79721efd6e71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e599f57-e8ba-4a78-a8de-93389bc0e6e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c931db7-c9c1-4d7c-8659-a78594c06d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3edbfddb-96c5-4997-a24f-d7a1006a01f0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5406d33f-9fca-4c3f-b933-88d01f6f3bad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7b8d64a-03f2-47cb-a62b-4f6a877e7f7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38ab5d22-589a-4032-863f-ba589156bbf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af8788c6-83ab-4c1a-b888-97f10d25ae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df6de0f5-def4-4f68-a871-8ad85b2376a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0020cf33-6189-424f-ada2-6c74c3ef22c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e3b7333-bcb7-4fdb-bda2-0947a573ea26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7602d239-dfe6-41fa-b6af-2ef200468081">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ca892ebc-e51d-46dd-95dc-a78a20f8626e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7438269e-b295-4183-9b94-7417d16c8b14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d382ea-800f-4f9d-80c3-8bef6e8a5dc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7085f2a2-88d6-43f3-b486-d8fee1e75218">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99134582-5a8c-4bcc-bebf-da4676e7a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7133333-4a33-46f6-aca2-bc7c432aa30a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f47a5586-ebe9-41b1-9844-44ed52052550">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_724e7034-65d0-4d26-995d-2cc45736495e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10ff5cf5-d7d1-439a-848d-788d77dbd40a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5b8f1c43-e90c-4587-8669-bf331953a643">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d35a277-c55f-4836-b36c-14fcb66f8f77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_593d0b12-0c6f-46f3-a675-5bc320b23e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c8577d7-eab5-453a-b5ec-3e88c1f69a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01fb6448-cd88-4c99-a93a-ce66fdf0b9ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a1e5cb-d60d-49bd-94b5-ae5ed77d95e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fead62ca-3226-4feb-94aa-7ef14946dabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bcb2d8c8-abb4-4b80-9e8c-4fc8d169dc6d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef66a335-fc26-4701-9790-79f6dd980150">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe0d6475-e165-45c0-8a0a-def79cf38182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0f65e91-5055-49e6-bcf6-9f607dd0ffa2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8fd01294-d5fb-4478-aab0-0c6b11eb195f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e7791f3-2f85-4c7c-87fe-f530bc9c34b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_055f6a1c-d9c4-4ec7-b72d-c385976c9b2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5adae9e3-7054-455b-8e44-93c55e875bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_717e37b0-3fcb-4c83-8c61-6f3bb9b305da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4490fe16-8b5a-4687-a603-3873c45cfb86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abc18a4c-d871-4631-a190-ec032f93d5df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74fca12b-d271-4fbc-82ff-70cf20e508a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d4a0b0-a444-4a06-8929-ae495a0f2399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59f4b07a-765a-4139-ab24-2040c49e6fef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1a3d91f-fcd8-45d9-9068-17367aabe864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aa8d0b3-7c00-4d3a-bc74-c2b2e6b93bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da927dcc-2cf1-405f-80d4-f7dd92117518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_66f28d02-03ca-4604-bfb5-31ab54d621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7848a48-ec4c-4aef-88d9-a75acc3eb65e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0f4a0f9-4c5d-4893-98c2-19b42e6ec40d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea7cda5f-7955-441d-a706-62050000be98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d4de290-a5a6-4525-888c-67cb8386065a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_658c5fbc-8d6d-40aa-a7a5-a2c5101bdb02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13119acb-18fa-4ac9-9d96-0a98c69b66e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e3c1c910-6fec-48e6-a071-f1bc05bff568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43709e36-106a-4bf0-94a0-67e433f9d58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_29d86cfe-511b-4b0e-886f-d808af28ac00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_58ce1bb1-e8fb-44c8-ba47-2325967e7140">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b67afef-e077-4f0c-8754-e862f2be799e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca6d3234-c045-4487-a1f2-023eda3c6b48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13db0e89-518f-422c-8ee0-bebcda57c914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37085430-1118-460f-86d8-a58274c29368">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6cb1b71-d49d-4b44-a7ee-8f8379ca6c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b876ab67-4bdd-45bd-a5b8-02c3b9e6492f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0975e90-01cf-440f-ab2c-1cbda073793e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c2797fb1-b15d-492c-a86f-900dc054eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c15a8b9c-87c5-4765-a698-bd3a743ea0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e900d4f0-88a0-4f10-b450-ecc7289fe172">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2fa583a9-e27a-445f-b11a-3cf60a6c096a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62b2ccb4-0d9c-4592-b19d-d21ac06c6bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9343a5e6-3fff-4379-b4b2-88ac2b9d5e30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fd34c6da-f9b4-4edb-abbb-229e9c0e6507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4576d17-b9dd-481e-a99a-9b2e86fe2c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5659175d-91c4-4e77-b2e3-de41cfee7a61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_88f90584-8048-4836-aed8-557a1be25574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4425d538-82c3-45f4-a79f-468ce22b1277">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c15e468-811f-493c-8431-c78323ee7261">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ef86e14-8dd5-4f53-b834-3693fd04025d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41a92499-948f-42e0-99d4-4c81b1763be6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aceea622-96cc-4cc0-a4ef-c0985a14aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef55c6e2-1559-4898-ae94-bf5aec5eee35">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c1066bc-6435-4370-adbf-6e5e9dca8a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b46e9d4f-f807-442d-b48e-25f59c33a0fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7a197074-f6dd-496d-98d8-ece105892059">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_afdda05b-9fda-4c5e-b67f-5a8835a9f019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6c15186-72d3-4946-a857-f709eddf838f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b63e438-cf9f-4456-a2e4-1d1600bc4943">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99c5da9f-56a9-4126-8ec8-27c0ffa69c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a721d8e-f3b7-4d26-8044-ff5e90d0cd32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd52bbb8-eb82-4bb2-8c14-37ae895d7f14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_021c9ae9-3d30-4a67-aa98-7c86f9f2669f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4db08985-bfd7-4f60-ae09-e3044e1143c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dd33081-800e-46fd-ab6d-3688e6d05155">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5d4dc3e3-1d65-421d-9995-ae5fe9b9ae99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_12e40f94-2cdc-4991-8c72-28352ab765ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b26843e-a219-44a3-8b10-e755dd65cc50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2b84dd51-5672-4c25-9b6c-eda83c8e6aef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8dce3f98-5a3f-47b6-8671-6264edb60f38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eef57a7f-1b38-43a9-a2a1-88d1d43c41ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2e8d3533-e650-41e8-ba9b-36b5ec94aadc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4957a875-6ba5-46ca-9ebc-5842f66e92f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b51b1dc-b52b-4d98-ae80-713d27ba53bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_571fbb8c-c22f-464a-a009-75887e5265cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f02a089b-51ec-46fe-ae11-2aab8b340bd4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b9574069-9cdb-498c-80b6-bacf8e33d6d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f67e88-6aa3-4155-953d-51300aefea7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54015ba-0d13-4c36-861e-13d092f9307d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4190d3e0-bea8-4b68-a705-a1359a5b8022">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97917706-3686-4103-bed3-0588a7169e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7536f1d-7c3f-45d7-8a79-842bf0992eec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61ef9abc-a0f9-4c1d-ad7d-cc9d81ca9b68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dba72ef-c7a8-4f5a-9b83-2d8dccecea7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aff8a4f6-0ddc-49cc-b04f-492336fb78ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7a42f18-f442-49bd-809f-5af6909a5bb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f11a1291-627d-47f6-8d13-d122d2907fa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a7027d7-d811-4bbb-9fbd-ea325624dac3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c354d477-f0f6-491b-af74-faf74282d996">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a1d8cdf-7ea7-4554-ac6b-d7755614ea93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b906ef20-f829-41ea-a58b-bee609b03812">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab799eb1-046f-4efa-a790-46f648e33aab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c44198e5-abbc-49d9-9b4e-8d5c545425fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5728316b-1343-42ef-a0dc-2582ddfce4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01957b23-1950-4ef7-9f12-e88028223835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aaf9837e-648a-4328-a7f2-1e524528ec4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2a8261e-43de-421d-a8cf-d18e51356b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_745a62ff-fa7b-415e-a80d-58499bd979a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfd66150-92b7-4637-96a1-10bf16bad932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19709704-48f5-4360-b6bc-454dabb4a91a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc0bebe2-35b8-4d32-a5dd-c866e110519d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ade4e44-a1a3-47c7-96f7-58ef549c8881">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ce1137e-97af-4f0c-8e97-d8362f9a6681">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_704bca7a-a16b-44af-a3cd-63ef88281c92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_771f698d-78d2-45f4-be66-2d71d49dab8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f86c5a9c-3aaa-4913-8c02-8ad29f83cda3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0371a00-0b14-46f1-b09c-25eefe811e0a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b541a7b-677b-4452-ba63-04630664276d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28cd2978-aafe-4b1d-a72b-800c2057fc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9114bea2-7789-40e9-b181-5c37526bff09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46d738cb-d6df-44ea-b946-4d780d06ceb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_625e468b-920d-4c28-805b-434508aafc60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f76818f-5a86-44b6-9f8e-2fa8425cf4ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c00a6123-f67a-4394-b0a2-9703b6fe7c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46a60d8c-5ee6-4b88-9d77-bf14dbd42e13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_842f35d2-8bc4-422e-9c6f-482c3319c75e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_223736f3-2dd8-400a-ae21-23490dceb5a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e7184e6-b0eb-4071-8f5b-ce9d3575ebd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d990be00-2c1a-4878-91fe-9d411db99e7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14de64f5-2498-4d4a-93fd-07ddc4faf4da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_248960f7-2bb3-4e4d-8ef5-9e4b5256e242">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc787984-7965-4911-874d-63951b71c9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_beef0f3c-1063-47c8-8c01-980f9d0ace04">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_efefc590-7ccf-4e2a-b1eb-29ce71bac7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2851c207-d0f0-4afa-8459-93e67ab046b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc647ca6-b570-44c6-9a95-9017a0d9a6c1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f69a138-dd10-4d1a-b4fb-bdaebbdf6bb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb12c256-e1e0-40f4-8409-f632dd91a567">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_197813ee-99dd-4dd7-8c7d-953125010823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad326602-7990-4820-b11e-d30fe8712f1e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c7f1716-7a9a-41f1-bbe3-a0c786036aee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e5e210cb-1713-4b5c-ba13-a23753fc6357">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6947b0e4-2183-40fc-bc41-71fb9826a566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ed6be82-6f0e-4e3a-9290-5440ac0e3210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f2ef388-bb24-45de-ad9e-e1d81b0a70e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d34ee87b-12ea-4264-be1d-77523cba6664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96509c69-be8a-41c3-aecd-cfe5a78a347d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fc8b50-beba-4f1b-9b37-44be779b4008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d93a35c6-2778-4e43-ab3a-949e0ba70465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5812071d-a8e9-43ca-8ccc-b51bad61713c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b8883d7-bfd7-440c-8b70-b542def33958">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7f4e2cc7-9c7e-4591-b673-e15674599f33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_69312939-c515-43c2-9907-6f7a9b4c2844">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5feef99d-86e6-42dc-9c15-685a70a1f1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88aa5ed7-9987-4bde-ba31-fb3b30f70285">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c18d4158-7fc8-4153-ae44-3b69c9326167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb77820f-64bd-4d5a-8a1a-a712fd8c3dd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8185f40d-99c0-494a-8fb6-1c2c1e36d884">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d843d9d-ad4a-4ceb-9ffb-1f9b8b2a892d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2ac50ab-cc63-4365-8bc8-5a0a2ec32143">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70091785-81cb-45d4-a120-97a3784b6f40">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f82c11fe-c49c-4676-98df-a97998557859">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b24f203-4333-4e3b-a822-f022244e1d92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cde6c0e-e554-4167-b71f-62b67afc85cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4e1a8fe-b9e8-42da-acd6-6ccec8014bb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e045e99-8d68-4ed8-9391-4309be949fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52120d04-2b1b-47b1-9581-72ba5a43d32e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c5d7ca3-84b6-4bf3-8e80-a725069ff9fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_877e8141-40e2-4022-81d0-7ca6b91fcfb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a36a24-459e-4f26-ba5f-5da5af49a4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_eca88a11-bf8b-4a75-ade9-2de5bea4877c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d827f489-f33e-4019-87af-4414e8baf08b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff3ff395-0043-4d1b-b7be-f7a978500713">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74b2a3b7-700d-4d2d-a24b-de95f780984f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d3b9648-41fd-46c5-a65e-4770c2379091">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38bd0277-d889-46cc-a57f-4dce84db3179">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac35b9f6-9769-4ea2-b7b7-a39fa5afe1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6487111-119f-4c04-b03a-4f358ad555ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a3956a79-3d90-444e-b18b-babe0a24c7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0886d513-eb42-4bfe-a1d1-91dd552d985f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3ef6f07-77db-4073-9b75-8c884a8227b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fe67305-2b8c-4275-b395-ab7968cd0272">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ad26464-ac9c-4a4d-9367-9adb3cc20cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac0b47a3-728f-4a27-8c82-47187058245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ae765c-598e-4e7a-a7e8-7ec76be26ff0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14440212-9e9c-4a98-ae20-bd02c0389b11">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b558016f-c443-4453-a846-56cb92195255">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9f1df3e-d035-4107-8c1a-ae630c1dd0b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6891853-d085-4539-87e5-a3b8c0a18445">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74abf6b5-ec41-47bc-bcd7-ead4aa9b4d4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a024617b-feac-4a5b-a1c7-5ceec0238f98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_053ae80c-2f62-4b2b-87ae-759d2bbafe48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_72caf4ce-0392-4a83-b9ef-66c1bf18cd42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_618b6fb8-cf30-49ec-98a0-16a816909cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6869cbe8-5336-4075-850d-5689210ea8b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5efa4008-dc17-4aec-8c9c-d3d19f2be5cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71b4a9b6-82e0-4375-805b-2116c6402f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4698229d-cd6e-4c86-8cca-e6d2005f3fa8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f83db32-bf0c-4cae-b788-13c0365c7c20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a97f14b-bc34-47b2-8772-22c5879d1cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1fdfb51f-2996-4790-b046-72e240d1e0ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f253934-45a9-4b3e-ab30-7e2ce8327ed1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_132e5e39-3f2f-418d-b826-1376ee0c715a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2db62614-6569-4e78-94a3-0006780692ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e3da9b20-f585-4c9c-93e5-14c19f2b6399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dffd3c04-567a-483b-bd21-95a2c659040a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f622f73b-4f50-45e7-a314-dd7abc1fbf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fafe1dfc-054b-4ed7-91ee-8d379326eec6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_835c90d6-b524-4dfc-baa2-91154554bb3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af61f0bd-2d4f-41a5-8108-5d6bbb9ceac5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62aee4c7-b396-4790-a96b-58735a58099e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8543a6eb-0473-4bcb-8ab0-59ba2fc58b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13c4e177-274f-4c6c-8a54-1666fa02f5cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b4f2a4b5-de1b-46e6-9caf-819d0d5f7756">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec6c71c-fbd3-47b3-a7df-259f8fcf18fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9cf81c-329a-40a9-b846-02b92c38b584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45d1f6db-a578-4885-86c4-fff085855ffd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60d8d59-4416-4646-a1cc-0f85a3ac109f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_63c4a7de-7676-4226-901b-6e8a9e63491b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27f1ae3b-e45d-4997-9a2f-af8fccfc9c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ede0ad83-2917-45a9-a53d-17dbf251a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2d6aa302-62c8-40ae-b6d7-4872d0a2c81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9187f8f4-cb9f-4497-954c-4e9470855a9a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b023345-3d98-4426-8967-f6be81e1828d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ae07a8e-253a-45de-a576-a70bd5668d58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1d3ead1-3f0f-40ee-943f-f1dee312b0a3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3b3ede6-1f39-4cf6-8970-363427783803">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e58009b8-1f83-4974-83fa-f2044fb95808">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5022d2fa-b3fb-4a51-9b0e-65566f9d8473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddad94f4-3682-4c83-839b-0aae8dde7bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be420f6b-ced7-44a1-ae07-7c136bfb1e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e65535d4-bfcd-41b3-96dd-2a50f50ab590">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5f92fe6e-b0e2-41ee-a046-28611580b915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87635d3c-7a14-4f8c-952e-6ee385bb6d83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4052ff8-e2da-4b60-b80c-c68fc1a60619">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ed5519f6-7ead-4c66-bd34-fb76ff46cafc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ceea3926-ece0-4b7f-a7d9-909e150d3d84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_29c7f86f-dcfa-4ff4-bce0-b1d88b129da2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_32467b45-4242-40f6-ae90-399a071e765c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c229d207-3189-4df5-85e1-37b21b353674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34394c63-2e6d-4553-ade0-bf94a78e4382">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f84f5c00-f7e2-404f-b646-fbab051c5d78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6d3aa49-e3d2-46b1-8d53-3f1f75e8aa4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d8d3d57-7ca8-4460-b92e-0970be0092aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f792f6d0-fe8a-4439-9e46-e461869601cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52b96eec-0446-40bc-818e-dc037aca27d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b92b26-84f9-428c-b42e-767cde1ee485">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c1572f8-54e9-4f58-b58e-4be8dcb49b80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddc2ea92-8895-4269-9512-fe42270e9a5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6904c68-be16-4784-a554-5e37a8906992">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_893b7d03-19c8-47d2-898d-eacffd52b8c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1285083e-4048-4afa-a315-b3cb3fd4781c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4ffcd89-c4be-4992-88b2-db12df2fc476">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a862cbfd-9088-49a4-a91a-4e32c22e9e43">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d015a1-51d9-46ff-aba2-2a10b7abc94d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b88e545f-683d-454e-bf38-a4b4a11c66e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df0b8e73-382d-4260-9489-8114c52cb9f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0d88a48-c7e1-46d7-a314-85c4f870919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f95ea0c-7967-4cc2-88dd-62ba25802230">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0cca45f1-e599-4046-bca2-f221f2fd0d69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7df41223-5692-4dbc-a02c-d0d7c1576298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1bcd4be-f73b-4aa8-9b0a-7514c7c50bc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e93dd0e3-db03-4ae7-bb2a-30ea502339da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_145e4229-0762-4f9e-95cb-fed99ad79e9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e360b1-fd0c-4c11-bbe3-c543d1af1a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_513d4e03-731e-4486-853e-49ec395312a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45a4646a-3dda-4a59-855a-ecd1fb44263f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_08aeec0c-32d0-40db-82e8-cff84194afd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b59d6e2-48d0-44d8-9a67-0106c94f0142">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45aee435-3966-4bd7-a2df-ccc5ed886045">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_20f86f62-6dcb-4b55-94fb-3f3e6de5521a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad48cbcc-0af7-4f32-9433-2fcbad64670b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_27ac5033-50ba-4225-9d50-ef7282186c0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74c4fed9-ccd6-4a23-abbe-a8d0d429460a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca797025-3a0e-46c3-92bb-00c36c229c63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed8e5966-f137-439f-aa01-b1cc7d49e74b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33b677a7-46fc-43c4-85ea-ad1351da9c4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2070290-3e27-42f5-80f9-8f6035aeb75c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cc431a-3e19-4339-851c-f5b1c6f85d36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9878ef4a-3f92-4c4f-8b67-6eaca87fc58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1163857-e5df-4f81-adb5-de5b3f4b13b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d94d4a5-e15b-4126-b4f1-c774996c1587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6f592ab-96ec-44c9-8837-3fa9668144a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94e72f33-d0b1-45eb-b58c-abc95358f80e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8cf22fc6-6d20-4aa0-81f0-3f34586cde7e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ff9c845-5984-4ddf-83c5-cb948ea978dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9cb09ce-880f-44da-8356-5e62c28e9556">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87db2dcf-7381-4bd1-af56-900c29170284">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d0c504a0-1dc1-4a84-a77c-dd4356d9c45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62836935-2777-43a9-b6b1-2d8ce915e99b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_301306f5-441d-42c4-a85b-b4dd619b1d54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d98d033-219a-4647-8ef3-214a241ceba0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_649ff81e-a994-439c-a3e1-79ca4b97f467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ee3600e-761d-444e-a54c-3b231bf6b0c6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_651d7211-bcfb-47c6-a62e-546f97cbdf31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d660b3a2-36f4-46af-965e-9ccf63921b99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06ef8f5f-ced4-44b1-89fe-636fde5295f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de006bd6-6239-4d9b-b431-975fc883ef69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2409fcc-0d8a-491c-a8ad-caf94d44c866">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8953b98f-b6ac-4fd9-b382-280dd9f83848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51c81d09-778d-4eb7-a792-b13cd11990e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_030fd25e-8a7c-4067-956b-95de2e43ca1b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eea0f6ae-4a78-41b2-8fc1-9b24e9bb1b2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_799401b5-7bad-4628-936c-272a47afe701">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b30e5c53-c685-4975-9ff7-395f24f94933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfdcd1a6-2100-459f-801d-cffdecc34978">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ac17236-8641-4330-acc4-a3546fa3be0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c2b5717d-14ab-4735-84c7-f08eec3c5151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92093091-9def-4b01-a1f4-97281f352dd7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_457739f8-564c-4260-a9b3-6e7ab51f19a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_29f45a6a-1c54-4cf0-82c7-18f8a94aa832">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b59ca157-0966-4c44-b922-2203edb1b072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12b76adb-53b7-4746-81e9-b6b66f3b395c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677cf6a1-0bef-416f-97a0-cfae59065c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e11c9d8-c96d-45de-bf98-be3f0191af7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b085e19-fd8b-4a19-8ef7-75a2a1b340e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_14b9ba51-ca52-4687-8618-aa9a4680a7fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3f25543-e935-456b-bc76-6fa1074135df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_09448cec-6754-4734-a17f-dfad905c44a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a3baf0e-2dbf-411b-b020-a2de9b0020df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_547408ac-ad5a-4f0c-b307-254a70440a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5862bea5-3fec-4d62-8c22-91f359b85c16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb76ec3-366c-44c5-8d38-728ed54ff389">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a8ab2f4-2478-432f-8c9e-8f2cb5f5d630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82e14c8-843c-4eb1-9432-72391eabdc02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03284608-2cac-46a1-9ff5-fe40d306eec9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc5b8041-f904-4ed5-8244-e97962a5caac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9489f62f-c3ab-4790-8054-ad01c5b0d5e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ecef8e03-2ae5-4c33-ace4-eb88a1ddd005">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_063f483b-b293-4c29-bd55-d372d3f4a341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17042f33-0046-48aa-ad84-d9efbde7078e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395a61b8-006a-4196-bb79-5cb27b25eab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9239f57a-e9c5-4fad-89a4-b8ea2bb28e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fcfd5cfc-f4e9-4a3c-acf7-ca2702751185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff76a3ee-bcfb-4db4-9bb2-974d6c21c42a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00e7942a-8a44-4f31-b35b-6c88bd506e89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72e10721-4709-4f0d-b005-2572bb18c770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2362f3c-d255-4610-958d-0e10053bc77c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f7c9d871-1586-4d82-bacf-c192bc284e34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145bc878-e3d0-4a68-999f-86ea26ae1990">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea6d0cf2-bf23-43f7-8409-991f9ae05b48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_337e83fa-bd65-4743-8321-42b10816e5fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676e07d5-62ab-4f73-8081-8f032b081774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f58dafd0-b948-4a63-bdc5-4ede3acb6afd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5afccff9-daca-4c68-8816-fb0044885a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7134e652-abe4-43ba-a026-b7e9d691a8ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3f60a0e0-4a65-44b0-ac9a-ecaaff0568f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d79d96-ba63-41a9-9ce0-85a38c48b050">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f14d84b1-2685-4ccc-a131-7dc23a20cad0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08e585b5-f18b-48b8-890e-b58b94cbf885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b9bf5836-6dbc-41ff-9ff1-0d01024ba9be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_52ec1e35-44c6-4fcd-a770-aa08f88d7795">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4dfb00b6-e3bb-424a-8e2a-3dc0e75138b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27b64a1b-ef39-463d-9343-1468c0720811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_992ca25e-c4db-43d8-8de3-7d4236242e8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7ecc7d69-bfd5-4fb5-8431-2b10b70edd88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4ea322a-da37-4bd3-b3f6-0e78ff502bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c40abacc-9e8b-489d-8671-de0b37aa8636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7a85746b-e339-4d05-972e-ff0e3eac549f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef89fef9-47bd-4286-b6ea-a99a281f039a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c24582-f9d5-4bbf-b7d6-b61f103a44fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_efed0d03-d7cc-4f26-8ea0-45848fe13aa9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_967d5338-3df4-486c-afa3-b5e88ac715d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd19b3b6-f6d1-45a4-8dc4-0fae74d2c3a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e919a839-3083-4a1c-b235-9336097753f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7fe68b1-6ed0-4ca7-9ade-c169c8374eed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14085fc9-b39f-419e-83e5-e2cab1d55160">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c821c5d-c3f3-4c50-b6db-ac35e16b97c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ce0efe1-62bb-4a5e-9733-f1cbdf080af5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3d8e9855-b1b8-40ef-ab65-b3c547a83cba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e308ac0-5c77-4bc6-a8b5-5ec33f548691">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d75db8c-3edc-4746-bc88-43066fc4ceb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6db6bdf1-075a-4fe6-9fde-b9591bc20d23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29fdda51-879b-4420-9d67-a14259902e2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bcae2b91-06e3-4f90-a51c-142614f8d6ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b539dc50-2b2d-42cc-af9e-8edcec28839c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3210626d-f10a-4215-a19c-6e68ee613be0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05e16d9e-15b8-449a-9037-b399ae6087a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c629896-e4df-4b62-bc96-f1258ec5c947">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f6e0ab3-52d0-46dc-b58e-93c5f22bd0f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_265e5d25-3027-4f0a-8a18-975067551770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26a6c4f6-6c52-4721-82b6-3c78f69b0ee4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d317588e-e08f-4292-8aef-6be6170c335b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ace3fb1-ff34-4a2e-bef3-e579c91380f0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cfa32d7-a521-4c3d-bb3c-265306a0320d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_272e6f11-15a5-4195-8a44-ecb091d1500d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b5baf11-9a74-40d5-900b-7352ec34da1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a85f927c-7844-4f5e-9391-108fa014f96e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d281e9c5-8246-4cd1-b81e-e8ff1b538a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab98a3b9-d124-440c-9f3d-4a4884dfb95d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f451588-ac24-4bbf-b20e-8cb3da0f0c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e441009-4aca-4646-b423-3b43c9fa7d68">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a281b9f5-89f0-4a22-8d46-b194d9bb411b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be3aced-f45f-4110-b799-7588f844f08e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d38dadbb-5707-41a9-b85e-66dc8b70f583">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d937e822-cd68-4dcf-8832-87c36ed4c7cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d492ddf4-a60e-4fb6-abe4-821fd2501932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca7cfc2c-1aa8-48c8-85ad-b0a1ac53495f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5bee6c3-edef-487c-abc4-66038a4fc79a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43e6fa8b-1193-43d7-9292-dd54a91e29e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f692ed1-d190-466a-b31d-138e71b9d2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ee620ab6-e452-4ca0-9e44-9133cd745cb4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b68fda8f-bd7b-4a4c-8983-fa5e733d294e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f51bca0-95ce-4cdf-baab-e02610175e71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1f96919-4686-42c5-b11d-80413fbf695c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1175e53-6cca-43ef-9550-4f088dfd2c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44975eb4-b7c7-4098-bf5d-076229b9598a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59fb8ddf-dbac-416d-b576-ff27c78f97ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3425cd4c-f477-4c35-9414-a074fcda03b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dbb3127d-13b6-4b18-a82d-429d7a661cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff1b53e1-3ba7-4331-b32a-431fcbe569c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48d3cfe4-1850-45cf-a38f-2463e84bbf4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_132a6e57-05b7-40f7-936d-8ad215faa067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec22b841-2d09-4c40-9094-2910f9d18f47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69dee46-8d4d-4321-bfb5-695e8cafc361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784648ac-b7c7-45b9-8b04-cd52657911de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16a4890e-2299-43aa-85aa-60d568a6f55b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c85bb9e-b82c-4148-9151-33ae459b1ea5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_31d058e1-7999-4900-8304-e699855178b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f055a8-4a29-4f1d-afe4-0a6255d8fbef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bd353fe8-a348-4ac3-93ae-173919e4b699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b0262344-289d-4b5c-89fe-a2ed32b4ca12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6ea1e1a-dbe8-4939-b05c-809b216ad452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02aa59e2-99d3-4957-b768-41f796d55d31">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b1c55cf-a01c-4f0c-a008-0f4c3f91f1b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6611048-9b76-4265-b03c-75500718c097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9024f22-f8e8-447b-875b-4ca9b01d799b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e3ba0a3-59cf-4d02-8c5d-e5a6846a0eb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fad1e6b7-5f14-4853-a74b-6677b5c0719e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6b142fa1-1890-4e15-9044-a1c3910f6538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27c3357b-8a1b-4130-bad2-fc753b66ec3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a94aefe0-21b4-462d-aff6-7aa79d6af0ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_255ca98c-c55c-4369-8358-031e6aae3279">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b627ac26-6fab-4f5b-b08a-f0bc8281227a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dfeaa24-c478-40bb-aacb-337c3ba958c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_533a0fb7-2cac-45af-b21b-6bc5e424689e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7e3c55c3-c306-4bad-86dd-f8cd84a7adac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8010fb5a-ccd3-46e8-bf62-76ddb2c39d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20c7a56a-a0b5-42fc-b168-b4256f98459d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d7307f8f-a895-4152-9146-3dff1dae3a45">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a42b677d-a545-4739-ab21-0906bc5547bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fb41ff7-7704-473d-a4d0-051663aaa078">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c26a2a3-27ed-4b94-83cd-17e4c607df1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_343e6a5b-fbe6-4747-8c53-1eb52d084263">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a640bd3f-ea54-40dc-a069-ae10b7b98e8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b63f3186-9667-4c33-871a-7e97ca96d072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0d68b555-1b95-423b-821a-2d321b2e53af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_090e9885-ef0d-40e5-abb6-e43fb1b8f24a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9fb9ad9-e629-46b4-850b-445a76ca39cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0acb4c9e-f5c0-4ab1-b811-10d8c74c7e95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a54a35ca-7b80-4008-af79-e44cca11d323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dc30822-bc18-4884-bc98-f167564638bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebd0ef2a-c759-42e5-bd7b-6bedcf57e560">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0b2aa62-3d71-41fc-a067-bcdaf1bdb2ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d02435-6273-4736-8568-3ac72f70d876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9365ce5d-c4b7-46f5-b929-259b1c0acd25">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dd5b60f-7c8e-4cdb-8e48-e1f8e14d54b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c854969b-0dc0-4d52-8549-20b433c77a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2dff895c-7df3-43b1-9d6f-371d946ceb94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a85cbe00-e62d-4fdc-a20f-7a5f3429f811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7e9c7d6-aaae-4c63-80a4-c463d4186c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1550bc6d-0c38-4f43-8aa5-d2ee7fb75810">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e269512-714c-4f4b-bea4-0ec09ad3c5c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_108759a7-92be-4837-a459-530d3d469d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3f15ee8-97f9-484c-bd1e-5497a0d3695a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_581aafca-3016-492f-a1f6-1dccbe761b20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eecb8405-190d-4db7-87d2-c00a985010b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a166efd4-dc5d-4c8c-b621-be5ae04ee995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_658e17f5-93f0-4cd9-a55f-bee355ab6427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97265ab7-cedf-49ee-a787-73b89c0bea8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cff70ad0-2745-4c83-92b0-9d2674884e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8144362d-e099-434f-98e0-5c5956d76c50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ecd98a2f-c81b-4ba8-80dd-c5e870ae5a8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b462b4-2e7e-4314-b5c7-a982f303dde4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf6cbd2f-5987-4ebc-b776-19232cd670d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2149a1d5-743e-4433-b55d-4ea03cb9d96d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b0bee1d-f5c8-41f8-a196-e0055949116f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d516a33-6095-49c5-91b1-7897d6d4af68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34608c0b-a18b-441e-9131-bd56073e45d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd94ebd3-d19e-4a18-9765-6701c33c17b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2166479e-4319-434c-b484-21ef1be759eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0101d57-44da-4395-9bc3-ec5770bb993f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5eecedbf-d6e1-4a37-afb2-ca148b34a874">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b353f73-ab00-437f-a2d4-9eb81e2b9298">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1e1fb9d-607d-4053-9be3-c699b18bb749">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c9559fff-bf85-4c78-b609-8673ac1ac5b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e8b6bc49-dcc6-451a-a59a-bbb38cbe4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_62ecfa5d-20ad-4605-951f-1b1ee85fc9cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2dcdd11f-f143-4f62-bac3-2648ed438d44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72933c8a-6d75-4fd6-a111-3912cdca4993">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5707f101-1574-4ac9-b315-76e8d0bdea8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fc51695-79d7-447d-b7d0-2d441a615dbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6eac4e6-904b-49e5-8643-fa10dde8dee3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6367f18b-da16-451f-9398-4dcae9461dfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d2353b1-df8a-4d93-aca0-e4755108539b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_62bf7bf9-411d-4e21-b3a9-598f88e52265">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71909016-4df2-4de9-9017-0af613c378a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72c8d946-969b-4911-9ef6-98c84304e8fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f86f8992-c397-4968-b61b-5d1ee0be135e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0bb4e66-8e2c-4258-b9bb-9d5f6fdb68b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b641ad1d-8f25-400d-8d06-0ee76124ce9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_06da1fb2-d197-4746-8669-418acdd11ef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f0b74cf-101a-4fcc-8b7f-5dfb37885d42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61d59f3d-dd4b-4488-b6dd-eef9d4cdb561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e91a7605-459b-4d91-bef4-eca132a0fe79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_60fa5a5b-8d4d-44b0-abc2-c2c9805035d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6604084-2693-4dde-a853-88ca9da67a80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_330ca30b-c80f-48fa-8bf7-1be251e000a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4d9534a5-0e6e-4bd8-8537-bd4919ff95d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_282c0f6b-a099-4c0d-80da-497535cf380f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db5668b-6269-42dc-8cf0-4d5f1edd75bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec70b485-7a69-4fb3-afc7-ff87095266f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_063a6c89-83de-45d6-b507-d333070c2f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9dab1799-adaa-4517-977c-ebe6a16d2549">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bf0fb38a-3e9f-4346-9366-6875ce97be73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a568e818-3e12-4ef1-b0d9-5bd46fd927eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b814bc8b-78d9-4faa-afd7-8ab401b6340f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff01ab24-a8a2-4a7f-9c5b-47940f37410a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db4eff7-f3a7-4b86-9c3e-414ab37d6771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57802d22-bf06-4f03-a7ca-3c8ef8b8d251">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_048330d9-3bbb-4b3d-9923-9a39eaead778">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e79f72e-ea6d-4cfe-aa54-d9261d98436e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d30f340-85c7-4d92-9577-cd96cc2f5d1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac74c520-a4ed-478d-92a7-4f485a50822c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_820e4f42-5173-4d16-b4b6-979e62ae9f35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f491bbb-1277-4229-a3e1-f8f10ba1b923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4796e0b3-1a9c-486e-bf68-fcdf5eb1bd64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7af55883-cbd1-4b4e-a1f3-ec6a28f641e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10c65879-6984-4e77-9fa6-34c3640edd5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb403c1c-7c91-46bf-b50b-424f2bc0cfd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97c4755c-1514-4404-ba19-5e804bba3b5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c339a2b9-fb0e-4670-b01b-0bc99c288d38">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_36ca438c-ccc1-4d35-949f-54817dc7d31c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec171de2-3ee8-4f73-96b8-bafd19f04677">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4b578fe6-79bb-4f4e-9a6f-4ac9b840d579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a456902d-0412-4ee4-b228-8a714ae36878">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315b18a-8654-4766-971f-dc5ddfac8ce7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9858fd9b-b96b-4df8-b153-e34219045db2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7419c7c5-a3e9-40c7-99db-621c91281ebb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfb0ee89-1778-48e7-aa6e-c2e0e042d331">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ea1abc7-2de0-4679-8e7f-631374e6a83a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fb07bd1b-bacb-4795-9c75-8cb1c5fa83a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9151fb81-9550-45d4-bd07-4683d29009aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83940b4e-267c-4c4c-b9a9-0d9027a52d67">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9372795f-ca2e-48b3-b41d-0880ae5d7991">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b7cbc2c-e5b4-4e1c-80e7-8de1fba51664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5fdfe70-9a41-492b-9f27-da15ebba8a72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7166895f-1edf-46f1-b802-40c4c0f7ede2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f2d5b22-dc04-4ed2-9638-317a3a8499d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ad8b9f-65df-462c-a914-26b406488a65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_450e1f78-108b-42f4-875d-bdb70269e9b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c831d6a-b29c-46bb-9ec0-e8e1a95f3ea9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c4a824a-2713-459d-a73f-ea5de799b0fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd3db492-87dd-4b09-8170-de53b4ab0249">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f2cded8-25d1-4851-9d10-76805fbf0350">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_432654df-26ec-4b72-bf22-d2ed67081a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a5c821d-15ab-4aad-b751-c9b46bd2fb53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a6652b1-3a02-467a-9ac4-07e00c70450f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b023ed9-5451-4e72-ad37-cf8ed02ce876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d69413cb-36c4-45b9-96a5-197a238a21d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50bbc7b2-6b08-4a8d-a9c2-d375ef380e6f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffe8f414-26b1-49eb-bc04-f72708ab201f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf7ffbfa-817e-4a65-a0ab-2c237a4ec04e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40abf24a-4c0e-4c70-91d3-a07e95c560d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e0e0d2d2-3a63-4684-a023-2daa39568822">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef5fc63f-d2c3-40e5-a1a3-092327cf3a5f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2733bcd5-5171-4254-9b71-d7d4822da04e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce699638-1fd6-4cc8-b5e7-da5014317b9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6dd43f1f-50a8-41ae-b7ed-ce110f47260e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_19f9acc1-d6cc-4cba-ab1a-39bc6330c6bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d58c01-2816-42b4-9026-b4a864be5971">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab88280f-88ae-4d19-9293-87d20c9555f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4c1ce33-8835-4644-85bd-df6b5d895e97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfb91ec8-3c9e-43b3-b0eb-2d8d432ff514">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2c2ebdb-c362-4dbd-8cdc-106859815a67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4512872-e0b0-49c0-a886-abcec20ed4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92d457d4-5831-4817-8dd0-252285238b17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11586e77-2f1b-48ef-a43d-3c3ccee74e9d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0ffc407-f68e-47c7-ae3d-e0357444b057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_488812d8-5ebf-42e9-a429-6e647b84fa5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf5edb31-3e2a-4b1c-824b-623eda6f0d49">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34d7c069-adc0-41a7-b8b6-2031ce11ef40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4736319-8c40-4ba2-9349-388c6e2231f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_feb099cd-62e8-4b2c-9a35-31961fa7f751">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfa33102-fb3c-40b6-b982-16f1db6cabdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f158ee-3379-452f-b5c4-3e6a6e9869e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e571827-4bcd-4f9c-a4ca-8f43fc1bf1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fcb52fed-20b5-48de-9187-a5bcc4b4bc55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e556c88-b5e0-46c7-9acc-cee3f394c3d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9993779b-feea-486a-ae35-2b21258ad63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be7c3e94-4419-4fed-aacc-75ff147f2a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b834a45-5de1-47ed-bb11-411d4631e322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_783ea7ca-a48e-474c-b2ac-d904da9ca09a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e96c03c-3d23-45ee-aca5-4dc6260b00b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66399c4d-6f60-4c2c-9275-23fc994898b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86670c41-42da-4ce3-8823-8c140a50621c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_846aed1a-7886-42e1-bff0-9c1d20867b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ac9a23a-c7b7-4368-9495-6a79740ccdd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ecc55ff-bf91-4ae1-a6b3-ae84c0f5a1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e04f8a12-64bc-402d-8135-fde49c9456a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2532ec3c-b602-428b-add3-c397c469e629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8747ee4-c3fa-4da8-9f95-523edc656e56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70e32c10-3c2b-439a-80a8-67794b3a501f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd59329e-ae4c-4ea7-a16c-1ed5ae6986c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6a44534-92c5-41c4-8e55-f21f2746c102">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39113052-5b6c-414f-8b14-c45da77d0961">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4becd58-5c0c-4842-98cc-22eb03b299d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c1270b9-bac0-4dc8-8577-5e54ccace42d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736d9926-2933-4786-b3f9-d831a26d493f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea268416-1911-411a-9871-a5e4e0d8532d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_810a4f75-02f8-47f8-a59b-bbe4a9e9fd32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_645391ee-b5b0-4663-a5a9-219880d387d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac44bb69-b7c8-4510-8e7d-27713ec34d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_617803ce-c01a-419e-bdc2-8ad91881204b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5a4dbd71-77ca-4909-a368-d4199225e92f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d0caaa59-77cf-4704-a71a-5771f0f65948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2dadea34-e273-4d47-bddd-e5811a5f3060">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de945cfb-1c19-454a-a288-3631d0d33d82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91a822b7-c670-4873-8a6c-60b180b100ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4c9a7e6-05c0-4b9d-bfb7-f0df1a033d94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8db43a7-acd3-42a5-a4f9-31bb793ebc41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec950292-2658-44d0-94e1-7ab461b27707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd883edc-c0de-417b-b378-06b106f94a05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_abcf9ee5-7753-4307-9a56-b119fdd62d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9feceb23-85e1-43cc-b4a2-c3e2465caa9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_15685edb-292c-4afd-ae2a-40d35a35ed21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a8c3fd-df2f-4963-8b4b-a55141d2956d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17092b96-3f07-4c32-add1-f029ffa6a018">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4dd4bcd-df20-47ad-b0d0-994799f393b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_734f6749-fc85-4447-b206-97e1b9a6da60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2ba4c89-a65b-4ff0-8ec2-1cfc6ba62415">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe36402a-ceef-4899-8e68-563a5528ef41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18ce150f-356e-449a-81f3-c71920e26569">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7575bc2-040d-43f4-8b66-98a8736a20e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b49bd25a-dae8-4ee3-8034-79541d1f2b19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ed6cdf6-03b4-4d44-bd05-cf1415e2e538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7367cd2c-ab45-48ae-b600-1b361ed30b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6204fe90-8afe-44b9-9daf-b27d4d1e054f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc1cbce3-d371-40e6-b379-af34f2e14c8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_070caf31-fafe-4ad3-bb49-81f0d801fe0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fa8b508-ef32-436d-a22d-2f1566b4c571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c6db05-c475-4b69-bf7d-98b2f77d0c30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0b69b9b8-0a43-4693-a724-ee34791e2049">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd7e3f-68ca-40bb-a4ec-bc4d38416f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51441483-9728-461b-ac63-30e57f41518e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be873af8-4dd3-40c5-8167-d27d925e3573">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc2cd4e1-70fe-44f1-a685-6439199241fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e9f43430-6b51-4306-99fa-e543c431f3f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f63b05d6-b2e1-439e-952c-63767d0ca702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4438e97-ec0d-4908-9114-7d6c48f89284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25b2d034-7d7a-4db4-a467-987c5b19b4cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_24b6307d-23d2-44a2-95f2-4f8d39d70e0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06334274-246c-4230-893a-302a747331ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_193894af-6766-4066-8dea-9fb9ffcedd4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c5785d7f-56da-4e61-83d5-2f18adb7b233">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66c811f7-adff-4a4e-94a1-b8038daf18d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b21b057b-e4f5-4cd2-90b1-32617e981260">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2fa674ab-5a22-48f8-aec0-6fae8dfed969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bdafb8c8-a619-4936-9f6f-79d0767617eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bdaefda6-56c3-4fee-832a-c7b1abfebfd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a74705c-5bbb-49e1-926d-d4aa5c52ab36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3becd1c-277c-4d5b-88f4-9c355ee975e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d486dc1a-d28a-4880-be97-4814c9a25b7a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2943a5be-cb31-4d8c-ad96-227e0193ace1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0853d553-a35d-45ec-a9a0-0d8184f76a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76b45095-2687-4271-805a-7bf60ed3551c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ec6b68d-ba61-4c55-b09c-bfbdb80ebcf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85214598-6383-438e-a4d2-ab029b7530e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc5543ec-b224-4bc7-9eba-a827e3058465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f733246b-e52f-4ed1-88c7-aced475bbee2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d86a131f-8960-4881-9ff7-7ae1a6d6d354">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0177aba7-d4b4-4e75-8e40-62222b87bf6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7742836c-da33-49fd-a00a-cc7e0321277b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d4c4a91-3ac3-4e24-903e-8ed844e5dcb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_512335a8-1004-4cfe-b462-f7ac341eef60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b4df3c1-a13b-40a4-82f5-66f82deb2cbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ec66737-2300-4657-9389-6282cbfed896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_710e51f5-0e13-41aa-ad39-0e6e38c4c5c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8e247e25-f821-4e40-bcc2-84579384b6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a36c16-7af8-49e7-bcf6-503669668780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d296778-ac03-4544-9620-df7302d93702">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ce08e898-8a0c-4b22-b375-651840464974">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8f229ad-ca28-4a4a-8277-eae642c78a9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5a98d74b-051b-45b8-864c-5bc17b868079">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_935533c4-c8b4-4d12-91d1-e357e32bb1cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee8c3a5c-d53b-42a6-84a6-d109057f66f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6e4f67c-da26-43bc-81e1-d91efef4bc0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_985a89c4-0962-4b76-9685-1cbb1b755fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e181c7ce-9b27-447d-b60c-7bf20fb74fd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7ca85a2-5dec-4379-924a-7bebfcab592b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b87135b-9de3-4278-936b-77fc18f47f98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaea47ae-5e05-40b3-9f34-6f857dfe9902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d4f4a91-6e54-42b2-8f8e-0b9c478cfc4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a799f946-7cb8-4538-a661-ebc68828235d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a5d488cb-2a2a-4f74-bf60-4a7c2afe5167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ab32114-c60b-49e4-b16d-59f43ae9b429">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d9ceb6d1-ef81-4fb4-999a-5c4a09bbda2b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_79a6ad94-a07b-447e-85c6-61dc4e3f2c41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c072731-8b09-473e-b65f-5d1c595f7d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f8545bf7-29e8-488e-8f7a-27d45dd27584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_001e3e3f-9f35-4adf-ae09-beaf7310f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76f3cd08-a9cf-442c-b664-7ffae80f34e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c8477581-f647-4fd1-bc0f-38da40a5c34b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_941ef755-9542-4b5e-bf50-bcc38e4e3e0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f65b7928-e759-4f20-96d0-03563432dcd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3c9d70ef-69b7-4294-888c-a1db7a6cd16e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84e2fb08-9c7c-468d-99da-88aef49b8955">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c6209ae-c301-44d9-a9f4-39e503aeeea6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_35d6a3fa-41cb-4def-a6f0-02242f07cc8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af3599f4-876f-413a-9e2f-61e4f97cd772">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_925cb008-fbf8-41b5-bccf-a9ba0207496d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3544d101-9166-48bf-8d7a-9830f8bd7e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c4961b0-db79-44fd-b894-3e3ca701e148">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_751f3c0b-38fd-4d93-92c2-210d657c929d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ad3d6235-3931-404e-96c9-eefea6cc2a51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_15f6523a-a6ca-4929-b2a6-797fe5165942">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_607ee7c9-c194-4980-bbeb-4871d045b117">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d595630a-5c38-41ca-8d89-e6de86401784">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4879caa-544c-436a-b481-ca7782fa14ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d468b176-1c1b-4e70-b89c-cfdb358d12c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39e8728a-cf2e-40ee-a6f3-60eeeb2b3bed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99a7243e-cd1c-4944-878f-353803f16173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f579bce8-a5a5-4af5-843f-b6774ebdc50e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e7e06c9e-85ac-467d-95a1-dee3fba2db7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2efd19a3-19a9-453b-8a62-1358a678e54f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_50cb2407-1a48-4d05-b50d-0eb7d0fe0d5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_59921408-ed5f-4010-8874-8c7cfc9cb99d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a6832ef0-2d40-4b67-81ec-7a22195700d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d14c5eb-de52-47c4-8527-6c2d90f6ba09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4257e0c0-571b-465c-bd0d-e6dd32b83599">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0fd26d9c-7a97-4480-a4c9-5927169899b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce509f30-fa28-4fb8-b93d-2e7d0753e01a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06be5c7a-6d6d-4bda-989c-3de94c0ad642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39381952-7a93-4505-b431-38b454ddf896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d75cbc77-7b81-46f7-a818-c80eb0b51a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2aed15b5-05d0-46a5-bfde-aa18a6e58bca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff83925e-7032-4d39-808f-131c849e3c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ad21880-4865-4369-a402-af2fe2d06469">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_823e97d4-6e60-4330-a062-2dc6dbd6aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7de33c3c-f761-4510-833e-4e658bb155ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bd21b61-bdd0-4bf4-baec-1df6fb7aba04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e097cc96-68b0-4776-9baa-0e05ac6d2079">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8f842892-67fe-404e-bb86-ec52099e76bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_369c7b20-7a1f-4e27-b826-b22fd852f92b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d3f27b3-8901-4993-a783-1c5cc360e39e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cc984ae-ba96-45d2-ae4e-36e988202551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85b55d99-54a0-44c9-be12-73aa01d85025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9438622-ec39-4de8-8bfe-8b7a7acb728e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2020f19d-8579-4c6a-bb85-33cbcf9c80fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2512e2f-f697-49c5-88ed-472ce66102d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ebfb91ff-e57a-4c99-82de-0f5c7bb20361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77f21387-12a9-4a66-a13f-3650ea2a0626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be648bd2-646f-465f-82d8-fc18fff2565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0d9d1f9-ac28-42fb-a3bd-873d848c0bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c1eff410-da05-4ed2-8a83-6d72a5b1ed9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f36d52fd-a011-4d3f-9886-ef1558392dd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b130e0c5-4e18-4c5e-9630-96c1e8523961">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3d60d422-5a45-4fde-b96e-83fcc351399a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71dde336-035e-4993-bf5e-ff65d982884a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5fc7015-c249-4da2-b59a-fda46e003a21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c25e18f8-ca13-4e18-8e6e-106713a05817">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003ae024-12b6-41bd-afb8-dbff8fc0716f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1fd2a69-ab09-4a4f-8e0f-1b3b2a7ed8ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4b5ce0e-676b-4e14-952f-0e70e5eec005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cabaaf52-7fc2-4375-b423-17217e547d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bc43aea-edf5-40ea-bb93-360747aaa871">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_35f390d0-fc3f-4dae-a334-b28e27ecd4cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d09ce77-c1a0-49c5-9da4-1743097d6b5e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2f12e17b-a03e-40bc-9633-3b062f903a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_befafd88-9e45-4aeb-bc91-72989f037361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4642aa0-952f-4c0d-a380-67e9ca5798c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_19ff8aa3-4c9a-41fd-8b5c-fb88ea00d914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23992233-1625-467a-afb5-7c7db2154274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d18c73c5-9283-456d-88a2-ed56c52068f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40db0b6a-2fed-42ff-b3fd-4146ac3a6b9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab9dcac3-38d2-4998-ae2e-743e9e93dbf7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87844dc5-0f00-4fdb-83bf-4df6a5a66c00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_397a5ac6-c21c-41e8-8bc3-37030f7791e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_46777efc-f783-4fc1-91de-03444ae43579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cac650bd-26a7-4597-8d04-f5210c60e5d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c7661b-773d-4e82-a011-20182f0d879f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72eb8f4f-06a8-4acb-8749-7c2c83001667">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0591bf58-eb3c-4ea5-9379-1dc6ff597412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a6ea8c7-7bb1-41ac-98c8-ecf05ba41d55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e35d55cb-7309-4c84-b62c-24c5701faed7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f22fc970-4d7c-4dac-94e9-f52e0faac4e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e70d3d1a-6c78-418c-97d1-03544787f442">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de1d2205-000f-412c-a692-27e23e6cb8ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d7a2c8d-6bdf-4432-ba34-64126abef849">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_14dde051-a9ec-4ec5-9832-422934488527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13f572fd-94dd-4eed-8ef3-ace0e748a2af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de08189c-2421-4654-b7cb-107162c73d63">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3a29e1c-911f-4564-a654-c6fa2f73900c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b0a3b7e5-2272-4789-b17d-9fc98ce6b190">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676d9d34-6500-4af6-b5b0-a64590ebdc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28831048-7986-4d83-9322-ad7b45aa6979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02c24ba5-c256-4bb1-8aca-18aaf5a4119d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cda097e5-c55f-4370-8046-a22566d23aa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3db309f7-b0f0-438a-9619-158dcf92e77e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7f5cd2a-e199-4fe4-8a07-000b61f6b849">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3559ab6-f11f-4163-9018-fd2d381786b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7080f5dd-d253-41a3-8978-1acb7fb725c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec4106bc-ce58-4d3b-8e92-880efd0b1664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10977b32-fdb7-43a9-ae61-93d4bf8d7afe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904d3954-8cda-412c-9749-e8bb17d66a92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0111008-7282-4c97-885c-7fab48bd8436">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_876454d7-7628-4133-9422-2ca5424ca361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9ff15473-2981-407b-a9c4-b2fb35aa3674">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_55ef1165-5526-42a2-b3bb-e8ec92717df8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c28c5416-4d5e-4bb5-abab-96a1565edfa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d927603-3d20-40ce-82ad-83b83ee19f72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_229408e4-2c2b-4574-a315-b735a27c779d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68082b8f-1b58-448c-b179-bb3cf663ae68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70edef45-f5a6-4dcc-8ac3-0ddabf759635">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ad9b069-1fed-4ad2-8270-2d803e8bb18a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdf583c1-b367-4df4-aa13-61564d6ab6d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92c79159-1d7a-40df-9703-3a5db5829183">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dae057b6-7b1a-426e-8e5d-2acbe7a43672">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd8175-e9d4-4ea7-ad36-55850bf37124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fa57a151-cb4b-467d-a0e5-025f0e879340">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29fa0b37-8927-4e2e-ad4e-fe8ace32f522">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372fb999-5a14-474c-a762-df4ec45be325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59a4afca-74e7-42f7-8568-57ad4f7f5a7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eb5af546-4e64-4615-b4be-c5f84c5afc69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e2e577d-945f-428e-96c0-85a30ddfb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc4aa6d8-c784-42b1-bd46-b5a7b0fbee37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ab4e7e3-cffd-4fb4-9903-775b019afed0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e958a796-f688-4058-ac62-e7ff354a8b2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba240b0-4442-4e3c-9b12-92037859dc8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58cefcd1-4074-4f65-b238-c8bd2807bb62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b7e5f911-cc7f-4035-b405-dce36c696979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b105dbf7-08b4-44f2-a809-7659b9b0c0f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dc8c8d-842c-4d37-9ddd-729767e27b17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a87b7beb-c39c-4b09-81e9-5ac4e5d6dca6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c5a9d89-ddb0-44bf-bc81-169851dcd038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ae060b4c-d898-4866-8934-72ad68a61d2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ff2d666-0eca-4c6b-909d-de8c8dcd5ff5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2416d8d-eb9f-4c0d-992e-584910dc95fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13563e1b-bc67-4100-a744-0b15bdcbc8f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b50e0e0-9880-458b-8ec1-df2b45b77707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3003a0e9-678d-4407-8d92-8ef9f603d17f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8927687e-896b-4610-9f61-0ff4ee7f0355">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_836cc85a-d634-47ce-9f91-cad257677a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9185dc-ee0f-48c3-be9b-0999eccbbe09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2608e084-b64a-419d-ae01-4b6cc1e71585">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_167d679d-7fd9-41f8-9d06-caa39dba4d17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f458e59-de2f-4f0e-b34c-3964259cb7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e60f6916-d41b-4f3e-9e12-d053db17fe84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d5f4047-8216-4d31-ac16-4a9a054c9322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a3bcd38-457d-4fb3-8e07-3bbd70861a2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_208ee53c-3823-49b8-a07e-4c96709a6290">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_132fabf0-f06c-484e-88e6-745ec73dc90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d366858-cfa5-4734-ada5-a1d4e1de96bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73ae19d9-1ac3-4fed-99c6-6a4638bb06fd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dbff479-ccd2-4bd7-9d0d-d7699ee4f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3af795-f0ef-42e6-bdcf-5998074e2330">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec7efa15-a618-44c1-9777-6d7d98c12e77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_105b771b-417b-4b18-9aae-2edb5c322c6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e02995be-5319-4997-89c6-0baa13af4633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c61435e-e1f9-4541-89e2-6263603b3b69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dff476e-df06-42c9-9efb-b4090eccb100">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1efff4-9a22-42b3-91df-2c842ef69d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_23c32af9-38b9-4c72-a024-eaacce4cd25a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67c313c3-0537-41d9-bf5a-0ce46862778e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c78abdb-f124-4796-b624-ca207adf405d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6df2135-d56f-4ede-ab61-32537752244b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bc5c2ec-af4a-49b9-8349-b9267dbb909b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4f648f4-68bf-4e8d-a158-24c7ff934d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b9a43ab-5f04-4a70-8105-4d1d6dea5cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07d9c908-2ca6-47f5-9b54-23668c13aea1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_188820ff-ff28-4597-8755-16e1f383ac16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92ae4c05-9849-413f-9950-08e73b719f53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3e291d07-59ff-4e54-9816-99637c944ce5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e993253d-fa2e-425e-8a54-ab9d59eceeb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bb91660-0de2-4d77-8dc0-b2dd97689d06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0be57c-dc2c-4fb6-83c3-f9dbb5bedcf9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe303d5b-825b-4378-83a0-91aad62189bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97347a26-0a57-438d-8632-a5da61335545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc4d10a6-b3e1-4e1a-9417-a6a54c099ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53554a66-e2ec-4121-a84f-bc5f58c3a39c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81767925-5b0d-4258-9684-c3609914ad4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_190cac75-5579-4ffe-844d-db8817b5c500">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8714d145-9c20-4532-852d-751b41958aac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904f003e-1ce9-4007-aa9f-00aac3c62a98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_214096b4-1ddd-4b94-a7c5-67cb764c0a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cdcc05e-df32-4ee8-b7a5-cb1f696db621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e32b1e8a-316f-47e4-a283-9b8dd0642e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3aece19d-4dd7-402b-a8d2-5d26d7ee3b39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db8c2187-33e2-4116-ab89-78beab00ea57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_78ead1cc-f404-4ee7-9fdf-ef48535800a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_22055254-fa36-47e3-a1a2-155d0a0cc771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_557a2416-503f-4222-9308-f18bccbd1d01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2470f09f-6853-4749-9034-4f203dd05145">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71fccfe4-5391-44df-b2df-5d66fde7db4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c091e57-8b19-4353-8d4c-313ee3863561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3cefb57d-57e1-4e3f-903f-69749aa540e3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f2d8a7d-95b2-4973-bef9-175379b439ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7f34bf2-27c1-481c-b244-d5bf555288ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_072343f7-33d8-44c6-bfb3-86f4b517797d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f53ca695-3ad2-436f-b57b-a0d82976e489">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b72db782-c1e2-47a6-bfee-76d98a50ed7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285196f-6ba9-482f-84b9-7bd3923b8e05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9c86c4c-2491-4427-ba0f-710ebde97af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec3d8a3-15ad-479d-a33f-5c01230dfc8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7d59712-1642-4092-9ee5-f67caca03a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f4c0f5d-b870-41b8-b34e-293e4d986355">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dbdc2b2-f9a3-4c59-b067-f65e01e1c62a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_74ea36c6-2edf-4166-96d0-d0d8e03ee4aa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c8effe0-03d0-48cb-a537-7a5e9e2809a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90803e77-364e-4047-8ac4-d4d18032eed9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_82adc907-8d3a-4b68-bb4e-6a74b4c9e7f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7306d11-ce28-4c9b-ad6f-e38fd8311161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5f35c9b-8ba6-4cc9-a4a7-30b3c05f361d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d94625fd-9209-448e-ba9a-d9419e7c7184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8621c35-abc4-4aea-8aa1-7c4f318308e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afadb174-03ee-420e-85b7-2cc1b03b5fc9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b9f9fa5c-16be-4030-ab78-85df203a3689">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ba01acea-929c-4066-b7f9-8a44679d7278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_868bdae4-132f-4de9-80a9-235a2f7649b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c93f0b0e-710f-45df-b479-efe99898bc58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4d7cdc2-47c4-4d81-8813-1307da791074">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c182723-b6c8-469f-8368-664cbe6c5ae9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a826a3e-f47f-4547-bc86-8d5c29802073">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71d7fc82-41ba-4769-aec6-c28a028c24f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6f20f8e-1d3b-463d-bcbb-74e286d08e4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e3de8b-6459-4ecc-9a7a-f07ad5e41dad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51015e38-eafb-4bea-8fda-d7254a752591">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7f865691-09f3-49ed-a046-6a9f927b88f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb298e3f-8717-47ae-8c74-0352837ea9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e34a8420-47f1-45d5-8a93-1a88750c93ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cc228ed-7b17-4a46-98c9-9b6dab5ecdab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0e39-4dd1-488c-9f42-261213615c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3fc35f4-afb3-4be8-9042-80c22938c1da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7fae11c-5433-4dea-8daa-573036118c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f8d7f2b5-d937-4798-8f49-2f9d6d366a37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_61654344-ea9d-47f6-bc0f-4c1f512f6460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71e972be-0b67-4baa-b9aa-d2af29f81dd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b836030e-56ce-4bda-a621-1cd3898f7a3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8905b57b-c2f5-4004-a604-898087cacd6e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c31d0b56-0d49-4611-bb21-4da3c47be957">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e12d10a0-1652-43b7-acff-b94dd8e81d99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285cad5-6de7-4403-b3f2-3cc8618a8428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62f45f9b-4214-4227-8a3d-8ec5bf11c1bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27857a57-dc46-46b3-be78-4a3e508faa27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_97ef7eea-fbed-4cca-8155-059d768bd25e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aad83482-c91c-4404-b6c5-2e4b0cf2c430">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_741b144a-92be-4316-a667-6d77127a3c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e783a6c6-9325-45bf-ae94-3e58253dcb28">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb5e5403-2a79-44a4-9175-3e0c6cde1a7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6ee4820-527a-4806-9ce4-2f0d42f31276">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dd1d63-111d-4dcb-a900-09f637cb1718">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70cd53c9-69bc-4bcf-a3ac-4e7ac464b1e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f3ff468-9121-48f9-8210-265dc8d4bdc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56f4ed47-0029-4843-ac3d-c989194a4f6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f57fe36c-18fc-40f7-8f07-d908b0a444e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec5c7335-88e4-4853-80bc-bff5cc1fec3f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c90725bd-093b-456b-b293-35b3d24e93e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b8b82bc-e378-430a-8d32-a757dbac9654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315475b-5bda-49ee-857d-d4909e35ac00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8605a6ae-08aa-4247-a681-37bfa08ddcab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_947b0817-ebfb-4448-9e46-1b205c39cb36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06dc1e7f-54a1-4ca4-9bae-106fa4fc0b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_34fba600-df3c-4444-92e6-44820bb53700">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d5b75fd-ef40-4687-9465-b9813bff0c55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12f3da88-6382-4ee0-9944-8ee455b9d12d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b80ba0c-7c2c-4247-9376-4d6c8150fe09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b246ab5-1854-4074-a138-ced059858bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9088e061-ab8e-4b2b-9c0b-b84ff5986524">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58ac5024-a283-465d-96e4-3958b4e5d587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_113e04bc-404b-4a53-ba47-2aae867c3bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_025d8e4f-7965-45cf-98c4-7cfaefcc2b38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06847793-4f82-43ea-9d81-98aa1e2596dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77a92fc5-b352-4ac4-9526-2c325a319aa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f575e4-4d82-41ad-a7e6-0c4a89a7846d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74525261-c7ef-4d31-9b26-15b564328d3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c95a00b3-90f7-4ae0-94c2-50696538217c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_707a27cd-6e44-4b2b-aeac-ec7fe86c87a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_acde90a6-1736-4d99-996f-f94f40387275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0de56081-b8f4-46b2-a104-342f7c06f81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06b6e45c-cf6e-49e4-85ed-66b9519391e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ade7d271-d264-48f8-9f66-84ae1e80ef77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35fd6ed3-a06a-41de-8588-3d779ab51fb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c861879-751f-4428-a068-75a4aa42e588">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_220d4678-9c77-48ce-aa02-b302549280a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_235615be-43b8-4c5b-b4cb-14db7ee8d61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5226f2b8-6339-4e7a-b351-7b464c9fcd25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31e9896f-9c68-4f37-8acf-d2c43cb44200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bccf7bb5-9fcf-41a4-8cf5-b5cf08d878c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a07fd55-9727-4c3b-aab0-14051933c782">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf5a4f02-dffe-4020-a13a-e045e31e4aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2efd1a7b-4bc5-4856-b2de-bcc27f4a2cde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0a9a1b03-c9e8-4187-956c-bac2bf1926d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_353093f4-bcf3-4890-85da-8c4aa9d6d6d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b6d2fa48-1a37-474f-990d-10d2d794bce6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_13574538-536b-4538-8e26-c6241ee2d5ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27efc09c-a8ce-4383-b44b-a4400909f8fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8b00173-49f3-42b9-bcdc-567771ef26ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c24f1de0-8b83-4a10-b680-d7cd903045b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e12f605-dc64-4ca7-bbe2-8b1a99b0e82b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acc178ac-8fb0-4df7-a38b-28fe75a170d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_49ef34e8-d89c-478e-806c-58fdfff64426">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6c25f839-f61c-4929-8ed2-75621b54683a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24a54926-5757-44e2-b82e-671a97a4246d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3419e66e-ddd7-49e3-8c10-6ad6c5f5c49d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d0a4264-7e61-4421-a1e6-90882ba91d0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95d6b06f-a866-4954-98d2-4e1f36a7d499">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5f288ec-4c79-4843-ad2a-10afd29f69e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4946888b-0e94-4c37-9f66-56b71e7e256a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a30cb194-1934-4fc5-b1f4-a49039bf46a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f58e858c-6f20-495e-9732-36ccfd05cf5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d61dc199-1ebe-4435-bbb3-8701fbb7df76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0acdfc8-d22b-44e5-b98a-e3beb4bc431d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_517ca612-cfe1-4358-ae6d-b05efa7f5171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6893ad1-b526-45a1-9b4b-82de55b52fcf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7618e19-9e6c-4a93-a8e5-7c0a3ec3f2b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4838ab73-e852-4a4f-8e14-d36cc6dde894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e64818e2-9253-4d51-ae0c-81d112e2cd5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c3a36588-a846-4a37-b181-afe3af3cf915">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_714070e7-1af3-4863-8885-8920f896f2f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_05372493-820b-4768-b6b3-b06cf4c88040">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2e0649e8-ae5f-4146-b539-55df36ed26f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dbb7f413-9cbd-468a-b57c-023e980826b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f829759-3787-4e7b-9c49-51fb44f490de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6586012-dd0f-4349-81ef-057a9818e91f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0551774b-ab93-4cf6-9afc-3f49ff2e5339">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d90700a-b751-46d6-9883-1afa754ca728">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ee00881-e663-4ef8-8e61-5a9d373b60eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_029a4186-6f37-475f-b0b2-d4888ec78456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7417b3f0-f39a-4da3-ad99-a0c5acd31dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7bf60b21-3cfd-4c15-92be-de3bf3987969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebe2830-5530-45ee-bca1-03f80a144de1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6857768a-9ce5-4491-856d-121d10953832">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45b979e1-6499-4853-8bae-ee72dab68308">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cd8ac52d-b2f1-42be-a279-de43a535b633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_318892f0-18d1-415a-8a4f-12e16802ed01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3896d698-274c-4aa2-b2dc-85550339e7e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0586ae6a-a2dd-42a2-8280-def5212f1885">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe7d3d87-0991-43d4-982c-3bfd6eabac43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67fb0682-a5a6-4906-a36d-cfa2097397a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d83d8c12-075f-48b0-b5f8-38259d641027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d886ae8-6347-4a11-965d-4486a842b72b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c1ec08c-6b4c-48a8-bf02-006c60e178a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37d7a305-3c5e-45e3-9792-0aa39d89a087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b89a5862-62ee-448a-adfc-b98dc77a6c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_466e04fa-ecf7-4c12-a305-5264e60badfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e4ab9e7-323b-4168-af5d-6cfe6914e92a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_782b4c70-97ca-4ac2-a57d-c1e49802e962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47c94546-4aca-4eac-b3e2-0f6ae04baba5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bfa323-d130-4b02-af40-1743043ef9a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_365b45e5-9725-4467-992c-44a30aa3aeb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02fde0e5-c682-4a0f-9691-475fb76be114">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5a0d3ee-b330-420c-85ff-dc7216fafbd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_370ed0c9-995f-45bc-91e7-b340199efb75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97f67aae-d210-4862-8d2e-78e4ee1057e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae5e385f-d5a6-4333-9bcd-13f60268cafe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5559d554-2049-48cd-8104-20ceed7b4686">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ba7f2c25-8fa2-41f5-8355-8beac83b5a65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_408d47b3-1f97-42f6-b331-0d61e5f90670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_965d13f4-485b-425b-8dfe-c897500fdf2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5b6d87d-a141-4762-80fb-6ade51c8d259">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a63b1ae8-cf67-4f81-913c-0470719183fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d01c2bb4-c8ab-4007-861b-449bb235e3f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b221fecc-3f56-466d-a7e0-7ede7a1aff0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_42d8d499-e591-46c3-96b0-0fa80adbf923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_18c74b81-234f-4bf6-9d2b-38816c082d78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed2cda40-9e01-4b05-a44c-17e790367156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63c6dbd4-a478-4642-b02a-ec6a5bd2d82d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c05a0e46-1a0a-42a7-8033-274b947fad1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_49ffe632-11ab-4d04-b22e-1a7de4ca7746">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c0115ef7-fd26-4d5e-b841-07d14b72b16a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_beb12705-81f2-4cba-8b89-321726c2ba08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_808645ff-087e-45ef-940e-26389858902e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_236ea25a-9487-490f-9886-1854ecb7dd5d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de290528-0feb-4427-a306-11c0789ad3a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c31e8fd-473d-4142-b1ef-a7741eaa41eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea5970d0-fe70-4953-8353-e1f908f04833">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cb01ec5b-3693-4d3a-9bbc-7433afe2c562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b906c8fe-3028-436c-a6e9-ebe0aa0bd0e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc43effe-3bcc-45c6-addc-8790363e2e81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4bcb575-87ea-4553-9bb2-c6114aea6ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_574d3b76-05e7-4206-b43a-2406be300e73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e809161f-b94e-40e1-aa05-c26b5db8319a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90532d5c-51b7-42e8-b997-7cd3aacb3b01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89ed2c1b-8753-49f4-a90c-1469a1db2d6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c321ce94-d20a-4ca1-ae56-0e345f8d8f39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d1b4265-e043-4df1-94d8-c9b3b2a2d74c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6ef71c8-d16f-43a2-a67e-c3f882aa5898">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d291384e-072c-4e36-ada9-1d78743a5f17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb70152-e11a-4835-b3b8-9607ee61012f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b347ac3-f5b9-47b8-a5be-86112eb518ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a1af822-b372-4f65-8a5a-fb7c2bc9fa46">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70bc8a62-4b3f-471c-8f26-4de6dcb587c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f47ee7a-dab5-437e-928d-f5fa1a931021">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_37259d03-2688-4269-b724-a019708c03c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ae7edf1-44ca-45bf-bdcc-b9f2db3d3383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a629244-1958-4b39-8124-9299af3f90ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25d6bfbc-0406-4021-a7a3-eaf27c8bf87b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbaa2b91-19f6-4276-a1a5-bd29c05847a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92cb244c-751d-45a3-a4df-744118e58171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34f3366a-08b6-4ff2-8d8d-25bd186e23d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88ad481f-2dc4-4bed-b6ad-4eb45eff8c85">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_073bf8d7-6f1c-4bdf-8589-f3e7118b1419">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15de3a48-a951-4860-bf45-0a7d3e496232">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40f29c78-d193-4938-964f-009a195cfcce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cfd8928d-63f2-491b-8f99-7f12bc865a43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a21eb818-fb97-4531-8b5f-fb94643421b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0bceaa1a-cde7-4481-a6ec-fc1f00e4d173">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dee9f7f-ab45-4ad1-97a5-1ed775bc0a1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d87472d-343d-4508-af27-99ba0013009d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76ca6183-d22f-4b08-90f6-608c23ae01e0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89fd8582-7f8a-4635-9309-c36ab173d8d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e54502c-3e0d-4961-a3f2-e1a19f9f15be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bbdd559e-0803-4e99-b9d6-73d9343ea7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0568054d-a321-41c7-8ae0-7f3e4e6d6efe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae5c783-5004-4cb5-902f-6c2e49f16d2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e65738a1-a385-46d9-bfb5-a85aa03dd1af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db28d434-76f8-4140-b103-101d760da602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64e9f5fc-90f4-4b7a-aaf9-87364ee47047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2fa69bc-0690-4b00-b689-0c313b529130">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2310d678-df3f-4460-9315-9346518888c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42a60441-ee00-4407-bd69-61ce56d08585">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_999e6491-6e9e-41fd-bd90-90ea018661cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0d8bf12-31cc-4ab3-a046-31a57efa5aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f192d0c1-711e-4760-8b00-fc1b798d7a02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc53a16a-a3c2-4f8a-8b0f-fd3ee7701b92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0d478a92-27c8-4122-8f65-e89167e50c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be723ea-f9a9-460f-88f6-f6ce88b9adc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3707ae37-c9f8-4bed-9e83-767995f2904a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f748d44b-1f22-4a0d-aac6-e9abfcd344d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a040a884-edb3-440e-8118-8473a3c88c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_12360317-55cf-4c68-86ac-bb6d7454dc66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_792975a0-5c5b-4c55-ac56-01684e17cb4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21034b29-0370-4459-ab1d-d54d10337173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cae54e92-78b6-443c-a94e-3808610aa607">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877f697-fbf0-411b-8b70-de015b64ed2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cefd7b3b-3bc8-414c-af54-efef4551a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80564bd9-c46d-48a3-9ee0-fe1d044715b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_470d84cc-b496-47b1-997a-3bc5b2898568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4b700d6-4419-4e60-96d4-f054f596ebb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f829f61b-477f-45d8-b5a4-cb19a3097682">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a700bfb5-accf-4acc-aef6-75b5b4b9d283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c319766-eb32-4975-8ef4-5ec8b325c3d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6572c581-24a4-47a9-a39e-74085116d4f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bfdb9f7f-01ce-4490-b1ff-42b5e2cc0317">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebdae831-2ebe-4c64-96e1-7b91aa2db64a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2acc7925-5dc1-4c32-a264-f384326d40b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67d15e4f-3211-47ca-a162-20bc863f456a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c17ac3-19ad-4a74-8105-be69ace57902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d447f6d1-7ced-4a18-b489-a848ecdd8f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_82a2c0de-02c4-48cf-a2bc-43c3b43f70c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a799c07-5afc-43ce-b6e5-07bf3ed01299">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23e5c5af-5021-486f-9313-ced0a3c0f78e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a54d4bb-318a-4594-accd-f73e0717c332">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30418a78-e345-4166-be71-c6811a5139a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c5983df-c5d5-4543-aa10-8c9d879a6374">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67dc3e00-7773-4b9a-af3a-8078a00423ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0c34f271-4f47-410e-a4d5-e6f3c8be9d05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_715f00f3-4358-445d-9f13-346e0ef19af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_493944a5-fdaf-4639-a919-4c5e720a062e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c822e6e-dbec-41ef-87fb-3d352bf3b4d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9fc9618-b87a-4744-9548-0d53ca4522fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bff94f8e-926e-467d-a828-c9f16173009c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edfb58f9-6d6a-4008-946e-e5b27b49797b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b7e37f7-ad7c-49a3-be0d-d7ac833b23cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aef1682a-ad01-4e95-8f68-29f223e6f177">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3d42bd6-cd90-44f7-839f-9c7d6dfe9649">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b68c57c2-3f55-438b-8c6a-3b9dc7666ef0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1be73187-7c73-4469-a943-23ea7399b3cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_967043a8-1caf-4faf-918e-70fb1864c57f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7dbcb3f2-427d-491a-a73f-b8eab7746d5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa6059d4-f302-448b-b6fd-62d762a2997c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_19697a59-ebbe-422b-b0d1-4a07469d2c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3009951e-b1d4-4b82-a877-470a516b3361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1221a04-19b6-4b6f-9cb6-06bed845b81e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f70cdd53-344d-4c70-a11b-c4bb7c9fea2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbe11006-c06f-4120-a209-0ac2fa08164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_755105c1-f410-4e09-87d0-5ef15746ff1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_034f40e3-2783-4202-8189-fe8b6e11bcdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c605939-9b97-448a-8051-6de0d751931b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3415f772-e20d-4104-ac5c-44683fffe2a2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bf36e9c-2d4c-4d3b-aaad-b21e7e3085ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd408c9-e801-423f-97a1-a5857d1ad4af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0e75e28c-718e-410b-b2d6-1539bc5e017d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d2dc1dfb-bedb-4a06-aef6-073ba5573610">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3e57554-31bf-4fba-9fcf-72fbcf3c24c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48b08358-167a-4ba5-8716-c7c79c76f989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_440d5403-5712-430b-871c-f1449bc683fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07f052be-64dd-4fca-907d-6852e038a6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3b04fb0a-9cc9-4ca4-9603-38b983258538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_475b64aa-d502-4417-8208-594fa2af4bf7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aff9e12b-a0cc-40ff-ad4c-21354b0de88f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1a973e3-96be-4a6f-a7ec-2f2862e2ffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53fe31c7-898e-427a-866d-f9d639564156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fafbfd-5596-4044-8d74-0992f06c8c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_233d686d-90e4-49df-91ed-b5ee6fbd0cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_598db54f-b81f-40f4-84b3-d92f72daaeb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e61eb85c-b7b0-4336-8e32-6a5c2a7145a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1d98bf9c-8243-4f7b-84eb-ec54a4b21b90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eee51978-7250-423f-9dbe-827906d8c019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_466b004f-e572-4666-84a1-2a772ee0b5e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_026dedc8-5998-4752-926e-f2cc48db14e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0df05e46-9c77-4f7c-9c28-38b92d66e07f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_85ab2be6-50f3-4381-9947-70df840ac3a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb8a4d63-989d-445b-b112-1e304b518cc1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd353504-cb09-44f5-8b25-f1e3e8801e61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_058f2f86-c3f2-4ba3-97d1-9f6906004cfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dcc4cbb-f0a3-4b73-9079-8d7c8c4941ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_342151b7-663b-47f7-8b53-2fa6224c2828">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f0bc0c2-c9e7-4e8f-b803-28c6f5b6548d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395651fa-2b08-485c-95e1-17a893d7d3b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2ac23bb-09bd-4ea7-b41a-5bf5ece19009">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee8c7797-c83e-44d7-93d5-cc60b64290bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b935634-82bc-4212-a612-3d84f1ca3962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d5bcf04-bd8d-4514-95dd-e69f13c19274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1c01a24c-a208-4b22-9903-79a2ec531d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6637d54a-210d-4025-92c6-4995da491520">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_264c6f54-7b73-4d1d-b95b-aa94cc0c0648">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b87edfe8-d64d-45c7-a4d5-5f6ade3ed928">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fab46ba-9cce-4e10-8989-9b54974aad69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2bf00d-7b46-40be-b277-a0840a5c63d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2569cf1b-e90a-4497-a949-7c29fb699a7c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0be40f90-cbc9-4369-94b5-2601506fc161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edfc8def-f6fa-4677-89aa-538653292967">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_020f3c9f-49b5-414c-b4da-8a181c4aef4a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a7038c54-b029-4d0f-b91a-a528c0603ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8ff51ca-83d8-4277-acc1-b260d7d222e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6149b0c5-3cdc-4fa3-8743-c97d0b1f1d09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efeffccf-a6c4-4517-9821-d938ee8fa3af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca2de83b-7f42-4e32-8d5a-0ece354dda71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_94e6073c-06ab-4928-bd4a-16d8bfcc85c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01d168e6-ade5-4828-9749-c9cedd71eebe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_606a464d-cb9c-4a42-b5a9-6bd5ebbb6595">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bc2c3508-b5d9-49b8-a05f-570e28feddc3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_83795781-3114-4144-a04d-4c0218a2526b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b6d0b90-ac02-4a7a-9af1-fdf9ac0d1968">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_829d7f0f-f7f6-48b3-9fe9-40f3e80ee793">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_556c4014-05ce-4318-9c92-92047428cef3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cee22e6-3110-4e02-bed4-8ca368110b4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d64beee8-381e-4dd4-867a-de9eb2a66310">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e49c05e0-c6bc-4d7e-960c-d3fa31a486b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ba5019-26cb-47d3-a5de-6ae0d1ef25b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9963b957-2de8-4a05-af6d-0661f387330f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_268f36ab-f34d-4460-887a-0dbc24dd712b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b443e54e-315f-477b-84d6-6d83a39f6582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d8011e8-c7b6-4240-b4e6-c084fcc656f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ae136d0-afbe-4cd3-8706-8d321ad21e77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c56bbb1a-8c33-4ac7-808b-5e5d608cf875">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4109393-e03b-4c7b-a1fb-68f16c5a7cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb22b97b-0a84-4bb9-a4b6-5ee546825505">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9305c134-9be1-4026-a7be-325c101808c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c44701df-674b-48c0-94e7-2c620ae5942c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52bce418-da4c-4366-9147-90f23d9ee414">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a611e83-5034-4d03-b49d-c2259085480b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2fd42f2-672e-49cb-89aa-ac029b972620">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a04b87c-e6be-43d4-8deb-64099c5ca9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c5eeef0-5d1e-4edf-9502-650fd596cb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fea85a80-5dad-4838-afcf-75cd6d1fb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_713b3db6-d6ea-4a82-b06f-41b9783f69a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bd036bf-ba6e-4988-ad02-c1aa6666ac71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9552d0dd-3606-49fa-9aff-3dabc358798a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26940964-aea6-404e-8941-bdef013c8cdb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1adf3588-5d2b-4eab-b7d2-30a16cee0515">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65930981-025c-4bdd-b596-7f62dd2561d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dfb9aa9f-a159-4fba-92b1-6699c5351725">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6498579-f6c9-456f-902c-9d19b549b62f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26f0578a-c48c-4ed3-9405-7136aa508830">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_124f89df-1b77-4379-9104-99b98925be65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7fe7db13-1783-4d2a-a28d-5f544b258215">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7865f19-c83d-4d89-83a1-c97ffb796b50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f232587-ef4e-458a-ba35-ef158ef922b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7e35b494-953f-4999-bfdb-bbd338329e40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d1b5735f-c0de-4f92-b6d5-ef48cbf3acae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cd4c469-6355-43a9-a5e0-ce8c00e18dab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_49de03bf-9e1e-422e-a69e-992d88da11b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_582c7383-519e-4e95-9adf-d9f4682eb24d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f563d686-694c-45b3-b865-a4cd8600efdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b25096d-00f9-493c-9281-086f23040240">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2729e62d-154b-493f-8d64-5be7d09e89f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7303683-4312-4b4f-b006-f19d2bdb4a53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4698552-6cf7-4edc-bd48-63f44e816764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_733c06d2-d42b-433a-9896-e0d6fcf9f32d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8d144de-e131-4d9d-8c7e-5bf07887df32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf630364-e744-49bd-95e8-ef6d2aa4a7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_158a8112-d449-451c-8048-c6f0a9ccc502">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56365e0e-6d39-4996-a813-c06ce027b7f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9154b45-62d9-4cec-bb90-8b7da0fe72ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ab1a7a4-b512-406b-bd86-e321a39b3c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee320934-b8e9-4ada-9357-7eaee8eb3086">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1410e2a5-1a0c-494f-9145-13ae508493ab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_06741fd3-bdac-4576-8d99-ce74f8873229">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10371938-cce5-4d1c-b82d-62a4e06bb278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a82616f9-19ad-4009-812a-a4242ea9216d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a3f956b-efc6-4e70-923d-9029413a0f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e81259a-44ee-43e0-90ef-ff3b7230fc06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77c54f25-f344-4794-b5ae-abc64a604c19">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_65928fe7-3119-4e0f-93c4-0efcb16c9889">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d09255f-8e8c-4e03-a33b-be6fc2d42cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a2b9d6d3-d281-42c5-b456-e3774492b58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cc24ef5-3e02-490c-aad5-eab050a7a09b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d16de56f-7bd6-444d-9033-50ad12a2dd17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49e72d64-61bc-49e4-a565-03efa5d1acac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6cc99e3b-ca3f-48f3-8bfb-3568f4bd8d3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12968947-f95c-4b8f-83b2-5f0be6468cd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b754364b-ed30-47a2-a7da-9e4d6b03e0b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a13b69a6-56b1-4302-b0aa-3e0d081eecc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8eca3ce7-0b31-4a9d-b32f-c3950b6a566b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e27937e7-537c-4e95-a726-226798fad970">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ad17838-e54a-4c82-8a76-e0fcf5c2164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e698365-e833-4996-9473-f06a71d5589d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dacf7f3b-2ff5-44ee-a2b9-2aa57613a8da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bf6e629-c40b-403d-a645-d75c413c1eb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71c7c564-e605-412d-b6c0-23bbd162ad74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9c399c4b-5712-4062-ae0f-b688af0abf8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82b12011-cf89-478c-a37f-7641faed076f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_622cc0c0-28c8-44df-b59f-442849dc17d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f50b0d66-c542-4520-82d6-cf362ae23dd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_981f8d40-cca6-4b14-a267-a52df3e27e28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d39fcc1-e4e8-416a-a1b8-23bb62b77122">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72e08efd-5a8c-4c2f-b168-945b4c3186fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f47a4f9b-2995-48d9-b4b2-15c179da2be0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e1969e-aa96-4aff-af51-289b2f5f6184">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_68762a18-5f8d-4758-81bd-9239b9599167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b12a945-b2bb-4f02-82cd-4b59978c2b6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55c94c33-048f-4560-bb89-1a7ee27877be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f2b990d0-4495-443b-850f-d159ff7b487d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ee9f380d-06d6-4eeb-b07f-74433ee23ef5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a0063-77eb-48c7-8a3a-108717a1e342">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_471d2814-6487-4a03-8f1a-20fc685d4574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4f45b63f-e24a-4d36-b81d-35a032a7f094">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69246fd4-e827-4c4e-814f-937e24af9cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857769c9-5ae7-4e03-b421-b496cd37e421">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0188ffa8-b7d9-419d-be90-546712bd99d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0caddb83-6772-48c8-8392-b8592da29ce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b030c208-5e93-4339-a4df-49716f2f7ca0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_665fc7dd-b3d6-48af-9489-a931ec2d728c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae9ad4b4-9db4-45ee-bc7c-507982451c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73bb8f1b-7fbb-4501-b6a6-2d62532da861">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69ebf4e7-8f76-484e-bfec-e17f43ca4fcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4770649-3999-4da1-aafa-f310796bfb38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cd6bd8f-b186-4bda-83d9-9978919a34d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6de1c0f1-63e1-4838-9ee5-50fa9c7b441f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9d29ca-490f-4343-a83a-e789adae5850">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48ee110a-0ae2-43e8-bc1b-7abd771bffa7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9fb29ff6-0f14-4848-815f-df067a483b21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b40a5b9-55e1-4e8e-a264-d6a2bc01bee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c693cbf3-a4e0-453b-adda-4025e954d286">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6eb2ea9e-ae8e-4f15-8a8e-256d297537a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fde71d0a-4cd8-4273-bc10-76dd1fd19e66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d2d2a00-7af0-40a7-9847-bc28c0c1ea23">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e83e957-0488-4692-88e3-8bbb2a691173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cd9e84b-d0d0-4f34-8381-a7b6f7c03ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44020251-68c0-42b1-a413-3a748a1ab55a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57c0a3a8-7306-47e3-9934-a50251ef5bba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_971c083b-37d3-4e4e-a1aa-cfaecacf5562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_712d9aa7-73f9-4897-8147-a85039c14211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a9e577e-ad31-49f4-8389-4ca6efa6181b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8453e888-4f01-4fa8-83cb-972ee72535dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91cbbb58-6fdb-4496-93c3-bbb3fa994bd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90c5968f-502f-4af4-a99b-500f99be089e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b748562-c7fa-4923-8e6a-4427939ab97d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_31215c2b-0e3d-4bdd-88dc-45dd0d473877">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_03388553-ce12-4a8e-9cfe-74622fe2d729">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91c214fb-62d2-430e-bc9a-76d136d1b683">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7b97d0b-2cab-4ff6-91a0-ec87303b18d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc8f845-7da1-477b-a7c6-418956ac6e80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b46d5c4-0bc9-4057-b52a-b3ce593eae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9b90290-a864-4599-8c79-4638611ba5de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e50dfb35-302a-4194-affa-eb06048ced86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_565f7f95-7442-4d72-82bf-cf99d732e17d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_884f8d38-b876-4ad6-b4c2-5ed16c445a58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5070e00b-3d37-47b2-97d3-5950de3bda10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3154beab-9876-4812-828c-aee1690971ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_508d06fb-a64b-4e4a-a836-e866b64db8c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_885fff4b-dc0a-4883-bb41-faeef51ebca5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0db9c722-ba04-452f-af36-e304d10c09fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_23a2a4e9-dc99-4a8d-9add-3ca0c97933f6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c02a9d5-d136-481b-997e-0dbb22363151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5653476c-dbd0-459f-b3d0-d2ad9975dbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d3dbad17-c193-4f54-b0df-c903d58903d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b288691-206e-4af0-8daf-e9a2dd7030f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27025919-dfe6-46d6-8488-095eb2927d08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec1df18b-3e04-4dfe-b264-82b497dace66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b1e30c4-d9ef-4c9c-a476-ce98100f35c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e579b00f-7530-407c-a998-3dec9b484ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_105bc9ed-8b9c-4aaa-b534-174d2f8126b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebcc901d-16ff-471f-9893-98de344c8277">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a096101-135f-4769-a102-be67822c8b8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10bb5ba5-7e15-4c5d-af9e-a947afbcde01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1ff25a54-512b-4914-a35d-98ca1342ae4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac6351d2-74a1-4f8c-8406-4d39c66676a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1e98c83-9051-49f4-8f9d-8e5203f765f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00933292-540a-4140-afeb-a6d0921a1994">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7aabdc4a-f063-48af-9976-cd6d5698db14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2de76924-7d29-4ac1-aa0e-cbe05c315c21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4842c5b-2bcf-4b09-bbd1-530fc01bf44e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad91ff76-5a92-451a-b74f-438c17d16665">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56feff01-9529-43ca-992c-b9f7ed0df41c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39ddeef7-8343-4da5-9c9b-283f25344dbd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5d7a62e9-15fe-4fcf-8a5e-c18e280317ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cb38a95-411a-4892-815e-6f272a1fe602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_22ffe2f8-2c9c-4d97-b486-5f92260163c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_96ab21dc-4b8b-4149-8a04-a61050c092a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdfaab97-2d5b-4a29-984f-e8e221b59ae1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e875bb6f-949a-431b-8199-7b2eeb3c7f14">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_84efe136-ee31-43dd-88af-ffd1637858fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a55355e3-2084-4438-8018-10d3755a97ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1899ca-0520-4a4c-8045-faf978e483a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37a31de5-f6f0-4ee5-b7d8-386f81866e35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b7a9125-651e-4392-9214-d4ddbdb52247">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2f0b9923-7398-4564-ad82-4bafa9778688">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_624525b5-e21c-4305-9ac5-ff7388b1001f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d37217f6-9cec-4c6f-805d-deca7c019fbb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9461a04e-4368-4f49-b3b6-2f05deb219bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae0b6a0d-a5eb-4f61-8b2c-a02e751e84d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04c8a74-9253-46b9-b6bd-9701dc35eab2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be945639-e526-4e91-a7df-a51110b91db0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1dfc97c0-c7b9-4c31-8f4a-a6d6ab182d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed9ad61e-b067-4f4c-bbb2-c41dc385d6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79603aaf-2a57-4463-8db1-671b1a2e220f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efabaf18-727b-4c00-a40c-f17833ed29dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe002e4a-1ec7-4895-86ac-558b453b515f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_20262ba5-86c1-47f2-932b-e0127e4f76d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1f99cde-ae8e-4ba1-9d73-01d49a79cb15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f86804b-4b7d-44a5-aa8c-8be0a817dcba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18f5c8ef-7b91-4ff1-ad12-25013fb2261c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b10151b-bb1c-42d3-a1d4-2405ed3692b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd81079-c54c-4362-a512-99e1574343ec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_46326a22-e670-4bea-b1cf-9c254602f2fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_671ff075-93d9-4eec-9954-3d1615290aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bfde40f-72b0-449c-8d42-637fbc9fd2b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9cfe9126-4dc0-4fe7-b98b-211301ed1b99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_706882f5-592d-4dbf-8de3-c5573164ff4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82267948-83d9-48d3-b8bd-a253eda0320b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86674381-d6d0-4318-88ff-c1894543ae67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bfcb49f7-6405-44d7-8045-14aea9e30b6d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9009bf32-48af-45a1-9d21-011ed8761328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1826f25c-9775-4f4f-b2b1-ae473c49e3b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7a71e962-82ea-4db6-a0fb-4975df482e2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fed39c-b567-4583-b5e7-b7b55af29412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b17a4fe-7e52-4091-8ed0-3aaeb20bad36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f5e9ea3-87cc-4bb8-9367-89a722729922">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5273405-4204-4386-a10f-f7c54e4f4238">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4bf260bd-da56-40ac-b0a9-aa914db52552">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0308fee4-f4a4-42a9-a181-5a87b1d39278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cb7100ed-7dcd-4b33-83d3-d2a0c4f3d3d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_356e63d0-5646-4a7b-8572-342dd3328f76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bef3a4e-f3ae-4cb1-835d-0e5d9f063ad8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c9e7d8-6d56-48b4-b8dc-a71f2d4b224e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1bb11d6a-188e-42e8-9304-e8a4ee0872a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7e54d3a-d5aa-4f53-afd7-6549180a071c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c78dc3b-842d-45a6-a8c7-430b2ba7b894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_520c328d-8cdc-425a-a674-f704abb85b1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_511860b2-8d73-404f-ac31-3690c0941043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd8849fd-c520-4587-9a6c-18d0f987bfaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4001dee1-5a46-480b-bee2-4f49f8336ed5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173717d5-e642-457d-9561-712c94fe0c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4c221fa-68a4-4b6a-a352-bb79f98caa60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2bdfd341-8eb2-4212-8f13-d86974a0d2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8f7de386-3c11-4fbf-b624-23fd3c1c562e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8e1bdcf-845f-499e-ae37-18f99362ad08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c797ea5-c893-4c9d-9e67-c90e8e199411">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1c420df-1842-41ad-819e-009e2c6b9a29">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ebf6639-df4d-4202-835e-d9a6be726cf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71632e7a-40a5-49e8-9ddf-b674a3cd0aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_849161e7-454d-4c72-a0af-047c5336f94e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89d54c89-fac5-4820-9e7c-2bfe46e356b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7f2ab18-b44f-4ff0-ae23-624e27b84d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4986ee49-2f30-4ac6-86a0-753bc271c311">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17b41316-5349-4bc1-8cf0-478a08f5b456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9b0f671-71a8-4cef-9ec7-8e98fbc6ae19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18b0b238-e39e-46d1-8b44-c343c305efde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_73c9270e-8671-4fdb-9c60-e5adcb17e72d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43cca838-8ddd-409c-b337-2e67b51a1d4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b1289ea-c81a-4e41-adeb-e00ddfa67bbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877c860-1f30-404b-bcc2-973e5eb01818">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3fed168-71e5-4be1-ad94-9cab9c37daa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5b81bb78-faaf-4c79-acd9-dee20dc0c61b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bd400616-4892-4133-be8b-398ae2219c89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d654b4a2-619d-472f-ad7a-f6da11cf4d4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc89f01e-591c-46f7-b57a-88b2deb6f051">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_734d06cc-67f7-4711-9fd6-fbdf778ab26c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b7472e2-0209-480d-afea-3cdaa1f3b566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f419035-11a2-4fb2-9aaf-9dd5d2f68558">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_868cbe39-38ec-4502-87c3-89c675fd01d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c59826ec-f49a-4f2e-9bff-450f400089f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d29eddf-8a9f-437b-915d-a171ba75e4d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b8f651fe-90c8-4acf-935b-3a28bbda1010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12d4f8ef-1503-435d-a08d-1172f0e8d4a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b4d225b7-cae1-4c84-a2cc-ec8d86545530">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3851fa4-a3e6-4620-9d84-e5f2e223d882">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0201cee2-9ba3-469a-a163-ff4d8f90339c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4a1bc43b-f726-47b9-af5c-c555b9460663">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e7c03dfa-74bb-4ae7-aae2-e3b13867e39e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22893df4-f066-4d77-9b20-41996fada264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713eb8dc-b3b6-40fb-ad61-4d88de8074cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a425377d-6338-4a06-ae87-a353daba71e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_234cf63c-93ab-46d8-a942-c61871c6c1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96120813-56ab-4482-a890-46d757bc9053">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_895c4d4b-23c3-4aaf-869a-84176c9c5ed6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5215b7c1-8498-4aa2-b3b5-d35d65fc4432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_540d8499-d8a6-4731-aa87-d0ac791ded2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88906a21-f574-4aef-915d-859acd1e22d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70afba82-3536-4952-b226-a329a794c7e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2090b49-5a3b-4f65-bf81-6fb949c6e77b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69b76bd-7138-45bd-bef8-e6a69172e021">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41196d74-dde1-470e-a114-485ebdbf53a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e80cb5-a4bb-4fb0-8754-25a61418b53b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67dfd7f9-e5a9-446f-aca5-9480722e279d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f1c9764d-7a62-4b2e-976d-8eceb473c52c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e8c1bf-b50c-4089-8ec2-7fede6310b5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cc8a469-7e37-44f6-895b-a38e53ba8c61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ce44f7a-e1fc-4554-8a26-2532ad150716">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_216b5db8-fd97-4534-8794-ef399bba9f06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_274432a3-9f3f-4229-a3ac-ac465ad8834c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86385e2b-890f-41fe-a051-ce32d787268e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c5d1874-528f-4b5d-b918-1808616d7d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_756d2942-df77-419e-b7c3-e43b68db0205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bed2fb-0f11-4f6b-b3e6-54108ce9f48e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb29035-f491-4bb4-85d1-a52b9731a61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e93ad931-1622-4890-99f5-1a0b86bb5cc8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8140af2b-d5f3-42e9-a3b2-b00593fe86be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ffc6a17-e0e8-4922-8d3a-6e5eb7c98cb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_402cd84e-9864-43f4-8dbb-63bf7cd1a0c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f41d01a5-a611-4390-a26b-18fa617aa345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713ca869-bea8-42c1-89c9-748ac1a2a210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_55fc5e5b-0d1f-4bcc-bf93-c8b921aed1fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d84ef8be-1d52-4db0-8f0f-982228b08963">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b740b750-4224-4059-b382-78942d33d819">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4971b9b-47da-4d2d-a33f-aca6a40ebb5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6fcf9d44-0aa0-4601-acec-32f45ad7d508">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82f01d0-3f3a-4fbd-9a3f-98a1e954e09d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c3cd7e7-115d-4869-91a6-70bd2e8a0879">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b134ce8-e167-4933-b483-9abc85f82a68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bcc360a4-e0de-4270-b3e3-2c0729527a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0de34ed6-5f54-4d96-b85c-f9cef605702a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3231c97c-9430-4350-8fa2-291f9293ff8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36da5543-1c92-4034-9537-b7236c3523f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4aa7d6c9-5036-4a5c-bafb-8aacb7e07fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da489a8-37d1-42fa-b44a-5ca3ec46da01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c597a409-1d5d-4f8b-85f1-afc3b592df8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_995c307a-76a6-4c64-8cb2-e814cbfb12fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5693ab73-76c1-422a-af9d-4b3bcd6d3a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f644f1c-6ed3-47c9-a38e-08a9485b207f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9bc005-cb3f-409f-820c-a5e040ed86e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fd822661-fd79-443e-b070-216e9012562e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_251ff7a5-1ad4-4805-a523-f27406ba6d79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce12731c-2b18-4e1f-aae9-29964c988cc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c161c630-05f7-4404-9947-055080df59a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_54136fba-4c59-45e0-95da-af7801dc09d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8734587b-a66e-445a-bd1f-6cb940b51c00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e6d45e9e-66db-4bb9-8d38-86c61edab12a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42e6c5ff-2a1f-423b-a9e3-9664e6627f4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2af328b-5185-4c38-b82f-0c4efcbd4ec5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67450fc0-6b2a-44ab-9128-d96d9676f9eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3aaff381-983e-4c90-a188-21ecb252229b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9041fe38-9715-48d6-8f4b-00ab3676a859">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8a2be9b-a47a-4ac6-8746-2c90af9e406f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb0e8f84-c639-49a9-a371-e1853cc9c701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9b24d9c-36c5-4858-87d6-2d837c4230bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7b028d2-f6ab-4e46-86f1-9afc8ef4aada">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16c68725-79d7-4807-aecc-018c600ca5d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_068cba16-15d4-458d-8d1e-14680f6a0841">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a442a01-9c9c-4edb-805d-fc3b45f89e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c8d0fb8-e4e7-4e8d-bb20-179996e179b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7bf7ffc-0480-4a79-a24d-b2d6601acb16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e46b1d1-347c-445b-a227-48aea8b8e2ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ba5d05a-ea6e-4f08-92de-61331f4b7ce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2e5fbe0-2c25-416f-bd5b-e04d9aa999f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ccefb321-71a9-4304-b680-6cd833613598">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc84b185-167b-4586-83b2-d6caac6cb45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68f575ef-5627-4282-9c58-c1e41eba70d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb56196f-75b4-4eeb-83a6-10e82c03a842">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_821c5870-ece1-4e61-9ff7-55588a7550b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6e6c67c-a057-4fe9-a74b-bde8f770bb4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cac2fa32-b7b9-489c-bd7c-a6db746f42d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fc8453e-ef8c-4bb4-9294-2a4e227544ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65e5a63f-cd9d-4a6b-81c9-8297e8add12b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb6439c8-04f0-407d-93ff-be80b9fda84d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3444efea-71a8-4c63-ba38-2ed9a6bfacaa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bc73643-70cd-496c-a6c0-55f2a679ef50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8599188e-23be-49ef-8aaa-2bfe07131eba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_51d5398f-d2cd-40f5-943a-48c008f0cd91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4b1710b-5144-49f7-aa16-78538eb731c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0026b68a-d9ca-4f76-8bed-993b99226fdd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_034d70b1-92d5-4259-a101-27f795ef79e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9b2f023-60c6-4246-bae8-1f304d7c046a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6065275-b0ba-4fe1-8c93-51befb9431a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_824a0775-e3d3-4af9-9950-5ad9c0f2acb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c3ecb7-c758-481d-af0a-85b852631da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fdfdeae9-a5ac-48dc-9b36-7779d7c45b07">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef7f8f3a-7613-4529-bf6a-4beb89a652e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0dffafff-ba7c-4bf2-8345-b32936bb7d86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b375a1eb-4e15-40e6-8931-21f756370ad8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a17eaf05-1e9d-47d9-84bb-52098403ebf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccf1734-7ea4-4030-b8ee-7a82d958edc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a878ee53-c51e-4a70-a80a-fb13a8db928b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8657f8e9-55a2-4388-a722-de31eec99cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42fbeebc-27b3-457f-b780-23328d760a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2ef59be7-e550-41c2-ad9f-a4e7fae6d3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ec6ef57-cfcb-47d1-b38b-6ca3220c5e02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20979194-0a0e-4f2f-8f25-8612d79fb907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c4ee866-a65f-4f9e-8d76-0a085de8e748">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0cb1e098-2473-44ba-8ace-88063372e452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ff52ade-2687-43e4-8fcc-5f099a77ae41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_568590c3-5871-4f14-ba81-c7895686ce80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0769e266-9d4a-4af6-b15a-89f29e34da03">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c16aff2-0a52-4ef9-a47b-8542e0c753ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd8422e1-afb2-4d1f-8ebb-931b8458508d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9d9b5953-6a6b-4b2d-8776-8f0a554bacf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c308372-aefd-4a3f-a694-4f9269fa5587">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4055725-3496-4afd-9eed-220b29535c3d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25d44ccc-4df7-4ae4-8c71-c7b06699a507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e984b7b-5485-47b0-b49a-043ae3aacbd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e6cfa0-aae4-4c01-8062-3dbe496f4574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87b48993-4fff-409e-8fac-71ac7496438e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60f5fdfb-bb99-48bf-8281-1a716d1e9cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c49006c-db19-4e93-a62f-4f74ce7b5671">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd9d62f0-ad1c-47e8-ab65-be18b6eecbae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_032e8c7b-951c-4471-bc78-04fa2abc164b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5400d815-e041-4be6-8e24-f4b4a55ea557">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6403f818-0982-411f-8685-1a954d578710">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab41767f-a4c3-4501-8fe6-2c53b0b29faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_518b887a-c883-4f6d-96bf-fefd70874c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5937e65-8f83-4221-a7ea-1b171d13f761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2964a972-3a4f-4f4d-bb34-2a87fbb7209c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_803e8c65-63e0-44e4-95b9-4a68587c9ebf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_28a90dc5-c31b-479c-8bd0-36ae75d91886">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7b5b4d52-a9b7-437d-b626-5013d30b573a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8809330-10c9-45a1-ba8e-56983312a283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15a8e6b-dff9-4599-a3f4-cc992e64a5eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_da85e8dd-137f-436d-8551-4c667949a953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c990151a-be6c-4ab6-bea5-3fa861d3f487">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c68683c3-4c6d-41e7-910a-f8fb69106e2d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9cd6b6e3-2fe6-4b21-a527-04ee4da982fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea51ec29-12dd-4c22-bd1c-f8b4d6c88c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d73ee5a1-22bd-479a-b8c2-cfac03997d0b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_00d337e1-f715-40b3-ba0d-330107be943a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e35079e-d21c-42b9-a71a-bd371ef325be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba54f75-4322-4260-a3ea-5c8a1fd8da22">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02cced8e-b04a-4c14-99eb-effab66cbbfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f499942-c1d7-47e2-b0c3-94f2db7b5d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db50e30-5d8c-41fc-92ae-ce10b51c1142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c76a037-c8f3-43f0-809f-c2d22fdc7c61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_942009fe-1099-46ff-8dfd-39bb6c8db838">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8330d965-e14a-4069-9ba5-af9cee313c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9a94a356-74e9-46df-97fb-5bb574ce5aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74896b7f-2442-4b14-9fd4-a345f81988ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80d06191-1b0a-44ba-8966-72b2cb09552f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_721cb49b-421d-4b7b-9009-5e492dc2fff2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cf5789-1e9f-49d3-bca8-81720d2a2e85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_042500b2-456e-440a-a299-70b68697b78e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61d12870-7112-4a95-9fdf-bb0548490252">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3f46115-af74-4aa6-86ae-154180f55b59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_766c7c0e-c479-4fb3-b381-e2664ad819a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_184724c2-9322-472e-ad84-f3d5ed3e8ab3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1a75e146-4a56-451c-9165-17ea4fb4a25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_effcbaaf-8216-43cc-b073-cfe772572506">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_44dbb378-126a-4790-98a5-6e6b6da2c8d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f4a76a-d81a-490a-85c0-8f01b63ab5ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2edeaf8b-6707-40c9-9fe2-ccf1f8eb347e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e3c8c14-3636-4f67-918b-08d3187d513d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ad35ae9-afda-4659-ac88-72a2bb9fe44e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f77d3121-7cef-4297-bc8d-745375d989c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_63e90e7a-e502-43a3-9128-eb540c6c00c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e510fe3f-7d44-4d7a-9f1f-3388843068d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01d20bb2-a8dd-407a-a54f-f4d90f2206f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc0eb440-7432-4aa2-8900-5a7646660733">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dafcd693-b165-4b36-88f9-6bd171a206ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47dcc68b-7686-488f-b77e-cbedaf655b09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a44d56b-3af4-4d12-831e-161bdb3b7217">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de415489-e0f2-4512-b73a-135b3e345a95">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4a169528-7bec-471a-8892-3f66276e37d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74ef52d5-c88f-4177-9d50-2a6e408bc8a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cef415e9-2e4d-41ec-8d65-54f834f290e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4df8a044-9965-4a70-91ad-3e0dab7ccc17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb6166e-1b65-4c55-94c3-b2157ed3517f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e19eba57-e9c1-47cf-ad50-59fe6b08c01e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_346a5319-3ec2-40a2-aefd-38dfacbbe97c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63c7ea9b-23ae-480c-b27b-f7764ef9d5a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_168c2329-960b-4f86-91db-ef94ad8f7dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_686e884a-a0b1-454e-b7d1-33c7ad46f89f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ec1f350c-c2ae-4665-8e68-45edcf92d1fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4edf081-2fb2-4da4-94db-98a2a596247f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_312f25f3-55bc-4417-848c-236d31d823f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f359893-b7c5-41b0-ada8-8df06cf7a8e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db1a4a3-7c77-4e7c-8a3b-65499a81fb30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc4c311e-d167-4d5f-8a36-c7c1c915bc04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ddcf7aac-e7c3-45e9-bd81-6146e951addd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af420f53-37ae-44db-abdd-79138f483c56">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13b3e3a3-d932-4e97-83f4-d63c4e1c8527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2463ff2c-7690-4dd6-bf44-039f9f475bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df6b50ee-af5a-4e61-9bda-0752ef238e3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d67568e7-c48d-479f-a4ef-51e35b018f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3be2355e-0065-43df-a264-57a295042faa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd875ee0-a6ef-4ca0-87ef-f6b5b079308b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41386a39-3f57-424b-a8b5-8d3b5a32bd79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eaf7e467-44ab-42e3-bcd7-70692bebbd62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aeb672ee-e2c9-4172-b7c6-3d3915821c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbbbea53-8f92-48c7-8cdc-a3fbd920c43b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bae580a2-0dcb-4ed6-86b1-f5f603b937dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4eb83445-5e74-42a9-9b92-e1cb3c6ba13e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33f8b01b-0fde-4257-bf74-20588be588ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_876a178a-7474-45e5-abc8-d9e3eb0d231c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2f24cd6-459c-49a4-b93d-9c6817cb1488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84507e60-680a-4b67-a596-c214ae0b8c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56715438-6a4b-49f6-bc4d-605136e0a3e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f46a611-ff04-4bda-a0be-9d29131f4b4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b1a2061-0ac8-49a9-9954-847d9862df0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec63eedd-ad1e-45d6-bae8-c797162a1e4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3971a8d-94bc-4b4e-973b-16844ffdbf18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8526a3ae-9742-4e33-ad46-dcb5e89af11b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f31a7a93-b405-47bc-82e0-5862c71ef7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1bdcf5ed-4a96-4d08-93db-65c2d5dd908f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90ffc2e4-3f7f-4b32-81e6-c4c2a792b458">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73487593-2e52-4172-9f55-c27fb539b609">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f7eb4e4-8de9-4352-8986-c31fbf58723a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6137d3e5-4586-417f-93c1-dc9e2b46adff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_696dc02a-5cfa-4723-913e-a5885b3e5885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_843f4407-c335-4824-8f2b-7f2ed4094014">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_947cb703-a50e-4602-b5a1-60cbeb8832c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f8860a6-75f7-44b6-94e5-01dbf0aa3de8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0220034a-1a6c-46b3-bfbf-a984702d3c1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4f54cbe-fc62-4410-bffb-0521959fc2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d3a0ccf-17a2-4beb-ac9b-7be3dcb0fb73">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc80f782-5c36-4239-8442-fb25c5d61c4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c216355b-0f57-4118-89bb-b2780f146bc2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6d75d35-3089-4dda-b69f-ff471b24aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ab9cfc0c-b194-4af0-9fa2-77978e43c0c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_63a8f42a-c8a8-4e9b-81c8-001bed4d2a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7f09426-095c-459e-8e0b-e38500fab1b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed7f9c93-a8e7-4999-9d18-f5bd01b65933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aa3a3f9-c86b-4641-b368-a099f8583656">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0fd18f1-856f-461f-bdd7-997115ef1044">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c78936d7-acfd-4a0d-aaae-0153ebc7d768">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_09e0f824-f92f-4e4e-92ec-7d6770b9d243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70993686-256c-46bd-a2fc-674f52ac59dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_65b03961-f9f6-420d-8f61-f44ba99fc4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de9a7b88-6748-4089-9d89-911dd957bee7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec4cad68-f17a-445d-922f-8a419d3fec9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7850bffe-8b78-4551-8f92-d52ef0addadb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c912ed7-2d69-4118-ac02-b9035f0d9e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_43b6fcd3-4a29-4e9f-b597-518117e3f111">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_009a7bac-59fd-4b36-a39c-a635cdf04418">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b0739c1-a932-452f-b10c-356d293b82a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec5176ac-a1d1-4f5c-9546-e9e47f6ad8e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ef8ecc8-7d0b-4507-9877-9f640b323ef2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b6c251a0-7f4c-4930-8e39-7a91fce144e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66e59497-02ee-4f54-ad5f-4f399b2eaab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_891c0f42-fb9f-4390-ae0f-307bc6cbfc64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04a2dbc5-819d-41de-a987-8d334031c175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc5d543b-bfcd-46be-8fea-1b2490b1ea9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9f5d49d-922f-44b2-9d78-ba41b47542a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41955f1e-f88d-4160-8879-ade4e9d027f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d97bfa8-9abe-4275-a2b0-1acbaa779613">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dfc5b8f-fecb-4041-ae98-3c2b1f96feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8dfa0c60-9696-4870-87d5-ec7d3e2b72a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15c0d9e-956d-4afe-9654-9ae5cbeae473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0a4153e-156d-4852-9921-6d1a1c1064e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df7dc1b3-5ad3-4697-b808-103a9b2e22a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d69e028f-ecb0-477b-9fdb-36594afce196">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c04f249c-6bbe-4db7-9637-a3bef2cd6599">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04b9b246-5df3-43be-a733-5aec27fd9be1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_00fbdcfb-3d3b-4378-8dcb-5608f6eaa51b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef59a32a-bc5c-4512-9437-86fdef2ac2d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a208f474-056d-48b6-a271-a7123684f108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a20e1cae-0b90-4139-b87d-9ce76e6219f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23db024a-d255-4402-b2cd-e7e0052f6e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816a0247-2a88-43d5-8de0-d4709dbffe98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9749f3a4-64c5-482c-87c6-37322d113948">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_580de0e9-f8c1-4969-811f-46712414524e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20f43d84-963d-41ca-8548-86be349e8471">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2bd46877-a632-4ddd-b880-1940461fb45d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_02f193ba-e746-4eda-ad79-9999ef27fe47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b569c39-9301-424f-959e-c45e0fd99f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91e9275d-053a-4d88-9d20-c094f2ccc85b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69f112ef-9f4c-42f3-9ac8-472698d68257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e47741b-e0d0-4985-913c-d95c500b7e48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1178ee67-c92b-4568-bdd2-101440661e16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8960c67-75b6-4aff-8b83-05fffd558dc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc81403a-372f-4310-824b-112e7bfcb323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1d717e38-50cc-44ad-a538-cea12eb5e1b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5465ff43-da95-44ae-b8e2-7f3b590e6c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9e6cf153-1255-4a4e-a3cb-8931792c077b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a29bb72-2f86-4d29-affe-b2391894c13d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d58201c-4d98-41ba-beb2-ff5d742fcb66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98fdd615-f480-4b42-9bb3-cea3b7c2fda8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0a978e78-aa93-426e-9765-368315bb94e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c873a17-42f2-4abf-8c47-e47021e0e3f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a5a6dfce-8298-4b76-8289-9e3fee8a8583">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0df7090c-0218-49e1-a3f7-cf30c8f9f8b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_177bf3c3-c744-4321-836a-a2fae0b0bbb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a551b9c1-3d7d-449a-84ee-1743fd7f9366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38a5688b-b7c0-45c5-9243-0293e2e48b94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad56fb97-89e8-4c97-84fe-98d7049617bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee95150b-76fc-4ba3-a9e3-8aa2a41479b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3304e735-d4f2-43dd-bb3a-22e720aa6d7d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2869b4e-01d4-4787-a309-e5c09b2214e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45bfc964-e77c-4912-993c-6ed38877d6a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d598576e-9992-4e55-ab22-7ac5e336c167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0387494e-d16b-44b8-903d-3aae7c4b2d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ea8cb0d-f908-40e8-8be5-f6cf397fc6c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47badf30-a042-4cbd-b2e5-027b03e98eca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a2503c0-15d6-484c-9d50-dcaf87e40afd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ac3075d-b630-4f72-9637-9e0d639eea21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a73abc8-c136-4d48-8b72-ccf7c89b569e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_443d1b23-9393-4b67-9596-b24170a7715e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2003d398-4989-457f-96d2-1d171aaa3496">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_467e0941-4ce6-41ca-9c73-fc30a3a465d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_434f488b-72ac-43d7-ad91-7397a8d1064f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e39401b-8a3e-45f5-9b9a-b23d200ded9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7396260-dcb7-4643-8440-4c22300245ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c6c8c-c3eb-4c10-9ed8-60b192b7e93d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10d7ad43-0c5a-4691-af6f-b2784e71188f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5169785-0581-44f2-ab10-12791b566cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa81dcb5-3516-4f66-8384-f28ec6470452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84b7f2f0-27e0-479f-93ac-7e5575559334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9da5e21a-cedc-4d7f-975e-b895d61a5b4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8b07eabb-e9c1-45a8-854a-b0e19382565c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d7048bf-1d51-442d-a7c5-42af545b53b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_667943d8-8735-412d-b993-d7f49ec6ec56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_78ab02ba-6e28-40f3-ad7c-e904efb2dce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f55d08b5-1ce5-462f-b19d-7e59303c7055">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0adb0e5d-57dd-4b49-9fb6-4b542a78e281">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fc722a0a-b5d9-4c9d-b2c6-aa57aa347267">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f46dacd-ec53-47a3-9ad0-e69d01af2a32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47e98763-4205-4c3f-9fca-580e6716eb93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7c51871b-8c97-4823-8108-47c7d756d416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422d93f-8f56-4ece-b98d-d6bfdacfbced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73252c52-15f1-4024-8dd3-b7f5c081e5b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c7306cd-aaf6-4452-bf95-aa1b65184654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a90aba9-d586-422e-8011-ee94ca4fa7c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bcf3d63-4745-4934-a4db-6c7e999c6cc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_acdd21e9-23fa-4c1f-adce-ec12996b7bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec2c9742-eb7a-4c04-84e9-7ff3c8cb7325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ddaae786-f86a-49d4-ab4e-8f62cf002977">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0b79f1c-045c-4a78-b3b6-8646f10b3864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39ac3d07-5ad3-4af4-85ed-08bd818a9c57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_febc165c-7c90-4f43-afb5-b99fcd6d0ae5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e8d3745-e50a-4068-91e4-fe628f09b912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b72232-5245-4b60-be58-4f5e8ac5fbfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_27f3ab55-1b69-46a2-817a-20f140d8cd91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dbcfdcc-7bc5-4654-bfd5-0eb2a6764f4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9985dadd-4bc9-4c0a-9952-68e4674633d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eeb5e115-4fd3-465d-846f-a8b94662e138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a93a0ae-8c5b-4578-aee6-66d0adaa0034">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ed23ba9-347c-4522-ab04-d6987fff54a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3321c52-80b8-43a6-ba29-433ed615fb9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e7079d-f268-4eb7-ab0d-986277db80ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd245486-24f1-4bd9-a5a0-8566fb209f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4585259-822e-4a6f-b0de-a7c1df729d57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d66a7f2a-ec30-4686-bfa9-5804598b7f1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e0a586e-4363-4731-9ebb-852e63184386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b2993f37-953a-4fc6-95df-364a30765e93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_879b6ec0-699e-4c45-95e1-8ec2b6f0b1ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_75e908a2-18b0-47cf-92ef-1c6e2d0b87ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af84240f-9aed-44db-b2fa-e1e428b93e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b675fdd4-61f1-4375-accd-7b6aa01e61a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d19a72c-2062-448c-8aec-ef4299deaef9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_85657dc2-b4a9-4900-90bd-9841b7283960">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0b1f34a-3695-4717-ab24-afd7b7f2a4c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_278a371e-c8a3-443c-9812-da6d05023804">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea4a6b35-dcbc-4dd1-a1c3-41af5b692519">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_387649d4-7c09-476e-8f8a-88778b3433f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1108f037-931a-4c97-ba81-1d3945e8a108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2796ac28-9104-41f1-a0f7-8c2b2b8c7e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6d589299-a69a-4252-af49-c04675260ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c00ff0c-aaad-4bd1-a28e-b2814d8544a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8045156f-db54-4b51-ba78-c03b95abc2a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a34bc6-1275-48c0-9620-13d697e84771">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6978d4dc-db26-4438-b821-7dc2d6de928f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_293a7321-4d59-4ac2-a737-ecf77e9722e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2e2ad7f0-44f4-4af2-82e3-77bc37ef1f54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d8ac7a7f-ddbc-407f-9405-dc3215bc0b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b09fc32-acb9-4459-877e-24322a0a83f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c41c99-9bf7-4d09-8101-027de2575f03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572a2fa4-34a0-449e-9795-578123117344">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_959ae440-87a5-461a-8c69-d91c6be97d4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_373278fc-18a1-4abd-b048-691670efb49c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc776d4c-f4e1-40d8-89a2-218707466d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2bab2b3-e4e7-4ef4-9ed8-fe3468bd5127">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c260bc-94c7-4cfd-a4d9-f2539e71b7fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10b57bad-d28a-40cf-8f33-3c48cf7fb4f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48680022-5b7b-4547-9e96-7fb49bb638fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8095e658-d0bb-43dd-845b-f036a180d704">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e90719ac-9754-4a36-bbf9-fb321ace6d2d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88b36e46-3e08-4a9c-86c8-a35e0556771a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1305bd82-d13f-463f-b23b-0a7beff54c8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27490d8b-7f83-437c-90e2-38655ae49692">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5812ba09-aecd-452f-ba1f-37c16d76b2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_83030d83-d89a-4ba8-92fa-3a20313fdd4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_38c2fb13-f108-471c-ab65-5731a64b6cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_109ddaba-7a47-45ac-877e-b4d0edefd18c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25c10f11-aad4-4271-9b83-6f26879a49b2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90193171-e667-46cb-a5f8-a79f5fb9a047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c4024fb-6fa3-45d1-bf4a-1a1c9e967701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75034b3f-0566-4bc4-9e77-4589ec5a3529">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ee4a0c2-7707-486d-b061-60cb3639131a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0cbf76-5e70-4ac1-a14e-1aeb435db65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3debb7b8-d827-48c8-827f-6dceae6c47fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1bf7aaf1-e4f6-4795-abd1-863d1c5e481a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6799f164-6554-4fc2-8c0e-83c42fea4ced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b3e639e9-c7a1-4eac-9134-b7ae9a1019d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_108be304-cf43-4c5a-8bf3-94fa3e8d74fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372e32b1-1aab-432b-9c3e-bc1b489d9e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dac4a438-5467-461a-87f3-b7a53957f069">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eebbadab-e107-4699-8e8c-fa9c1f93e384">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04be338c-4123-4d3c-907d-cfe7e46e082a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dc3386cd-4655-4bdc-97fa-b6d42a53a6dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df932d23-c0fc-424d-b8c2-f3e6599fa319">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1cf568f6-4c0b-4a61-918e-d6ff3351b8cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cb029e5b-97a2-4f2a-abcd-e6e0fdefc53f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f455767-aa17-45df-8151-164007b94c58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe42c63-3b53-41e3-b839-0f65d0069446">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1eb2294-922e-4794-8a02-65e81ca3371c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee5a5db3-c2b3-479e-80db-614dd45941e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44a01d28-5f0f-433d-9765-93694bb03814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_91c721ce-fd9d-42b6-85d7-574a9f1ac063">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35eb4da6-136b-4bca-8604-47e75286e65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4044b56c-de8a-49b2-9a24-8d72190aa272">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da881031-0b0d-40b6-86a5-aafdbfa81931">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a94c14fa-0352-43d6-8f52-27d7ed31fbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_982d9d6c-a0b3-4977-9ac7-6542cc61f4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2e1acf0-3a18-4654-b0c6-1f49191aa7f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac2f8368-74fa-4e99-9ecc-00d828bae587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db7e5d95-3bcb-4838-8615-e20786189b81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2c8b805-99c5-4822-a5e0-8b7715404d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39133449-53e6-450a-bbb9-2a9f492816ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52cf4172-5261-4ed2-b0f2-153da4661c73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_759a9435-a21e-4f99-a560-85da57a1d290">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0ab7585f-f58b-4966-873c-f67bb20f6b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4406299b-b743-49fb-aaf9-da8a976adf9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_149e05ed-ded0-4b52-9f8b-a74fd2961737">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d81de1fd-80d7-46f9-ab23-eb276e288ee6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da192a0-4748-4919-af6c-739d407d0d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d3e78a-4c0d-4af9-91b7-ad6b70ac9a08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4de32c8f-fbec-44e8-b08c-4b1f7f0ebaff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_247f2ed6-5a4f-477e-b5de-c71d021f919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0b877750-4384-4ec3-bb38-08ee5ccf16d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9c8c518-9a45-4371-bd8d-47e5a3520e74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be89e92c-bdaf-4807-acb6-4025d0a88244">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee9c1f11-acf2-44de-905d-5f284b2f2e99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7540f357-0df7-4c75-930f-21d4e0cf46b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7948fd33-023b-4cba-b871-f34288cdd5e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56081645-b0f9-492d-a015-67797a891d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7eacae3-b893-4773-8a15-c0c58eded027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aa5ddeac-c8e9-40cb-a1d1-9f7ea09b3630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12af6be9-e7c9-48ed-94ec-5d6f90db8dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a34654ae-5aee-4fc6-bdc2-5ec098a6a2e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_60196fc6-3c06-45c7-ad3a-d58ffcea6351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d6ffcf6-4c89-431e-8efe-472592c985d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c4fe896-13ef-487f-8ff9-2dfedad5b2b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8cd607f-df0e-4528-8b90-5b4718af222f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7fda72c2-1863-4339-a7a4-f6b3e2b6fbef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6d1299a0-430a-4b38-892a-45af9c3963b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea273147-7151-4e4f-9db9-1fcb630b401b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e24c6d73-f009-4bd6-8a3f-55799db87823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_018b9ff1-6444-4689-b68c-97b463b09946">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6a79ce6f-d266-4de9-a41c-650ab243444e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70a7cf98-4c62-4403-b08e-76c9392f56eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c4f817-3a34-431f-a6fe-db0ca3ad14b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_242be4f0-4ccc-4c64-8ca8-285c5f801e05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1747a54e-2f1b-460a-96e9-f1e004c0fc50">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1cf3a401-e334-4e2b-b888-747c70fcee33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5923661-1d0c-4844-b6d1-4ee4c6953345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dbd09afc-8674-45f5-a0ec-f55886cf9441">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f120ca0e-d965-4061-ba03-9ddd552b5aae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd539541-75e6-4ca8-9f8d-b27aef8a0d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cf00de-bf8e-4a71-a89e-ba65c7d70449">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_21bb583a-c74f-4282-8144-3cf309cc0088">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a65ee9f-719f-4f47-9dfa-ba9ff879cdd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9d9a73b9-313a-4e9b-8fa0-cbba3d566d96">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_585ae3c4-d76b-4fb1-bc52-cc2665b7bff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a471487-7727-4db6-ac27-ea7374e03907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc862be6-abcf-4e48-b9bd-d1865d75558e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_df93daff-7fbf-4ba9-9486-40503806d1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bc441fb3-f4a0-4696-9076-82679a508d59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c3d8d60b-befc-4d71-a319-22ba6e25bb74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1d980b-aaf8-4ee7-b7b1-bbce95a7748e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486d1e9b-549a-42df-ad67-29d2016f4571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fe878612-3cd3-4f69-8d54-6f4fd236cda8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dcd0ebfe-3623-4fc3-89df-ad719955b5f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4446022-9134-45c6-bb58-b7a27696b416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24f3e454-8e14-4307-af4c-b8767213f69f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c57189dd-499b-42a1-b6fb-40bc90d3a310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_804162b3-4b87-423b-9dad-13464536caea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1eff0e72-3247-4107-9993-1298d21ecee5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bc82a1c-068d-4239-b014-3e770cd1c98f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e61e1ae-4fb7-4b1c-bf38-bb156bdb052b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_abc4c98f-3c84-4a3c-a195-03f724cce1e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53d5747b-9ebd-469e-a3e4-df8d5abb2c28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad5a88de-f5bf-4fa2-b3fc-510e9e8d3c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_64d83d6d-d0cd-4903-8112-392b2344dfb9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e85227f9-582b-468f-ae33-3c98845cd6db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a53cb408-2e26-4fa5-b28d-20627309624e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_86b5e424-cfe9-4df4-a2e0-2c9029f68f74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6137780-8fde-4ca3-91f1-64a5945e332b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_520b33bf-bad6-407f-a1a9-6f9105538d74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29d5088a-c14a-4618-ba86-5567efa2066b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7579990-1de5-4ca6-9653-82ccc5732f00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_095d7783-c130-45ad-917a-c2dd3768cb3e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c9b6315-c3b1-4e8e-a21f-67f978c07c5b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57779485-dd57-4100-859b-10cacc1c835f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_240ef7c2-1e73-4fcb-a83b-0d111cbf2e37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd5f3cad-2a76-4762-94ec-98a3c293daf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfdd1c93-6dfd-46b6-813b-0a5845e15134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a5be388-1f63-4417-9d57-f6a8d7f6c174">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0fa19015-6980-4456-aa50-cf912583bbcd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ab6db68-d9ef-4fab-9e9a-3375d6ecce58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9327214-7ce2-4fcb-8be7-d157202b62a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395280f8-b83c-4445-8d46-c5e5796fd2c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1cd39a2-57f4-477f-b935-966f5a9b061d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f20a0e2f-0b05-403c-981a-8b622394964e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f60585d4-e1ef-457a-85d5-a0cc458b1138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4f6fa4a-f388-4aca-a526-4034b8eaa0f6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fc3f67-b589-46aa-9a14-df1c38f536bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b901fad0-2935-4ad2-8c60-ca6f514d7ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c82adf2-700c-4e2d-8783-691c7eb0739e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a18a8468-b108-467a-865a-cc01df943616">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2c51b1a-fe39-428c-8e64-d34cca938997">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afe375c5-fa11-4fff-8684-c4c3797d88aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b864d96c-56d9-456e-abbc-339fb8a509a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e788d4bc-4664-4c67-bbbf-1e2b9efa5a73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad243881-6037-440f-9c2d-b0a9e64c6a64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0832547-0582-43c4-aec9-e5c9f203a373">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3edfd931-7c3a-46eb-aafd-7dd35d41352a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6efbdd1-ef1a-40c6-ac2d-27d367139d20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b902ca3b-88e7-4ccd-ae42-54fd37157ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1af658f5-3255-4bfb-93ea-05de03e79987">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d5e9708-d4db-4e19-aae8-90f09cd7929c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd656c03-02f2-49d2-8ac6-ad27bab92a22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf134a58-533c-41d9-9b3d-064ea328e676">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_36b31222-5177-44b2-8c7e-386051e7f428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0f32ce7-ec0d-45f2-83f0-a0de0b3f6667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36e242c4-596e-4412-9920-1ca45dfd68d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8cddec43-6655-4716-bf29-100b760b612f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7d2dad33-7520-4b06-bfe3-cebda9ee7513">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9815c625-a36f-4d07-b707-ec66d33859a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d0de5dd-fd98-4de6-bad1-e85580ba0e08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1c91801-83f7-4a77-956a-ca55e5d1e3a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ceaba128-fbcf-4166-9394-68d7f0ca3752">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b15b72d6-5cdb-4d59-9668-79ef523ce4f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8e480977-b24c-4952-a093-809cb4d24763">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5c1c711c-85e7-4fd5-be4a-ccff8eb4b5ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbb9371f-1a37-4003-b48a-8988d30d076c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5b42e1f-179a-4c97-bcee-364d1ff170ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ff6fe352-30e8-47cc-9b3f-0616a04687a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f677199a-7a7e-45a6-8b95-8237f459bc82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02e3ac29-d97f-43d1-b090-d6a871b884dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_601283cb-11d9-4caf-87c7-fdaed3433b0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_654a5c27-2a08-4691-8295-275e8d822171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77f5430e-044c-47e4-817b-bb82a39203cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00ecf5a0-0f32-4b79-8e19-ea08c4983582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af84eb50-6345-4236-85e1-0ec2f50a2809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dcbbc1f4-df6f-4356-a98d-e3b93cb2e392">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d404e4c-8304-4c93-8b97-ed2d89c816a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ca824ca-5d7f-41ff-a5ac-f3de76328507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e7f5a4b7-165d-4279-9faa-59831ac0e6a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f1c65454-d63d-47d1-ab82-933a498abc9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853b1603-5024-4c08-bca0-8e16defc3084">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_950ce21d-3058-4a86-8fc5-5c6da09dfd7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_087cf93a-9ea4-4c8a-9e45-9fc42acee0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92dd2c93-1279-472f-8d40-7e64631b28c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_84fe57a7-bdaa-4724-b43f-d941fb289764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e098bffa-f41b-4b69-a028-c4feab4acf86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4bac56f-597b-479b-b57b-b2aac2d58bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cac11f7-d0bf-44d0-8b8c-a10afa30e275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e44de395-9fb0-4220-ac41-10c9c37f6b98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea85bc90-6724-4580-b1e9-bc7626750460">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed8ba83b-973a-43bc-a272-e96e8cdf3621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e19b554-54eb-4aab-a6d2-7a770a88753a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736eee20-3b0c-44b1-b424-ab399710d6c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_010e4f03-e0d7-4cb8-bac6-98ac3f8de025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_042c4356-75cf-4e9b-891d-aa5d10db05cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_208fa1ec-4809-4807-9ec4-23588a1fb467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f657ecda-9d23-4a5a-9c0b-4fdf40cacee5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_523f1059-be27-4b98-818c-62a820e334d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a29f47d7-80e9-4691-8ada-76fc5c2f6bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53f12aec-e862-46fa-8bc0-4d0d0cfda200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69205394-a998-48be-b6b9-371c49e07ba0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d0b9c19-7f40-45d3-9f15-b20a17310fca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82888fdf-f683-41d7-a848-5279ecc53dcd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63289c77-5071-4fbb-ab73-7b68d4ab818f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8725834-bc02-4f24-a7d1-29c293e23121">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a226cea4-b1cf-4320-a67b-3bce18909a0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5ffb8a8d-d3c4-45db-97bf-b76c935dc4ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c8f602-8ba4-4b42-a483-280414838fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9634de15-4459-4e22-b5c5-17c70fde0999">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdec0538-30f7-4067-8987-308455db1f8c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a77b59ef-a76f-476c-babd-80ad5708e843">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0666e484-9392-43de-83ac-819c383b3a55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b81a42b8-e4e7-478e-ba0a-50a6e0d60e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3bb2f1c1-4602-4b78-b837-bb503c6934dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c551043-5d5a-4968-8a63-7f6a3b7132f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4637e379-f30c-4a31-84bd-ffd62fd2e46f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c03176f-cf7d-421f-9fa6-a1d8c92c4fe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aeb7f15-4f3d-4387-8586-53359e2c0bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c9b0c3f-561c-47b2-9629-81810731b547">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10641ef0-825e-4819-a601-f845fd541f49">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4649cd4e-eb8e-44c4-8cf4-8b52de8527b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cdc2941-1a71-46b8-a3f4-022f1702baab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5b696508-e2ab-434a-8d1b-b5f5cf48933d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1377b5e7-b31a-411f-a56d-254840d49146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5af16294-f0ff-4adc-9a35-fe26c735a205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7086329f-c75e-4401-bf18-c12448d0599c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da05ed8f-45bc-48dc-93a8-aaaea133cc93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_249cc69e-c3bf-4569-98df-982eb0b02755">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_519ff774-dfc3-4080-874f-8c6dffd4c9db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c12f960-6db8-403d-adc7-63d01d1f7b05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cda35508-43fc-4439-ab19-434bb3f04372">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acfad03-f47a-4c03-aae3-33bfb6afefe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a638d024-ed4a-41e5-929e-cb4854c84eee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fa30b0a-0b40-4e75-9fcf-a2cb760bdd7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1248a6-fecf-454c-967c-b71aeb1e0089">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_681ff111-c345-4c75-969a-1eb7a391a4e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_207f8550-12ba-4999-b92e-624be0b8dda4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f167c3c9-799a-4e7f-8bb7-32cf1b7b4f11">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a07ffd7-8004-4de8-9250-9c6429d6f865">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2875bd0e-b8e6-4ecb-a19f-cb48be23d6d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0c7a8c2c-1ae0-41ef-8239-2c3104922d12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83705ed0-b3f1-4918-9fbd-c8cc40df7d22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74e6e7cb-dc2a-4415-ae20-1573ff8836b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90663f13-bdea-49ae-9480-f45efa86e5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0eac8aa6-0f09-436a-8629-5f7028184b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65fa9ac4-a534-448f-8cd0-c38ac7424048">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ff2d05a-6222-4638-9733-1eef61762494">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6820822a-c4d6-4729-90de-29b9def7cf36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a93a36f6-3a25-4c76-9cd9-78c3d42fbdde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e472adfe-10a1-4a92-b3bd-7b5b5ed2486b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83cf789e-d6e9-41de-b519-aa03739f45f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6d58856-e665-4d79-98f5-afd84db54f69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784d6612-2600-4426-92e4-7027acffd95f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13896b4e-3e41-420f-b862-a0a3d21ceb96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_666c7a62-6e20-490a-a1c0-cbfb3c7436a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ff7ed84-33d3-43ab-8376-70a048059152">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14854eba-847f-49b3-8e20-ca94a2f5b9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a9b204ab-1f6e-425f-90cf-898fcd1a7407">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed504220-d7be-48d7-9805-32d3e3c0e5d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c227f1c0-e34a-4741-8d9f-fac803867ef7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb64a662-23fa-4075-9a28-e41e6adf1d71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2d83d0ac-c4b2-47de-a28e-ab512147e83d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7cda8444-ab66-4c14-87f1-12402e45c61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c737ad7-aec2-4180-a72f-d72e244d844a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_133ac243-cbba-47fe-9390-45cbdb008ccb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_872f7b3c-5276-4ce6-b962-0d8b25432d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_189e8e34-f99f-4574-9f08-b8b440464c4b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67cb191e-4133-42e0-add2-607ec93ac3bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb848d85-ce2a-4998-bc42-c56e2faaa553">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_992ea9eb-ce43-4464-a1d3-194fbc6b4ba3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677076a2-8d3d-4f6b-a22d-43b9d496a2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60eb085-3818-4f34-93dc-e7c38e532bfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c0b212b-ce81-4c15-929a-40cc841586ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc7d3b4-6640-49a4-bebd-48161c16bf96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_287c3a3a-9ab4-42be-abe8-142a3b70bf16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_277a94a1-0bcc-44ec-8db1-eb5021c13cab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5a7c9d0-d63d-4e0e-9bf5-95a77cf9cc84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e70d7203-74eb-4383-8a46-da218ed8dce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0614cd6-77e6-463b-98ec-e93ffcba4e75">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e905378-e9c1-4fca-b4a0-c5acf1066973">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99e9719d-ed7b-49f5-b9ed-f4ed85e139ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_37e88aeb-098a-41fc-9e1a-52baadb16798">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd243800-375f-4158-9a2e-e99a8b0a8977">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffc28114-bb4e-476b-9411-5930ed3c523d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acbd5f5d-d985-46d8-9b39-51c1ec77654c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a8f2b10-d625-4291-bbb2-c1fc90c3d4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f23c38bc-87bc-4431-9393-a0cc4d3170c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fa31a3b-1cdd-4926-98eb-7e35a81b18bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f3c2261-ef07-49ba-b884-bebd1494fb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b045d88-1984-4a69-bbf1-f50f6b1ed6ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38fd34c-89a5-4c12-84f2-09fbd8009033">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edbf147e-3aa0-4d6f-b4e9-39601d31597e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a58f4ab-dc05-48bb-9b39-3cb5f45fd2e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8bf36f7-97e0-42ad-864f-2f2edcb88bfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2323e83d-47dc-40de-a144-16eb4e03305b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3c11ea-49cb-4716-9818-5c12949903b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87f4fdd0-5e5d-42bf-97b2-4cff37d86182">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb9b8e19-399f-4574-822d-52b132b2a422">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02522a83-995b-4bcd-b3e9-375364be6b0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_798b3459-1bef-4fc3-8355-fdf9bf179a3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43a027cb-d98c-4ca4-9d54-5af8fe884f01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7c12a36-2bc3-4fab-9d03-d242fdc47304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95306b19-c314-4249-9726-7ef3f94e0d01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ca2305f-ff10-4b1d-b5ac-044bb4c10f74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_78b67db8-75de-4d10-a3d3-fd218675b991">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c76d6e4-2822-44a0-a623-695a0e7f9d3a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e202178-e806-4523-a1bd-f93869911a50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfe9440b-926f-4cce-bf8c-a8f6d487a36f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33626ba5-36b3-474a-a6c7-2c281ff87ec4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e6e2210-e273-4be6-95f9-5688af27f518">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ee8789c-7502-4fe5-90a1-6e73dc9c505e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6133f8b6-0bde-45e5-8f0f-028ebdcf5e51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ad218d74-0a8e-4012-8e2f-0e4b7a336d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c1e52ca-76a7-4811-a892-befb669f3507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_18fd6434-e78f-46b5-82c2-d3ebc9a988de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e648bb24-7214-4a6a-b0a5-a9fe6b8b61b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94d3e68e-9865-4ec2-b05e-248a8bdc3d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_101f17cf-add4-42aa-b827-9fcee3063868">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_93711071-4cf8-4adf-86ec-c6a32d98f266">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64cca2a6-8c18-4f0e-a042-fee853c9f2fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_180895e9-b096-458c-8c97-9c4a72ce7baf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f9420713-0860-41dd-8ba4-9afeb786243f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61f2d29b-5e0d-45e1-8dd8-d0420e496f28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71cfb5dc-ba9d-408e-b18a-81f2094e2f7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17ee7463-034c-4288-8bc7-137ac0a633f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1322195a-a94f-471d-97a1-36aaa5291e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01b1f9cb-d4c6-49b9-8308-a4fe08646434">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab4438b3-f56e-46e0-8d20-4e4129be3372">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f297db3a-e6df-4def-8490-9c3a9b21c27b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_890cc6c9-ad70-4730-a9b0-cdf9c5cac5ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8c6fcf8-d0e6-4535-a745-c08a0054f3ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dcba6d8b-5108-43ce-a5fc-b36e4b065d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52753638-c365-4f1c-81f0-f9fb6fb0d58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ba74212-2d31-402a-b2b0-f3634b0fb61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c87a5c7-5bef-41a5-962c-12bd1cf3d6a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2bf5b977-f2d6-46aa-a673-2f66e395b78b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef3a0e9c-40ac-4a1e-a041-86f72e7d5b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5e0a7a8-420f-4cff-b55b-e6e139165aa5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13ed373b-2943-4988-ad54-980c97b6289f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d6452b62-9209-4e95-b4c8-b3f87293609d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e679a526-99fb-4b23-b39c-566137ce3f75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8a4eb8a9-a1a9-4251-bf2b-4f8c975cf86e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a9bf8bd-6672-4e21-b8bb-e9e91f34e994">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_294557d1-3730-4819-8d03-96456f3fb912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e2daf53-4341-4911-980f-3022b8066b06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7fc0c8a-db70-4c61-b04e-6169c45e6742">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b83a5d31-4ee4-4219-98c9-aaf54ed1f572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_16af6b93-4e31-4e18-a77a-e4539fbbc6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_766b42c3-ce28-41e3-bbfc-786e84c88654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18029036-faee-43a5-8a1c-6439d7404892">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2d90918a-2664-43ab-ba72-50862a4cba1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5fc88920-3f1a-4427-8110-f4bc8a88aaf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1768cfd7-5909-4887-8b25-fc3e38b59dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0147f1f9-332e-4e9d-a8d9-e49d4605f776">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_866002ce-f7f8-46ce-921d-f83f33ee8d46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9226ad6a-e864-4c79-a107-ac6669389ece">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3fa8af05-471c-4f84-9804-2364ab4d0142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f8e378-97b4-4f9d-9b3f-be0fa08c737b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6abb7518-e189-477e-bebd-3b47fbf2925f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08dbcd9f-0cb1-478b-9d54-9251d09fd380">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6c00c6b-4fb8-42b9-aa43-be4aedf68d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395ebb43-da61-4761-9bd9-015b17860fc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b177b6cc-2918-4ee8-a5f2-bd619448a2ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c167ce0a-7228-4516-973a-d0267c640bbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9224a58f-f44c-4dad-95f9-d57b2f19fdfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_009bd855-5a73-40a8-b2db-4147028f51e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d617fbd2-7202-4dd8-8747-bcef9c2c5304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b667f9d-2ac9-4b00-b8ec-120472c203a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39552eb2-2347-493b-a342-36112dd61761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca73dc61-46db-48cd-b6ac-020490792c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12e678-c7ef-46bb-93dc-bd6c4fae421e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3635c9b3-b303-457e-8e50-6af4bf971c81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ed3d1d8-306c-4634-9e74-e55ce4231da4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5431f42a-4340-4948-81f8-b6dc1d46bd85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a549c145-0195-47ab-9ea4-77c6d452a452">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e8510213-3fae-44cd-8c15-4af0efd3142f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff76ff5b-f84d-4bfc-b06f-19f833592c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b52eaa-13cb-4ac3-a2e7-fced09e07ce7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9de60e0d-f60f-4269-b79b-392086bc26e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7954e8ef-e8fa-45c9-a1ed-cc05cb0e38a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11316af2-1bf8-40c3-a347-97344c20ad02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50f7ffe9-6211-4a14-a182-778413891848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_87540be5-5b92-4ea2-bc7d-5b3a26a87c91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f97ece6f-a45e-4473-8e6a-44a98b809134">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c02fc72-0dd4-4386-9b66-933757038c0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_867a6bed-e19c-48e8-a2f3-1926d9616bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02bf56b6-a3a2-4fab-bf0b-44e24794fd3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ecf22d39-597b-4818-b5a8-c31e0720bfc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ced36e4b-41e8-4728-b496-b75bab9931a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34ba3909-aa3e-4d0b-a427-063609b352eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf9be7ff-0016-4672-9459-a0b1516a2101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3227f4eb-27db-4eb2-969a-3af0b573b8be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_22693f43-01c5-4cc4-87d4-61d6b5fc763d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cd4e84e-7059-4b13-9285-4e8f4c356a2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6640ed22-d3ed-4ece-8619-61a1d5d51798">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e7ea311-332e-47d7-b933-6c6df5c31f77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bca5d88c-41fb-4e64-ae21-d1cc14551a8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ab93ba3-8eef-4341-82ab-71ab7e39fa30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e6e188b5-450f-4a43-86af-ba5bcfd661ee">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2bcad28-b999-4f20-bacd-724c9f78c298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cdca876b-026f-48e4-8bef-c9b1dcf12eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9c318374-62a4-4ff7-9cb1-d9a784db08dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca11ec26-3b01-4bf9-84db-24ac4f0248d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8705133d-cdf1-4be9-b24f-e9b2e676a388">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b540bd1e-385f-4dbb-9e2b-56ddb1eb21d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a47fb97d-2d7b-4251-9f17-312b1e07eac5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18a57444-1e35-48a3-a599-55c7a6e7af15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebe2f330-1adb-431a-aeee-4a6a21167603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4c70b357-5014-42b6-a0ee-fec1c2469a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a01662c5-96de-418f-91a5-b16db1b66c81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_87c006b7-bb18-4a80-80da-0eb053d7b15a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f276409-96e1-405c-9e75-4d9fccc8bf87">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_034ec4b5-bd8c-4a92-99a2-1f730be3f002">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bfc273d8-d57c-4ca6-a117-69a5e0ecb2d6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_392cef6c-b0ef-4cb7-a61b-d92b77e1f8b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82bd5ada-01e6-4702-b2bc-43685a564dca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0203b79-c207-44ec-a455-1076786151ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2957eef7-ef17-4284-8b72-885290a5d4c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb554827-e2b3-4174-8618-2fac9fb13cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68ca1c46-e3bc-4281-a44c-882106869b58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_081ff2d8-2c7f-4dea-b78a-d67d6abc4db8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d02ad0d1-25fe-4737-9c11-d7409abb063b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8be185ca-2d62-4f9c-8e1e-caab88cc2025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9664ae2d-68fa-4059-9ffb-473fe2c0cd86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9284884-794f-4ee0-8ef3-402a142e0bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857587f3-78c0-4084-ad11-e09272976390">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_432d7e6b-c2e8-444f-b028-b234d1ef1e88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a5b57d1-932a-4f96-8583-89781b773ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf0a0c29-48a3-41b7-bf37-d440fd41eba2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a7e0964-17b7-46d6-8d1a-268c8cdf3e64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23d6d5b0-ace1-4f4b-865e-5a827364f543">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ef890e7-a6b1-4294-85e1-3fb193760bde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb9c11-e256-4e10-8312-fdfe2385c71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc21f7b2-afe6-482f-af4f-92fd14b5abfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad6c979f-657b-4e73-ba68-257d15d08a72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9990ad7d-38f1-4620-b15c-019273d58f41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c87e7e5-b2a7-40c8-98fb-101f3db6c73e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b79df498-dcfe-4fa8-b694-04d76cfe87b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a676aa7-4dd9-446d-986d-794ce499f297">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f1f0e9e5-3f7f-4a7a-b8e0-3dad27794a06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e9770c9-db90-45bf-84af-be3839c382c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7565f8a-903e-4b04-91ee-dce04a6097a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2eb48637-02e4-4857-bf33-7421a2bd903e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5cbe4d57-0c5a-4e3d-8104-c43f35f3b8c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe00b674-5c44-4794-9a2b-525f35f7f13a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_038e4bd6-fe6e-48cd-8b3b-8617fcf53b16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b8f4ab56-0cae-479f-b994-a089285bf453">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fc5009-d32e-48a7-8fa4-0a892b95543d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f170f287-d4c0-4aa8-bb8a-be6a691759fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1173766-06ad-455b-8adf-663574665ef2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbde89f5-f08e-478a-8a73-f1203842d380">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26c96fbe-07bb-454b-bafe-0b66e0d91779">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66f5f987-6746-4ddf-8291-e079aae6f88f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d1abd8a-4a75-450b-9814-efee70c1f00e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7203f60-7692-4edd-919e-212721c83323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_314d2ba4-7d01-4433-866f-7ed52d8c266f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e1c9ddf7-9f1e-46a2-b210-fcc7a90dd361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e781a75-395c-4675-b1c9-8090f7136a9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d88cc96-bf93-4569-aaa9-b85447f5d6b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5e012982-8c5b-49fe-a915-9984a9844629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99f7bda1-69e0-474c-b2ef-27c28b95a477">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21a9a1e4-817d-4f3c-a06a-88c050bd8a01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a461b809-62d4-448d-8596-070fbc82bcd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88c1f50f-7065-428a-a48e-3955c95e0a83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3633500c-289a-447f-84ea-ee2adf5d8f06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0fb79a27-0296-460e-96bf-344c9748e998">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_320e4ca8-bc24-41ca-89e8-88fb69a20780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d52c596-f3b5-4ce2-ad1f-c662b2590caf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0c87d80-0936-4412-8a9b-c023ac69a7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46f656f6-4f2e-402e-93de-2f4de8fe6b6b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_86fe6bb9-d204-429d-8827-606b790a951a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65a6018d-1102-48c8-bad8-c5a8effaff81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fb4c745-f703-47ce-8de2-bfbbcaeaafc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc383940-5969-4abf-92be-59f7730681f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a02474-3467-4c31-80c7-4c1d43af0cbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1e7c81ed-90ef-4fff-9d64-df1dbba18891">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_270bc494-7c22-455b-a3e0-e1c31732dfc0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0da6b145-a096-4b6a-8359-91e83a938787">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ef5af20-1c4b-49a2-8110-1d688fa10a75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b698233d-7707-4afc-a8c4-ef3860860220">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2d5eb8c-d2e4-461a-a3c6-af74b86875b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_067b340d-de06-4c93-b738-322c9e63f326">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_884b6d2f-b17f-47ab-b894-29709041ea27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_175d59cd-5dbb-4625-981c-cb434b49c02e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7701a0d-bdd9-4f72-b55d-db2c6b054614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b1fe23e9-b568-46d1-9b05-3976637f31cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aab9f87e-3481-4ad1-9af4-85bab1baad21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc158be9-9c3d-46f8-894a-bfda40b4e8d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a8f056b-8c01-4df9-9819-6fb78eee91e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d3637a3-ce8e-4969-a955-19e3a93f2460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb458537-8f24-43a4-9114-692c0daec131">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e806f44d-97f4-44e3-8726-a61f5883335b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a7c0188-4d39-4dd3-8004-9b473b22b3b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f71a10a7-44bc-463d-abb6-e483dc630541">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2e8ced2-7ebb-4a01-a1e4-55f059b92fa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2f6cea0-e313-41ad-96f5-87800121a518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ad72c6b-d938-497c-8618-859b5d3e5884">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f1cf396-8d86-4e6f-a52d-e1af86772ceb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3251f608-0688-4dc4-9dc8-e3091bdac7ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8fd3fc61-31a0-43bd-b0c6-cafdd829679a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fbbd787-319f-444d-a059-3a5536c03ff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b7f797d-4bd2-4df1-9cc2-a888aec7662d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d2eb25c9-57ff-4877-a01d-57ad4b5ad6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f8d3ac3-bcdf-4d13-afbf-63bf24e38d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1342fe65-f28a-4ae6-97ac-46ffc8b6ea76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b546ffa7-d00d-44d4-b9b0-f2a6dc043c97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486326b9-4614-40ef-b499-57360c1454e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65e01f10-db8a-405d-96f2-ecb2436ea1bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173fb145-6c85-4837-8c26-642a031183cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39748ac4-8994-41ef-86ad-aa593876e300">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8feab797-7f0e-4657-8282-79c8b499523a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5838d0b-841c-4085-876f-1356e29461b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66238552-d9de-4b1b-9b46-7f3d2f028039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce8a387e-0ea0-425c-ac7a-1e5dbe93e6f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_28e4a7ba-04a3-4c8e-9d98-9b47f86b7ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dff8a9f5-f6be-4746-a6cf-9e0fb46ef3a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dd48faee-7455-4f0f-8f4a-77e7491becc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50ef0e35-d57a-446f-a4d2-2c9554e2d57e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e0f1d46-62c3-4360-90a8-bff00e7cf60e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b424c2b7-3a7f-497f-80c7-0a30f96676fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a833d30d-19f5-4e6b-9f91-19343a3ef516">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95506cd3-1c3d-4793-89f9-65cb4c8dbe8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3991ca5b-3c5e-4b1e-a604-17fc2269d13b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0b6e1d-6cc9-4cc1-91eb-2548f3a71765">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df182f4d-e0de-492d-a328-0043b36cc033">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21bf0113-445f-4a34-9358-bf53c533c485">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80a0e5c9-61fa-4204-b743-9351bb56ed69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_632eb5a9-9e2d-4eaa-a7b2-00d881f0b85a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b386a96a-0e25-40f1-acd0-e6db2ead045b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10196086-9e19-44bb-b597-102575b853e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b6bb26-e66c-4d36-b242-8da8298dfbcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_40fa729e-1cbc-40e8-9150-07e62aeff0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b2ae2b3-068b-4f40-b89c-183060300298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_233b7c4f-1118-4246-b7b4-8ffb83cea2d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47c6c1b2-0598-4985-ac70-ea6696ec5bc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec420356-2092-46dd-bd46-319011559d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffdebe6f-5731-427d-a69f-bb6a72a5842c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b6b8c7a-4fe0-488e-a01a-1e14170230d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_516c7e02-238e-4cd1-9e09-495bdeb37206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ca2a83-900c-40db-b703-573ca798e017">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2026e7a-6ae4-4e02-9429-3d7c0044c104">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_16daa926-0bcb-48ee-9fbd-f92fda0d41f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0d4db3-6da2-4152-bef0-416b2d5b0f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c08f3b3b-a1c8-409a-90e4-8a48873e7d62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c9829-f820-487d-9ff7-f9d743f2bc6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01815773-3d66-4ea9-a4b5-7e3bc5e21bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11eb003e-8feb-491c-aab0-f4290351e574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3fc6d901-d47c-45b8-932c-9503f5e191e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_346ad448-e260-4eb5-ad22-909cf41d55e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0aa15e9b-4db7-4647-80f3-6faffbbed9af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e186c8cf-20ad-49f0-8181-cebfb9de7644">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2695dfad-50df-46b7-a2f9-455baf0a39eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ccb801e0-67da-49ea-9ae8-eb6b74fd3796">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_518c2ad8-6722-49fb-aeba-027b9834fa12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_768736df-6aba-4013-a7fe-5a4d2415efc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c98ae667-4b00-438c-a4e8-11eaac1449fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aa48cfef-d128-4b07-a145-71146779f621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dad66b7c-ead5-4597-b4bf-97239b0854d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_571e8263-08c1-4586-a8e7-327d1f5ff2be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c344c2f7-1f7a-485e-ba0d-980abab192a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac2bbd87-5d42-4fff-967c-30d4052d4a0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d381ddfa-6e11-4efa-b898-c5d0ecdda246">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a14bcea2-8848-4ed2-8671-6e9c1db7b38f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7eee8ba0-c290-4cc6-9b99-cc978ad4a55f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b660b46b-f89e-44ba-a2f2-5f7ce2e38699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f5a225e-9d00-494d-90ec-44352d98d4e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ba7b635c-3031-40ea-8907-63881e80b42c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c94e6b68-da6c-43d1-94fd-09ad60c74134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6fc20583-c9d8-48f1-833c-e332515ccb72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ff1d968-f352-433c-91e4-2086b875b068">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f57e0ec-227b-48ba-8a55-8b1792a44c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4caf17b-3b80-4f50-84cf-3c9800262e53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_750abbc2-9c8f-478b-967e-5bca6ccb6649">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d877c8a9-ebf3-4468-9bf5-bd35e802914d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dbdb1b4-0575-43d8-ac61-faf72cb621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1b858452-c35d-428a-8b4b-90f21ad07836">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa7083b1-1a9b-4973-84b9-df7487d7f4aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4462db5-e42e-40fb-827a-196a16d123c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df2d3e44-0edf-416c-98ab-3efbaf98a66c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_64b2c7d7-d7b7-4c1c-9f86-b1adea0698d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2f1d3e-8f67-47c6-8e9a-dbd477da2acb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b75cd36a-7f05-4fe3-af88-ff32fe39e6dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0897b098-e2d5-483b-a708-28f47c435413">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc31b2ff-8ba5-43f8-947a-2f11dd26492b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69d4e272-32f2-46ff-a0ee-95358129563a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe46cdb5-2ea1-4fcb-b508-6ca5aa09db3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69d1ccd2-3730-4278-99bf-9ca956be4401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa397ea5-dffe-475a-86f9-d00d21ac01e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25cee9f9-9bef-42be-b860-ab3beead7814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f441e1ff-6bae-4314-98bd-5b1689de1b2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ada9951-1e02-4889-8745-f13dc4148ad6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed408729-5a92-4002-8a8f-ae384ce3620a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_688fc72b-057d-4a98-98c3-f962aeaa22d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_347aaee1-bd55-40a5-99e9-fa9bdc3a9ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3e50ea0b-e624-4ac7-8e6a-29876963b392">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6f1e5e9-d979-47a3-83d4-817003628745">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5318967-afcc-4fcc-b0de-d5f2522a95a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8082da6f-11ee-4cba-96f9-5258414b720d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e704656-b276-46da-b8cc-b757bc42fabb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e9f91b69-a29b-44ea-aa0f-cff86ee80320">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5adebd33-20e8-4c94-b02c-d9033c3a891a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad86e83d-6334-4dd8-b642-b4c16d65329a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c96e50b9-ea15-4421-b6c8-bd9c9158a69a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f43dae36-6df4-46ba-9dc2-01543e80e0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b8b0b9a9-af8b-41d2-a4f8-940637e63f70">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b345e74a-9570-4cb9-9a59-928390e3dc44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17abdb92-0180-4bcf-8ae7-dd923630f360">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0b78ffaa-9859-4658-af17-c8d355633556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9acb676e-054f-4e61-b60d-3371c3320b52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9315b98-af75-40bb-bf8e-05bd03d43db5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9dfeeaef-5c49-4c2c-97b1-03876970bee4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36d76f23-8e75-492b-8f9d-4d68d2dab71c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6a076be-4135-4592-85cf-1f22fb0528a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6fcfb68-394c-4c29-9cef-9e41fdeeee26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_420cad1e-e8fd-47fc-a747-b9032181f6c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b664adb-6099-4a04-a498-dc33ba0fd5b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39cf2a82-5f62-4cef-9bd1-1af4f783291a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7eaeea7-ce64-4a47-86ac-0eec8c65c8aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fa594a2-56ff-41fa-aaf3-c9491755b684">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00865800-7a32-4d63-91f6-88217af4743d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0b0cafd-9ee4-41aa-ad86-965a7e4a00bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_287ea6e7-a365-4038-b8d7-d7f01677255b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd5768e1-dc34-4e62-b9ed-bc8ffcdc0000">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f383c35-5d1f-410b-a60d-d67e1f48f646">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_679919d3-fc46-4791-b7d8-8a87d0bfbb91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_835c00ee-21be-46df-98ff-e6cc1cfabd3c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0434708a-79d9-4740-b697-2bfbd525260d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed1043ac-f6fb-4f30-8a2f-177e4fdcb26b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cafaa7fd-26d1-4609-8186-f9af8022be4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d43e0f0a-5253-41b4-9e43-ef864af5b857">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3d02781-552d-4bbd-952c-f753034b5ece">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46c8e67a-37d6-4498-a6e1-148ad0fcf682">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74a95e4a-dc88-479c-8aa2-fc194cc595ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d27fc6e-5da0-4d89-8d93-8bbee127638d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_17cb9e95-1fb1-4fad-95bc-9cb4cb1eabd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a6b0d1-4103-414f-98f3-14009ce91e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1286c4ed-c414-4282-af59-91af27cb856c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b591b30-bfd2-49b3-9bd5-4eb808638a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38733a74-2927-4247-8fe6-065cd9fdf7de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abe5f6b0-6e09-41d8-b326-685828bb5fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57e7e6c3-e0a6-4ac3-a0e3-392e749b3dd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40d166e5-8a94-461c-96be-c7b40c9b0c26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_159904f5-dc85-438e-adb2-0f7accdab22e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2eb9abb5-9566-4c1c-9e11-c2f6ee115cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba08c29-26cc-4706-ac27-26692aac8c88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c7d6536-ea8d-4b7b-be12-6be542b1db2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d62d7e5-64c4-4d08-8a84-543433b71491">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff03ac62-f2e0-4beb-a79e-447a8dbcf53c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b729ff6-e8d4-40a8-a250-8546f9d43ff9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d917556d-7af8-4d62-912f-cee8779b78ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57df35dc-cdbf-498c-a3d5-7f5da2618ba2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3e47bb0d-8a7d-4e68-bab4-e4b55c2be04c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_09b5337b-759c-4cda-b09e-fc2131692bfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6554fd18-1d49-48eb-88d8-289134c6e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1baf8007-34b4-410a-bd34-21ba83f132e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ea887338-df13-41c6-81c8-10ddf6501626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dbf3737-7c17-4e23-b698-a6231fc95c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cf25bb9-e5be-466a-9eda-76d00e20aead">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_181c1a17-a777-4729-8e13-5d427ad49c94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7bad0622-8a66-4e8c-ad40-dc0a25bf0123">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73e5d2d1-d756-4b50-8069-e663130f1816">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6296a5-b265-47cf-b634-c8e0e8fff1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90364382-c1c6-4471-850f-7ebf7e718070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3ba7162-1168-4478-97a5-1f522aab0b8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34818fdb-09a6-4567-be70-0bfe57e6cba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dea346f3-01e8-4b63-bbe3-5aeea6ea9129">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0e08d7a-7d6a-4cb3-8a77-447b121443cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d8569a51-3dcb-49ee-95e1-193d570db5be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ccffd22-4277-4a42-9dc9-86b270a0f291">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e8f404b-ad7e-4684-bc52-e3464e34ee79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fa3678ca-1dd0-4be0-aac6-a5cf857e7d60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19bb3455-dba7-4049-8350-9fc3c29ff4cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4274888e-6e49-4d9e-9563-b483331f8424">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80fa1756-f607-4448-ad06-dd7b5e69ec38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ac383d2-d853-4b4e-b0af-171813d0b7aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff8e4c1c-ad07-489e-ba11-43217dd68dad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8d3d915-6065-4890-943e-4cf5c69a97a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_563b8841-aa4b-4bf2-a54f-8f069829f070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f1203b6-43c0-44bf-ba48-25564bbefef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57a42edc-5e05-4604-b596-f01ab114f5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd023497-58d7-4396-8f9d-a9bd364f8c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45d740ad-e86f-40d0-9008-fd671acbef6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33c8f510-825b-4689-a374-f96650937c33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe2c5d47-fa92-41ec-b454-3cb1c878437e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9f2dc0-6618-4f8f-a284-22aa15d23fb7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cfe03e9-7d00-4eb7-be53-4b443d69703a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a26ae26e-b636-4503-ab26-2f5946d511a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0759a425-647a-4247-b66b-26357a147542">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6ae1641-50f7-45be-9833-bf04ddcf7697">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6cc414f9-05d7-45a2-a19e-958faed12395">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eda4be62-674c-4d62-bec3-33bf3bdd6294">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a241b4fe-ce93-46b3-ba20-126ed4574adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fdad08-fd5a-4f4a-8ae4-296ea3184087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0d653c1-85b7-4edb-b412-90836f207efd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a897e54e-1f4e-49f0-a8b8-d1b79c28413a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b3d8eb66-45fc-4b9c-9206-5b87bd362315">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bffd0293-189f-4b46-9e82-f8951326d01d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bda2a584-06ba-4aa3-8af1-945d6ad9829d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b37c45-5751-4c50-862e-d2f811623bd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e9f123e-b540-4391-833f-84e5f9b7e63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8911f118-6ed7-4424-b8e1-a6885482ddbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3da39f62-762a-4533-9485-f1849e5f8812">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dffdb415-95a8-496a-ad1a-93cdeb444fae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7ed6624-d332-4a9a-a96b-b31bcb1ef24c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccb6edb-253e-4e1d-85da-c68ef40f59a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa063f2e-1205-4d1a-a549-3ccc5b31e65d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_443775ac-c8ba-4e4d-a91f-d1926ba21744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ef85f09-3622-4a12-87bf-fefcecc01e4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28b3e895-483c-478d-a5a3-7b9d7c9e11f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a0244ab3-80e5-4c20-b201-a142d50e6ec1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c8e0d41-008e-48dc-af1e-e988941e71ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0ba9bc8-9cb8-41f9-be4e-a8f6184e1432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4e958ea-f50c-472b-8c35-9b2a606d4310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d0edeee-fb82-46ff-9ad7-8937813fd4a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf4393c0-21c2-4e35-b330-c1acda2647ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_72627757-688f-4752-a751-c9e2bd554d2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3d5e8cc-be34-4d4a-a586-ce582737826b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10180352-5b41-43e5-8bab-bbd40fc3053b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10313794-08ff-4455-90e6-a439d474d0ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_22ac1bc2-c0f8-4d04-897f-c24e25f28f4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aad73b40-3e9c-40ac-834d-4c0243a5c334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f492ecb1-1a65-4013-99f8-49edc9d7d556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_307df982-5918-4ad2-8c83-1cbc9b7906ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31cfec00-6695-4126-b60a-98c4cd7132e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cf36442f-8f07-4110-aecd-1c7124608dd2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53e398ff-d48d-4e1b-acf0-be0965777d35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4615f36c-51ee-4eb0-945c-d57636d7fbb3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_db7be977-a065-4bb0-8b27-d44e0a6cac16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c3bbfbe-faab-4429-8c29-799f941f9add">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed71bbb4-203f-42dc-8a01-e3b144ea8ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_54cc9d2a-325e-4545-a35c-d322e006a8d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5731482a-7053-4716-866b-ab26f39cad97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aea5de0b-5724-497a-b712-f813e6c55462">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_350e99eb-81c8-4938-9014-f14d16cc0989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a83373ad-d7a8-400b-9d4d-cf7a0dac3d73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_030a749a-f8db-4c51-a67f-571efd180ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fe0f5c1-8319-4dc7-ac10-643c4d4ac0c4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3105ff97-c823-4905-b049-f467bc8e0810">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d4658ae-163f-40e5-ab58-754de44a9565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f655fe14-241f-462d-9fb3-a58dd791a31b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_97da8dc3-3290-45e8-92ae-a01611dc0b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_513211dc-4e13-49b8-b8f9-8a062e6136e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bdb83ed-36d7-4e74-9e77-1237f7695622">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f605145-f6fd-4665-9672-8fef199d1592">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e8c477a-837a-416a-8283-44318182f678">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47b201ba-930a-423f-b4be-a71805471077">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4bae3a8-84d1-40fd-b83c-a9bf8c206d9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c6145b2-effe-4953-9f32-2e49388dca38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fbbaea94-c6b8-4492-99c4-08893180b6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4decc4c0-9950-4fdc-8682-dca579e200cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f851b27-33f3-45f3-aefb-2c134479e2ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b061adbe-26eb-4721-a6c9-e78026e0f915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b79434bc-5187-4184-a806-7a39037a7640">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b395e7f-bd27-41ce-a590-eeb60a5f502b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee96be74-4d86-4eb1-9150-2d594bfcfe1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d08a684-cdcb-484a-a767-03b10f4ada7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb24cba-8dff-4ef9-9ba5-dbdb086e77e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_706e83b8-c1de-43d0-bafd-57766513c62e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f468d841-1bf6-470e-85d4-55d34fab8bff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a78dbd51-f64b-4abf-9154-3c138316e279">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90c04b95-703a-4bae-82b8-7edf3075aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f193bd8f-badf-4600-82ac-f212d1f33534">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_340082f1-db9c-446d-97df-80e45aa0058b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e33fc23-0e6a-411e-b0eb-67b1271cf383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89c3d444-cf42-4e48-9825-96160ba9895f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71f8df70-c805-42fc-9a09-c9527e6f8175">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_09c871ac-e7a9-40ac-9580-ed616b994397">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6a25879-018d-46a3-82a7-81b9b99b609c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf08be5d-b85e-46be-9378-6eb35540e070">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6398ff9b-368e-4aa0-9a7b-8d9a2d095835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a94e93-5272-46b4-85ed-7a173200852f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e87b2c5-e7b5-428a-b836-5e55a23693a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05d6e5c3-2268-437e-829c-9e9107a18dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7951c520-ccd7-46b8-a3a5-fd879cd12257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6adbd31d-0c80-48ec-84d6-000aac8d9a85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:ControlArea rdf:about="#_1f9ecd81-e069-4040-bd64-f34b0fac3a60">
+    <cim:ControlArea.netInterchange>210</cim:ControlArea.netInterchange>
+  </cim:ControlArea>
+    <cim:Terminal rdf:about="#_65a95678-1819-43cd-94d2-a03756822725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c96df9d-39fa-46fe-a424-7b3e50184f79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c6a1e49-17b2-46fc-8e32-c95dec33eba8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_unexpected_unexpected/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/conformity-modified/cas-1.1.3-data-4.0.3/SmallGrid/HVDC_lcc_unexpected_unexpected/SmallGridTestConfiguration_HVDC_SSH_v3.0.0.xml
@@ -1,0 +1,12953 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:5bc75f63-85bc-d020-02d8-1d9358dae159">
+    <md:Model.scenarioTime>2030-01-02T09:00:00</md:Model.scenarioTime>
+    <md:Model.created>2014-10-22T09:01:25.830</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment: Small Grid HVDC Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E "as it is". To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.version>4</md:Model.version>
+	<md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://GB/Planning/ENTSOE/2</md:Model.modelingAuthoritySet>
+    <md:Model.DependentOn rdf:resource="urn:uuid:a97cec76-42cc-bf53-2269-4f5abcce7244" />
+	<md:Model.Supersedes rdf:resource="urn:uuid:2fea4dd9-083b-f2b0-7b57-568efb25ccf9"/>
+  </md:FullModel>
+  <cim:ACDCConverterDCTerminal rdf:about="#_7780ec9e-6743-4c53-aac2-f123637d5274">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_c4af08e0-9608-4654-b74f-e359a7a29dfc">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_0193405c-4f37-421a-b7e6-9c4a8904eaf8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_9b40dc62-2c36-4b70-b931-db436ddb3fad">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_412aed14-a85f-4828-a751-221172c48263">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_61a0a556-ae4c-42a0-bda3-7423cea7e6ff">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_e4b9540a-1a8c-4f8b-a8a5-b7c0dc0d1df8">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:ACDCConverterDCTerminal rdf:about="#_3844652e-cd36-43e8-9e90-a1bbe2d85dfa">
+  	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:ACDCConverterDCTerminal>
+  <cim:DCTerminal rdf:about="#_a03cc8fb-fe85-4a7e-b96e-5c074abed705">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_e768024e-1c0c-4c0f-b023-5deb11d64dfc">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_5be89c2c-b370-46ce-8844-338414489fb3">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_d2dac22c-7798-4a59-b5db-3e4fd307abda">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_6bc9072c-735e-4016-9ae8-acc2d37f1fba">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_02d46e89-85fe-4756-aeb5-4869950f8776">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_bbc66594-69da-46d5-9a1b-2f4a706fb6a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:DCTerminal rdf:about="#_600ea926-a53e-4f42-92b1-aa10bfeb79a5">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:DCTerminal>
+  <cim:Terminal rdf:about="#_0471bd25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04682030-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe868-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0470d2c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0237-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667281-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0234-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c4474-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a1673-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc79-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500450-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bfb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640186-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04776270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04619088-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d8a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce94-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04814d86-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465fd54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e431-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d851-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893cc3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047c6b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b148-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453add6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459a142-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d98e6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801509-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04597a34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828605-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464289a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c633-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc426-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0661-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465af34-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04860874-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500454-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505274-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472a784-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452c378-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2b7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b5fa2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e12-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd35-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0447c6f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812675-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e2a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04773b69-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b092-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc82-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459c855-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483706b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c33c9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4da-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04507980-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3891-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481514-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f00-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab84b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c33-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452ea84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b202-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f9fd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046cb413-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04801506-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454e651-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046735d6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492681-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662461-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865694-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e193a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1184-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745537-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472f5a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837060-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c8772-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0450798a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684744-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea71-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455347a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479ac63-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04636547-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048aea76-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b47-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b978a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04828601-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b207-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2947-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725960-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b55-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481c2ba-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04481517-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a3c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046030f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04605808-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a2194-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cae80-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048badc2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04690a98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04716f08-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf53-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04795e46-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04719611-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047abdd8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04885261-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04878f1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c4a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044bbe98-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e224-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04505270-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531190-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a4e31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed161-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0473b8f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04686e5b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b366-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f94b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b095-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e0e18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c906-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0467f924-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04544a16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0459ef61-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837069-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cdb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468e383-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500455-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455d0b2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f01-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04675ce4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04656113-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9786-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04845acb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04880440-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e227-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745535-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a7548-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a10e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04793738-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460f444-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d2949-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453fbf5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046512f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487b620-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a6a26-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04854522-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549834-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb43-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04837066-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2ea-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e13a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a96c7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04725965-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b9785-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7600-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04720b44-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457f391-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044afb42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531198-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0475188b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04561ed6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c877a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b066b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047ae4e0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614262-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04834957-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765105-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d379-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046205b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485452a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479fa89-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f8f24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04611b58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ca8f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb1b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ef879-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04649dc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04887972-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492680-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c5ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477feb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab848-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4040-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e436-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0233-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c17d3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479102b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d645-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04670ec2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d7a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ed6fa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449e9d9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04865695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045338a4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b5484-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04798557-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045ed164-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8348-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b0bf2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04642899-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a6fbb-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466e7b5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b4ef6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045386c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046f4c22-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046fe865-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461697a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04742e24-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b0668-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480d856-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478e91a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c56-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d5054-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f0395-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04483c21-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d0238-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fbbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bf65b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046931a0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04806320-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04638c58-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f4103-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047a48a1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b5a14-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b1180-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044974a9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04616975-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04723258-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482860a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04789af1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044778d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492688-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047cb9a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461dea7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047629f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f017-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047120e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486336-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047f51b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04558294-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471bd29-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04808a30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04529c66-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04753f92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c22f6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c65f2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d910-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04667287-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04518afa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047602e5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a5f07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046958b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048ac362-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d294a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04662468-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045115c2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0455f7c6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6817-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047dcb17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04640181-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047df222-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04479fe9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9139-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3895-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04817494-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451d915-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d2ed5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448d862-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0456e225-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531196-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b792-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4317-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d10-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a623-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf49-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048915b0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0468bc78-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04812676-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a2722-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570934-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b3894-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044be5a2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044a37f0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0453d4e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044f6811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b36a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045a3d83-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046adf57-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04745533-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046b2d74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046eafe5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044b2254-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04803c1c-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463b364-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048c7110-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0452755a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e8e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840ca7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489d905-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce92-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04633e38-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b7606-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477d7a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ab846-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a4316-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c30-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b84-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522732-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048719e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047eb572-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046ba2a5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0460a627-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd36-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04840caa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045cd594-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045fe2d8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04697fc0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047147f3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045bc428-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e67-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8340-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04736ad5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04758db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048b86b4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476c638-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044aad27-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b209-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04893ccc-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e8346-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047bcf48-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047084aa-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04607f19-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ef2e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04500452-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048a754b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04627ae0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480ff6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04542305-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04747c42-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047d7cf3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483be81-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474553a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e75-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481749a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d1e25-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04614268-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e3ab3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046a9138-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046e88d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4693-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b27e3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045d71d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04592c18-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04731cb7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047da403-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480b140-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e6758-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045c1240-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486334-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522734-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046efe07-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f70-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045841b9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0480150a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0448ff77-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04522737-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04784cd2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04570939-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b51-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046476b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04502b62-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04492686-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04590500-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04486337-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631ccc1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474f17b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0463654a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04700f74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0488eeab-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0479d376-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464ebe7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0464c4d5-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04765100-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3307-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04767811-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045b9d17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047b3303-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0472ce97-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045868c4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04882b59-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d5-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046d9e74-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044ecbda-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0481e9c0-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04622cc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0451b205-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04555b85-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0471e432-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044d4536-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0487dd31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0461b799-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0483e592-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0482ad17-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047fc6e2-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04531191-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0485ba54-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0486cbc1-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454bf45-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5631f3d1-d9d2-11e2-bb49-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0454983a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0457cc88-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048433b8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044e7db6-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04549830-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462c902-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045e5c31-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_047e4047-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0465d641-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045163e8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0474ca6b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045645e4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0478c20a-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0462f018-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0476ed4b-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0466c0a7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_046c8d06-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0477b094-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04494d96-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0489b1f7-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04513cd3-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045dbff8-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04577e64-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_044c0cb9-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04851e16-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_045f4695-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_048481d4-c766-11e1-8775-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:about="#_0448d86a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044bbe92-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>16</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044d1e22-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04819ba4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>46</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048433b6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ca8f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854525-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f08-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047fedf2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476781a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0477627b-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04697fc9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>90</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0481c2b3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448d863-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>61</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>28</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04747c44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>130</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047e1936-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cae82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>48</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045b00d5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>62</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046efe03-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>71</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b89-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0447ee05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94b4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048bfbe0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ea4c0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>52</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e4a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046205b5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>7</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048b5fa5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>70</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b7b95-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>15</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04716f06-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0483be82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>31</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046d0232-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>6</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453d4e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb44-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>113</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>32</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044aad24-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a219a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0489b1f2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04798556-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>277</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>113</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>33</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047abdd7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04791028-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04817492-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f94ba-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>23</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044ecbd1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>2</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0463da70-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>25</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>13</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047b0bf0-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0461b790-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046b0665-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>38</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04689566-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>9</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04547126-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>77</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>14</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044a5f05-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>54</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04812679-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>14</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04742e27-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2257-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>15</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0466246a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>16</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04488a49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048740f1-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>47</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047d7cf6-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>24</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044b2251-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047dcb12-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>18</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046adf5a-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>8</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0476ed42-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>13</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045c8777-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>85</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04854520-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>59</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04778989-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>27</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>11</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045cfca7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>23</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0479fa87-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>45</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>25</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0449e9d7-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>53</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0451d918-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>42</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0482fb36-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045dbff2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>66</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>20</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0484cffb-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>26</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0448b150-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>43</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04867dab-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04481515-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>68</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>36</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_048a9c51-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04524e46-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>11</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0485e168-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>20</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>9</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044afb49-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>21</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046c3ee3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>34</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045f6da2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>60</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>34</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c0cb3-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>5</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04555b82-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>78</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0458ddf4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>65</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04682035-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>39</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04887973-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>5</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045645e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>51</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>27</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0474f170-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>12</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046a4319-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>19</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>2</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045d4ac9-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>31</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>17</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044c81e4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>42</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0462c904-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>22</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_045163e2-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>87</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>30</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_046dc585-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>17</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>4</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_04566cf5-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>37</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_047a48a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>30</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>12</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0453add4-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>28</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>7</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_0450a093-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>84</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>18</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_044974a8-c766-11e1-8775-005056c00008">
+    <cim:EnergyConsumer.p>63</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>22</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EquivalentInjection rdf:about="#_5631ccc0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>184</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d4-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>6</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_5631f3d0-d9d2-11e2-bb49-005056c00008">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>20</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>8</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:ThermalGeneratingUnit rdf:about="#_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044ca8f0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-85</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_668eb671-5c36-4351-a95d-53ca850581db">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.680008</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_f26d4eb3-ebdb-4025-8080-f856ce656b42">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-450</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_7566f2a7-61eb-42fe-a59a-8276257fdbc6">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>230.999985</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e5a479a8-ab8d-4a54-bb52-376874ae2784">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04856c34-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-7</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b55d80d5-720f-46f9-897f-ff8c5eaf8b44">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.644</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_9a6bdb3c-346d-4426-8127-5f6cbf0150b2">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047fc6e6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-4</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_98f667da-02d1-4a31-b826-44314a1fbbfe">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>33.495</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_fec62959-21c5-4921-90b2-7c85e9f3bfab">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0452ea80-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-36</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_9db08c95-4586-4a2b-87e3-5a17c944b43a">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.36</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e54b499b-436c-4b89-9803-b1d75e2fa364">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_044cd00a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-252</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.243988</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_27799004-aa1e-4889-ba95-ee6fdae64895">
+    <cim:GeneratingUnit.normalPF>1</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_048aea70-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-513.437439</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>62.1325531</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_827a9c80-183d-4e33-9e73-ef0aab3dfb13">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>136.62</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0458ddf1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-391</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_12b01822-ca11-4cf8-a6b4-2f8ff805ca20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>221.1</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e3753d6d-b894-4cce-b6fa-307c50dc107f">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04859346-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-204</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_dff93c01-9c84-4c1f-8529-66c054ed9e37">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>135.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d9948603-709f-41dd-a0ff-2ebda091255a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_047f0391-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-392</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_23727856-fd9b-4124-a981-4e862148f3bb">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_56975783-9739-40fc-8ec1-e1de8cb06c9a">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045ab2b0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-220</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b8449cd9-5a17-497e-bf04-70f728b0f9f2">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>138.599991</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_e56da2eb-bb6a-4133-953c-40073c5bc5f4">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046bf0c4-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-40</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_d41be6b4-155e-4c8f-b46b-16b50c49f0f4">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.319992</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_83fae784-1da1-4055-8108-ba978276d1b6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04633e31-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-19</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5f711f63-f631-45d3-b26c-33821ab2ee56">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_a6ec9760-88da-48df-a23f-7877e7c85ccd">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_045868c1-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-477</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_e6131af8-c298-413b-84e3-4e21c3b6b06f">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>137.28</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_2621b09a-22e3-4630-b3bd-32c102e36741">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0489b1fa-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-607</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b0d662e5-64c9-4d59-b8e0-9b1ed175769b">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_05df66ba-3f64-40cb-8b18-c66d26c4e2c1">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0483224a-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-314</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_c1d29442-5f57-41d1-bb60-4b74b4994c20">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>223.3</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_04839777-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-155</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_29df1e0b-36ca-4536-97b4-6f98b84d49d8">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.02</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_17852426-f663-4add-9a2b-0a635d51f101">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_0472a789-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-160</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.34</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ThermalGeneratingUnit rdf:about="#_b97aee41-3115-4cfd-9071-b52fb44d0b66">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_046c3ee7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-48</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:RegulatingControl rdf:about="#_5005c073-28d1-4a7d-b257-649dec43ec73">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.06</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:RatioTapChanger rdf:about="#_047df228-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_047d2ed8-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044974a0-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_045eaa55-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0488797a-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_044b4964-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0447c6f3-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+    <cim:RatioTapChanger rdf:about="#_04682034-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>31</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_0487dd39-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_04549831-c766-11e1-8775-005056c00008">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:LinearShuntCompensator rdf:about="#_04553478-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_f4cdc674-4a66-4ab8-8d4f-552cb066e259">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>129.935</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0475dbd6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_a7768441-642e-48a2-b4a8-0ae06bebf676">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.419</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0447c6f6-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_c701959a-91c1-4a35-9a37-71fb790426ca">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.676</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_048b5fa9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99c6c4ad-5247-4058-96d4-ee8495103e85">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>134.723</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045b00d9-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_be267a3c-f7a7-4bdf-bb17-71b773247fbf">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>132.66</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0460cd38-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_069d84c6-bd26-4c26-ac6c-e801a0202a00">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.814</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0489d903-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>127.423</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0450eeb7-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6c36f421-303e-4932-93a9-5b0ff86cb7d4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>131.565</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_045c6067-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2d222dd9-7306-4afd-baa5-fd303b0eeb40">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.066</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04558293-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>124.763</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0466c0a0-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_99931a87-ee15-4fd0-b251-9556df7fe598">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>133.002</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_0449e9d5-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_6cc38790-c6a6-4309-99f4-a3258e24e785">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>126.403</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_047825c8-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_2a6c1dcd-201b-4911-83b2-c16acc50a0f4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.212</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:LinearShuntCompensator rdf:about="#_04684741-c766-11e1-8775-005056c00008">
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>5</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_eae61817-d3cb-488f-a1f3-13bc8e31431b">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>1</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>130.323</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:CsConverter rdf:about="#_7393a68e-c4e6-48dd-9347-543858363fdb">
+	<cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>480</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.unexpected" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.dcVoltage" />
+    <cim:CsConverter.targetAlpha>13</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>0</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:CsConverter rdf:about="#_9793118d-5ba1-4a9c-b2e0-db1d15be5913">
+    <cim:ACDCConverter.p>-63.8</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>55</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-63.8</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:CsConverter.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsOperatingModeKind.unexpected" />
+    <cim:CsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#CsPpccControlKind.activePower" />
+    <cim:CsConverter.targetAlpha>0</cim:CsConverter.targetAlpha>
+    <cim:CsConverter.targetGamma>17</cim:CsConverter.targetGamma>
+    <cim:CsConverter.targetIdc>0</cim:CsConverter.targetIdc>
+  </cim:CsConverter>
+  <cim:RatioTapChanger rdf:about="#_ee9505e1-96d7-49b3-9d1a-924397ffb27e">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_a5bf9702-545a-437d-9663-773550202828">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_739658a7-e08b-4395-8d79-93e87b7855e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:RatioTapChanger rdf:about="#_ea8cd467-31f0-40dc-95d7-4064463724c4">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>1</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_c089eb25-9f67-4d82-88a8-635dd4808bae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_453bdc57-5855-4eb5-8712-d6a0255e0da8">
+	<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:VsConverter rdf:about="#_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd">
+	<cim:ACDCConverter.p>-153.5</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>-153.5</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>0</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.pPcc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>213.54</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:VsConverter rdf:about="#_b46bfb8e-7af6-459e-acf3-53a42c943a7c">
+    <cim:ACDCConverter.p>0</cim:ACDCConverter.p>
+    <cim:ACDCConverter.q>0</cim:ACDCConverter.q>
+    <cim:ACDCConverter.targetPpcc>0</cim:ACDCConverter.targetPpcc>
+    <cim:ACDCConverter.targetUdc>360</cim:ACDCConverter.targetUdc>
+    <cim:VsConverter.droop>0.05</cim:VsConverter.droop>
+    <cim:VsConverter.droopCompensation>0</cim:VsConverter.droopCompensation>
+    <cim:VsConverter.pPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsPpccControlKind.udc" />
+    <cim:VsConverter.qPccControl rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#VsQpccControlKind.voltagePcc" />
+    <cim:VsConverter.qShare>0</cim:VsConverter.qShare>
+    <cim:VsConverter.targetQpcc>0</cim:VsConverter.targetQpcc>
+    <cim:VsConverter.targetUpcc>218.47</cim:VsConverter.targetUpcc>
+  </cim:VsConverter>
+  <cim:Terminal rdf:about="#_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe0e60b-3870-44fb-ba93-a056228f9636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_071bb138-ff00-4874-8acc-a884aa5cf4a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a168e701-bd48-4f66-8f0b-0f69b2545530">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8cac1e7-4826-4ecd-bac1-f4085fc15956">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dda862d5-7727-420c-be3a-a6a30e0b4c65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f72bfe50-f1ae-4f21-a477-f62e75a636af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfe1e320-861b-4d31-a076-5ddc474e4a05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14d37503-25e4-40e2-b20f-4de429a0dd00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c7f5674c-44a0-42d6-a701-4706b14c3eac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_21e25548-adca-48b3-b2a4-c000485222ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb3e09c9-fee1-4407-935d-ce2d342dbd7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e141e4b7-12e4-4b78-ae07-e8ab741ef9cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5de34198-471c-48af-a0b2-e5ae14970738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b862807c-b874-4b47-ae4e-59e4479bfac6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d88d693-242f-459c-bf12-267c22ba7809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d1cfe9e-3f42-4b3a-af90-111257354f8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41a94bfb-c430-4007-b29f-b89204ec913f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42ee39f4-ef6a-421c-a581-5da2682980ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_43724816-f5f6-4374-8ac4-96565bd5aa59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f1e8a6-8e32-479b-b73b-79823a3e1a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c37e51b5-c01e-45e9-88dd-957334a720ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe09b58a-7b27-4460-b596-c5886b3645ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8219d169-b5c2-467f-acbe-b04e0d39a7ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bff67964-ffa7-4243-943a-07c911e18dcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f4d752a-acee-4ad4-93fe-ad3cb6722d51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88d448f2-1777-46d4-840c-f64a7bea8a12">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c5dcb2-81f9-4076-b9d6-fb43a1a76d9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8e16607-1e6a-482b-8b4e-e5d990b93a4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cd484cd-37a9-4454-88e4-ab538b00a7da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3184d830-8702-40c1-9f52-c8e23eb3feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e68e5c02-683e-409e-8371-bb2e5f947c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b97c5dc2-7cd3-4a6d-9f6c-d18ca2229ea8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb5279-2c55-4531-b91d-3b71fa7f1674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a90f437c-e33f-4571-baa4-14f6e6a5be19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b64e6a0-436c-4389-be48-9dd120beb218">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe9cbbd7-a68e-4a3f-950d-3b1c2278b0fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b5a3e17-a13b-4158-8b91-a4303fe7e433">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f472e138-541e-429e-aeed-e632232888b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1e00a228-c452-418b-9db5-0a0ffbc5a5d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_26698a8c-a280-406e-b882-9037efe6a03a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145597a6-9fde-4bf2-b2fe-8a4c6c5f4774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd76d8e2-4515-4964-af8e-67885c73ad5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_883bebaa-0b47-45b9-8d4e-75f8784dbabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9145eb98-9d67-4793-b83a-967c6ff56e1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7c10087-4ab2-44cf-9362-3ead8a066326">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a5780b7-5e74-4532-b3c1-d1617bc090b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aeb3fe0-66f5-4f34-a79b-14f777313348">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b60203f-42be-4959-8f9f-10aa7e6812f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca41ef76-12a4-45d9-8665-946b5d46b7f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8de12885-e525-4726-a2a9-80a9eaf637f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef70c25a-ab63-467c-a0c5-c0d5ecf22f82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_79ae9e2d-942f-4878-be1b-a9e7e2971740">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a22db682-0414-4fda-ae6e-9e48d11a5565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5578e708-945c-468c-b7ac-56a738f7701f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4820525-8b5e-4f46-9a5d-7b93cadc813b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b95964af-8fe3-44e0-91ea-d1d71c7bf25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c58d4a-2ad5-4eb5-abe7-e79c1cde9d71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9bc8d338-1940-419e-98f6-8ae664bde365">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e5bfa23b-0c58-4ef8-a317-bc7a65457ba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e64d1ea0-1cc8-4317-9d6e-ec2fce5eeb77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d5377df-3bb0-4d2d-b6e7-e08f369a28df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f2156a1-b0c1-4bd7-aff8-17e4acfb98f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e030a6dd-e9c9-4aba-bb6e-8ed4b7add9e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae1f9fe4-1234-4ec7-b2a9-c6077a19d401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9385a5d5-0ce1-4218-ad3d-2645077a1bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cf89592-6284-4711-a283-848c6e97203b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91291202-267f-4ca0-b8a0-0ef3cd7b0d3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eb152b46-922a-48eb-a401-854a48d592dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a74688c8-f01f-4419-91e1-790b7d8637e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b85df60f-96a8-4187-b01f-018879647feb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_730d18de-6962-40b1-94cc-b1175fc098f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca3640a9-b054-4d3a-879b-8ed41d028ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fd6a4b6-c0ec-44b7-9ab9-b8ec781850d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c23c7c69-c302-4315-ad2e-4d5389140def">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c801bf-3eb3-46f5-8295-4c816d9bb318">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d3c4d8e1-11c8-4876-b4b0-906e5b7a73a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c06fc0e0-1893-4e97-b465-e24f6a934e84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_085ccbba-fa65-4793-82ac-f8d599966ced">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4c27dbc-6761-4286-9c91-debd13ac59a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_11f29b11-5932-4ba4-9a4d-7295d9ded126">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d64d90c-e2bc-416e-bc3b-75cb2866b13f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7097128-535f-4435-ac2d-dc1f01b38b72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43252980-acea-46e9-a46f-0b8d923cb4fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a9bc577-2923-4546-9c2e-a28d8a2bb2d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4de6e42-ee62-432a-a8f9-311154ca4545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1e250b6-b8c0-4b8f-86af-d654b592efe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77171614-596f-4d4c-8f88-9603a8225203">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_800fb8b4-0209-40bd-9a5c-098a9d5bd46a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_599a8732-3d99-4067-b506-3fcef610c47b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b90d47e8-e306-4b82-b7de-071f8ba139a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_50413d47-3ac4-4933-8d6d-6136134d1cd1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_51ff9c76-7b34-490d-af24-56521461f98e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0a4f-8817-40ed-b729-55c92d171c5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ca5e61b-bce8-4488-9a89-a13faf616146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_07aeceff-a2da-441f-9c1f-65f5bea46ddd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60dbae27-1064-4d48-8b63-60969b90b01c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1d5b0f7-a631-4cb6-be6f-ff459dafede2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3a46f9cc-a382-49d4-a2e0-5353e7f09803">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fb1a0d9e-d78a-4f35-b1a7-4e77ea9cab61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_974090ae-7987-43d6-8dfd-965bf0b8c7b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed826093-243b-43c6-9cba-b5487b34d56b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_987874b2-d6b4-40ae-84c2-09d47aa16fe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c11374d8-1dfc-4494-8c10-8ee6e792dd41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_baca14fe-c74f-453a-88ed-bbcbd0aa5a6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10fba6d2-bc82-493b-b4fa-928668273f68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a02c16bd-ad21-47c2-a34c-c1cff1e19015">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3de5af1e-30d0-4503-b58d-b4fe3a1e084c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01c6db55-d351-46fb-9f2d-13c1de997349">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e46cfed7-5361-44e6-9ea2-0be51afe2287">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_53feaad1-74b3-4cdd-98c6-045d45061593">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c5c6689-a80f-488a-b9cc-23667dd2e923">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b2ee2f-b05b-4c5d-a1f6-addff43e7070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_745264ab-02d8-4377-971d-38e58d86f3cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_902e06e1-e0cc-408f-987e-4483dcf5a4eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_39019b70-09ba-470e-8dd8-e35080b2b090">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf0d0769-33ed-4bab-b86a-a34f6fa059d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_066fe35b-8e2d-4bdd-97e2-b66d2d6a1147">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0f32dc6-eeed-4c00-98dd-22b8191b674b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da140b84-888f-4608-8a2a-b355ff10e175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1dd52921-a7ba-4bd6-ab24-1240f2f30301">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9809db90-fa03-4ea9-a507-c327adb29ec7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_349a9ac5-71b8-442b-ad95-93d514881b07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0449ad8d-0b1e-483c-a333-adadb108d264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83cf2f18-0417-4b5f-915a-a8610df259b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17901350-2daa-4c42-a4e5-3a39dd813f13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8c102c6-1217-40c3-b05f-bda872504328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b557b2a5-2259-46ca-9681-73ed8578bb64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_85c693ac-04b6-4bcc-a3bc-1a47837f5c51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12e9d7c1-ec4a-435a-9f87-af7519f81d19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c2feb87e-acf9-42af-b093-c69ca64b0282">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc64ae88-ea38-4e5e-a850-c965ad4811e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_205ce345-8ff3-4f47-97d7-0c00c0f51259">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_110d1aa8-d200-4684-8266-26b5f69ab5f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57bea695-1bcb-4abf-9a2a-a2270d257a2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b687f746-a11b-4250-9a2b-92fb615faca3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff90c538-e532-4da1-85fd-f966a3e6cfd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c9aabb45-f6be-49f5-81c3-6a6fff595b20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b10eb7dd-58cd-4846-92e3-4371938950e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbee05eb-f6ec-48ac-8f45-6e801f352b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24b4767f-a3ac-45e4-9c9e-1e6f63c13e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10f7b85d-f7a2-4346-93f3-d026b3437ae4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_120699d4-88c2-48e3-a094-737b515cb65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_47f09825-70f4-4225-9a99-167a37ed724d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d95135a6-a2f3-42f6-ac01-44e9459fea02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_32b22d72-0891-4711-b2bb-7cb89e348e00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_360c39c1-9801-4f23-858c-459a2eb08725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_298e3c2c-e3fd-4cd7-b38e-a5cc7790dd05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ce1d70e-9fdb-4110-829d-d3f0e2144b26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a59ae689-2f80-4159-9641-7a9286868f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_62f6a018-d394-47f3-9f1d-66303cc80a53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7c55b814-99a0-412a-b837-150f33b099c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f280c3c-7c31-4233-8845-42d0290431dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a5f2d-17cd-4194-a8eb-ee4f3cb5b22c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2afa6c27-acaa-4d28-a6cf-3283b98c8fe5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac4c08a2-5201-4366-b7f1-d86fae43245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_308169e1-3f4a-4bec-b3ea-0ebc76d5bc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fd08ae73-ab6a-46a2-9cd7-4316852a4604">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ee5fdbd-b7db-4e3f-bdd3-b5de81dba6f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07bd6984-102c-4162-9555-858f90689d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34e5d3b4-7e84-4389-a389-b1e799c1e2f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7796b60-d57a-4401-91d9-fdbcabab4dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1fb6f240-a6c7-4597-ba87-ab70943b397e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae668ec-5d22-4cc9-aa65-749a4098cfcf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13521110-8ae1-4f60-b218-5e8b75bfd923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3368d4b-4206-4671-91ea-350fba2e9039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45ddc3e8-863f-4519-8fe7-a4f746cbe9aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_20705efc-e9d4-4664-b3d0-095d62ff29d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_822fd5ed-1f12-4abc-9487-8e98657da101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_201811a2-df0c-4ff5-ac68-2956151d94c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8103baed-0e59-45ae-b521-6118cbe2da01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe1856-7c93-4b98-bee2-9dabc7b62fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_708aaaa8-e7c6-443b-8285-91504fe45b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8cc8b9c-5b5b-4b4a-8610-03d974c74739">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9a1601-96ee-495f-9f88-e5b1e439d9d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b3ae708b-6f42-425e-8dd5-00d6daadb551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c0edefe-d42e-4966-ad5a-f120620ea284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8345da91-c150-4265-922d-5308fdc44671">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6df484-0741-4f53-81e2-6e70cfd5a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67785dbe-ab63-4618-8737-6150fce2c56c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39312527-1286-4662-9cf5-c5e3cae10de6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a3f499c2-f337-43b0-9b6f-5849b58eb1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4d1a84b-45c6-410c-b4c0-e74399ba3f6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35414171-4c4d-4f95-9580-9fba40cfbc2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2be79109-4947-48be-9f48-587e8cfdaf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db602221-867c-4da7-8f29-8ce8ac7dcdce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6651b16c-1772-4788-b21a-93531b87e488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6d3c05da-fa71-4424-8c56-8400c9528908">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_98dd0655-72b5-44f8-8950-70ba30e70bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd1daa5c-eefb-4712-89b0-a81967839921">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7bfef0f0-3061-4827-b75b-29bb615a2586">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7706ff68-778e-47fd-afb2-a9b19a1021df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422336f-9b82-4511-8613-997ecb41c564">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_919ef501-e345-48f4-92f6-f3f9917d961d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38d1ea1-2686-480d-a8e0-70c6f7c4a6f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb56fda5-c1ce-46dd-91ec-73fc396a6ec0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f85a3a47-79fc-408c-a671-6dae0a3fd2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2af82b02-99ad-4353-95d9-8933f1f03ed8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_90bdf796-f9f8-439e-88c4-2aed057f8728">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acb6cbec-a463-4186-816c-13d6f9e8f8f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2671dcd-4825-469d-92a4-11a7c1168e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f199ee7d-42c2-4eea-b369-8605bb280c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db969abf-2a57-4780-a11e-d100009e1c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853c07ea-f383-48c1-86f3-88e38fb111b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d74efa59-9559-467d-847f-20c752ef7a0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71f3eff0-c211-475d-bfc7-5761e3d51925">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2083790-f439-4a1a-be0b-3d40dc6bd591">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_830f9eba-407e-4c21-b958-58c1c566bdc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5c932ecc-c9fd-407f-ab7c-bc6bf6d37c42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c16a8f4c-9b2e-443f-b642-9e425306592c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_516714e5-4f88-4718-976d-98699566123e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_731906a3-3e0d-4904-9226-5bce546bf1be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6bba47d-244a-47dd-8cf5-f9ce2d619482">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c299175-5b93-4a5d-98e3-1e0d98759953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac9424f2-22d1-41ba-b520-0674ebae6a33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0bed41a7-c52e-44a9-a378-8ee6057a60c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f45c35c5-e0b7-4a4a-a7e5-065f2cc79a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92e84348-2aad-427e-8224-863e9c987476">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_42abf657-9f60-4bda-b557-ea055a58f606">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a88a858f-a4f9-4a7c-a7a1-599aa2a98bd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c82ed1a8-5ed9-463f-87e9-21df6f621661">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c754faaa-23fb-4cd8-b9f8-64a692c467e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c548e424-3e91-469d-8d41-c15924cc0735">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e79f20f-77d1-440c-9517-b03244fcb642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbdf8582-a8e4-467c-ae4f-6bc08aba7057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_352fef36-0467-4ec6-8b85-d38af06da2f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_71a7543b-d3e6-4c6b-a724-4d34681cffc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c2f7966-0719-4ede-ac47-c93bcec328ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cda62ce-a773-418a-8562-975eff37d6ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf038e04-bf8c-4655-85c0-657b65fda472">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f91ff24b-4608-42bc-8165-3845d9d89a3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c57369e1-70f0-4ab7-ab95-0ca6d1d20b00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f05307b2-779f-4931-ab27-1c812eec0e09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10cb7e56-91ea-41b4-9698-9ed591d4a610">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b54615f-86ab-42fd-a7b6-091f420c6185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159809cd-32b7-4d81-bdc3-f4521a5611dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40021451-2f6c-4c08-8206-0f9577efbc02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53df2bde-0065-4e2a-8f79-8b9887289cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da880e10-59e4-42f9-88ad-bb19fd0995df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ffb2763c-86ee-422c-ad01-19a27c2f5d95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82d50004-0240-44a0-946b-1136ce73ca33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddd3b955-2005-4764-9bb2-94f1a0b57ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1072268-4956-4f91-999b-829a5160c6a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3f6df38-eaa2-4ba8-8267-2ea812b5b730">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4808825-dec5-4d4e-a575-d6b617e60f4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a243601a-7f53-42f8-9e0c-7d3ddda35309">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8713048a-be6c-4fbe-af8a-018305cb793e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7508d369-6037-4398-a0f5-85136d240f10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_215eef72-26d5-43d5-9728-b716a6eb398b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cf45286-0bc4-4244-9187-d90880603533">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4dd81da8-8ce2-4aed-81fd-54b4ee4566ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2edf2c26-ba96-42a7-bbca-bdce425dc719">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_37451d52-ada3-4155-9718-f2cbac55ea7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bb72b3a9-db44-4120-b8d2-ceae058fc3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e20cebb-95f4-46a1-86f5-30706c326241">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c5cd262a-00eb-4b1e-aa14-af39769452f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f41b17b5-937f-41ee-9be3-6582238dfde8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e39b164c-e8d1-4120-92c2-d51ef5331858">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c794fbfb-111e-4bd4-bc4f-22539cf5a14b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_481b6412-4dd5-43ec-a4f3-fd0cceb8fbd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_75da10ab-1e91-4b8d-94a6-022e3a31020a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35b12500-941e-433a-a80e-43850be4aa09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e2e8adb4-e6ae-4d8d-b946-bc510782ffb8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f8d2d0c-a59b-43c9-9c09-0d5ab82e3b3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cf6338c-83dc-4336-a40e-396191812535">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_19c6f61e-b720-454a-a47f-7f2c51dd0de1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9de4515a-0b24-405f-9920-6beff64f39fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_35fa07b6-905a-43fd-aa2c-c1b6ba8c2738">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a74196-8d0c-4d96-9eff-1db74605a665">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572e87e4-428f-4ba0-8148-585a3ad489c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53cb22fe-b2b8-4b42-9c90-c46f4b52e32a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b61be02-219e-401a-84ab-137d8a522a31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49649668-8e65-46b9-a759-ed5b1c2f3475">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_12b661c8-e048-4af8-8e1b-6fcaa75e0a27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8967ed7e-f69e-49de-87c5-3e424ff043ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6c92e2ed-107b-45a8-8618-4bbe372d15af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1ff47f6-e080-4f99-bfe0-0d44e36ed6af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f13674a-e4d9-432a-931f-7e823ccf41ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_569d3c0b-1dd9-4175-afa1-b4a43a0f768c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c51731eb-388b-471e-84ab-39c64b56d1f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_159e2c73-99e7-4c61-84cb-8b56e8703a78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d4a77b1-cf38-4213-9584-62d8813b8e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c3cb471-aab3-4d54-a738-d6deb20a22b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92c4d859-708f-440a-b6bc-cbbdfd0c6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8500b6e8-3687-4c94-b665-b84ee822b1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a8407c09-50cf-42be-a06a-3ffb9affbea3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9552f175-d04f-4789-94a1-8cab3ce656da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1a64602-04ae-4adf-be2e-03f2f6f8d1a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1693cc70-297a-4d11-8f9a-6da05e8afabe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b40a4b1a-6ec4-4eb0-b09e-274f28a19e10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d50ed217-8664-4101-a79c-02e1b5753702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6022dd0-29a4-4921-8b60-dc855a2794a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ea3ac4b-c6c8-4d96-b1bf-47d064be4317">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ffc5985-1458-44fd-85eb-755b32fa5b9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_32b4075c-eb28-480f-9770-c79c28617f2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26970c44-1c28-45a4-8327-f9d544822995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45ba6338-e010-4c7b-bb0c-22c9bfc0e435">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_326c6626-3a7d-4415-b9ab-8a2a4f0ada10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_388c280e-dcc7-45f3-98e1-587260e1b369">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ba14b260-4f8b-437f-9464-3aaf7d17ebd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fa746ea-521c-4ebb-ab9a-961099f261c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_333cb385-6e3d-48ae-9653-e6ca5835a27f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_609f5d51-8bad-46ea-a50d-cb2725642283">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e09087b9-1874-4158-910a-a468d445f4e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c8def7d-c9c6-469b-8115-d832ecd100e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acda9192-b001-4925-99a2-7ea65a81b267">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_178dfb1a-7c01-459e-805c-2e2046495275">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203eb441-0e19-4f62-804a-582232ecb670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e44585ef-eaea-423e-8531-d641e8826802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c6dc912-1aad-4cdd-a31e-73d43122e59a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d057d3c-d61a-41e0-9737-432b5ada155c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab849915-3e6b-4677-991d-e447a4db0f5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_041d24f9-1f82-4572-b813-ef4155a06173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23f9448d-9c57-4843-b921-aa60104ed2fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_96016276-135f-47a4-8755-188a64bb58d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27429877-cb1a-4b4b-85c7-92ae6726c79f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b39b22f8-b659-4550-9084-67aa7f7f0ffc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7fadc3a7-981a-4da8-a7eb-7085ca13e62f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_24e5c55d-e28b-45c9-a430-c9726b2914c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1043f8f9-8018-4203-8ec3-5fb793a1aa65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd347645-1c88-4697-9cc2-3e4abee5489a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a675d01-61ef-416f-9ded-1e5f734fce59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fccb783a-2f63-428c-b673-df05f116a386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23dc57ad-b8f9-462e-bb07-e2a7b879e944">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70cddb78-0926-4f3d-9f04-d0f2992a53e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_91c5b0ca-964c-4e71-85ce-3e4c34c39c62">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a330abcb-4a34-4ccd-9608-a09ca5e660d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc62a2c3-2da0-400c-98cd-1b8c3d1e1851">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_123ee6c9-8eff-4182-a6be-b14ade88b4fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b05826a5-4010-46c7-8cc1-2a4e588b911a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e52c2f08-e57b-4336-ad61-e315ddd425d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdff05a2-d002-4be8-a815-794b6a1f4025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_08cb8736-36b3-4225-997b-9e9d8b24398e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_664735e6-7c6d-4483-bb17-1b04b78187bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be1c75ee-d6ef-4c9f-a1f6-1e0f57d8aa6c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f91f072-ee1c-4484-8d13-5beacf3327b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c8216652-9e1d-41ce-a916-e3087ea5b445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4569417d-00a0-413e-a233-981ee337f5ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d38f0bfa-be3d-4373-b90d-25b44a3a5da7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbab36af-ad99-42dc-a330-7631cf62d18e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_198ffc44-f46d-4f3c-9d2b-b00564f56603">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_785b252c-70a9-4f1c-bb8b-0144e0c34393">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7ee4f1cc-2ec3-487b-be5f-448ba1098364">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1dc6a8-5807-4b72-8352-aa38b7ef65c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47f462e0-6cc8-4085-b44d-a737dcfc58a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3698d996-dbcd-4ca1-a37b-ccee8e5dd75d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebf4e82b-8581-49d3-af44-466ad5ea5beb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88fc4b51-b403-4d0e-ad17-53a083adf8d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_67dc16f2-6949-47e1-b0fe-24ea05e11bed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d802a3bb-92c9-4fd2-872c-8ea459589526">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2769e0a4-1dd7-4690-a2d4-c2a4e877d6ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fbe8ded1-d7f0-4670-b721-ee137eccc9f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a07a7054-1160-4fe1-8753-18700a3178a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21084cc5-b2fb-49fd-b186-93bcf6b7cacd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0e40411-5b47-43c6-bd1f-f26ef82c761c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4322f8ba-4c64-48d6-85f7-7feb029e02ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8152d58-e869-4e34-ba72-e6a0250f09d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de2baf32-b5d9-4bbf-a286-ee7ad91c29ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d6d8c290-8ac9-4364-8e20-50201070dd1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cb3d25-f7a4-464a-9530-c0f6f2b11aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ee4ec5b-6b89-4d91-ae82-fa24d7d9e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2de64646-e09b-4942-ba68-2162bb1d979f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0945558c-d1dd-46ef-bfd3-6d0cdd75b650">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d98fdbd5-ddbe-49ce-bcfc-259d2c399282">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_da23cbf5-92fc-402d-9e75-2007112a3f65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca3b225a-2b14-4324-a2dd-00ff96571ecf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ea2d464-a933-4e76-8c57-df5e29dd0948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72dff77f-fc9f-4ef2-b366-9aed8d81046a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e461b2-8712-4afa-b271-2132865b1341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816c2a66-edc1-46f4-bd0d-4e699b823836">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2aa0739-9784-4743-814d-ad6a586a59c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_480e9cf2-a17d-453d-8f6a-013c28fcf0f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8feb73e1-4390-443c-ac47-834bde0ea038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28c7e854-bf10-4c96-8f26-2ae14a703e31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e4e2100-c19c-400b-9b6f-2333e3808b98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_359a47c4-a101-430b-9db8-7408d78f8461">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76475b35-db74-44f3-abff-712442eb405a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba94349-afaa-48c8-bfee-61910d7d1d3c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3885f06d-f07b-4cad-92c4-0f8080c30303">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f69ab1b-604d-4ae4-ab51-9cd0d53c37a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5e8a806-f0b1-4bf6-9b57-929d670efd58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c338198-266d-44fd-8764-ff2a3268a067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1f7e1e82-5754-4fa6-8940-937f91087a25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8ca6df3e-0210-4e88-9620-4bee4bbe7072">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ea84499-a970-45ee-8be2-8cc9ab5dc2c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7993d16-c661-40a6-be19-d4fa0622950f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52870298-2d98-4bdf-ae81-2e477350eb87">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8389405d-9280-4803-bace-2ee38355fafa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e75b0fc3-f421-4ffc-b561-fc9ee5815972">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9128d5db-cbf5-4234-bd30-22c604210b35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a64ecd0-d2b8-4bac-beb1-bc8c8c451a4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2973b3c1-7d40-4ce0-bc30-b8bbc9245641">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a061825-baae-4496-8f93-6c3283ca85dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d662cb35-3827-44a5-a3df-576e423d7f32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b254ac83-1713-4c0c-950e-e82a7202e4d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43473fa2-f081-4f68-9b5f-69d2a75f5e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c43f06b7-fa8c-4aa1-bdd3-6e194480695e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a789d5-207a-4059-9cf4-0d8c5c0bb4a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4b8a765-2040-4572-a6e1-26c29549a549">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_865773df-833a-4310-a335-9e014d4e4d79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_abce531c-5509-4558-a719-7e01a9ac9005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1162fbcd-0df3-4aeb-b5f9-0d8fe58c55eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b22ddb30-b0d8-4a03-bed3-36ad77a3c2d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ec9d5e7-5de2-4792-9a86-03be2cb1838b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24630e95-086d-4fb7-ab52-0c8f447b4010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75e6fea8-348a-43f4-81c6-c5c1410ad595">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_825b65e2-24f7-4b23-adac-ad62053e0323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e1293a1-22ce-491f-a2f3-35e030a88667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d658fe4-38bb-4b80-89eb-d8f550a95fa2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e10d1db8-788a-44de-ba42-57edc9539967">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b554668f-bfb9-48f1-9bae-7d23e0f421ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beab0b69-1a8a-4d32-a111-6129bd8e468f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bee5c82a-500b-4921-8166-d664da1fdb2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_584dde80-3141-4bf2-99e9-cfee485d38af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df108430-9a62-4d23-ae3f-411cfbabd93a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03564f3b-c300-43ef-81d5-5f32696ca734">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0d79f3b-ad55-4f76-8d1c-e1b086da71ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20a90dba-1a5c-4f63-94a6-4bdc9a797602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6616d5e-edaa-4a8f-80c4-ee8ce85b31e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_065b6429-bfb7-4474-8500-887ec059494e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afa75dae-3ef6-4a83-95f4-1ed757b73580">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7974968-25a3-4664-bfd6-eb4e57880faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b7f411f0-e6f4-435b-a618-b1801a393d7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cacb34e5-35e0-4430-8c83-3ba4662fe7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76de976d-9edd-41e0-a14a-9c3bf5b509c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a8f004-7214-4a5b-89a8-fb99d5ed06d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dba29713-3989-41b0-89f9-a00883e9ddaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e685a6c7-06ef-4810-b74b-02c66aaa2f40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e458bc3c-51da-4496-9872-65d448af1133">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_870a57ae-f39d-45a0-9a9f-8402539c2c44">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd06f193-5870-4dd1-b594-b3e3b0ed6c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f02ee40c-f678-4ffd-b9f9-25285e43451f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d989ccb9-8582-41ba-8028-96a149e9402c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bc00a444-0894-4316-9fcb-508834ba9c38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd28ef43-261d-4dc5-afb6-8af0e9b6a2ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_142dec8c-d69e-4dc5-99a7-77ec0eb1dc03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef5f45e8-622c-49d5-a98a-71d47862d0ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b3d29cd-0a79-4315-af49-9d8c938ed76d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cc9423f-d622-43ad-bae1-77352fec565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a2a86fda-ad55-4b0a-b89c-2249a3d87c62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfcf9a1c-9418-4f53-b867-ecf7a735786f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b066d371-c699-42ce-aa1f-9262e331dd58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa0532a1-f44c-4447-936b-5241f29b4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cd198483-e657-460e-a753-771668b6455e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b0697f6-9428-422d-9bc5-3c95eb881ed4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b0e4433-ebd5-4af9-96da-62c2120aaccc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8cd999d-efb3-4d33-8565-1ff34a512572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e5e024a-be13-4ed4-b298-cbd85e03eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b04bbd4-394c-4fd2-a57c-5b0ce7b8328d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c82c6f0c-0683-453c-be75-9d1292c7b04a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f770f7d-f55f-40a9-b77b-2249a6771467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_add69c46-4996-4189-b8c5-496dd7f98a9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d255438d-d4f1-4e0e-b09a-ac843779dac7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4cac272-ef4d-4576-b391-284439f9c285">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58193dca-5bac-436a-9292-9ce96ba22418">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed897479-dbe9-4fde-93dc-15e7e0ff68e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_964dece9-6c0b-47df-9d43-e9b422360913">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67877821-e62a-4526-8b36-3115e852e88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29f5c6f6-b2ad-4aa7-96a1-cc8d2ff4b614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_81a13e90-2b4b-4a09-9ee2-eeafd9e00bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cab260bf-1740-4f3e-8882-f4cbba442795">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_46e90e7e-887f-4771-8caf-07f3ddf5b3e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a8e8f80-5d6c-4b17-904b-64dc2fff2262">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa77f9ed-8a3f-4d87-98ac-0a7375a86fb6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4374bc16-61ca-4b5a-9d9f-798fa48b665f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd77817-e562-4b18-928e-a519da1f2124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac14aa5b-4fde-4251-b311-33015973af60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5131569-0960-445b-8cf0-340c24986c0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6744f681-5c6f-4566-826e-524754bf8a1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4173c4e7-f582-40c2-b317-fa1d8edeb448">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cf483c45-14a3-419e-91df-689c1dffe6d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce3cebcb-219c-4426-a7b9-a174401a66c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aeb54478-bfea-4787-b466-90df885b1c33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4a408d5-2c11-49a8-b0e1-fb4e7b4545f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebfeab9-b411-4d19-a937-e3e9c4ea19ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b367e89a-724c-4a9a-a2de-a7d44de2c1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac672323-d104-419f-a71f-4ce30e297d82">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_91dab2ee-b23a-4591-88be-d0020bf6ca9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_51f3b44f-e443-401d-84ae-b8e86c4b270b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4725e87-14c3-431a-814b-d7e174e12658">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_76f12467-9fe0-47f8-9c3a-79c8075d0c39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88fd8c00-aa5d-4bba-9d81-40538478b744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fdb1052-84a7-4bc2-9e00-b6c03e26adca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c8707e87-05c6-4f12-97be-5c71b626e8b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e0d1edb-a714-487e-85d0-0023872faf7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bda506a-f6b5-4f4a-b8ee-1d4957f48cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2851ba40-fad5-4db5-b45b-481d141f197f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f14bee3a-c4ad-4778-95c2-0211fc182eb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91899442-8c02-44d8-8b35-c512b257104e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4eba8816-da7b-4a57-8825-62061d59eb8a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a30fa62-5391-43eb-9ef9-81d417b7d445">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55bc9730-8c40-451b-8199-cdd4170be47a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_187cb72e-9561-44b9-9624-a40a68adf40c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaf25965-83e7-470f-9207-e8729d4bd007">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003c3228-ae26-4e1e-b2ba-173885fa9f5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba63da6f-556b-47f5-9e8f-90f8b8e7fab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03e26ee9-a3fc-4c22-b0ec-5b56c9659504">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b5cbc4c-3b65-4de1-960c-20cbb7a93c23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f9f8103-498e-48dd-a025-031b7a357d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4876f051-8bdb-4900-9acd-a5ccfefc9732">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6ca903-3d8e-4566-8497-69c094b27fdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8c2d0e3-0b5f-4fa2-ae70-769bc1e229ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97528f91-9197-4833-a0ef-509553c108ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af52cd86-fb78-4aae-a5e4-899bbb32afad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_844c3edc-a332-4684-bd75-d2dfd5f3bb0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79e5c665-133a-40c0-b624-24695482f6b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6dddc74-a83d-4295-aee3-81685a166f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba1543ba-b338-437f-b377-c21d79b8f66a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0ab92b74-70d0-4546-abc9-4ebe526966fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_188dd9c9-8052-41a6-918f-dad2f04072e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c03b674c-609f-4376-8ef6-e5c8cbc8a37e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51cdcacb-8528-415e-96c6-d5ce8b2ef440">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c38b13a2-fdfe-4efe-952d-66ddf616d722">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a66aa870-a14d-4ebe-98fb-56dadc7cad89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7bfbf56-b417-4d5d-969e-2dc60af24f55">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aaa9f9d2-61a4-48c4-8b74-9f1cea3dcf19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7eb7cd9-22bc-4182-9ace-4a7283dee574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59a28b95-3bb8-45b4-a0dc-93bf57a4621a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53fd4b3d-190c-44fa-a4da-a06af831ee73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4442b941-d4d5-4ca7-bb8d-5a427f0e3821">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7ba9ee4-7854-4f0a-8527-e67110d01ca7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_83bd7a12-4fbd-4219-b9f2-8a70e5d36a69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5fcf6744-b487-434f-8a95-531fb0ebeb65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2e562797-dba0-4f5a-9c34-5bd39c9d4694">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c864bd86-d942-42e1-ab35-ac890c49f5de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ded25e34-2f5b-45bf-b847-b9f87b9de7ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_412cb19b-097c-4378-b3f3-cf5b731e677d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1b501608-150d-4e0e-a33d-403a1ddd70de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f849bf17-7777-4aac-a443-f34aef90c1c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea9a9a67-57b3-4e54-8850-9634c88b0fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07cdd920-0989-4add-afb5-de33f3e28212">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af78f809-0fca-4913-8e81-0bf6d1836582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_721fb0fa-b655-4188-9fe8-639356861427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_280c464a-a4ec-46ed-8a3b-b18e807ea7cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d578c1f8-6516-415e-a1b1-18a592ca45ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3bcafc5d-6dc8-4de5-b4d5-eb468c889fd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c1fa00fc-fedb-41f0-8a45-09c6856a38cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7289d742-f3ca-4b60-9e58-b6da7497219c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_219cf87c-2e4d-4254-ad89-9ee4bce93e99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b04a6c9b-435d-45e2-8e43-d7b159a64e6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f145836d-2f92-4563-90ff-55f68863c206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d824f3c2-f6b4-460b-8875-8e822ef5d542">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45101256-dc1d-41ee-aeef-65ef96bddfe9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9e3c9fe9-71e6-4a25-b457-8fdade0cf6d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2925711a-ecfe-4584-95fa-216a76889e0e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbe15b06-0197-471d-a3bd-08a22b40e4e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_53a237e7-aee3-4680-b1e0-3204ddaa07a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e6ea76c8-471f-4d7f-afd7-df09fec29637">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19490fb3-067e-4068-bcea-4a2ee8a27fb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56d744cc-18d1-42a8-b559-be005071f72a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5540a41a-7beb-456b-ab92-d6e9bac08adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d15ece-a13a-4f72-a22c-d0df5b4d42e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa27116c-d2fd-4d60-ad61-0bba8bf76d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0570db62-851b-4096-89b3-306a830f9d08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7b243c85-0fcd-43e7-9caa-16aef19823e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a2d7e12d-d6ad-4b3a-afd5-1259bf58612d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0afde8ea-487c-4f36-8090-f72727664eef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8aa5a02d-03c8-4aea-829a-ae2aae86f897">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba870de3-4f01-4c36-a70a-836982d78be2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b712d454-cc47-4381-a23b-83696157c215">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40872517-e212-4794-ba82-e587fedd9a57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1122014a-cc7a-46e2-a3de-4b03c23b43f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d3d8bd1-1bd8-4b9b-aa6a-d3057c751e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c1fdd5a1-0341-4524-aca5-6b77f18930c2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30b48ec4-7a67-46d8-927f-f135edf85da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce183715-8db9-44a3-b4ff-c224869d4f5d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a29c607-c616-4405-a680-f472693b6c02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f872969d-a939-45c4-9254-acf26f5d05b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6788a97-75e7-4609-806a-927f5ab7b097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fc04519-665e-4785-adf1-846f1bbc4bab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8c8eaa7-f1a5-49ff-b392-8eeafc898658">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f99fb43c-62c5-4639-8053-66758542a7fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b6fc7aa-035f-4630-9048-7dba8d02450b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33c4b2d1-1210-4147-b097-77dbc9bb672e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac04fce3-ee20-4127-a581-50bc78421887">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f49f8d8-32b1-4522-92d4-19c3a726e0bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5cdcb762-8802-4370-ade2-f2cb1ff713c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ee50c6a-92c6-4446-ab9d-f18863a55bcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e81b0bc8-2b54-4ea9-b9b3-1f0bbe7afbba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_859c4ebc-14bb-432d-829f-70f94d346847">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e317ddfd-c060-46a5-8279-74abf6b28979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad1e1809-32f2-4cf7-b9f4-3eae73b294c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36c4cd74-a5e8-4ae8-826d-7a82578086a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2436005-f7ba-4729-b7ce-4c62da0adf39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_92d4a147-300d-4b06-85b6-741b6700f71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a706fcf4-819a-4598-96f7-c9647368a248">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6e3ad789-b748-46a5-9c80-1b60f334e802">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50679c3e-cfb5-4a11-a9e1-e578f88371ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ddb0e6eb-82a8-4246-b77a-2155477ebdd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fcc31e9f-277e-462f-bc16-0330cd3163af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e25f3ef4-5c5e-4546-ac7d-53ecf70aa9ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea847c13-d0be-4616-ad58-1769b7d799ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5fcefe6a-7bd6-488f-8dd1-26b7e23b55a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5c51845-f008-4108-9e64-1a913591741e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3334eb38-fe2d-48f2-978c-c7088acf1e7b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8f4e9bf-7c05-46e5-accf-e021501658e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6bbc18a0-9898-4620-9dea-8a547b996fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4927304-e6d5-41d4-b669-d0ddf7d05853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5909fee3-e912-47ac-ac18-990aa009f211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b0d4c18-9941-4d4c-865c-88b1a8c0dc12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b8877ec-b6e4-4f9f-b1e5-18ea5e1b35e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_507de8fe-a640-43aa-94b3-8be6dabe22b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5d4c518-715d-4049-aac9-002f60e13bbb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_390d1cea-c5b7-49db-9a04-226290e027ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9ab11de-1ca8-476d-8c7c-7364b4bc3bf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3cb7a299-166a-4ec6-98c4-21c0708e92bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_716eb523-8ac1-4154-b7da-92242b3b61ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb7a7e2-47e8-47b1-9f51-ac53838a652e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6a85b772-385e-4c24-b4c3-e16d66dc1603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb7bc05a-c1be-492f-80da-4eace7ca08cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7c5c0d1-9a22-4edd-8bdc-386f781bce15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_daba953d-958b-4002-a3d8-ee9944bfd07d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57a5e5f7-befc-4422-8f0e-26335a11c5ae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f3318d5-eccc-45de-9579-2f989e144c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96cdf652-f2ac-4e90-b56f-1cfdd4c21cdd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a21110ce-7fe9-4dc1-b2d3-cf4704ca6c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c94db8fe-c4a3-4178-af77-d688d8a64408">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89fe4a5c-784c-484c-8337-9768c6689f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc8b7ccf-7888-4967-aed6-eb5d343179f2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29113799-f271-4951-a18f-ac987e0e09a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7c3c200-930b-4a90-8dfa-9f839cebf79d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a464cdf-d261-4c53-a320-9be8618fa0d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24ea3acf-ec02-4609-b9e6-da4f477b7a60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ce04a2f-8e18-4bae-9267-07ade5132cb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ebfcf35-fa99-4bb7-8204-0c94fccdaff4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d6c972a-8fb2-4dbf-aa6a-ed82e0c0b3be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dccf116d-491e-4e69-9ea8-8101ad6ec043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66e91c22-b40e-4e8b-8502-27007d0accc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d2bdda8-6ba3-4fbd-acac-7a14cfd8552d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d80d39f-69f1-4dc5-946b-cc151ecda5ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12ba20-35c6-48dd-9694-bdfa799fce94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_167c8171-868d-4aea-a0ee-46d2620d07ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b888c561-d178-45ad-a230-1e5addfe2106">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c344ba5-2ccc-4a21-be2c-aeebe2b6483c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95fd436e-f77a-473c-91d7-6aa7715a985d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb51de1d-6ca3-4a05-a78b-aca3707e3fa0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b295e329-a5ba-405a-8300-6eb7751d5f42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8667e660-8674-45c6-beb5-7a8c5016497c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37a461fb-e8ae-40e8-ba2d-04176c0fc86a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_990bab29-8285-4d4f-9568-8d76adf2e329">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7615cd28-6642-4ed4-aa07-41fcf005901c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70fbecbd-a570-40b0-b924-9dee18a0033c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ceab391-9b32-40ae-a4ca-a1876f5c77d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36783286-75df-4d91-8996-b28c539c0af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25834ef0-16fb-4334-bb5d-f4573046692b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b78831ec-6458-4f71-83df-dc4911f17fe2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c8111a2-d58c-4cd6-ac92-65b5016ab9b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_049942ff-eb3c-47b7-8037-dbe0742de940">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41484357-f128-4be7-8ae7-27bdc4b86019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d612c351-c679-4e42-929d-30dabcf165ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06343fcd-f7cd-463d-9be4-e945953fd82e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e983c04-7dae-4061-9233-f5654965744b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_547bd475-13fe-483a-8458-71d3c783493c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1f1508-11df-4d70-82af-061d2ca91351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e03205d7-a924-40f9-a3de-2b83f1e37bc2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fb84e7-ad1f-4124-8c51-051ac93c5a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c1fa02e8-02f0-456a-b06c-ccd75879889a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9fa2e723-ed6d-4a1f-858b-423dabe74184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af9a95ae-eb9a-4491-a957-2829445d67a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2406d38e-44d5-4ed7-af86-823636e9a488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2c6b929-0196-4434-88f1-a805d4c48986">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6db42efe-97eb-43c5-bc1b-c47c564f3066">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1d6ce52-59f2-416d-a8fc-10fe7e19096c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_560bf83d-89b1-49c8-b344-48c32eaffeac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f38de7a-9d74-4d51-b1ab-5da7b960ffc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c88a1ec0-0fd6-4ba2-81e2-be367d0f4df2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca498289-9312-4a5e-8dd2-23cef664abb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9fd6394-daeb-4698-b348-275e808d6afa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86d88bbb-ea78-4904-b49f-53fd2bb4d191">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31accc74-faad-4484-b101-f73ef44a6936">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41526c5e-6b58-416e-8b3c-6424b0acb3fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11cf92b2-84a0-47fe-a195-f0e64010f8dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bbe7369-d00f-473d-8b0f-691d98291bb2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85c2b8e8-79c3-4ef8-8c1e-d6827a6d718c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81228225-5cb8-46cb-ae11-d29586a1e2ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d6f3a82-2659-40d8-ab95-8a2bd5fc6265">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a960f0-930e-4403-97ad-3691fb54d700">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc031930-2fef-4625-8e81-5e393e3ae979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8d28d23-305d-4634-9eab-d844d194e774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84f4f334-5f2c-4c88-8d1e-28203511eca2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd1091dc-e3a1-4166-9ec9-dc1722819f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7801660b-310a-46ec-be58-28a687126bec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a4c90d8-4c22-4948-8791-53f8ca5d4622">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27d75556-9ede-437c-b23e-d79dc1dc96ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c51a0cdb-d467-4d24-877a-7775e82b53c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_86c18cb1-3611-4361-8a20-4b8fe0384de6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15a078c8-16a6-459c-8f79-40a9ca4a6572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c4d4d990-9de9-471e-b1e4-694e37b7b9ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37502de3-cfc1-4b05-bd5b-ed9030f8f189">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4e417d1-226a-4b14-bd6d-28351e5628ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54ba944-901e-40df-840a-d23df6f7a88a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d318d295-ccfd-47d3-8f1a-043d208aceab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a68248c1-14fb-4dda-b56f-e13a5aa7f527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b135ab26-112f-420d-85f0-80758a7585db">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_31101594-c7f5-45a2-ba6b-27e8f669cefb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd1b6f49-5364-40a3-bdbe-2d82edd1437b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_55cbfc96-cde3-435a-a7f9-ba18fcd0638e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b67b401a-51a7-4330-9d7c-943ffec2f6a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b749a48c-ebf1-40f5-a322-68053428edc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c4f9c0c-1a4b-442f-a4bf-406aeefcc4c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90c30a29-5734-4a13-aad2-5797a77639d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d0a545b-ea46-4ed8-a24f-40c92b051ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b81fa63a-0bc7-4b07-a18e-659a715bcc1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_762575f8-bbb2-4377-bad1-861be802222a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dbad50ed-ffe1-4f0b-b052-2d78375b5463">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e782e39-34a0-4f10-8569-f499394ff261">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1657588a-9956-4af9-ba4f-5b748460b57f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f61f229-a94e-4cfd-9fc1-0399486ffc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c221c69-bd4b-47e5-a647-7f1159e00af0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f53e5a2-d64a-4f0f-8c2a-a443eb46ca6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5a83883-e82c-4672-8b1b-1f636ef7e8e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ea96345-5a97-4a05-b4b2-310f4d0afd29">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f84a5f8-b9a7-4872-9053-b1ef88e2d05d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8819d649-f8e2-4e89-a972-a50bc9c9fcff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01cb8d57-9bad-4964-88e1-b30f590fb4c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7a1d0c9-9b78-4278-af7a-b2b1231cad51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a74a4aec-0927-4239-9575-0cb091400067">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee9adf37-e0a5-4e76-9283-7f1724ad6853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68cc2320-f052-4f83-bb13-d1f4fba57eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38c9825c-4892-4cd6-b9e0-c4adad69a028">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_210557c6-8c1e-46fa-9045-fe56f0c89153">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c1d4660-f77d-452e-8aad-55c5eb44d24f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98b17987-57ae-48d2-8676-f875506d5927">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1b979e7b-cfae-4605-b8e4-9a5fc3be5cfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37f05fac-fd02-4322-9f59-d7defa1c9c2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01df9095-b5fb-4e49-a1a5-1aeedb85f23f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08675ad1-6474-40b2-97c3-0a52b7663139">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7dca1366-a6a6-4577-bd7d-d653e9739366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_25539bb9-f941-43fd-b933-79a889e1038f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_203587d3-1f66-4dce-bdbb-222273112bf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e31e4207-59a8-4219-8cd9-900e92f76717">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ba58280-2b98-4ba2-9e29-94e847ae6fbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64485f9e-8a5e-4388-92fa-f558d6b90e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95bbe69a-d4d6-4ab2-836a-1008b8caffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_479ea762-732a-4eb9-915c-2b88c78fabe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e835c60a-dc97-4554-9544-fcabed551f58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0c82da2-3dea-43d9-9cc1-4d39c9a43b78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_342803ad-2a21-431e-859e-5ee83a93cc91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_93c8c2ee-ca43-4e2b-84a0-2f1bfec243ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_84e84bc3-3fc5-4759-8a09-3bac5643687d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e83af75-d5fc-49f9-82f5-4dff21fbbeae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_315a215e-faf9-4824-9446-b23a5fbc46f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1822bb-61f2-41e3-9f6f-2803fb0e53f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e859328e-c8cb-48ba-81a8-c3d69072787f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bb1238d-127f-482f-b129-003cafd854cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00d4de7f-97a1-4ee1-affd-236e5ca7669a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_06cf8848-6457-458a-8535-40f3b914107a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b2a2428-1a4d-46f3-85de-fb147e11f451">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90836758-b0f5-4d95-8b21-a6c1003de8ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_feebd7e5-b054-4c98-a96b-b28c48f82243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b097aa4-01e9-4d1a-8f1e-c63c4131ad9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_771f6532-a3aa-43ac-b1ce-0882c959f109">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acbc514-341a-4d18-ac85-8e4cfe2f382b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea41c901-8756-447c-bf4d-2d335b26ca9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77fa6aae-4ad7-4b72-b051-e6f28d5b142e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_76d4e8f2-3f11-44e1-9f63-8c2be3ec5162">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99da10c6-16c3-4dbd-99d6-83f1e0842025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd575cc-c1f8-4bdc-a62f-ef6220a31456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72cc6651-81f7-46ef-b37c-7fc46aec73e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62b9e7fb-d6f3-49ac-9a42-d77ee831eee9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07aa0735-959a-42b2-b4f3-6074067aafec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ae60514-69c6-4288-8e65-a598a25c9c90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3cf6bc3a-337d-4393-9090-f9060f0eb182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_129bf6e2-5b6b-4bfc-87e2-fe9b5212a467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80972da9-13cc-4b7f-9e1e-6343fa94224d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5316a4bf-19be-49e9-98e9-e7509b4a2a23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45e90f13-81c0-49fa-8677-5b58fa5ffd80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2234ba5-52c8-40a2-acd4-9a57460b3d57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4427f2f-4949-4d59-a3e0-79721efd6e71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e599f57-e8ba-4a78-a8de-93389bc0e6e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c931db7-c9c1-4d7c-8659-a78594c06d40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3edbfddb-96c5-4997-a24f-d7a1006a01f0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5406d33f-9fca-4c3f-b933-88d01f6f3bad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7b8d64a-03f2-47cb-a62b-4f6a877e7f7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38ab5d22-589a-4032-863f-ba589156bbf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af8788c6-83ab-4c1a-b888-97f10d25ae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df6de0f5-def4-4f68-a871-8ad85b2376a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0020cf33-6189-424f-ada2-6c74c3ef22c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1e3b7333-bcb7-4fdb-bda2-0947a573ea26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7602d239-dfe6-41fa-b6af-2ef200468081">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ca892ebc-e51d-46dd-95dc-a78a20f8626e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7438269e-b295-4183-9b94-7417d16c8b14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d382ea-800f-4f9d-80c3-8bef6e8a5dc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7085f2a2-88d6-43f3-b486-d8fee1e75218">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99134582-5a8c-4bcc-bebf-da4676e7a853">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7133333-4a33-46f6-aca2-bc7c432aa30a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f47a5586-ebe9-41b1-9844-44ed52052550">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_724e7034-65d0-4d26-995d-2cc45736495e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10ff5cf5-d7d1-439a-848d-788d77dbd40a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5b8f1c43-e90c-4587-8669-bf331953a643">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d35a277-c55f-4836-b36c-14fcb66f8f77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_593d0b12-0c6f-46f3-a675-5bc320b23e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c8577d7-eab5-453a-b5ec-3e88c1f69a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01fb6448-cd88-4c99-a93a-ce66fdf0b9ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a1e5cb-d60d-49bd-94b5-ae5ed77d95e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fead62ca-3226-4feb-94aa-7ef14946dabf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bcb2d8c8-abb4-4b80-9e8c-4fc8d169dc6d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef66a335-fc26-4701-9790-79f6dd980150">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe0d6475-e165-45c0-8a0a-def79cf38182">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a0f65e91-5055-49e6-bcf6-9f607dd0ffa2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8fd01294-d5fb-4478-aab0-0c6b11eb195f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e7791f3-2f85-4c7c-87fe-f530bc9c34b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_055f6a1c-d9c4-4ec7-b72d-c385976c9b2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5adae9e3-7054-455b-8e44-93c55e875bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_717e37b0-3fcb-4c83-8c61-6f3bb9b305da">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4490fe16-8b5a-4687-a603-3873c45cfb86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abc18a4c-d871-4631-a190-ec032f93d5df">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74fca12b-d271-4fbc-82ff-70cf20e508a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5d4a0b0-a444-4a06-8929-ae495a0f2399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_59f4b07a-765a-4139-ab24-2040c49e6fef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b1a3d91f-fcd8-45d9-9068-17367aabe864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aa8d0b3-7c00-4d3a-bc74-c2b2e6b93bf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da927dcc-2cf1-405f-80d4-f7dd92117518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_66f28d02-03ca-4604-bfb5-31ab54d621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7848a48-ec4c-4aef-88d9-a75acc3eb65e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0f4a0f9-4c5d-4893-98c2-19b42e6ec40d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea7cda5f-7955-441d-a706-62050000be98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d4de290-a5a6-4525-888c-67cb8386065a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_658c5fbc-8d6d-40aa-a7a5-a2c5101bdb02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13119acb-18fa-4ac9-9d96-0a98c69b66e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e3c1c910-6fec-48e6-a071-f1bc05bff568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43709e36-106a-4bf0-94a0-67e433f9d58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_29d86cfe-511b-4b0e-886f-d808af28ac00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_58ce1bb1-e8fb-44c8-ba47-2325967e7140">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b67afef-e077-4f0c-8754-e862f2be799e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca6d3234-c045-4487-a1f2-023eda3c6b48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13db0e89-518f-422c-8ee0-bebcda57c914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37085430-1118-460f-86d8-a58274c29368">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6cb1b71-d49d-4b44-a7ee-8f8379ca6c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b876ab67-4bdd-45bd-a5b8-02c3b9e6492f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0975e90-01cf-440f-ab2c-1cbda073793e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c2797fb1-b15d-492c-a86f-900dc054eaf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c15a8b9c-87c5-4765-a698-bd3a743ea0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e900d4f0-88a0-4f10-b450-ecc7289fe172">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2fa583a9-e27a-445f-b11a-3cf60a6c096a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62b2ccb4-0d9c-4592-b19d-d21ac06c6bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9343a5e6-3fff-4379-b4b2-88ac2b9d5e30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fd34c6da-f9b4-4edb-abbb-229e9c0e6507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4576d17-b9dd-481e-a99a-9b2e86fe2c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5659175d-91c4-4e77-b2e3-de41cfee7a61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_88f90584-8048-4836-aed8-557a1be25574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4425d538-82c3-45f4-a79f-468ce22b1277">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c15e468-811f-493c-8431-c78323ee7261">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ef86e14-8dd5-4f53-b834-3693fd04025d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41a92499-948f-42e0-99d4-4c81b1763be6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aceea622-96cc-4cc0-a4ef-c0985a14aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef55c6e2-1559-4898-ae94-bf5aec5eee35">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1c1066bc-6435-4370-adbf-6e5e9dca8a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b46e9d4f-f807-442d-b48e-25f59c33a0fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7a197074-f6dd-496d-98d8-ece105892059">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_afdda05b-9fda-4c5e-b67f-5a8835a9f019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6c15186-72d3-4946-a857-f709eddf838f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b63e438-cf9f-4456-a2e4-1d1600bc4943">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99c5da9f-56a9-4126-8ec8-27c0ffa69c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a721d8e-f3b7-4d26-8044-ff5e90d0cd32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd52bbb8-eb82-4bb2-8c14-37ae895d7f14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_021c9ae9-3d30-4a67-aa98-7c86f9f2669f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4db08985-bfd7-4f60-ae09-e3044e1143c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dd33081-800e-46fd-ab6d-3688e6d05155">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5d4dc3e3-1d65-421d-9995-ae5fe9b9ae99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_12e40f94-2cdc-4991-8c72-28352ab765ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b26843e-a219-44a3-8b10-e755dd65cc50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2b84dd51-5672-4c25-9b6c-eda83c8e6aef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8dce3f98-5a3f-47b6-8671-6264edb60f38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eef57a7f-1b38-43a9-a2a1-88d1d43c41ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2e8d3533-e650-41e8-ba9b-36b5ec94aadc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4957a875-6ba5-46ca-9ebc-5842f66e92f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b51b1dc-b52b-4d98-ae80-713d27ba53bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_571fbb8c-c22f-464a-a009-75887e5265cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f02a089b-51ec-46fe-ae11-2aab8b340bd4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b9574069-9cdb-498c-80b6-bacf8e33d6d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f67e88-6aa3-4155-953d-51300aefea7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b54015ba-0d13-4c36-861e-13d092f9307d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4190d3e0-bea8-4b68-a705-a1359a5b8022">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97917706-3686-4103-bed3-0588a7169e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7536f1d-7c3f-45d7-8a79-842bf0992eec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61ef9abc-a0f9-4c1d-ad7d-cc9d81ca9b68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dba72ef-c7a8-4f5a-9b83-2d8dccecea7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aff8a4f6-0ddc-49cc-b04f-492336fb78ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7a42f18-f442-49bd-809f-5af6909a5bb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f11a1291-627d-47f6-8d13-d122d2907fa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a7027d7-d811-4bbb-9fbd-ea325624dac3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c354d477-f0f6-491b-af74-faf74282d996">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a1d8cdf-7ea7-4554-ac6b-d7755614ea93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b906ef20-f829-41ea-a58b-bee609b03812">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab799eb1-046f-4efa-a790-46f648e33aab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c44198e5-abbc-49d9-9b4e-8d5c545425fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5728316b-1343-42ef-a0dc-2582ddfce4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01957b23-1950-4ef7-9f12-e88028223835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aaf9837e-648a-4328-a7f2-1e524528ec4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2a8261e-43de-421d-a8cf-d18e51356b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_745a62ff-fa7b-415e-a80d-58499bd979a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfd66150-92b7-4637-96a1-10bf16bad932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19709704-48f5-4360-b6bc-454dabb4a91a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc0bebe2-35b8-4d32-a5dd-c866e110519d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ade4e44-a1a3-47c7-96f7-58ef549c8881">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ce1137e-97af-4f0c-8e97-d8362f9a6681">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_704bca7a-a16b-44af-a3cd-63ef88281c92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_771f698d-78d2-45f4-be66-2d71d49dab8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f86c5a9c-3aaa-4913-8c02-8ad29f83cda3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0371a00-0b14-46f1-b09c-25eefe811e0a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b541a7b-677b-4452-ba63-04630664276d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_28cd2978-aafe-4b1d-a72b-800c2057fc98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9114bea2-7789-40e9-b181-5c37526bff09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46d738cb-d6df-44ea-b946-4d780d06ceb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_625e468b-920d-4c28-805b-434508aafc60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f76818f-5a86-44b6-9f8e-2fa8425cf4ed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c00a6123-f67a-4394-b0a2-9703b6fe7c5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46a60d8c-5ee6-4b88-9d77-bf14dbd42e13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_842f35d2-8bc4-422e-9c6f-482c3319c75e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_223736f3-2dd8-400a-ae21-23490dceb5a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e7184e6-b0eb-4071-8f5b-ce9d3575ebd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d990be00-2c1a-4878-91fe-9d411db99e7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14de64f5-2498-4d4a-93fd-07ddc4faf4da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_248960f7-2bb3-4e4d-8ef5-9e4b5256e242">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc787984-7965-4911-874d-63951b71c9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_beef0f3c-1063-47c8-8c01-980f9d0ace04">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_efefc590-7ccf-4e2a-b1eb-29ce71bac7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2851c207-d0f0-4afa-8459-93e67ab046b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dc647ca6-b570-44c6-9a95-9017a0d9a6c1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f69a138-dd10-4d1a-b4fb-bdaebbdf6bb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb12c256-e1e0-40f4-8409-f632dd91a567">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_197813ee-99dd-4dd7-8c7d-953125010823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad326602-7990-4820-b11e-d30fe8712f1e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c7f1716-7a9a-41f1-bbe3-a0c786036aee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e5e210cb-1713-4b5c-ba13-a23753fc6357">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6947b0e4-2183-40fc-bc41-71fb9826a566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ed6be82-6f0e-4e3a-9290-5440ac0e3210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f2ef388-bb24-45de-ad9e-e1d81b0a70e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d34ee87b-12ea-4264-be1d-77523cba6664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96509c69-be8a-41c3-aecd-cfe5a78a347d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fc8b50-beba-4f1b-9b37-44be779b4008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d93a35c6-2778-4e43-ab3a-949e0ba70465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5812071d-a8e9-43ca-8ccc-b51bad61713c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b8883d7-bfd7-440c-8b70-b542def33958">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7f4e2cc7-9c7e-4591-b673-e15674599f33">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_69312939-c515-43c2-9907-6f7a9b4c2844">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5feef99d-86e6-42dc-9c15-685a70a1f1aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88aa5ed7-9987-4bde-ba31-fb3b30f70285">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c18d4158-7fc8-4153-ae44-3b69c9326167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bb77820f-64bd-4d5a-8a1a-a712fd8c3dd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8185f40d-99c0-494a-8fb6-1c2c1e36d884">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d843d9d-ad4a-4ceb-9ffb-1f9b8b2a892d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2ac50ab-cc63-4365-8bc8-5a0a2ec32143">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70091785-81cb-45d4-a120-97a3784b6f40">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f82c11fe-c49c-4676-98df-a97998557859">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9b24f203-4333-4e3b-a822-f022244e1d92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cde6c0e-e554-4167-b71f-62b67afc85cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4e1a8fe-b9e8-42da-acd6-6ccec8014bb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e045e99-8d68-4ed8-9391-4309be949fed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52120d04-2b1b-47b1-9581-72ba5a43d32e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c5d7ca3-84b6-4bf3-8e80-a725069ff9fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_877e8141-40e2-4022-81d0-7ca6b91fcfb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a36a24-459e-4f26-ba5f-5da5af49a4e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_eca88a11-bf8b-4a75-ade9-2de5bea4877c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d827f489-f33e-4019-87af-4414e8baf08b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff3ff395-0043-4d1b-b7be-f7a978500713">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_74b2a3b7-700d-4d2d-a24b-de95f780984f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d3b9648-41fd-46c5-a65e-4770c2379091">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38bd0277-d889-46cc-a57f-4dce84db3179">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac35b9f6-9769-4ea2-b7b7-a39fa5afe1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6487111-119f-4c04-b03a-4f358ad555ad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a3956a79-3d90-444e-b18b-babe0a24c7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0886d513-eb42-4bfe-a1d1-91dd552d985f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3ef6f07-77db-4073-9b75-8c884a8227b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fe67305-2b8c-4275-b395-ab7968cd0272">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ad26464-ac9c-4a4d-9367-9adb3cc20cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac0b47a3-728f-4a27-8c82-47187058245e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ae765c-598e-4e7a-a7e8-7ec76be26ff0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_14440212-9e9c-4a98-ae20-bd02c0389b11">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b558016f-c443-4453-a846-56cb92195255">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9f1df3e-d035-4107-8c1a-ae630c1dd0b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6891853-d085-4539-87e5-a3b8c0a18445">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74abf6b5-ec41-47bc-bcd7-ead4aa9b4d4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a024617b-feac-4a5b-a1c7-5ceec0238f98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_053ae80c-2f62-4b2b-87ae-759d2bbafe48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_72caf4ce-0392-4a83-b9ef-66c1bf18cd42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_618b6fb8-cf30-49ec-98a0-16a816909cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6869cbe8-5336-4075-850d-5689210ea8b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5efa4008-dc17-4aec-8c9c-d3d19f2be5cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71b4a9b6-82e0-4375-805b-2116c6402f44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4698229d-cd6e-4c86-8cca-e6d2005f3fa8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4f83db32-bf0c-4cae-b788-13c0365c7c20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a97f14b-bc34-47b2-8772-22c5879d1cb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1fdfb51f-2996-4790-b046-72e240d1e0ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f253934-45a9-4b3e-ab30-7e2ce8327ed1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_132e5e39-3f2f-418d-b826-1376ee0c715a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2db62614-6569-4e78-94a3-0006780692ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e3da9b20-f585-4c9c-93e5-14c19f2b6399">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dffd3c04-567a-483b-bd21-95a2c659040a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f622f73b-4f50-45e7-a314-dd7abc1fbf13">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fafe1dfc-054b-4ed7-91ee-8d379326eec6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_835c90d6-b524-4dfc-baa2-91154554bb3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af61f0bd-2d4f-41a5-8108-5d6bbb9ceac5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62aee4c7-b396-4790-a96b-58735a58099e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8543a6eb-0473-4bcb-8ab0-59ba2fc58b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13c4e177-274f-4c6c-8a54-1666fa02f5cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b4f2a4b5-de1b-46e6-9caf-819d0d5f7756">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec6c71c-fbd3-47b3-a7df-259f8fcf18fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9cf81c-329a-40a9-b846-02b92c38b584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_45d1f6db-a578-4885-86c4-fff085855ffd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60d8d59-4416-4646-a1cc-0f85a3ac109f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_63c4a7de-7676-4226-901b-6e8a9e63491b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27f1ae3b-e45d-4997-9a2f-af8fccfc9c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ede0ad83-2917-45a9-a53d-17dbf251a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2d6aa302-62c8-40ae-b6d7-4872d0a2c81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9187f8f4-cb9f-4497-954c-4e9470855a9a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b023345-3d98-4426-8967-f6be81e1828d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ae07a8e-253a-45de-a576-a70bd5668d58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1d3ead1-3f0f-40ee-943f-f1dee312b0a3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3b3ede6-1f39-4cf6-8970-363427783803">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e58009b8-1f83-4974-83fa-f2044fb95808">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5022d2fa-b3fb-4a51-9b0e-65566f9d8473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddad94f4-3682-4c83-839b-0aae8dde7bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be420f6b-ced7-44a1-ae07-7c136bfb1e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e65535d4-bfcd-41b3-96dd-2a50f50ab590">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5f92fe6e-b0e2-41ee-a046-28611580b915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87635d3c-7a14-4f8c-952e-6ee385bb6d83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f4052ff8-e2da-4b60-b80c-c68fc1a60619">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ed5519f6-7ead-4c66-bd34-fb76ff46cafc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ceea3926-ece0-4b7f-a7d9-909e150d3d84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_29c7f86f-dcfa-4ff4-bce0-b1d88b129da2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_32467b45-4242-40f6-ae90-399a071e765c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c229d207-3189-4df5-85e1-37b21b353674">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34394c63-2e6d-4553-ade0-bf94a78e4382">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f84f5c00-f7e2-404f-b646-fbab051c5d78">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6d3aa49-e3d2-46b1-8d53-3f1f75e8aa4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9d8d3d57-7ca8-4460-b92e-0970be0092aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f792f6d0-fe8a-4439-9e46-e461869601cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52b96eec-0446-40bc-818e-dc037aca27d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b92b26-84f9-428c-b42e-767cde1ee485">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c1572f8-54e9-4f58-b58e-4be8dcb49b80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ddc2ea92-8895-4269-9512-fe42270e9a5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6904c68-be16-4784-a554-5e37a8906992">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_893b7d03-19c8-47d2-898d-eacffd52b8c8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1285083e-4048-4afa-a315-b3cb3fd4781c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4ffcd89-c4be-4992-88b2-db12df2fc476">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a862cbfd-9088-49a4-a91a-4e32c22e9e43">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d015a1-51d9-46ff-aba2-2a10b7abc94d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b88e545f-683d-454e-bf38-a4b4a11c66e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df0b8e73-382d-4260-9489-8114c52cb9f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0d88a48-c7e1-46d7-a314-85c4f870919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f95ea0c-7967-4cc2-88dd-62ba25802230">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0cca45f1-e599-4046-bca2-f221f2fd0d69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7df41223-5692-4dbc-a02c-d0d7c1576298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1bcd4be-f73b-4aa8-9b0a-7514c7c50bc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e93dd0e3-db03-4ae7-bb2a-30ea502339da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_145e4229-0762-4f9e-95cb-fed99ad79e9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e360b1-fd0c-4c11-bbe3-c543d1af1a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_513d4e03-731e-4486-853e-49ec395312a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45a4646a-3dda-4a59-855a-ecd1fb44263f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_08aeec0c-32d0-40db-82e8-cff84194afd9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b59d6e2-48d0-44d8-9a67-0106c94f0142">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45aee435-3966-4bd7-a2df-ccc5ed886045">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_20f86f62-6dcb-4b55-94fb-3f3e6de5521a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad48cbcc-0af7-4f32-9433-2fcbad64670b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_27ac5033-50ba-4225-9d50-ef7282186c0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74c4fed9-ccd6-4a23-abbe-a8d0d429460a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca797025-3a0e-46c3-92bb-00c36c229c63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed8e5966-f137-439f-aa01-b1cc7d49e74b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33b677a7-46fc-43c4-85ea-ad1351da9c4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2070290-3e27-42f5-80f9-8f6035aeb75c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cc431a-3e19-4339-851c-f5b1c6f85d36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9878ef4a-3f92-4c4f-8b67-6eaca87fc58f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1163857-e5df-4f81-adb5-de5b3f4b13b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d94d4a5-e15b-4126-b4f1-c774996c1587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6f592ab-96ec-44c9-8837-3fa9668144a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94e72f33-d0b1-45eb-b58c-abc95358f80e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8cf22fc6-6d20-4aa0-81f0-3f34586cde7e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ff9c845-5984-4ddf-83c5-cb948ea978dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9cb09ce-880f-44da-8356-5e62c28e9556">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87db2dcf-7381-4bd1-af56-900c29170284">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d0c504a0-1dc1-4a84-a77c-dd4356d9c45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62836935-2777-43a9-b6b1-2d8ce915e99b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_301306f5-441d-42c4-a85b-b4dd619b1d54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d98d033-219a-4647-8ef3-214a241ceba0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_649ff81e-a994-439c-a3e1-79ca4b97f467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ee3600e-761d-444e-a54c-3b231bf6b0c6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_651d7211-bcfb-47c6-a62e-546f97cbdf31">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d660b3a2-36f4-46af-965e-9ccf63921b99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06ef8f5f-ced4-44b1-89fe-636fde5295f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de006bd6-6239-4d9b-b431-975fc883ef69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2409fcc-0d8a-491c-a8ad-caf94d44c866">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8953b98f-b6ac-4fd9-b382-280dd9f83848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51c81d09-778d-4eb7-a792-b13cd11990e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_030fd25e-8a7c-4067-956b-95de2e43ca1b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eea0f6ae-4a78-41b2-8fc1-9b24e9bb1b2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_799401b5-7bad-4628-936c-272a47afe701">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b30e5c53-c685-4975-9ff7-395f24f94933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cfdcd1a6-2100-459f-801d-cffdecc34978">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ac17236-8641-4330-acc4-a3546fa3be0c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c2b5717d-14ab-4735-84c7-f08eec3c5151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92093091-9def-4b01-a1f4-97281f352dd7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_457739f8-564c-4260-a9b3-6e7ab51f19a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_29f45a6a-1c54-4cf0-82c7-18f8a94aa832">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b59ca157-0966-4c44-b922-2203edb1b072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12b76adb-53b7-4746-81e9-b6b66f3b395c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677cf6a1-0bef-416f-97a0-cfae59065c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e11c9d8-c96d-45de-bf98-be3f0191af7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b085e19-fd8b-4a19-8ef7-75a2a1b340e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_14b9ba51-ca52-4687-8618-aa9a4680a7fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3f25543-e935-456b-bc76-6fa1074135df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_09448cec-6754-4734-a17f-dfad905c44a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a3baf0e-2dbf-411b-b020-a2de9b0020df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_547408ac-ad5a-4f0c-b307-254a70440a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5862bea5-3fec-4d62-8c22-91f359b85c16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb76ec3-366c-44c5-8d38-728ed54ff389">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8a8ab2f4-2478-432f-8c9e-8f2cb5f5d630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82e14c8-843c-4eb1-9432-72391eabdc02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_03284608-2cac-46a1-9ff5-fe40d306eec9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc5b8041-f904-4ed5-8244-e97962a5caac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9489f62f-c3ab-4790-8054-ad01c5b0d5e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ecef8e03-2ae5-4c33-ace4-eb88a1ddd005">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_063f483b-b293-4c29-bd55-d372d3f4a341">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17042f33-0046-48aa-ad84-d9efbde7078e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395a61b8-006a-4196-bb79-5cb27b25eab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9239f57a-e9c5-4fad-89a4-b8ea2bb28e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fcfd5cfc-f4e9-4a3c-acf7-ca2702751185">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff76a3ee-bcfb-4db4-9bb2-974d6c21c42a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00e7942a-8a44-4f31-b35b-6c88bd506e89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72e10721-4709-4f0d-b005-2572bb18c770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2362f3c-d255-4610-958d-0e10053bc77c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f7c9d871-1586-4d82-bacf-c192bc284e34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_145bc878-e3d0-4a68-999f-86ea26ae1990">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea6d0cf2-bf23-43f7-8409-991f9ae05b48">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_337e83fa-bd65-4743-8321-42b10816e5fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676e07d5-62ab-4f73-8081-8f032b081774">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f58dafd0-b948-4a63-bdc5-4ede3acb6afd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5afccff9-daca-4c68-8816-fb0044885a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7134e652-abe4-43ba-a026-b7e9d691a8ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3f60a0e0-4a65-44b0-ac9a-ecaaff0568f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d1d79d96-ba63-41a9-9ce0-85a38c48b050">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f14d84b1-2685-4ccc-a131-7dc23a20cad0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08e585b5-f18b-48b8-890e-b58b94cbf885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b9bf5836-6dbc-41ff-9ff1-0d01024ba9be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_52ec1e35-44c6-4fcd-a770-aa08f88d7795">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4dfb00b6-e3bb-424a-8e2a-3dc0e75138b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27b64a1b-ef39-463d-9343-1468c0720811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_992ca25e-c4db-43d8-8de3-7d4236242e8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7ecc7d69-bfd5-4fb5-8431-2b10b70edd88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a4ea322a-da37-4bd3-b3f6-0e78ff502bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c40abacc-9e8b-489d-8671-de0b37aa8636">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7a85746b-e339-4d05-972e-ff0e3eac549f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef89fef9-47bd-4286-b6ea-a99a281f039a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c24582-f9d5-4bbf-b7d6-b61f103a44fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_efed0d03-d7cc-4f26-8ea0-45848fe13aa9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_967d5338-3df4-486c-afa3-b5e88ac715d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd19b3b6-f6d1-45a4-8dc4-0fae74d2c3a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e919a839-3083-4a1c-b235-9336097753f7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7fe68b1-6ed0-4ca7-9ade-c169c8374eed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14085fc9-b39f-419e-83e5-e2cab1d55160">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1c821c5d-c3f3-4c50-b6db-ac35e16b97c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ce0efe1-62bb-4a5e-9733-f1cbdf080af5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3d8e9855-b1b8-40ef-ab65-b3c547a83cba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3e308ac0-5c77-4bc6-a8b5-5ec33f548691">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d75db8c-3edc-4746-bc88-43066fc4ceb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6db6bdf1-075a-4fe6-9fde-b9591bc20d23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29fdda51-879b-4420-9d67-a14259902e2c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bcae2b91-06e3-4f90-a51c-142614f8d6ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b539dc50-2b2d-42cc-af9e-8edcec28839c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3210626d-f10a-4215-a19c-6e68ee613be0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05e16d9e-15b8-449a-9037-b399ae6087a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c629896-e4df-4b62-bc96-f1258ec5c947">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f6e0ab3-52d0-46dc-b58e-93c5f22bd0f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_265e5d25-3027-4f0a-8a18-975067551770">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26a6c4f6-6c52-4721-82b6-3c78f69b0ee4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d317588e-e08f-4292-8aef-6be6170c335b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ace3fb1-ff34-4a2e-bef3-e579c91380f0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8cfa32d7-a521-4c3d-bb3c-265306a0320d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_272e6f11-15a5-4195-8a44-ecb091d1500d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b5baf11-9a74-40d5-900b-7352ec34da1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a85f927c-7844-4f5e-9391-108fa014f96e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d281e9c5-8246-4cd1-b81e-e8ff1b538a41">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab98a3b9-d124-440c-9f3d-4a4884dfb95d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f451588-ac24-4bbf-b20e-8cb3da0f0c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e441009-4aca-4646-b423-3b43c9fa7d68">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a281b9f5-89f0-4a22-8d46-b194d9bb411b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be3aced-f45f-4110-b799-7588f844f08e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d38dadbb-5707-41a9-b85e-66dc8b70f583">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d937e822-cd68-4dcf-8832-87c36ed4c7cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d492ddf4-a60e-4fb6-abe4-821fd2501932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca7cfc2c-1aa8-48c8-85ad-b0a1ac53495f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5bee6c3-edef-487c-abc4-66038a4fc79a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43e6fa8b-1193-43d7-9292-dd54a91e29e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f692ed1-d190-466a-b31d-138e71b9d2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ee620ab6-e452-4ca0-9e44-9133cd745cb4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b68fda8f-bd7b-4a4c-8983-fa5e733d294e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f51bca0-95ce-4cdf-baab-e02610175e71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1f96919-4686-42c5-b11d-80413fbf695c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e1175e53-6cca-43ef-9550-4f088dfd2c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44975eb4-b7c7-4098-bf5d-076229b9598a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59fb8ddf-dbac-416d-b576-ff27c78f97ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3425cd4c-f477-4c35-9414-a074fcda03b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dbb3127d-13b6-4b18-a82d-429d7a661cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff1b53e1-3ba7-4331-b32a-431fcbe569c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48d3cfe4-1850-45cf-a38f-2463e84bbf4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_132a6e57-05b7-40f7-936d-8ad215faa067">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec22b841-2d09-4c40-9094-2910f9d18f47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69dee46-8d4d-4321-bfb5-695e8cafc361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784648ac-b7c7-45b9-8b04-cd52657911de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16a4890e-2299-43aa-85aa-60d568a6f55b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c85bb9e-b82c-4148-9151-33ae459b1ea5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_31d058e1-7999-4900-8304-e699855178b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70f055a8-4a29-4f1d-afe4-0a6255d8fbef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bd353fe8-a348-4ac3-93ae-173919e4b699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b0262344-289d-4b5c-89fe-a2ed32b4ca12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f6ea1e1a-dbe8-4939-b05c-809b216ad452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02aa59e2-99d3-4957-b768-41f796d55d31">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b1c55cf-a01c-4f0c-a008-0f4c3f91f1b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6611048-9b76-4265-b03c-75500718c097">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9024f22-f8e8-447b-875b-4ca9b01d799b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e3ba0a3-59cf-4d02-8c5d-e5a6846a0eb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fad1e6b7-5f14-4853-a74b-6677b5c0719e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6b142fa1-1890-4e15-9044-a1c3910f6538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_27c3357b-8a1b-4130-bad2-fc753b66ec3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a94aefe0-21b4-462d-aff6-7aa79d6af0ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_255ca98c-c55c-4369-8358-031e6aae3279">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b627ac26-6fab-4f5b-b08a-f0bc8281227a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dfeaa24-c478-40bb-aacb-337c3ba958c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_533a0fb7-2cac-45af-b21b-6bc5e424689e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7e3c55c3-c306-4bad-86dd-f8cd84a7adac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8010fb5a-ccd3-46e8-bf62-76ddb2c39d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20c7a56a-a0b5-42fc-b168-b4256f98459d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d7307f8f-a895-4152-9146-3dff1dae3a45">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a42b677d-a545-4739-ab21-0906bc5547bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fb41ff7-7704-473d-a4d0-051663aaa078">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c26a2a3-27ed-4b94-83cd-17e4c607df1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_343e6a5b-fbe6-4747-8c53-1eb52d084263">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a640bd3f-ea54-40dc-a069-ae10b7b98e8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b63f3186-9667-4c33-871a-7e97ca96d072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0d68b555-1b95-423b-821a-2d321b2e53af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_090e9885-ef0d-40e5-abb6-e43fb1b8f24a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9fb9ad9-e629-46b4-850b-445a76ca39cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0acb4c9e-f5c0-4ab1-b811-10d8c74c7e95">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a54a35ca-7b80-4008-af79-e44cca11d323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dc30822-bc18-4884-bc98-f167564638bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebd0ef2a-c759-42e5-bd7b-6bedcf57e560">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0b2aa62-3d71-41fc-a067-bcdaf1bdb2ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d02435-6273-4736-8568-3ac72f70d876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9365ce5d-c4b7-46f5-b929-259b1c0acd25">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dd5b60f-7c8e-4cdb-8e48-e1f8e14d54b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c854969b-0dc0-4d52-8549-20b433c77a92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2dff895c-7df3-43b1-9d6f-371d946ceb94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a85cbe00-e62d-4fdc-a20f-7a5f3429f811">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7e9c7d6-aaae-4c63-80a4-c463d4186c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1550bc6d-0c38-4f43-8aa5-d2ee7fb75810">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e269512-714c-4f4b-bea4-0ec09ad3c5c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_108759a7-92be-4837-a459-530d3d469d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3f15ee8-97f9-484c-bd1e-5497a0d3695a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_581aafca-3016-492f-a1f6-1dccbe761b20">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eecb8405-190d-4db7-87d2-c00a985010b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a166efd4-dc5d-4c8c-b621-be5ae04ee995">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_658e17f5-93f0-4cd9-a55f-bee355ab6427">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97265ab7-cedf-49ee-a787-73b89c0bea8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cff70ad0-2745-4c83-92b0-9d2674884e8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8144362d-e099-434f-98e0-5c5956d76c50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ecd98a2f-c81b-4ba8-80dd-c5e870ae5a8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b462b4-2e7e-4314-b5c7-a982f303dde4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf6cbd2f-5987-4ebc-b776-19232cd670d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2149a1d5-743e-4433-b55d-4ea03cb9d96d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b0bee1d-f5c8-41f8-a196-e0055949116f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1d516a33-6095-49c5-91b1-7897d6d4af68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34608c0b-a18b-441e-9131-bd56073e45d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fd94ebd3-d19e-4a18-9765-6701c33c17b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2166479e-4319-434c-b484-21ef1be759eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0101d57-44da-4395-9bc3-ec5770bb993f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5eecedbf-d6e1-4a37-afb2-ca148b34a874">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b353f73-ab00-437f-a2d4-9eb81e2b9298">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1e1fb9d-607d-4053-9be3-c699b18bb749">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c9559fff-bf85-4c78-b609-8673ac1ac5b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e8b6bc49-dcc6-451a-a59a-bbb38cbe4b34">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_62ecfa5d-20ad-4605-951f-1b1ee85fc9cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2dcdd11f-f143-4f62-bac3-2648ed438d44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72933c8a-6d75-4fd6-a111-3912cdca4993">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5707f101-1574-4ac9-b315-76e8d0bdea8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fc51695-79d7-447d-b7d0-2d441a615dbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6eac4e6-904b-49e5-8643-fa10dde8dee3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6367f18b-da16-451f-9398-4dcae9461dfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d2353b1-df8a-4d93-aca0-e4755108539b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_62bf7bf9-411d-4e21-b3a9-598f88e52265">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71909016-4df2-4de9-9017-0af613c378a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_72c8d946-969b-4911-9ef6-98c84304e8fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f86f8992-c397-4968-b61b-5d1ee0be135e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0bb4e66-8e2c-4258-b9bb-9d5f6fdb68b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b641ad1d-8f25-400d-8d06-0ee76124ce9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_06da1fb2-d197-4746-8669-418acdd11ef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f0b74cf-101a-4fcc-8b7f-5dfb37885d42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61d59f3d-dd4b-4488-b6dd-eef9d4cdb561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e91a7605-459b-4d91-bef4-eca132a0fe79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_60fa5a5b-8d4d-44b0-abc2-c2c9805035d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6604084-2693-4dde-a853-88ca9da67a80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_330ca30b-c80f-48fa-8bf7-1be251e000a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4d9534a5-0e6e-4bd8-8537-bd4919ff95d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_282c0f6b-a099-4c0d-80da-497535cf380f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db5668b-6269-42dc-8cf0-4d5f1edd75bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec70b485-7a69-4fb3-afc7-ff87095266f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_063a6c89-83de-45d6-b507-d333070c2f19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9dab1799-adaa-4517-977c-ebe6a16d2549">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bf0fb38a-3e9f-4346-9366-6875ce97be73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a568e818-3e12-4ef1-b0d9-5bd46fd927eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b814bc8b-78d9-4faa-afd7-8ab401b6340f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff01ab24-a8a2-4a7f-9c5b-47940f37410a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db4eff7-f3a7-4b86-9c3e-414ab37d6771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_57802d22-bf06-4f03-a7ca-3c8ef8b8d251">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_048330d9-3bbb-4b3d-9923-9a39eaead778">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e79f72e-ea6d-4cfe-aa54-d9261d98436e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d30f340-85c7-4d92-9577-cd96cc2f5d1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac74c520-a4ed-478d-92a7-4f485a50822c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_820e4f42-5173-4d16-b4b6-979e62ae9f35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f491bbb-1277-4229-a3e1-f8f10ba1b923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4796e0b3-1a9c-486e-bf68-fcdf5eb1bd64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7af55883-cbd1-4b4e-a1f3-ec6a28f641e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10c65879-6984-4e77-9fa6-34c3640edd5c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb403c1c-7c91-46bf-b50b-424f2bc0cfd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97c4755c-1514-4404-ba19-5e804bba3b5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c339a2b9-fb0e-4670-b01b-0bc99c288d38">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_36ca438c-ccc1-4d35-949f-54817dc7d31c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec171de2-3ee8-4f73-96b8-bafd19f04677">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4b578fe6-79bb-4f4e-9a6f-4ac9b840d579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a456902d-0412-4ee4-b228-8a714ae36878">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315b18a-8654-4766-971f-dc5ddfac8ce7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9858fd9b-b96b-4df8-b153-e34219045db2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7419c7c5-a3e9-40c7-99db-621c91281ebb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfb0ee89-1778-48e7-aa6e-c2e0e042d331">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ea1abc7-2de0-4679-8e7f-631374e6a83a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fb07bd1b-bacb-4795-9c75-8cb1c5fa83a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9151fb81-9550-45d4-bd07-4683d29009aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83940b4e-267c-4c4c-b9a9-0d9027a52d67">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9372795f-ca2e-48b3-b41d-0880ae5d7991">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b7cbc2c-e5b4-4e1c-80e7-8de1fba51664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5fdfe70-9a41-492b-9f27-da15ebba8a72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7166895f-1edf-46f1-b802-40c4c0f7ede2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f2d5b22-dc04-4ed2-9638-317a3a8499d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ad8b9f-65df-462c-a914-26b406488a65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_450e1f78-108b-42f4-875d-bdb70269e9b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c831d6a-b29c-46bb-9ec0-e8e1a95f3ea9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c4a824a-2713-459d-a73f-ea5de799b0fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd3db492-87dd-4b09-8170-de53b4ab0249">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f2cded8-25d1-4851-9d10-76805fbf0350">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_432654df-26ec-4b72-bf22-d2ed67081a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5a5c821d-15ab-4aad-b751-c9b46bd2fb53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a6652b1-3a02-467a-9ac4-07e00c70450f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b023ed9-5451-4e72-ad37-cf8ed02ce876">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d69413cb-36c4-45b9-96a5-197a238a21d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_50bbc7b2-6b08-4a8d-a9c2-d375ef380e6f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffe8f414-26b1-49eb-bc04-f72708ab201f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf7ffbfa-817e-4a65-a0ab-2c237a4ec04e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_40abf24a-4c0e-4c70-91d3-a07e95c560d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e0e0d2d2-3a63-4684-a023-2daa39568822">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef5fc63f-d2c3-40e5-a1a3-092327cf3a5f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2733bcd5-5171-4254-9b71-d7d4822da04e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce699638-1fd6-4cc8-b5e7-da5014317b9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6dd43f1f-50a8-41ae-b7ed-ce110f47260e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_19f9acc1-d6cc-4cba-ab1a-39bc6330c6bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_73d58c01-2816-42b4-9026-b4a864be5971">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab88280f-88ae-4d19-9293-87d20c9555f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c4c1ce33-8835-4644-85bd-df6b5d895e97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfb91ec8-3c9e-43b3-b0eb-2d8d432ff514">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2c2ebdb-c362-4dbd-8cdc-106859815a67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4512872-e0b0-49c0-a886-abcec20ed4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92d457d4-5831-4817-8dd0-252285238b17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11586e77-2f1b-48ef-a43d-3c3ccee74e9d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0ffc407-f68e-47c7-ae3d-e0357444b057">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_488812d8-5ebf-42e9-a429-6e647b84fa5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf5edb31-3e2a-4b1c-824b-623eda6f0d49">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34d7c069-adc0-41a7-b8b6-2031ce11ef40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4736319-8c40-4ba2-9349-388c6e2231f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_feb099cd-62e8-4b2c-9a35-31961fa7f751">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfa33102-fb3c-40b6-b982-16f1db6cabdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f158ee-3379-452f-b5c4-3e6a6e9869e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5e571827-4bcd-4f9c-a4ca-8f43fc1bf1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fcb52fed-20b5-48de-9187-a5bcc4b4bc55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6e556c88-b5e0-46c7-9acc-cee3f394c3d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9993779b-feea-486a-ae35-2b21258ad63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be7c3e94-4419-4fed-aacc-75ff147f2a3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b834a45-5de1-47ed-bb11-411d4631e322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_783ea7ca-a48e-474c-b2ac-d904da9ca09a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e96c03c-3d23-45ee-aca5-4dc6260b00b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66399c4d-6f60-4c2c-9275-23fc994898b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86670c41-42da-4ce3-8823-8c140a50621c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_846aed1a-7886-42e1-bff0-9c1d20867b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ac9a23a-c7b7-4368-9495-6a79740ccdd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ecc55ff-bf91-4ae1-a6b3-ae84c0f5a1f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e04f8a12-64bc-402d-8135-fde49c9456a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2532ec3c-b602-428b-add3-c397c469e629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8747ee4-c3fa-4da8-9f95-523edc656e56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70e32c10-3c2b-439a-80a8-67794b3a501f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fd59329e-ae4c-4ea7-a16c-1ed5ae6986c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a6a44534-92c5-41c4-8e55-f21f2746c102">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39113052-5b6c-414f-8b14-c45da77d0961">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4becd58-5c0c-4842-98cc-22eb03b299d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8c1270b9-bac0-4dc8-8577-5e54ccace42d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736d9926-2933-4786-b3f9-d831a26d493f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea268416-1911-411a-9871-a5e4e0d8532d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_810a4f75-02f8-47f8-a59b-bbe4a9e9fd32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_645391ee-b5b0-4663-a5a9-219880d387d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac44bb69-b7c8-4510-8e7d-27713ec34d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_617803ce-c01a-419e-bdc2-8ad91881204b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5a4dbd71-77ca-4909-a368-d4199225e92f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d0caaa59-77cf-4704-a71a-5771f0f65948">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2dadea34-e273-4d47-bddd-e5811a5f3060">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de945cfb-1c19-454a-a288-3631d0d33d82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91a822b7-c670-4873-8a6c-60b180b100ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4c9a7e6-05c0-4b9d-bfb7-f0df1a033d94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8db43a7-acd3-42a5-a4f9-31bb793ebc41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec950292-2658-44d0-94e1-7ab461b27707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd883edc-c0de-417b-b378-06b106f94a05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_abcf9ee5-7753-4307-9a56-b119fdd62d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9feceb23-85e1-43cc-b4a2-c3e2465caa9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_15685edb-292c-4afd-ae2a-40d35a35ed21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2a8c3fd-df2f-4963-8b4b-a55141d2956d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17092b96-3f07-4c32-add1-f029ffa6a018">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4dd4bcd-df20-47ad-b0d0-994799f393b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_734f6749-fc85-4447-b206-97e1b9a6da60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a2ba4c89-a65b-4ff0-8ec2-1cfc6ba62415">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe36402a-ceef-4899-8e68-563a5528ef41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18ce150f-356e-449a-81f3-c71920e26569">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b7575bc2-040d-43f4-8b66-98a8736a20e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b49bd25a-dae8-4ee3-8034-79541d1f2b19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ed6cdf6-03b4-4d44-bd05-cf1415e2e538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7367cd2c-ab45-48ae-b600-1b361ed30b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6204fe90-8afe-44b9-9daf-b27d4d1e054f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc1cbce3-d371-40e6-b379-af34f2e14c8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_070caf31-fafe-4ad3-bb49-81f0d801fe0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fa8b508-ef32-436d-a22d-2f1566b4c571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c6db05-c475-4b69-bf7d-98b2f77d0c30">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0b69b9b8-0a43-4693-a724-ee34791e2049">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd7e3f-68ca-40bb-a4ec-bc4d38416f9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_51441483-9728-461b-ac63-30e57f41518e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_be873af8-4dd3-40c5-8167-d27d925e3573">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc2cd4e1-70fe-44f1-a685-6439199241fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e9f43430-6b51-4306-99fa-e543c431f3f1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f63b05d6-b2e1-439e-952c-63767d0ca702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4438e97-ec0d-4908-9114-7d6c48f89284">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_25b2d034-7d7a-4db4-a467-987c5b19b4cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_24b6307d-23d2-44a2-95f2-4f8d39d70e0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06334274-246c-4230-893a-302a747331ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_193894af-6766-4066-8dea-9fb9ffcedd4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c5785d7f-56da-4e61-83d5-2f18adb7b233">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66c811f7-adff-4a4e-94a1-b8038daf18d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b21b057b-e4f5-4cd2-90b1-32617e981260">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2fa674ab-5a22-48f8-aec0-6fae8dfed969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bdafb8c8-a619-4936-9f6f-79d0767617eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bdaefda6-56c3-4fee-832a-c7b1abfebfd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a74705c-5bbb-49e1-926d-d4aa5c52ab36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3becd1c-277c-4d5b-88f4-9c355ee975e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d486dc1a-d28a-4880-be97-4814c9a25b7a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2943a5be-cb31-4d8c-ad96-227e0193ace1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0853d553-a35d-45ec-a9a0-0d8184f76a07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76b45095-2687-4271-805a-7bf60ed3551c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ec6b68d-ba61-4c55-b09c-bfbdb80ebcf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85214598-6383-438e-a4d2-ab029b7530e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc5543ec-b224-4bc7-9eba-a827e3058465">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f733246b-e52f-4ed1-88c7-aced475bbee2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d86a131f-8960-4881-9ff7-7ae1a6d6d354">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0177aba7-d4b4-4e75-8e40-62222b87bf6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7742836c-da33-49fd-a00a-cc7e0321277b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d4c4a91-3ac3-4e24-903e-8ed844e5dcb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_512335a8-1004-4cfe-b462-f7ac341eef60">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b4df3c1-a13b-40a4-82f5-66f82deb2cbc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ec66737-2300-4657-9389-6282cbfed896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_710e51f5-0e13-41aa-ad39-0e6e38c4c5c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8e247e25-f821-4e40-bcc2-84579384b6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a36c16-7af8-49e7-bcf6-503669668780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d296778-ac03-4544-9620-df7302d93702">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ce08e898-8a0c-4b22-b375-651840464974">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8f229ad-ca28-4a4a-8277-eae642c78a9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5a98d74b-051b-45b8-864c-5bc17b868079">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_935533c4-c8b4-4d12-91d1-e357e32bb1cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee8c3a5c-d53b-42a6-84a6-d109057f66f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6e4f67c-da26-43bc-81e1-d91efef4bc0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_985a89c4-0962-4b76-9685-1cbb1b755fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e181c7ce-9b27-447d-b60c-7bf20fb74fd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7ca85a2-5dec-4379-924a-7bebfcab592b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b87135b-9de3-4278-936b-77fc18f47f98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eaea47ae-5e05-40b3-9f34-6f857dfe9902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d4f4a91-6e54-42b2-8f8e-0b9c478cfc4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a799f946-7cb8-4538-a661-ebc68828235d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a5d488cb-2a2a-4f74-bf60-4a7c2afe5167">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ab32114-c60b-49e4-b16d-59f43ae9b429">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d9ceb6d1-ef81-4fb4-999a-5c4a09bbda2b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_79a6ad94-a07b-447e-85c6-61dc4e3f2c41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c072731-8b09-473e-b65f-5d1c595f7d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f8545bf7-29e8-488e-8f7a-27d45dd27584">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_001e3e3f-9f35-4adf-ae09-beaf7310f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76f3cd08-a9cf-442c-b664-7ffae80f34e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c8477581-f647-4fd1-bc0f-38da40a5c34b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_941ef755-9542-4b5e-bf50-bcc38e4e3e0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f65b7928-e759-4f20-96d0-03563432dcd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3c9d70ef-69b7-4294-888c-a1db7a6cd16e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84e2fb08-9c7c-468d-99da-88aef49b8955">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c6209ae-c301-44d9-a9f4-39e503aeeea6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_35d6a3fa-41cb-4def-a6f0-02242f07cc8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af3599f4-876f-413a-9e2f-61e4f97cd772">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_925cb008-fbf8-41b5-bccf-a9ba0207496d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3544d101-9166-48bf-8d7a-9830f8bd7e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c4961b0-db79-44fd-b894-3e3ca701e148">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_751f3c0b-38fd-4d93-92c2-210d657c929d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ad3d6235-3931-404e-96c9-eefea6cc2a51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_15f6523a-a6ca-4929-b2a6-797fe5165942">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_607ee7c9-c194-4980-bbeb-4871d045b117">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d595630a-5c38-41ca-8d89-e6de86401784">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4879caa-544c-436a-b481-ca7782fa14ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d468b176-1c1b-4e70-b89c-cfdb358d12c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39e8728a-cf2e-40ee-a6f3-60eeeb2b3bed">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_99a7243e-cd1c-4944-878f-353803f16173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f579bce8-a5a5-4af5-843f-b6774ebdc50e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e7e06c9e-85ac-467d-95a1-dee3fba2db7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2efd19a3-19a9-453b-8a62-1358a678e54f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_50cb2407-1a48-4d05-b50d-0eb7d0fe0d5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_59921408-ed5f-4010-8874-8c7cfc9cb99d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a6832ef0-2d40-4b67-81ec-7a22195700d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7d14c5eb-de52-47c4-8527-6c2d90f6ba09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4257e0c0-571b-465c-bd0d-e6dd32b83599">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0fd26d9c-7a97-4480-a4c9-5927169899b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ce509f30-fa28-4fb8-b93d-2e7d0753e01a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06be5c7a-6d6d-4bda-989c-3de94c0ad642">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39381952-7a93-4505-b431-38b454ddf896">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d75cbc77-7b81-46f7-a818-c80eb0b51a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2aed15b5-05d0-46a5-bfde-aa18a6e58bca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ff83925e-7032-4d39-808f-131c849e3c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ad21880-4865-4369-a402-af2fe2d06469">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_823e97d4-6e60-4330-a062-2dc6dbd6aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7de33c3c-f761-4510-833e-4e658bb155ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bd21b61-bdd0-4bf4-baec-1df6fb7aba04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e097cc96-68b0-4776-9baa-0e05ac6d2079">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8f842892-67fe-404e-bb86-ec52099e76bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_369c7b20-7a1f-4e27-b826-b22fd852f92b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d3f27b3-8901-4993-a783-1c5cc360e39e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cc984ae-ba96-45d2-ae4e-36e988202551">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_85b55d99-54a0-44c9-be12-73aa01d85025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9438622-ec39-4de8-8bfe-8b7a7acb728e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2020f19d-8579-4c6a-bb85-33cbcf9c80fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2512e2f-f697-49c5-88ed-472ce66102d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ebfb91ff-e57a-4c99-82de-0f5c7bb20361">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77f21387-12a9-4a66-a13f-3650ea2a0626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be648bd2-646f-465f-82d8-fc18fff2565b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0d9d1f9-ac28-42fb-a3bd-873d848c0bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c1eff410-da05-4ed2-8a83-6d72a5b1ed9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f36d52fd-a011-4d3f-9886-ef1558392dd2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b130e0c5-4e18-4c5e-9630-96c1e8523961">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3d60d422-5a45-4fde-b96e-83fcc351399a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71dde336-035e-4993-bf5e-ff65d982884a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5fc7015-c249-4da2-b59a-fda46e003a21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c25e18f8-ca13-4e18-8e6e-106713a05817">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_003ae024-12b6-41bd-afb8-dbff8fc0716f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1fd2a69-ab09-4a4f-8e0f-1b3b2a7ed8ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d4b5ce0e-676b-4e14-952f-0e70e5eec005">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cabaaf52-7fc2-4375-b423-17217e547d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bc43aea-edf5-40ea-bb93-360747aaa871">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_35f390d0-fc3f-4dae-a334-b28e27ecd4cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d09ce77-c1a0-49c5-9da4-1743097d6b5e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2f12e17b-a03e-40bc-9633-3b062f903a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_befafd88-9e45-4aeb-bc91-72989f037361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4642aa0-952f-4c0d-a380-67e9ca5798c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_19ff8aa3-4c9a-41fd-8b5c-fb88ea00d914">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23992233-1625-467a-afb5-7c7db2154274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d18c73c5-9283-456d-88a2-ed56c52068f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40db0b6a-2fed-42ff-b3fd-4146ac3a6b9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ab9dcac3-38d2-4998-ae2e-743e9e93dbf7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_87844dc5-0f00-4fdb-83bf-4df6a5a66c00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_397a5ac6-c21c-41e8-8bc3-37030f7791e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_46777efc-f783-4fc1-91de-03444ae43579">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cac650bd-26a7-4597-8d04-f5210c60e5d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92c7661b-773d-4e82-a011-20182f0d879f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72eb8f4f-06a8-4acb-8749-7c2c83001667">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0591bf58-eb3c-4ea5-9379-1dc6ff597412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a6ea8c7-7bb1-41ac-98c8-ecf05ba41d55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e35d55cb-7309-4c84-b62c-24c5701faed7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f22fc970-4d7c-4dac-94e9-f52e0faac4e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e70d3d1a-6c78-418c-97d1-03544787f442">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de1d2205-000f-412c-a692-27e23e6cb8ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7d7a2c8d-6bdf-4432-ba34-64126abef849">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_14dde051-a9ec-4ec5-9832-422934488527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13f572fd-94dd-4eed-8ef3-ace0e748a2af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_de08189c-2421-4654-b7cb-107162c73d63">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3a29e1c-911f-4564-a654-c6fa2f73900c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b0a3b7e5-2272-4789-b17d-9fc98ce6b190">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_676d9d34-6500-4af6-b5b0-a64590ebdc9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28831048-7986-4d83-9322-ad7b45aa6979">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02c24ba5-c256-4bb1-8aca-18aaf5a4119d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cda097e5-c55f-4370-8046-a22566d23aa9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3db309f7-b0f0-438a-9619-158dcf92e77e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7f5cd2a-e199-4fe4-8a07-000b61f6b849">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3559ab6-f11f-4163-9018-fd2d381786b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7080f5dd-d253-41a3-8978-1acb7fb725c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec4106bc-ce58-4d3b-8e92-880efd0b1664">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10977b32-fdb7-43a9-ae61-93d4bf8d7afe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904d3954-8cda-412c-9749-e8bb17d66a92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e0111008-7282-4c97-885c-7fab48bd8436">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_876454d7-7628-4133-9422-2ca5424ca361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9ff15473-2981-407b-a9c4-b2fb35aa3674">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_55ef1165-5526-42a2-b3bb-e8ec92717df8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c28c5416-4d5e-4bb5-abab-96a1565edfa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d927603-3d20-40ce-82ad-83b83ee19f72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_229408e4-2c2b-4574-a315-b735a27c779d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_68082b8f-1b58-448c-b179-bb3cf663ae68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70edef45-f5a6-4dcc-8ac3-0ddabf759635">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ad9b069-1fed-4ad2-8270-2d803e8bb18a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdf583c1-b367-4df4-aa13-61564d6ab6d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92c79159-1d7a-40df-9703-3a5db5829183">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dae057b6-7b1a-426e-8e5d-2acbe7a43672">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2fd8175-e9d4-4ea7-ad36-55850bf37124">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fa57a151-cb4b-467d-a0e5-025f0e879340">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_29fa0b37-8927-4e2e-ad4e-fe8ace32f522">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372fb999-5a14-474c-a762-df4ec45be325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_59a4afca-74e7-42f7-8568-57ad4f7f5a7a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eb5af546-4e64-4615-b4be-c5f84c5afc69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e2e577d-945f-428e-96c0-85a30ddfb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc4aa6d8-c784-42b1-bd46-b5a7b0fbee37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ab4e7e3-cffd-4fb4-9903-775b019afed0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e958a796-f688-4058-ac62-e7ff354a8b2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba240b0-4442-4e3c-9b12-92037859dc8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58cefcd1-4074-4f65-b238-c8bd2807bb62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b7e5f911-cc7f-4035-b405-dce36c696979">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b105dbf7-08b4-44f2-a809-7659b9b0c0f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dc8c8d-842c-4d37-9ddd-729767e27b17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a87b7beb-c39c-4b09-81e9-5ac4e5d6dca6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c5a9d89-ddb0-44bf-bc81-169851dcd038">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ae060b4c-d898-4866-8934-72ad68a61d2f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ff2d666-0eca-4c6b-909d-de8c8dcd5ff5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2416d8d-eb9f-4c0d-992e-584910dc95fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_13563e1b-bc67-4100-a744-0b15bdcbc8f5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b50e0e0-9880-458b-8ec1-df2b45b77707">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3003a0e9-678d-4407-8d92-8ef9f603d17f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8927687e-896b-4610-9f61-0ff4ee7f0355">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_836cc85a-d634-47ce-9f91-cad257677a21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9185dc-ee0f-48c3-be9b-0999eccbbe09">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2608e084-b64a-419d-ae01-4b6cc1e71585">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_167d679d-7fd9-41f8-9d06-caa39dba4d17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f458e59-de2f-4f0e-b34c-3964259cb7b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e60f6916-d41b-4f3e-9e12-d053db17fe84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d5f4047-8216-4d31-ac16-4a9a054c9322">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a3bcd38-457d-4fb3-8e07-3bbd70861a2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_208ee53c-3823-49b8-a07e-4c96709a6290">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_132fabf0-f06c-484e-88e6-745ec73dc90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d366858-cfa5-4734-ada5-a1d4e1de96bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73ae19d9-1ac3-4fed-99c6-6a4638bb06fd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dbff479-ccd2-4bd7-9d0d-d7699ee4f5ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3af795-f0ef-42e6-bdcf-5998074e2330">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec7efa15-a618-44c1-9777-6d7d98c12e77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_105b771b-417b-4b18-9aae-2edb5c322c6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e02995be-5319-4997-89c6-0baa13af4633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5c61435e-e1f9-4541-89e2-6263603b3b69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dff476e-df06-42c9-9efb-b4090eccb100">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca1efff4-9a22-42b3-91df-2c842ef69d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_23c32af9-38b9-4c72-a024-eaacce4cd25a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67c313c3-0537-41d9-bf5a-0ce46862778e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c78abdb-f124-4796-b624-ca207adf405d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f6df2135-d56f-4ede-ab61-32537752244b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6bc5c2ec-af4a-49b9-8349-b9267dbb909b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4f648f4-68bf-4e8d-a158-24c7ff934d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b9a43ab-5f04-4a70-8105-4d1d6dea5cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07d9c908-2ca6-47f5-9b54-23668c13aea1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_188820ff-ff28-4597-8755-16e1f383ac16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_92ae4c05-9849-413f-9950-08e73b719f53">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3e291d07-59ff-4e54-9816-99637c944ce5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e993253d-fa2e-425e-8a54-ab9d59eceeb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bb91660-0de2-4d77-8dc0-b2dd97689d06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0be57c-dc2c-4fb6-83c3-f9dbb5bedcf9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe303d5b-825b-4378-83a0-91aad62189bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97347a26-0a57-438d-8632-a5da61335545">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc4d10a6-b3e1-4e1a-9417-a6a54c099ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53554a66-e2ec-4121-a84f-bc5f58c3a39c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81767925-5b0d-4258-9684-c3609914ad4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_190cac75-5579-4ffe-844d-db8817b5c500">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8714d145-9c20-4532-852d-751b41958aac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_904f003e-1ce9-4007-aa9f-00aac3c62a98">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_214096b4-1ddd-4b94-a7c5-67cb764c0a52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cdcc05e-df32-4ee8-b7a5-cb1f696db621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e32b1e8a-316f-47e4-a283-9b8dd0642e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3aece19d-4dd7-402b-a8d2-5d26d7ee3b39">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_db8c2187-33e2-4116-ab89-78beab00ea57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_78ead1cc-f404-4ee7-9fdf-ef48535800a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_22055254-fa36-47e3-a1a2-155d0a0cc771">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_557a2416-503f-4222-9308-f18bccbd1d01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2470f09f-6853-4749-9034-4f203dd05145">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_71fccfe4-5391-44df-b2df-5d66fde7db4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c091e57-8b19-4353-8d4c-313ee3863561">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3cefb57d-57e1-4e3f-903f-69749aa540e3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f2d8a7d-95b2-4973-bef9-175379b439ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7f34bf2-27c1-481c-b244-d5bf555288ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_072343f7-33d8-44c6-bfb3-86f4b517797d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f53ca695-3ad2-436f-b57b-a0d82976e489">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b72db782-c1e2-47a6-bfee-76d98a50ed7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285196f-6ba9-482f-84b9-7bd3923b8e05">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9c86c4c-2491-4427-ba0f-710ebde97af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ec3d8a3-15ad-479d-a33f-5c01230dfc8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7d59712-1642-4092-9ee5-f67caca03a5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f4c0f5d-b870-41b8-b34e-293e4d986355">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dbdc2b2-f9a3-4c59-b067-f65e01e1c62a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_74ea36c6-2edf-4166-96d0-d0d8e03ee4aa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c8effe0-03d0-48cb-a537-7a5e9e2809a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90803e77-364e-4047-8ac4-d4d18032eed9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_82adc907-8d3a-4b68-bb4e-6a74b4c9e7f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7306d11-ce28-4c9b-ad6f-e38fd8311161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5f35c9b-8ba6-4cc9-a4a7-30b3c05f361d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d94625fd-9209-448e-ba9a-d9419e7c7184">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8621c35-abc4-4aea-8aa1-7c4f318308e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afadb174-03ee-420e-85b7-2cc1b03b5fc9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b9f9fa5c-16be-4030-ab78-85df203a3689">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ba01acea-929c-4066-b7f9-8a44679d7278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_868bdae4-132f-4de9-80a9-235a2f7649b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c93f0b0e-710f-45df-b479-efe99898bc58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4d7cdc2-47c4-4d81-8813-1307da791074">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c182723-b6c8-469f-8368-664cbe6c5ae9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a826a3e-f47f-4547-bc86-8d5c29802073">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71d7fc82-41ba-4769-aec6-c28a028c24f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b6f20f8e-1d3b-463d-bcbb-74e286d08e4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e3de8b-6459-4ecc-9a7a-f07ad5e41dad">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_51015e38-eafb-4bea-8fda-d7254a752591">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7f865691-09f3-49ed-a046-6a9f927b88f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb298e3f-8717-47ae-8c74-0352837ea9c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e34a8420-47f1-45d5-8a93-1a88750c93ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2cc228ed-7b17-4a46-98c9-9b6dab5ecdab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3eca0e39-4dd1-488c-9f42-261213615c8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3fc35f4-afb3-4be8-9042-80c22938c1da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7fae11c-5433-4dea-8daa-573036118c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f8d7f2b5-d937-4798-8f49-2f9d6d366a37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_61654344-ea9d-47f6-bc0f-4c1f512f6460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_71e972be-0b67-4baa-b9aa-d2af29f81dd5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b836030e-56ce-4bda-a621-1cd3898f7a3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8905b57b-c2f5-4004-a604-898087cacd6e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c31d0b56-0d49-4611-bb21-4da3c47be957">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e12d10a0-1652-43b7-acff-b94dd8e81d99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9285cad5-6de7-4403-b3f2-3cc8618a8428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_62f45f9b-4214-4227-8a3d-8ec5bf11c1bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27857a57-dc46-46b3-be78-4a3e508faa27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_97ef7eea-fbed-4cca-8155-059d768bd25e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aad83482-c91c-4404-b6c5-2e4b0cf2c430">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_741b144a-92be-4316-a667-6d77127a3c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e783a6c6-9325-45bf-ae94-3e58253dcb28">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb5e5403-2a79-44a4-9175-3e0c6cde1a7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c6ee4820-527a-4806-9ce4-2f0d42f31276">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4dd1d63-111d-4dcb-a900-09f637cb1718">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70cd53c9-69bc-4bcf-a3ac-4e7ac464b1e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f3ff468-9121-48f9-8210-265dc8d4bdc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56f4ed47-0029-4843-ac3d-c989194a4f6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f57fe36c-18fc-40f7-8f07-d908b0a444e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec5c7335-88e4-4853-80bc-bff5cc1fec3f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c90725bd-093b-456b-b293-35b3d24e93e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6b8b82bc-e378-430a-8d32-a757dbac9654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e315475b-5bda-49ee-857d-d4909e35ac00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8605a6ae-08aa-4247-a681-37bfa08ddcab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_947b0817-ebfb-4448-9e46-1b205c39cb36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06dc1e7f-54a1-4ca4-9bae-106fa4fc0b18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_34fba600-df3c-4444-92e6-44820bb53700">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d5b75fd-ef40-4687-9465-b9813bff0c55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12f3da88-6382-4ee0-9944-8ee455b9d12d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7b80ba0c-7c2c-4247-9376-4d6c8150fe09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5b246ab5-1854-4074-a138-ced059858bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9088e061-ab8e-4b2b-9c0b-b84ff5986524">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_58ac5024-a283-465d-96e4-3958b4e5d587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_113e04bc-404b-4a53-ba47-2aae867c3bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_025d8e4f-7965-45cf-98c4-7cfaefcc2b38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_06847793-4f82-43ea-9d81-98aa1e2596dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77a92fc5-b352-4ac4-9526-2c325a319aa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f575e4-4d82-41ad-a7e6-0c4a89a7846d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74525261-c7ef-4d31-9b26-15b564328d3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c95a00b3-90f7-4ae0-94c2-50696538217c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_707a27cd-6e44-4b2b-aeac-ec7fe86c87a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_acde90a6-1736-4d99-996f-f94f40387275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0de56081-b8f4-46b2-a104-342f7c06f81c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_06b6e45c-cf6e-49e4-85ed-66b9519391e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ade7d271-d264-48f8-9f66-84ae1e80ef77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35fd6ed3-a06a-41de-8588-3d779ab51fb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c861879-751f-4428-a068-75a4aa42e588">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_220d4678-9c77-48ce-aa02-b302549280a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_235615be-43b8-4c5b-b4cb-14db7ee8d61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5226f2b8-6339-4e7a-b351-7b464c9fcd25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31e9896f-9c68-4f37-8acf-d2c43cb44200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bccf7bb5-9fcf-41a4-8cf5-b5cf08d878c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4a07fd55-9727-4c3b-aab0-14051933c782">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf5a4f02-dffe-4020-a13a-e045e31e4aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2efd1a7b-4bc5-4856-b2de-bcc27f4a2cde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0a9a1b03-c9e8-4187-956c-bac2bf1926d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_353093f4-bcf3-4890-85da-8c4aa9d6d6d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b6d2fa48-1a37-474f-990d-10d2d794bce6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_13574538-536b-4538-8e26-c6241ee2d5ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27efc09c-a8ce-4383-b44b-a4400909f8fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8b00173-49f3-42b9-bcdc-567771ef26ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c24f1de0-8b83-4a10-b680-d7cd903045b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e12f605-dc64-4ca7-bbe2-8b1a99b0e82b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_acc178ac-8fb0-4df7-a38b-28fe75a170d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_49ef34e8-d89c-478e-806c-58fdfff64426">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6c25f839-f61c-4929-8ed2-75621b54683a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24a54926-5757-44e2-b82e-671a97a4246d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3419e66e-ddd7-49e3-8c10-6ad6c5f5c49d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d0a4264-7e61-4421-a1e6-90882ba91d0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95d6b06f-a866-4954-98d2-4e1f36a7d499">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5f288ec-4c79-4843-ad2a-10afd29f69e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4946888b-0e94-4c37-9f66-56b71e7e256a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a30cb194-1934-4fc5-b1f4-a49039bf46a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f58e858c-6f20-495e-9732-36ccfd05cf5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d61dc199-1ebe-4435-bbb3-8701fbb7df76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e0acdfc8-d22b-44e5-b98a-e3beb4bc431d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_517ca612-cfe1-4358-ae6d-b05efa7f5171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6893ad1-b526-45a1-9b4b-82de55b52fcf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7618e19-9e6c-4a93-a8e5-7c0a3ec3f2b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4838ab73-e852-4a4f-8e14-d36cc6dde894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e64818e2-9253-4d51-ae0c-81d112e2cd5e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c3a36588-a846-4a37-b181-afe3af3cf915">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_714070e7-1af3-4863-8885-8920f896f2f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_05372493-820b-4768-b6b3-b06cf4c88040">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2e0649e8-ae5f-4146-b539-55df36ed26f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dbb7f413-9cbd-468a-b57c-023e980826b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f829759-3787-4e7b-9c49-51fb44f490de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6586012-dd0f-4349-81ef-057a9818e91f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0551774b-ab93-4cf6-9afc-3f49ff2e5339">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5d90700a-b751-46d6-9883-1afa754ca728">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ee00881-e663-4ef8-8e61-5a9d373b60eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_029a4186-6f37-475f-b0b2-d4888ec78456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7417b3f0-f39a-4da3-ad99-a0c5acd31dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7bf60b21-3cfd-4c15-92be-de3bf3987969">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3ebe2830-5530-45ee-bca1-03f80a144de1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6857768a-9ce5-4491-856d-121d10953832">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_45b979e1-6499-4853-8bae-ee72dab68308">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cd8ac52d-b2f1-42be-a279-de43a535b633">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_318892f0-18d1-415a-8a4f-12e16802ed01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3896d698-274c-4aa2-b2dc-85550339e7e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0586ae6a-a2dd-42a2-8280-def5212f1885">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe7d3d87-0991-43d4-982c-3bfd6eabac43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67fb0682-a5a6-4906-a36d-cfa2097397a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d83d8c12-075f-48b0-b5f8-38259d641027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0d886ae8-6347-4a11-965d-4486a842b72b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c1ec08c-6b4c-48a8-bf02-006c60e178a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37d7a305-3c5e-45e3-9792-0aa39d89a087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b89a5862-62ee-448a-adfc-b98dc77a6c06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_466e04fa-ecf7-4c12-a305-5264e60badfd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e4ab9e7-323b-4168-af5d-6cfe6914e92a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_782b4c70-97ca-4ac2-a57d-c1e49802e962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47c94546-4aca-4eac-b3e2-0f6ae04baba5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bfa323-d130-4b02-af40-1743043ef9a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_365b45e5-9725-4467-992c-44a30aa3aeb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02fde0e5-c682-4a0f-9691-475fb76be114">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f5a0d3ee-b330-420c-85ff-dc7216fafbd1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_370ed0c9-995f-45bc-91e7-b340199efb75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_97f67aae-d210-4862-8d2e-78e4ee1057e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae5e385f-d5a6-4333-9bcd-13f60268cafe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5559d554-2049-48cd-8104-20ceed7b4686">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ba7f2c25-8fa2-41f5-8355-8beac83b5a65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_408d47b3-1f97-42f6-b331-0d61e5f90670">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_965d13f4-485b-425b-8dfe-c897500fdf2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5b6d87d-a141-4762-80fb-6ade51c8d259">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a63b1ae8-cf67-4f81-913c-0470719183fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d01c2bb4-c8ab-4007-861b-449bb235e3f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b221fecc-3f56-466d-a7e0-7ede7a1aff0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_42d8d499-e591-46c3-96b0-0fa80adbf923">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_18c74b81-234f-4bf6-9d2b-38816c082d78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed2cda40-9e01-4b05-a44c-17e790367156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63c6dbd4-a478-4642-b02a-ec6a5bd2d82d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c05a0e46-1a0a-42a7-8033-274b947fad1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_49ffe632-11ab-4d04-b22e-1a7de4ca7746">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c0115ef7-fd26-4d5e-b841-07d14b72b16a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_beb12705-81f2-4cba-8b89-321726c2ba08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_808645ff-087e-45ef-940e-26389858902e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_236ea25a-9487-490f-9886-1854ecb7dd5d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_de290528-0feb-4427-a306-11c0789ad3a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c31e8fd-473d-4142-b1ef-a7741eaa41eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea5970d0-fe70-4953-8353-e1f908f04833">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cb01ec5b-3693-4d3a-9bbc-7433afe2c562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b906c8fe-3028-436c-a6e9-ebe0aa0bd0e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bc43effe-3bcc-45c6-addc-8790363e2e81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e4bcb575-87ea-4553-9bb2-c6114aea6ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_574d3b76-05e7-4206-b43a-2406be300e73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e809161f-b94e-40e1-aa05-c26b5db8319a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90532d5c-51b7-42e8-b997-7cd3aacb3b01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89ed2c1b-8753-49f4-a90c-1469a1db2d6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c321ce94-d20a-4ca1-ae56-0e345f8d8f39">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8d1b4265-e043-4df1-94d8-c9b3b2a2d74c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6ef71c8-d16f-43a2-a67e-c3f882aa5898">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d291384e-072c-4e36-ada9-1d78743a5f17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb70152-e11a-4835-b3b8-9607ee61012f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b347ac3-f5b9-47b8-a5be-86112eb518ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a1af822-b372-4f65-8a5a-fb7c2bc9fa46">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70bc8a62-4b3f-471c-8f26-4de6dcb587c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6f47ee7a-dab5-437e-928d-f5fa1a931021">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_37259d03-2688-4269-b724-a019708c03c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7ae7edf1-44ca-45bf-bdcc-b9f2db3d3383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a629244-1958-4b39-8124-9299af3f90ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25d6bfbc-0406-4021-a7a3-eaf27c8bf87b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbaa2b91-19f6-4276-a1a5-bd29c05847a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92cb244c-751d-45a3-a4df-744118e58171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_34f3366a-08b6-4ff2-8d8d-25bd186e23d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88ad481f-2dc4-4bed-b6ad-4eb45eff8c85">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_073bf8d7-6f1c-4bdf-8589-f3e7118b1419">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15de3a48-a951-4860-bf45-0a7d3e496232">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_40f29c78-d193-4938-964f-009a195cfcce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cfd8928d-63f2-491b-8f99-7f12bc865a43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a21eb818-fb97-4531-8b5f-fb94643421b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0bceaa1a-cde7-4481-a6ec-fc1f00e4d173">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5dee9f7f-ab45-4ad1-97a5-1ed775bc0a1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8d87472d-343d-4508-af27-99ba0013009d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_76ca6183-d22f-4b08-90f6-608c23ae01e0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89fd8582-7f8a-4635-9309-c36ab173d8d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e54502c-3e0d-4961-a3f2-e1a19f9f15be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bbdd559e-0803-4e99-b9d6-73d9343ea7e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0568054d-a321-41c7-8ae0-7f3e4e6d6efe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ae5c783-5004-4cb5-902f-6c2e49f16d2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e65738a1-a385-46d9-bfb5-a85aa03dd1af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db28d434-76f8-4140-b103-101d760da602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64e9f5fc-90f4-4b7a-aaf9-87364ee47047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b2fa69bc-0690-4b00-b689-0c313b529130">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2310d678-df3f-4460-9315-9346518888c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42a60441-ee00-4407-bd69-61ce56d08585">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_999e6491-6e9e-41fd-bd90-90ea018661cd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c0d8bf12-31cc-4ab3-a046-31a57efa5aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f192d0c1-711e-4760-8b00-fc1b798d7a02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc53a16a-a3c2-4f8a-8b0f-fd3ee7701b92">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0d478a92-27c8-4122-8f65-e89167e50c46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3be723ea-f9a9-460f-88f6-f6ce88b9adc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3707ae37-c9f8-4bed-9e83-767995f2904a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f748d44b-1f22-4a0d-aac6-e9abfcd344d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a040a884-edb3-440e-8118-8473a3c88c92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_12360317-55cf-4c68-86ac-bb6d7454dc66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_792975a0-5c5b-4c55-ac56-01684e17cb4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_21034b29-0370-4459-ab1d-d54d10337173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cae54e92-78b6-443c-a94e-3808610aa607">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877f697-fbf0-411b-8b70-de015b64ed2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cefd7b3b-3bc8-414c-af54-efef4551a90c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80564bd9-c46d-48a3-9ee0-fe1d044715b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_470d84cc-b496-47b1-997a-3bc5b2898568">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4b700d6-4419-4e60-96d4-f054f596ebb9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f829f61b-477f-45d8-b5a4-cb19a3097682">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a700bfb5-accf-4acc-aef6-75b5b4b9d283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c319766-eb32-4975-8ef4-5ec8b325c3d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6572c581-24a4-47a9-a39e-74085116d4f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bfdb9f7f-01ce-4490-b1ff-42b5e2cc0317">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ebdae831-2ebe-4c64-96e1-7b91aa2db64a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2acc7925-5dc1-4c32-a264-f384326d40b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67d15e4f-3211-47ca-a162-20bc863f456a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c17ac3-19ad-4a74-8105-be69ace57902">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d447f6d1-7ced-4a18-b489-a848ecdd8f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_82a2c0de-02c4-48cf-a2bc-43c3b43f70c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a799c07-5afc-43ce-b6e5-07bf3ed01299">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23e5c5af-5021-486f-9313-ced0a3c0f78e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9a54d4bb-318a-4594-accd-f73e0717c332">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_30418a78-e345-4166-be71-c6811a5139a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c5983df-c5d5-4543-aa10-8c9d879a6374">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_67dc3e00-7773-4b9a-af3a-8078a00423ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0c34f271-4f47-410e-a4d5-e6f3c8be9d05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_715f00f3-4358-445d-9f13-346e0ef19af4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_493944a5-fdaf-4639-a919-4c5e720a062e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c822e6e-dbec-41ef-87fb-3d352bf3b4d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9fc9618-b87a-4744-9548-0d53ca4522fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bff94f8e-926e-467d-a828-c9f16173009c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edfb58f9-6d6a-4008-946e-e5b27b49797b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b7e37f7-ad7c-49a3-be0d-d7ac833b23cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aef1682a-ad01-4e95-8f68-29f223e6f177">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f3d42bd6-cd90-44f7-839f-9c7d6dfe9649">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b68c57c2-3f55-438b-8c6a-3b9dc7666ef0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1be73187-7c73-4469-a943-23ea7399b3cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_967043a8-1caf-4faf-918e-70fb1864c57f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7dbcb3f2-427d-491a-a73f-b8eab7746d5b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa6059d4-f302-448b-b6fd-62d762a2997c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_19697a59-ebbe-422b-b0d1-4a07469d2c5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3009951e-b1d4-4b82-a877-470a516b3361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1221a04-19b6-4b6f-9cb6-06bed845b81e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f70cdd53-344d-4c70-a11b-c4bb7c9fea2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbe11006-c06f-4120-a209-0ac2fa08164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_755105c1-f410-4e09-87d0-5ef15746ff1c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_034f40e3-2783-4202-8189-fe8b6e11bcdb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c605939-9b97-448a-8051-6de0d751931b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3415f772-e20d-4104-ac5c-44683fffe2a2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bf36e9c-2d4c-4d3b-aaad-b21e7e3085ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bd408c9-e801-423f-97a1-a5857d1ad4af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0e75e28c-718e-410b-b2d6-1539bc5e017d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d2dc1dfb-bedb-4a06-aef6-073ba5573610">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3e57554-31bf-4fba-9fcf-72fbcf3c24c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48b08358-167a-4ba5-8716-c7c79c76f989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_440d5403-5712-430b-871c-f1449bc683fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07f052be-64dd-4fca-907d-6852e038a6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3b04fb0a-9cc9-4ca4-9603-38b983258538">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_475b64aa-d502-4417-8208-594fa2af4bf7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aff9e12b-a0cc-40ff-ad4c-21354b0de88f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1a973e3-96be-4a6f-a7ec-2f2862e2ffe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53fe31c7-898e-427a-866d-f9d639564156">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a8fafbfd-5596-4044-8d74-0992f06c8c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_233d686d-90e4-49df-91ed-b5ee6fbd0cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_598db54f-b81f-40f4-84b3-d92f72daaeb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e61eb85c-b7b0-4336-8e32-6a5c2a7145a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1d98bf9c-8243-4f7b-84eb-ec54a4b21b90">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eee51978-7250-423f-9dbe-827906d8c019">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_466b004f-e572-4666-84a1-2a772ee0b5e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_026dedc8-5998-4752-926e-f2cc48db14e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0df05e46-9c77-4f7c-9c28-38b92d66e07f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_85ab2be6-50f3-4381-9947-70df840ac3a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb8a4d63-989d-445b-b112-1e304b518cc1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd353504-cb09-44f5-8b25-f1e3e8801e61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_058f2f86-c3f2-4ba3-97d1-9f6906004cfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dcc4cbb-f0a3-4b73-9079-8d7c8c4941ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_342151b7-663b-47f7-8b53-2fa6224c2828">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1f0bc0c2-c9e7-4e8f-b803-28c6f5b6548d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395651fa-2b08-485c-95e1-17a893d7d3b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2ac23bb-09bd-4ea7-b41a-5bf5ece19009">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee8c7797-c83e-44d7-93d5-cc60b64290bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b935634-82bc-4212-a612-3d84f1ca3962">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d5bcf04-bd8d-4514-95dd-e69f13c19274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1c01a24c-a208-4b22-9903-79a2ec531d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6637d54a-210d-4025-92c6-4995da491520">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_264c6f54-7b73-4d1d-b95b-aa94cc0c0648">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b87edfe8-d64d-45c7-a4d5-5f6ade3ed928">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fab46ba-9cce-4e10-8989-9b54974aad69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2bf00d-7b46-40be-b277-a0840a5c63d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2569cf1b-e90a-4497-a949-7c29fb699a7c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0be40f90-cbc9-4369-94b5-2601506fc161">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edfc8def-f6fa-4677-89aa-538653292967">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_020f3c9f-49b5-414c-b4da-8a181c4aef4a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a7038c54-b029-4d0f-b91a-a528c0603ce2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8ff51ca-83d8-4277-acc1-b260d7d222e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6149b0c5-3cdc-4fa3-8743-c97d0b1f1d09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efeffccf-a6c4-4517-9821-d938ee8fa3af">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca2de83b-7f42-4e32-8d5a-0ece354dda71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_94e6073c-06ab-4928-bd4a-16d8bfcc85c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01d168e6-ade5-4828-9749-c9cedd71eebe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_606a464d-cb9c-4a42-b5a9-6bd5ebbb6595">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bc2c3508-b5d9-49b8-a05f-570e28feddc3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_83795781-3114-4144-a04d-4c0218a2526b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b6d0b90-ac02-4a7a-9af1-fdf9ac0d1968">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_829d7f0f-f7f6-48b3-9fe9-40f3e80ee793">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_556c4014-05ce-4318-9c92-92047428cef3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cee22e6-3110-4e02-bed4-8ca368110b4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d64beee8-381e-4dd4-867a-de9eb2a66310">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e49c05e0-c6bc-4d7e-960c-d3fa31a486b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0ba5019-26cb-47d3-a5de-6ae0d1ef25b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9963b957-2de8-4a05-af6d-0661f387330f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_268f36ab-f34d-4460-887a-0dbc24dd712b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b443e54e-315f-477b-84d6-6d83a39f6582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d8011e8-c7b6-4240-b4e6-c084fcc656f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2ae136d0-afbe-4cd3-8706-8d321ad21e77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c56bbb1a-8c33-4ac7-808b-5e5d608cf875">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f4109393-e03b-4c7b-a1fb-68f16c5a7cff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb22b97b-0a84-4bb9-a4b6-5ee546825505">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9305c134-9be1-4026-a7be-325c101808c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c44701df-674b-48c0-94e7-2c620ae5942c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52bce418-da4c-4366-9147-90f23d9ee414">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a611e83-5034-4d03-b49d-c2259085480b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2fd42f2-672e-49cb-89aa-ac029b972620">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a04b87c-e6be-43d4-8deb-64099c5ca9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c5eeef0-5d1e-4edf-9502-650fd596cb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fea85a80-5dad-4838-afcf-75cd6d1fb65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_713b3db6-d6ea-4a82-b06f-41b9783f69a5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bd036bf-ba6e-4988-ad02-c1aa6666ac71">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9552d0dd-3606-49fa-9aff-3dabc358798a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_26940964-aea6-404e-8941-bdef013c8cdb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1adf3588-5d2b-4eab-b7d2-30a16cee0515">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65930981-025c-4bdd-b596-7f62dd2561d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dfb9aa9f-a159-4fba-92b1-6699c5351725">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6498579-f6c9-456f-902c-9d19b549b62f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26f0578a-c48c-4ed3-9405-7136aa508830">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_124f89df-1b77-4379-9104-99b98925be65">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7fe7db13-1783-4d2a-a28d-5f544b258215">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c7865f19-c83d-4d89-83a1-c97ffb796b50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f232587-ef4e-458a-ba35-ef158ef922b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7e35b494-953f-4999-bfdb-bbd338329e40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d1b5735f-c0de-4f92-b6d5-ef48cbf3acae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cd4c469-6355-43a9-a5e0-ce8c00e18dab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_49de03bf-9e1e-422e-a69e-992d88da11b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_582c7383-519e-4e95-9adf-d9f4682eb24d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f563d686-694c-45b3-b865-a4cd8600efdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b25096d-00f9-493c-9281-086f23040240">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2729e62d-154b-493f-8d64-5be7d09e89f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7303683-4312-4b4f-b006-f19d2bdb4a53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e4698552-6cf7-4edc-bd48-63f44e816764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_733c06d2-d42b-433a-9896-e0d6fcf9f32d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8d144de-e131-4d9d-8c7e-5bf07887df32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bf630364-e744-49bd-95e8-ef6d2aa4a7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_158a8112-d449-451c-8048-c6f0a9ccc502">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56365e0e-6d39-4996-a813-c06ce027b7f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a9154b45-62d9-4cec-bb90-8b7da0fe72ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ab1a7a4-b512-406b-bd86-e321a39b3c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee320934-b8e9-4ada-9357-7eaee8eb3086">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1410e2a5-1a0c-494f-9145-13ae508493ab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_06741fd3-bdac-4576-8d99-ce74f8873229">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10371938-cce5-4d1c-b82d-62a4e06bb278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a82616f9-19ad-4009-812a-a4242ea9216d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a3f956b-efc6-4e70-923d-9029413a0f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e81259a-44ee-43e0-90ef-ff3b7230fc06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77c54f25-f344-4794-b5ae-abc64a604c19">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_65928fe7-3119-4e0f-93c4-0efcb16c9889">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d09255f-8e8c-4e03-a33b-be6fc2d42cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a2b9d6d3-d281-42c5-b456-e3774492b58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cc24ef5-3e02-490c-aad5-eab050a7a09b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d16de56f-7bd6-444d-9033-50ad12a2dd17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_49e72d64-61bc-49e4-a565-03efa5d1acac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6cc99e3b-ca3f-48f3-8bfb-3568f4bd8d3b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12968947-f95c-4b8f-83b2-5f0be6468cd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b754364b-ed30-47a2-a7da-9e4d6b03e0b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a13b69a6-56b1-4302-b0aa-3e0d081eecc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8eca3ce7-0b31-4a9d-b32f-c3950b6a566b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e27937e7-537c-4e95-a726-226798fad970">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ad17838-e54a-4c82-8a76-e0fcf5c2164e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e698365-e833-4996-9473-f06a71d5589d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dacf7f3b-2ff5-44ee-a2b9-2aa57613a8da">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bf6e629-c40b-403d-a645-d75c413c1eb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71c7c564-e605-412d-b6c0-23bbd162ad74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9c399c4b-5712-4062-ae0f-b688af0abf8e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_82b12011-cf89-478c-a37f-7641faed076f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_622cc0c0-28c8-44df-b59f-442849dc17d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f50b0d66-c542-4520-82d6-cf362ae23dd9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_981f8d40-cca6-4b14-a267-a52df3e27e28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d39fcc1-e4e8-416a-a1b8-23bb62b77122">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_72e08efd-5a8c-4c2f-b168-945b4c3186fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f47a4f9b-2995-48d9-b4b2-15c179da2be0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e1969e-aa96-4aff-af51-289b2f5f6184">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_68762a18-5f8d-4758-81bd-9239b9599167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b12a945-b2bb-4f02-82cd-4b59978c2b6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55c94c33-048f-4560-bb89-1a7ee27877be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f2b990d0-4495-443b-850f-d159ff7b487d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ee9f380d-06d6-4eeb-b07f-74433ee23ef5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14a0063-77eb-48c7-8a3a-108717a1e342">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_471d2814-6487-4a03-8f1a-20fc685d4574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4f45b63f-e24a-4d36-b81d-35a032a7f094">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69246fd4-e827-4c4e-814f-937e24af9cb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857769c9-5ae7-4e03-b421-b496cd37e421">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0188ffa8-b7d9-419d-be90-546712bd99d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0caddb83-6772-48c8-8392-b8592da29ce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b030c208-5e93-4339-a4df-49716f2f7ca0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_665fc7dd-b3d6-48af-9489-a931ec2d728c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae9ad4b4-9db4-45ee-bc7c-507982451c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73bb8f1b-7fbb-4501-b6a6-2d62532da861">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69ebf4e7-8f76-484e-bfec-e17f43ca4fcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4770649-3999-4da1-aafa-f310796bfb38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cd6bd8f-b186-4bda-83d9-9978919a34d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6de1c0f1-63e1-4838-9ee5-50fa9c7b441f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ef9d29ca-490f-4343-a83a-e789adae5850">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_48ee110a-0ae2-43e8-bc1b-7abd771bffa7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9fb29ff6-0f14-4848-815f-df067a483b21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b40a5b9-55e1-4e8e-a264-d6a2bc01bee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c693cbf3-a4e0-453b-adda-4025e954d286">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6eb2ea9e-ae8e-4f15-8a8e-256d297537a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fde71d0a-4cd8-4273-bc10-76dd1fd19e66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d2d2a00-7af0-40a7-9847-bc28c0c1ea23">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e83e957-0488-4692-88e3-8bbb2a691173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cd9e84b-d0d0-4f34-8381-a7b6f7c03ee0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44020251-68c0-42b1-a413-3a748a1ab55a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57c0a3a8-7306-47e3-9934-a50251ef5bba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_971c083b-37d3-4e4e-a1aa-cfaecacf5562">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_712d9aa7-73f9-4897-8147-a85039c14211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9a9e577e-ad31-49f4-8389-4ca6efa6181b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8453e888-4f01-4fa8-83cb-972ee72535dc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91cbbb58-6fdb-4496-93c3-bbb3fa994bd6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90c5968f-502f-4af4-a99b-500f99be089e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b748562-c7fa-4923-8e6a-4427939ab97d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_31215c2b-0e3d-4bdd-88dc-45dd0d473877">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_03388553-ce12-4a8e-9cfe-74622fe2d729">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_91c214fb-62d2-430e-bc9a-76d136d1b683">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7b97d0b-2cab-4ff6-91a0-ec87303b18d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc8f845-7da1-477b-a7c6-418956ac6e80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b46d5c4-0bc9-4057-b52a-b3ce593eae13">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9b90290-a864-4599-8c79-4638611ba5de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e50dfb35-302a-4194-affa-eb06048ced86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_565f7f95-7442-4d72-82bf-cf99d732e17d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_884f8d38-b876-4ad6-b4c2-5ed16c445a58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5070e00b-3d37-47b2-97d3-5950de3bda10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3154beab-9876-4812-828c-aee1690971ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_508d06fb-a64b-4e4a-a836-e866b64db8c7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_885fff4b-dc0a-4883-bb41-faeef51ebca5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0db9c722-ba04-452f-af36-e304d10c09fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_23a2a4e9-dc99-4a8d-9add-3ca0c97933f6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c02a9d5-d136-481b-997e-0dbb22363151">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5653476c-dbd0-459f-b3d0-d2ad9975dbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d3dbad17-c193-4f54-b0df-c903d58903d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b288691-206e-4af0-8daf-e9a2dd7030f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_27025919-dfe6-46d6-8488-095eb2927d08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec1df18b-3e04-4dfe-b264-82b497dace66">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3b1e30c4-d9ef-4c9c-a476-ce98100f35c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e579b00f-7530-407c-a998-3dec9b484ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_105bc9ed-8b9c-4aaa-b534-174d2f8126b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebcc901d-16ff-471f-9893-98de344c8277">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a096101-135f-4769-a102-be67822c8b8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10bb5ba5-7e15-4c5d-af9e-a947afbcde01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1ff25a54-512b-4914-a35d-98ca1342ae4f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ac6351d2-74a1-4f8c-8406-4d39c66676a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1e98c83-9051-49f4-8f9d-8e5203f765f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_00933292-540a-4140-afeb-a6d0921a1994">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7aabdc4a-f063-48af-9976-cd6d5698db14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2de76924-7d29-4ac1-aa0e-cbe05c315c21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d4842c5b-2bcf-4b09-bbd1-530fc01bf44e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad91ff76-5a92-451a-b74f-438c17d16665">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56feff01-9529-43ca-992c-b9f7ed0df41c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39ddeef7-8343-4da5-9c9b-283f25344dbd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5d7a62e9-15fe-4fcf-8a5e-c18e280317ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4cb38a95-411a-4892-815e-6f272a1fe602">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_22ffe2f8-2c9c-4d97-b486-5f92260163c3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_96ab21dc-4b8b-4149-8a04-a61050c092a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fdfaab97-2d5b-4a29-984f-e8e221b59ae1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e875bb6f-949a-431b-8199-7b2eeb3c7f14">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_84efe136-ee31-43dd-88af-ffd1637858fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a55355e3-2084-4438-8018-10d3755a97ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e1899ca-0520-4a4c-8045-faf978e483a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_37a31de5-f6f0-4ee5-b7d8-386f81866e35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8b7a9125-651e-4392-9214-d4ddbdb52247">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2f0b9923-7398-4564-ad82-4bafa9778688">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_624525b5-e21c-4305-9ac5-ff7388b1001f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d37217f6-9cec-4c6f-805d-deca7c019fbb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9461a04e-4368-4f49-b3b6-2f05deb219bd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ae0b6a0d-a5eb-4f61-8b2c-a02e751e84d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04c8a74-9253-46b9-b6bd-9701dc35eab2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_be945639-e526-4e91-a7df-a51110b91db0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1dfc97c0-c7b9-4c31-8f4a-a6d6ab182d5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed9ad61e-b067-4f4c-bbb2-c41dc385d6c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79603aaf-2a57-4463-8db1-671b1a2e220f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_efabaf18-727b-4c00-a40c-f17833ed29dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe002e4a-1ec7-4895-86ac-558b453b515f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_20262ba5-86c1-47f2-932b-e0127e4f76d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d1f99cde-ae8e-4ba1-9d73-01d49a79cb15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f86804b-4b7d-44a5-aa8c-8be0a817dcba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18f5c8ef-7b91-4ff1-ad12-25013fb2261c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6b10151b-bb1c-42d3-a1d4-2405ed3692b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_edd81079-c54c-4362-a512-99e1574343ec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_46326a22-e670-4bea-b1cf-9c254602f2fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_671ff075-93d9-4eec-9954-3d1615290aec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bfde40f-72b0-449c-8d42-637fbc9fd2b1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9cfe9126-4dc0-4fe7-b98b-211301ed1b99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_706882f5-592d-4dbf-8de3-c5573164ff4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82267948-83d9-48d3-b8bd-a253eda0320b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_86674381-d6d0-4318-88ff-c1894543ae67">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bfcb49f7-6405-44d7-8045-14aea9e30b6d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9009bf32-48af-45a1-9d21-011ed8761328">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1826f25c-9775-4f4f-b2b1-ae473c49e3b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7a71e962-82ea-4db6-a0fb-4975df482e2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fed39c-b567-4583-b5e7-b7b55af29412">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8b17a4fe-7e52-4091-8ed0-3aaeb20bad36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2f5e9ea3-87cc-4bb8-9367-89a722729922">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5273405-4204-4386-a10f-f7c54e4f4238">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4bf260bd-da56-40ac-b0a9-aa914db52552">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0308fee4-f4a4-42a9-a181-5a87b1d39278">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cb7100ed-7dcd-4b33-83d3-d2a0c4f3d3d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_356e63d0-5646-4a7b-8572-342dd3328f76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bef3a4e-f3ae-4cb1-835d-0e5d9f063ad8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c9e7d8-6d56-48b4-b8dc-a71f2d4b224e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1bb11d6a-188e-42e8-9304-e8a4ee0872a8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c7e54d3a-d5aa-4f53-afd7-6549180a071c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c78dc3b-842d-45a6-a8c7-430b2ba7b894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_520c328d-8cdc-425a-a674-f704abb85b1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_511860b2-8d73-404f-ac31-3690c0941043">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd8849fd-c520-4587-9a6c-18d0f987bfaf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4001dee1-5a46-480b-bee2-4f49f8336ed5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173717d5-e642-457d-9561-712c94fe0c34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4c221fa-68a4-4b6a-a352-bb79f98caa60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2bdfd341-8eb2-4212-8f13-d86974a0d2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8f7de386-3c11-4fbf-b624-23fd3c1c562e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8e1bdcf-845f-499e-ae37-18f99362ad08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c797ea5-c893-4c9d-9e67-c90e8e199411">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f1c420df-1842-41ad-819e-009e2c6b9a29">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3ebf6639-df4d-4202-835e-d9a6be726cf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_71632e7a-40a5-49e8-9ddf-b674a3cd0aa7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_849161e7-454d-4c72-a0af-047c5336f94e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_89d54c89-fac5-4820-9e7c-2bfe46e356b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7f2ab18-b44f-4ff0-ae23-624e27b84d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4986ee49-2f30-4ac6-86a0-753bc271c311">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17b41316-5349-4bc1-8cf0-478a08f5b456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9b0f671-71a8-4cef-9ec7-8e98fbc6ae19">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_18b0b238-e39e-46d1-8b44-c343c305efde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_73c9270e-8671-4fdb-9c60-e5adcb17e72d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43cca838-8ddd-409c-b337-2e67b51a1d4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9b1289ea-c81a-4e41-adeb-e00ddfa67bbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1877c860-1f30-404b-bcc2-973e5eb01818">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3fed168-71e5-4be1-ad94-9cab9c37daa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5b81bb78-faaf-4c79-acd9-dee20dc0c61b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bd400616-4892-4133-be8b-398ae2219c89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d654b4a2-619d-472f-ad7a-f6da11cf4d4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fc89f01e-591c-46f7-b57a-88b2deb6f051">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_734d06cc-67f7-4711-9fd6-fbdf778ab26c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b7472e2-0209-480d-afea-3cdaa1f3b566">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f419035-11a2-4fb2-9aaf-9dd5d2f68558">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_868cbe39-38ec-4502-87c3-89c675fd01d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c59826ec-f49a-4f2e-9bff-450f400089f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d29eddf-8a9f-437b-915d-a171ba75e4d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b8f651fe-90c8-4acf-935b-3a28bbda1010">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_12d4f8ef-1503-435d-a08d-1172f0e8d4a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b4d225b7-cae1-4c84-a2cc-ec8d86545530">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d3851fa4-a3e6-4620-9d84-e5f2e223d882">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0201cee2-9ba3-469a-a163-ff4d8f90339c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4a1bc43b-f726-47b9-af5c-c555b9460663">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e7c03dfa-74bb-4ae7-aae2-e3b13867e39e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22893df4-f066-4d77-9b20-41996fada264">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713eb8dc-b3b6-40fb-ad61-4d88de8074cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a425377d-6338-4a06-ae87-a353daba71e4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_234cf63c-93ab-46d8-a942-c61871c6c1c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_96120813-56ab-4482-a890-46d757bc9053">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_895c4d4b-23c3-4aaf-869a-84176c9c5ed6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5215b7c1-8498-4aa2-b3b5-d35d65fc4432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_540d8499-d8a6-4731-aa87-d0ac791ded2b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_88906a21-f574-4aef-915d-859acd1e22d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_70afba82-3536-4952-b226-a329a794c7e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2090b49-5a3b-4f65-bf81-6fb949c6e77b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f69b76bd-7138-45bd-bef8-e6a69172e021">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_41196d74-dde1-470e-a114-485ebdbf53a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_15e80cb5-a4bb-4fb0-8754-25a61418b53b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_67dfd7f9-e5a9-446f-aca5-9480722e279d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f1c9764d-7a62-4b2e-976d-8eceb473c52c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e8c1bf-b50c-4089-8ec2-7fede6310b5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4cc8a469-7e37-44f6-895b-a38e53ba8c61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9ce44f7a-e1fc-4554-8a26-2532ad150716">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_216b5db8-fd97-4534-8794-ef399bba9f06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_274432a3-9f3f-4229-a3ac-ac465ad8834c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_86385e2b-890f-41fe-a051-ce32d787268e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c5d1874-528f-4b5d-b918-1808616d7d07">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_756d2942-df77-419e-b7c3-e43b68db0205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3bed2fb-0f11-4f6b-b3e6-54108ce9f48e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbb29035-f491-4bb4-85d1-a52b9731a61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e93ad931-1622-4890-99f5-1a0b86bb5cc8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8140af2b-d5f3-42e9-a3b2-b00593fe86be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ffc6a17-e0e8-4922-8d3a-6e5eb7c98cb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_402cd84e-9864-43f4-8dbb-63bf7cd1a0c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f41d01a5-a611-4390-a26b-18fa617aa345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_713ca869-bea8-42c1-89c9-748ac1a2a210">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_55fc5e5b-0d1f-4bcc-bf93-c8b921aed1fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d84ef8be-1d52-4db0-8f0f-982228b08963">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b740b750-4224-4059-b382-78942d33d819">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4971b9b-47da-4d2d-a33f-aca6a40ebb5a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6fcf9d44-0aa0-4601-acec-32f45ad7d508">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b82f01d0-3f3a-4fbd-9a3f-98a1e954e09d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c3cd7e7-115d-4869-91a6-70bd2e8a0879">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1b134ce8-e167-4933-b483-9abc85f82a68">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bcc360a4-e0de-4270-b3e3-2c0729527a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0de34ed6-5f54-4d96-b85c-f9cef605702a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3231c97c-9430-4350-8fa2-291f9293ff8e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36da5543-1c92-4034-9537-b7236c3523f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4aa7d6c9-5036-4a5c-bafb-8aacb7e07fc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da489a8-37d1-42fa-b44a-5ca3ec46da01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c597a409-1d5d-4f8b-85f1-afc3b592df8d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_995c307a-76a6-4c64-8cb2-e814cbfb12fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5693ab73-76c1-422a-af9d-4b3bcd6d3a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f644f1c-6ed3-47c9-a38e-08a9485b207f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cc9bc005-cb3f-409f-820c-a5e040ed86e5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fd822661-fd79-443e-b070-216e9012562e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_251ff7a5-1ad4-4805-a523-f27406ba6d79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce12731c-2b18-4e1f-aae9-29964c988cc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c161c630-05f7-4404-9947-055080df59a2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_54136fba-4c59-45e0-95da-af7801dc09d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8734587b-a66e-445a-bd1f-6cb940b51c00">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e6d45e9e-66db-4bb9-8d38-86c61edab12a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42e6c5ff-2a1f-423b-a9e3-9664e6627f4d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c2af328b-5185-4c38-b82f-0c4efcbd4ec5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67450fc0-6b2a-44ab-9128-d96d9676f9eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3aaff381-983e-4c90-a188-21ecb252229b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9041fe38-9715-48d6-8f4b-00ab3676a859">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8a2be9b-a47a-4ac6-8746-2c90af9e406f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb0e8f84-c639-49a9-a371-e1853cc9c701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f9b24d9c-36c5-4858-87d6-2d837c4230bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f7b028d2-f6ab-4e46-86f1-9afc8ef4aada">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16c68725-79d7-4807-aecc-018c600ca5d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_068cba16-15d4-458d-8d1e-14680f6a0841">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a442a01-9c9c-4edb-805d-fc3b45f89e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c8d0fb8-e4e7-4e8d-bb20-179996e179b4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a7bf7ffc-0480-4a79-a24d-b2d6601acb16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6e46b1d1-347c-445b-a227-48aea8b8e2ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ba5d05a-ea6e-4f08-92de-61331f4b7ce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2e5fbe0-2c25-416f-bd5b-e04d9aa999f9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ccefb321-71a9-4304-b680-6cd833613598">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc84b185-167b-4586-83b2-d6caac6cb45f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68f575ef-5627-4282-9c58-c1e41eba70d7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb56196f-75b4-4eeb-83a6-10e82c03a842">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_821c5870-ece1-4e61-9ff7-55588a7550b0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6e6c67c-a057-4fe9-a74b-bde8f770bb4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cac2fa32-b7b9-489c-bd7c-a6db746f42d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8fc8453e-ef8c-4bb4-9294-2a4e227544ab">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65e5a63f-cd9d-4a6b-81c9-8297e8add12b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb6439c8-04f0-407d-93ff-be80b9fda84d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3444efea-71a8-4c63-ba38-2ed9a6bfacaa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1bc73643-70cd-496c-a6c0-55f2a679ef50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8599188e-23be-49ef-8aaa-2bfe07131eba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_51d5398f-d2cd-40f5-943a-48c008f0cd91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4b1710b-5144-49f7-aa16-78538eb731c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0026b68a-d9ca-4f76-8bed-993b99226fdd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_034d70b1-92d5-4259-a101-27f795ef79e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9b2f023-60c6-4246-bae8-1f304d7c046a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6065275-b0ba-4fe1-8c93-51befb9431a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_824a0775-e3d3-4af9-9950-5ad9c0f2acb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33c3ecb7-c758-481d-af0a-85b852631da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fdfdeae9-a5ac-48dc-9b36-7779d7c45b07">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef7f8f3a-7613-4529-bf6a-4beb89a652e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0dffafff-ba7c-4bf2-8345-b32936bb7d86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b375a1eb-4e15-40e6-8931-21f756370ad8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a17eaf05-1e9d-47d9-84bb-52098403ebf6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccf1734-7ea4-4030-b8ee-7a82d958edc4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a878ee53-c51e-4a70-a80a-fb13a8db928b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8657f8e9-55a2-4388-a722-de31eec99cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42fbeebc-27b3-457f-b780-23328d760a14">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2ef59be7-e550-41c2-ad9f-a4e7fae6d3fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0ec6ef57-cfcb-47d1-b38b-6ca3220c5e02">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20979194-0a0e-4f2f-8f25-8612d79fb907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c4ee866-a65f-4f9e-8d76-0a085de8e748">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0cb1e098-2473-44ba-8ace-88063372e452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ff52ade-2687-43e4-8fcc-5f099a77ae41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_568590c3-5871-4f14-ba81-c7895686ce80">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0769e266-9d4a-4af6-b15a-89f29e34da03">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c16aff2-0a52-4ef9-a47b-8542e0c753ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dd8422e1-afb2-4d1f-8ebb-931b8458508d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9d9b5953-6a6b-4b2d-8776-8f0a554bacf1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c308372-aefd-4a3f-a694-4f9269fa5587">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e4055725-3496-4afd-9eed-220b29535c3d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25d44ccc-4df7-4ae4-8c71-c7b06699a507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e984b7b-5485-47b0-b49a-043ae3aacbd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56e6cfa0-aae4-4c01-8062-3dbe496f4574">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87b48993-4fff-409e-8fac-71ac7496438e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_60f5fdfb-bb99-48bf-8281-1a716d1e9cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7c49006c-db19-4e93-a62f-4f74ce7b5671">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cd9d62f0-ad1c-47e8-ab65-be18b6eecbae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_032e8c7b-951c-4471-bc78-04fa2abc164b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5400d815-e041-4be6-8e24-f4b4a55ea557">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6403f818-0982-411f-8685-1a954d578710">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab41767f-a4c3-4501-8fe6-2c53b0b29faf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_518b887a-c883-4f6d-96bf-fefd70874c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5937e65-8f83-4221-a7ea-1b171d13f761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2964a972-3a4f-4f4d-bb34-2a87fbb7209c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_803e8c65-63e0-44e4-95b9-4a68587c9ebf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_28a90dc5-c31b-479c-8bd0-36ae75d91886">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7b5b4d52-a9b7-437d-b626-5013d30b573a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b8809330-10c9-45a1-ba8e-56983312a283">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15a8e6b-dff9-4599-a3f4-cc992e64a5eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_da85e8dd-137f-436d-8551-4c667949a953">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c990151a-be6c-4ab6-bea5-3fa861d3f487">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c68683c3-4c6d-41e7-910a-f8fb69106e2d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9cd6b6e3-2fe6-4b21-a527-04ee4da982fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea51ec29-12dd-4c22-bd1c-f8b4d6c88c79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d73ee5a1-22bd-479a-b8c2-cfac03997d0b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_00d337e1-f715-40b3-ba0d-330107be943a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e35079e-d21c-42b9-a71a-bd371ef325be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ba54f75-4322-4260-a3ea-5c8a1fd8da22">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_02cced8e-b04a-4c14-99eb-effab66cbbfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f499942-c1d7-47e2-b0c3-94f2db7b5d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9db50e30-5d8c-41fc-92ae-ce10b51c1142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2c76a037-c8f3-43f0-809f-c2d22fdc7c61">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_942009fe-1099-46ff-8dfd-39bb6c8db838">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8330d965-e14a-4069-9ba5-af9cee313c84">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9a94a356-74e9-46df-97fb-5bb574ce5aa1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74896b7f-2442-4b14-9fd4-a345f81988ff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_80d06191-1b0a-44ba-8966-72b2cb09552f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_721cb49b-421d-4b7b-9009-5e492dc2fff2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e1cf5789-1e9f-49d3-bca8-81720d2a2e85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_042500b2-456e-440a-a299-70b68697b78e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_61d12870-7112-4a95-9fdf-bb0548490252">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3f46115-af74-4aa6-86ae-154180f55b59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_766c7c0e-c479-4fb3-b381-e2664ad819a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_184724c2-9322-472e-ad84-f3d5ed3e8ab3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1a75e146-4a56-451c-9165-17ea4fb4a25e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_effcbaaf-8216-43cc-b073-cfe772572506">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_44dbb378-126a-4790-98a5-6e6b6da2c8d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04f4a76a-d81a-490a-85c0-8f01b63ab5ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2edeaf8b-6707-40c9-9fe2-ccf1f8eb347e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9e3c8c14-3636-4f67-918b-08d3187d513d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ad35ae9-afda-4659-ac88-72a2bb9fe44e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f77d3121-7cef-4297-bc8d-745375d989c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_63e90e7a-e502-43a3-9128-eb540c6c00c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e510fe3f-7d44-4d7a-9f1f-3388843068d8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01d20bb2-a8dd-407a-a54f-f4d90f2206f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cc0eb440-7432-4aa2-8900-5a7646660733">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dafcd693-b165-4b36-88f9-6bd171a206ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47dcc68b-7686-488f-b77e-cbedaf655b09">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6a44d56b-3af4-4d12-831e-161bdb3b7217">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de415489-e0f2-4512-b73a-135b3e345a95">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4a169528-7bec-471a-8892-3f66276e37d4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_74ef52d5-c88f-4177-9d50-2a6e408bc8a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cef415e9-2e4d-41ec-8d65-54f834f290e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4df8a044-9965-4a70-91ad-3e0dab7ccc17">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fbb6166e-1b65-4c55-94c3-b2157ed3517f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e19eba57-e9c1-47cf-ad50-59fe6b08c01e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_346a5319-3ec2-40a2-aefd-38dfacbbe97c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63c7ea9b-23ae-480c-b27b-f7764ef9d5a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_168c2329-960b-4f86-91db-ef94ad8f7dd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_686e884a-a0b1-454e-b7d1-33c7ad46f89f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ec1f350c-c2ae-4665-8e68-45edcf92d1fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4edf081-2fb2-4da4-94db-98a2a596247f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_312f25f3-55bc-4417-848c-236d31d823f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7f359893-b7c5-41b0-ada8-8df06cf7a8e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1db1a4a3-7c77-4e7c-8a3b-65499a81fb30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dc4c311e-d167-4d5f-8a36-c7c1c915bc04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ddcf7aac-e7c3-45e9-bd81-6146e951addd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_af420f53-37ae-44db-abdd-79138f483c56">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13b3e3a3-d932-4e97-83f4-d63c4e1c8527">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2463ff2c-7690-4dd6-bf44-039f9f475bb1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df6b50ee-af5a-4e61-9bda-0752ef238e3a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d67568e7-c48d-479f-a4ef-51e35b018f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3be2355e-0065-43df-a264-57a295042faa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd875ee0-a6ef-4ca0-87ef-f6b5b079308b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41386a39-3f57-424b-a8b5-8d3b5a32bd79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eaf7e467-44ab-42e3-bcd7-70692bebbd62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aeb672ee-e2c9-4172-b7c6-3d3915821c7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fbbbea53-8f92-48c7-8cdc-a3fbd920c43b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bae580a2-0dcb-4ed6-86b1-f5f603b937dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4eb83445-5e74-42a9-9b92-e1cb3c6ba13e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_33f8b01b-0fde-4257-bf74-20588be588ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_876a178a-7474-45e5-abc8-d9e3eb0d231c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2f24cd6-459c-49a4-b93d-9c6817cb1488">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84507e60-680a-4b67-a596-c214ae0b8c40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_56715438-6a4b-49f6-bc4d-605136e0a3e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f46a611-ff04-4bda-a0be-9d29131f4b4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b1a2061-0ac8-49a9-9954-847d9862df0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec63eedd-ad1e-45d6-bae8-c797162a1e4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c3971a8d-94bc-4b4e-973b-16844ffdbf18">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8526a3ae-9742-4e33-ad46-dcb5e89af11b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f31a7a93-b405-47bc-82e0-5862c71ef7b8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1bdcf5ed-4a96-4d08-93db-65c2d5dd908f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90ffc2e4-3f7f-4b32-81e6-c4c2a792b458">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73487593-2e52-4172-9f55-c27fb539b609">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3f7eb4e4-8de9-4352-8986-c31fbf58723a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6137d3e5-4586-417f-93c1-dc9e2b46adff">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_696dc02a-5cfa-4723-913e-a5885b3e5885">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_843f4407-c335-4824-8f2b-7f2ed4094014">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_947cb703-a50e-4602-b5a1-60cbeb8832c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1f8860a6-75f7-44b6-94e5-01dbf0aa3de8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0220034a-1a6c-46b3-bfbf-a984702d3c1c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4f54cbe-fc62-4410-bffb-0521959fc2d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d3a0ccf-17a2-4beb-ac9b-7be3dcb0fb73">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc80f782-5c36-4239-8442-fb25c5d61c4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c216355b-0f57-4118-89bb-b2780f146bc2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6d75d35-3089-4dda-b69f-ff471b24aded">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ab9cfc0c-b194-4af0-9fa2-77978e43c0c4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_63a8f42a-c8a8-4e9b-81c8-001bed4d2a63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7f09426-095c-459e-8e0b-e38500fab1b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ed7f9c93-a8e7-4999-9d18-f5bd01b65933">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8aa3a3f9-c86b-4641-b368-a099f8583656">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f0fd18f1-856f-461f-bdd7-997115ef1044">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c78936d7-acfd-4a0d-aaae-0153ebc7d768">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_09e0f824-f92f-4e4e-92ec-7d6770b9d243">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_70993686-256c-46bd-a2fc-674f52ac59dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_65b03961-f9f6-420d-8f61-f44ba99fc4cc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_de9a7b88-6748-4089-9d89-911dd957bee7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ec4cad68-f17a-445d-922f-8a419d3fec9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7850bffe-8b78-4551-8f92-d52ef0addadb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c912ed7-2d69-4118-ac02-b9035f0d9e5c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_43b6fcd3-4a29-4e9f-b597-518117e3f111">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_009a7bac-59fd-4b36-a39c-a635cdf04418">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4b0739c1-a932-452f-b10c-356d293b82a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ec5176ac-a1d1-4f5c-9546-e9e47f6ad8e7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ef8ecc8-7d0b-4507-9877-9f640b323ef2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b6c251a0-7f4c-4930-8e39-7a91fce144e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66e59497-02ee-4f54-ad5f-4f399b2eaab0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_891c0f42-fb9f-4390-ae0f-307bc6cbfc64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04a2dbc5-819d-41de-a987-8d334031c175">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cc5d543b-bfcd-46be-8fea-1b2490b1ea9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f9f5d49d-922f-44b2-9d78-ba41b47542a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_41955f1e-f88d-4160-8879-ade4e9d027f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4d97bfa8-9abe-4275-a2b0-1acbaa779613">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8dfc5b8f-fecb-4041-ae98-3c2b1f96feb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8dfa0c60-9696-4870-87d5-ec7d3e2b72a9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f15c0d9e-956d-4afe-9654-9ae5cbeae473">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0a4153e-156d-4852-9921-6d1a1c1064e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df7dc1b3-5ad3-4697-b808-103a9b2e22a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d69e028f-ecb0-477b-9fdb-36594afce196">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c04f249c-6bbe-4db7-9637-a3bef2cd6599">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04b9b246-5df3-43be-a733-5aec27fd9be1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_00fbdcfb-3d3b-4378-8dcb-5608f6eaa51b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ef59a32a-bc5c-4512-9437-86fdef2ac2d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a208f474-056d-48b6-a271-a7123684f108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a20e1cae-0b90-4139-b87d-9ce76e6219f4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_23db024a-d255-4402-b2cd-e7e0052f6e7d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_816a0247-2a88-43d5-8de0-d4709dbffe98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9749f3a4-64c5-482c-87c6-37322d113948">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_580de0e9-f8c1-4969-811f-46712414524e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_20f43d84-963d-41ca-8548-86be349e8471">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2bd46877-a632-4ddd-b880-1940461fb45d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_02f193ba-e746-4eda-ad79-9999ef27fe47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b569c39-9301-424f-959e-c45e0fd99f26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_91e9275d-053a-4d88-9d20-c094f2ccc85b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_69f112ef-9f4c-42f3-9ac8-472698d68257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8e47741b-e0d0-4985-913c-d95c500b7e48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1178ee67-c92b-4568-bdd2-101440661e16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a8960c67-75b6-4aff-8b83-05fffd558dc6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc81403a-372f-4310-824b-112e7bfcb323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1d717e38-50cc-44ad-a538-cea12eb5e1b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5465ff43-da95-44ae-b8e2-7f3b590e6c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9e6cf153-1255-4a4e-a3cb-8931792c077b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a29bb72-2f86-4d29-affe-b2391894c13d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d58201c-4d98-41ba-beb2-ff5d742fcb66">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98fdd615-f480-4b42-9bb3-cea3b7c2fda8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0a978e78-aa93-426e-9765-368315bb94e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c873a17-42f2-4abf-8c47-e47021e0e3f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a5a6dfce-8298-4b76-8289-9e3fee8a8583">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0df7090c-0218-49e1-a3f7-cf30c8f9f8b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_177bf3c3-c744-4321-836a-a2fae0b0bbb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a551b9c1-3d7d-449a-84ee-1743fd7f9366">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_38a5688b-b7c0-45c5-9243-0293e2e48b94">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ad56fb97-89e8-4c97-84fe-98d7049617bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee95150b-76fc-4ba3-a9e3-8aa2a41479b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3304e735-d4f2-43dd-bb3a-22e720aa6d7d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e2869b4e-01d4-4787-a309-e5c09b2214e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_45bfc964-e77c-4912-993c-6ed38877d6a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d598576e-9992-4e55-ab22-7ac5e336c167">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0387494e-d16b-44b8-903d-3aae7c4b2d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ea8cb0d-f908-40e8-8be5-f6cf397fc6c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47badf30-a042-4cbd-b2e5-027b03e98eca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5a2503c0-15d6-484c-9d50-dcaf87e40afd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ac3075d-b630-4f72-9637-9e0d639eea21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a73abc8-c136-4d48-8b72-ccf7c89b569e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_443d1b23-9393-4b67-9596-b24170a7715e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2003d398-4989-457f-96d2-1d171aaa3496">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_467e0941-4ce6-41ca-9c73-fc30a3a465d2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_434f488b-72ac-43d7-ad91-7397a8d1064f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e39401b-8a3e-45f5-9b9a-b23d200ded9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f7396260-dcb7-4643-8440-4c22300245ef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c6c8c-c3eb-4c10-9ed8-60b192b7e93d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10d7ad43-0c5a-4691-af6f-b2784e71188f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d5169785-0581-44f2-ab10-12791b566cc9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa81dcb5-3516-4f66-8384-f28ec6470452">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_84b7f2f0-27e0-479f-93ac-7e5575559334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9da5e21a-cedc-4d7f-975e-b895d61a5b4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8b07eabb-e9c1-45a8-854a-b0e19382565c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d7048bf-1d51-442d-a7c5-42af545b53b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_667943d8-8735-412d-b993-d7f49ec6ec56">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_78ab02ba-6e28-40f3-ad7c-e904efb2dce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f55d08b5-1ce5-462f-b19d-7e59303c7055">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0adb0e5d-57dd-4b49-9fb6-4b542a78e281">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fc722a0a-b5d9-4c9d-b2c6-aa57aa347267">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3f46dacd-ec53-47a3-9ad0-e69d01af2a32">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47e98763-4205-4c3f-9fca-580e6716eb93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7c51871b-8c97-4823-8108-47c7d756d416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5422d93f-8f56-4ece-b98d-d6bfdacfbced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_73252c52-15f1-4024-8dd3-b7f5c081e5b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c7306cd-aaf6-4452-bf95-aa1b65184654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a90aba9-d586-422e-8011-ee94ca4fa7c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9bcf3d63-4745-4934-a4db-6c7e999c6cc7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_acdd21e9-23fa-4c1f-adce-ec12996b7bf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ec2c9742-eb7a-4c04-84e9-7ff3c8cb7325">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ddaae786-f86a-49d4-ab4e-8f62cf002977">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d0b79f1c-045c-4a78-b3b6-8646f10b3864">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39ac3d07-5ad3-4af4-85ed-08bd818a9c57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_febc165c-7c90-4f43-afb5-b99fcd6d0ae5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e8d3745-e50a-4068-91e4-fe628f09b912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48b72232-5245-4b60-be58-4f5e8ac5fbfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_27f3ab55-1b69-46a2-817a-20f140d8cd91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dbcfdcc-7bc5-4654-bfd5-0eb2a6764f4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9985dadd-4bc9-4c0a-9952-68e4674633d0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eeb5e115-4fd3-465d-846f-a8b94662e138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4a93a0ae-8c5b-4578-aee6-66d0adaa0034">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ed23ba9-347c-4522-ab04-d6987fff54a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f3321c52-80b8-43a6-ba29-433ed615fb9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d5e7079d-f268-4eb7-ab0d-986277db80ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd245486-24f1-4bd9-a5a0-8566fb209f65">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b4585259-822e-4a6f-b0de-a7c1df729d57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d66a7f2a-ec30-4686-bfa9-5804598b7f1f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e0a586e-4363-4731-9ebb-852e63184386">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b2993f37-953a-4fc6-95df-364a30765e93">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_879b6ec0-699e-4c45-95e1-8ec2b6f0b1ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_75e908a2-18b0-47cf-92ef-1c6e2d0b87ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_af84240f-9aed-44db-b2fa-e1e428b93e1b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b675fdd4-61f1-4375-accd-7b6aa01e61a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6d19a72c-2062-448c-8aec-ef4299deaef9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_85657dc2-b4a9-4900-90bd-9841b7283960">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0b1f34a-3695-4717-ab24-afd7b7f2a4c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_278a371e-c8a3-443c-9812-da6d05023804">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_ea4a6b35-dcbc-4dd1-a1c3-41af5b692519">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_387649d4-7c09-476e-8f8a-88778b3433f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1108f037-931a-4c97-ba81-1d3945e8a108">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2796ac28-9104-41f1-a0f7-8c2b2b8c7e88">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6d589299-a69a-4252-af49-c04675260ed8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c00ff0c-aaad-4bd1-a28e-b2814d8544a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8045156f-db54-4b51-ba78-c03b95abc2a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34a34bc6-1275-48c0-9620-13d697e84771">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6978d4dc-db26-4438-b821-7dc2d6de928f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_293a7321-4d59-4ac2-a737-ecf77e9722e4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2e2ad7f0-44f4-4af2-82e3-77bc37ef1f54">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d8ac7a7f-ddbc-407f-9405-dc3215bc0b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b09fc32-acb9-4459-877e-24322a0a83f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11c41c99-9bf7-4d09-8101-027de2575f03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_572a2fa4-34a0-449e-9795-578123117344">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_959ae440-87a5-461a-8c69-d91c6be97d4f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_373278fc-18a1-4abd-b048-691670efb49c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bc776d4c-f4e1-40d8-89a2-218707466d21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2bab2b3-e4e7-4ef4-9ed8-fe3468bd5127">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_44c260bc-94c7-4cfd-a4d9-f2539e71b7fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10b57bad-d28a-40cf-8f33-3c48cf7fb4f1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_48680022-5b7b-4547-9e96-7fb49bb638fb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8095e658-d0bb-43dd-845b-f036a180d704">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e90719ac-9754-4a36-bbf9-fb321ace6d2d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88b36e46-3e08-4a9c-86c8-a35e0556771a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1305bd82-d13f-463f-b23b-0a7beff54c8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_27490d8b-7f83-437c-90e2-38655ae49692">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5812ba09-aecd-452f-ba1f-37c16d76b2b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_83030d83-d89a-4ba8-92fa-3a20313fdd4e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_38c2fb13-f108-471c-ab65-5731a64b6cd0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_109ddaba-7a47-45ac-877e-b4d0edefd18c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_25c10f11-aad4-4271-9b83-6f26879a49b2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90193171-e667-46cb-a5f8-a79f5fb9a047">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c4024fb-6fa3-45d1-bf4a-1a1c9e967701">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_75034b3f-0566-4bc4-9e77-4589ec5a3529">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0ee4a0c2-7707-486d-b061-60cb3639131a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0cbf76-5e70-4ac1-a14e-1aeb435db65a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3debb7b8-d827-48c8-827f-6dceae6c47fa">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1bf7aaf1-e4f6-4795-abd1-863d1c5e481a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6799f164-6554-4fc2-8c0e-83c42fea4ced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b3e639e9-c7a1-4eac-9134-b7ae9a1019d5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_108be304-cf43-4c5a-8bf3-94fa3e8d74fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_372e32b1-1aab-432b-9c3e-bc1b489d9e36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dac4a438-5467-461a-87f3-b7a53957f069">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eebbadab-e107-4699-8e8c-fa9c1f93e384">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04be338c-4123-4d3c-907d-cfe7e46e082a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dc3386cd-4655-4bdc-97fa-b6d42a53a6dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_df932d23-c0fc-424d-b8c2-f3e6599fa319">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1cf568f6-4c0b-4a61-918e-d6ff3351b8cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cb029e5b-97a2-4f2a-abcd-e6e0fdefc53f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0f455767-aa17-45df-8151-164007b94c58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_afe42c63-3b53-41e3-b839-0f65d0069446">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1eb2294-922e-4794-8a02-65e81ca3371c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ee5a5db3-c2b3-479e-80db-614dd45941e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_44a01d28-5f0f-433d-9765-93694bb03814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_91c721ce-fd9d-42b6-85d7-574a9f1ac063">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_35eb4da6-136b-4bca-8604-47e75286e65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4044b56c-de8a-49b2-9a24-8d72190aa272">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_da881031-0b0d-40b6-86a5-aafdbfa81931">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a94c14fa-0352-43d6-8f52-27d7ed31fbca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_982d9d6c-a0b3-4977-9ac7-6542cc61f4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2e1acf0-3a18-4654-b0c6-1f49191aa7f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac2f8368-74fa-4e99-9ecc-00d828bae587">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_db7e5d95-3bcb-4838-8615-e20786189b81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2c8b805-99c5-4822-a5e0-8b7715404d30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_39133449-53e6-450a-bbb9-2a9f492816ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_52cf4172-5261-4ed2-b0f2-153da4661c73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_759a9435-a21e-4f99-a560-85da57a1d290">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0ab7585f-f58b-4966-873c-f67bb20f6b74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4406299b-b743-49fb-aaf9-da8a976adf9c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_149e05ed-ded0-4b52-9f8b-a74fd2961737">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d81de1fd-80d7-46f9-ab23-eb276e288ee6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0da192a0-4748-4919-af6c-739d407d0d0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7d3e78a-4c0d-4af9-91b7-ad6b70ac9a08">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4de32c8f-fbec-44e8-b08c-4b1f7f0ebaff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_247f2ed6-5a4f-477e-b5de-c71d021f919c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0b877750-4384-4ec3-bb38-08ee5ccf16d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d9c8c518-9a45-4371-bd8d-47e5a3520e74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_be89e92c-bdaf-4807-acb6-4025d0a88244">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ee9c1f11-acf2-44de-905d-5f284b2f2e99">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7540f357-0df7-4c75-930f-21d4e0cf46b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7948fd33-023b-4cba-b871-f34288cdd5e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56081645-b0f9-492d-a015-67797a891d61">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7eacae3-b893-4773-8a15-c0c58eded027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aa5ddeac-c8e9-40cb-a1d1-9f7ea09b3630">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_12af6be9-e7c9-48ed-94ec-5d6f90db8dfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a34654ae-5aee-4fc6-bdc2-5ec098a6a2e5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_60196fc6-3c06-45c7-ad3a-d58ffcea6351">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6d6ffcf6-4c89-431e-8efe-472592c985d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8c4fe896-13ef-487f-8ff9-2dfedad5b2b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8cd607f-df0e-4528-8b90-5b4718af222f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_7fda72c2-1863-4339-a7a4-f6b3e2b6fbef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6d1299a0-430a-4b38-892a-45af9c3963b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea273147-7151-4e4f-9db9-1fcb630b401b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e24c6d73-f009-4bd6-8a3f-55799db87823">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_018b9ff1-6444-4689-b68c-97b463b09946">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6a79ce6f-d266-4de9-a41c-650ab243444e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_70a7cf98-4c62-4403-b08e-76c9392f56eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f8c4f817-3a34-431f-a6fe-db0ca3ad14b5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_242be4f0-4ccc-4c64-8ca8-285c5f801e05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1747a54e-2f1b-460a-96e9-f1e004c0fc50">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1cf3a401-e334-4e2b-b888-747c70fcee33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b5923661-1d0c-4844-b6d1-4ee4c6953345">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dbd09afc-8674-45f5-a0ec-f55886cf9441">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f120ca0e-d965-4061-ba03-9ddd552b5aae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd539541-75e6-4ca8-9f8d-b27aef8a0d93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_98cf00de-bf8e-4a71-a89e-ba65c7d70449">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_21bb583a-c74f-4282-8144-3cf309cc0088">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a65ee9f-719f-4f47-9dfa-ba9ff879cdd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9d9a73b9-313a-4e9b-8fa0-cbba3d566d96">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_585ae3c4-d76b-4fb1-bc52-cc2665b7bff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2a471487-7727-4db6-ac27-ea7374e03907">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fc862be6-abcf-4e48-b9bd-d1865d75558e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_df93daff-7fbf-4ba9-9486-40503806d1a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bc441fb3-f4a0-4696-9076-82679a508d59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c3d8d60b-befc-4d71-a319-22ba6e25bb74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1d980b-aaf8-4ee7-b7b1-bbce95a7748e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486d1e9b-549a-42df-ad67-29d2016f4571">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fe878612-3cd3-4f69-8d54-6f4fd236cda8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_dcd0ebfe-3623-4fc3-89df-ad719955b5f2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d4446022-9134-45c6-bb58-b7a27696b416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_24f3e454-8e14-4307-af4c-b8767213f69f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c57189dd-499b-42a1-b6fb-40bc90d3a310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_804162b3-4b87-423b-9dad-13464536caea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1eff0e72-3247-4107-9993-1298d21ecee5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bc82a1c-068d-4239-b014-3e770cd1c98f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5e61e1ae-4fb7-4b1c-bf38-bb156bdb052b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_abc4c98f-3c84-4a3c-a195-03f724cce1e9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_53d5747b-9ebd-469e-a3e4-df8d5abb2c28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad5a88de-f5bf-4fa2-b3fc-510e9e8d3c37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_64d83d6d-d0cd-4903-8112-392b2344dfb9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e85227f9-582b-468f-ae33-3c98845cd6db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a53cb408-2e26-4fa5-b28d-20627309624e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_86b5e424-cfe9-4df4-a2e0-2c9029f68f74">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f6137780-8fde-4ca3-91f1-64a5945e332b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_520b33bf-bad6-407f-a1a9-6f9105538d74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_29d5088a-c14a-4618-ba86-5567efa2066b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7579990-1de5-4ca6-9653-82ccc5732f00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_095d7783-c130-45ad-917a-c2dd3768cb3e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c9b6315-c3b1-4e8e-a21f-67f978c07c5b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57779485-dd57-4100-859b-10cacc1c835f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_240ef7c2-1e73-4fcb-a83b-0d111cbf2e37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bd5f3cad-2a76-4762-94ec-98a3c293daf1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dfdd1c93-6dfd-46b6-813b-0a5845e15134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a5be388-1f63-4417-9d57-f6a8d7f6c174">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0fa19015-6980-4456-aa50-cf912583bbcd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9ab6db68-d9ef-4fab-9e9a-3375d6ecce58">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d9327214-7ce2-4fcb-8be7-d157202b62a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_395280f8-b83c-4445-8d46-c5e5796fd2c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1cd39a2-57f4-477f-b935-966f5a9b061d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f20a0e2f-0b05-403c-981a-8b622394964e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f60585d4-e1ef-457a-85d5-a0cc458b1138">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4f6fa4a-f388-4aca-a526-4034b8eaa0f6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fc3f67-b589-46aa-9a14-df1c38f536bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b901fad0-2935-4ad2-8c60-ca6f514d7ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3c82adf2-700c-4e2d-8783-691c7eb0739e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a18a8468-b108-467a-865a-cc01df943616">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2c51b1a-fe39-428c-8e64-d34cca938997">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_afe375c5-fa11-4fff-8684-c4c3797d88aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b864d96c-56d9-456e-abbc-339fb8a509a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e788d4bc-4664-4c67-bbbf-1e2b9efa5a73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad243881-6037-440f-9c2d-b0a9e64c6a64">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b0832547-0582-43c4-aec9-e5c9f203a373">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3edfd931-7c3a-46eb-aafd-7dd35d41352a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e6efbdd1-ef1a-40c6-ac2d-27d367139d20">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b902ca3b-88e7-4ccd-ae42-54fd37157ac4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1af658f5-3255-4bfb-93ea-05de03e79987">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d5e9708-d4db-4e19-aae8-90f09cd7929c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd656c03-02f2-49d2-8ac6-ad27bab92a22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cf134a58-533c-41d9-9b3d-064ea328e676">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_36b31222-5177-44b2-8c7e-386051e7f428">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c0f32ce7-ec0d-45f2-83f0-a0de0b3f6667">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36e242c4-596e-4412-9920-1ca45dfd68d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8cddec43-6655-4716-bf29-100b760b612f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7d2dad33-7520-4b06-bfe3-cebda9ee7513">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9815c625-a36f-4d07-b707-ec66d33859a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3d0de5dd-fd98-4de6-bad1-e85580ba0e08">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a1c91801-83f7-4a77-956a-ca55e5d1e3a0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ceaba128-fbcf-4166-9394-68d7f0ca3752">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b15b72d6-5cdb-4d59-9668-79ef523ce4f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8e480977-b24c-4952-a093-809cb4d24763">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5c1c711c-85e7-4fd5-be4a-ccff8eb4b5ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bbb9371f-1a37-4003-b48a-8988d30d076c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b5b42e1f-179a-4c97-bcee-364d1ff170ec">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ff6fe352-30e8-47cc-9b3f-0616a04687a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f677199a-7a7e-45a6-8b95-8237f459bc82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02e3ac29-d97f-43d1-b090-d6a871b884dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_601283cb-11d9-4caf-87c7-fdaed3433b0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_654a5c27-2a08-4691-8295-275e8d822171">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_77f5430e-044c-47e4-817b-bb82a39203cc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00ecf5a0-0f32-4b79-8e19-ea08c4983582">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_af84eb50-6345-4236-85e1-0ec2f50a2809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_dcbbc1f4-df6f-4356-a98d-e3b93cb2e392">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4d404e4c-8304-4c93-8b97-ed2d89c816a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5ca824ca-5d7f-41ff-a5ac-f3de76328507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e7f5a4b7-165d-4279-9faa-59831ac0e6a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f1c65454-d63d-47d1-ab82-933a498abc9e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_853b1603-5024-4c08-bca0-8e16defc3084">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_950ce21d-3058-4a86-8fc5-5c6da09dfd7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_087cf93a-9ea4-4c8a-9e45-9fc42acee0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_92dd2c93-1279-472f-8d40-7e64631b28c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_84fe57a7-bdaa-4724-b43f-d941fb289764">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e098bffa-f41b-4b69-a028-c4feab4acf86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4bac56f-597b-479b-b57b-b2aac2d58bb4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1cac11f7-d0bf-44d0-8b8c-a10afa30e275">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e44de395-9fb0-4220-ac41-10c9c37f6b98">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea85bc90-6724-4580-b1e9-bc7626750460">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed8ba83b-973a-43bc-a272-e96e8cdf3621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e19b554-54eb-4aab-a6d2-7a770a88753a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_736eee20-3b0c-44b1-b424-ab399710d6c6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_010e4f03-e0d7-4cb8-bac6-98ac3f8de025">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_042c4356-75cf-4e9b-891d-aa5d10db05cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_208fa1ec-4809-4807-9ec4-23588a1fb467">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f657ecda-9d23-4a5a-9c0b-4fdf40cacee5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_523f1059-be27-4b98-818c-62a820e334d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a29f47d7-80e9-4691-8ada-76fc5c2f6bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53f12aec-e862-46fa-8bc0-4d0d0cfda200">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69205394-a998-48be-b6b9-371c49e07ba0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9d0b9c19-7f40-45d3-9f15-b20a17310fca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82888fdf-f683-41d7-a848-5279ecc53dcd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_63289c77-5071-4fbb-ab73-7b68d4ab818f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8725834-bc02-4f24-a7d1-29c293e23121">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a226cea4-b1cf-4320-a67b-3bce18909a0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5ffb8a8d-d3c4-45db-97bf-b76c935dc4ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_88c8f602-8ba4-4b42-a483-280414838fdc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9634de15-4459-4e22-b5c5-17c70fde0999">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cdec0538-30f7-4067-8987-308455db1f8c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a77b59ef-a76f-476c-babd-80ad5708e843">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0666e484-9392-43de-83ac-819c383b3a55">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b81a42b8-e4e7-478e-ba0a-50a6e0d60e57">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3bb2f1c1-4602-4b78-b837-bb503c6934dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1c551043-5d5a-4968-8a63-7f6a3b7132f4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4637e379-f30c-4a31-84bd-ffd62fd2e46f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c03176f-cf7d-421f-9fa6-a1d8c92c4fe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5aeb7f15-4f3d-4387-8586-53359e2c0bb8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7c9b0c3f-561c-47b2-9629-81810731b547">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_10641ef0-825e-4819-a601-f845fd541f49">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4649cd4e-eb8e-44c4-8cf4-8b52de8527b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2cdc2941-1a71-46b8-a3f4-022f1702baab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5b696508-e2ab-434a-8d1b-b5f5cf48933d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1377b5e7-b31a-411f-a56d-254840d49146">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5af16294-f0ff-4adc-9a35-fe26c735a205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7086329f-c75e-4401-bf18-c12448d0599c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da05ed8f-45bc-48dc-93a8-aaaea133cc93">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_249cc69e-c3bf-4569-98df-982eb0b02755">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_519ff774-dfc3-4080-874f-8c6dffd4c9db">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c12f960-6db8-403d-adc7-63d01d1f7b05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cda35508-43fc-4439-ab19-434bb3f04372">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0acfad03-f47a-4c03-aae3-33bfb6afefe1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a638d024-ed4a-41e5-929e-cb4854c84eee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3fa30b0a-0b40-4e75-9fcf-a2cb760bdd7b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8b1248a6-fecf-454c-967c-b71aeb1e0089">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_681ff111-c345-4c75-969a-1eb7a391a4e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_207f8550-12ba-4999-b92e-624be0b8dda4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f167c3c9-799a-4e7f-8bb7-32cf1b7b4f11">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0a07ffd7-8004-4de8-9250-9c6429d6f865">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2875bd0e-b8e6-4ecb-a19f-cb48be23d6d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0c7a8c2c-1ae0-41ef-8239-2c3104922d12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83705ed0-b3f1-4918-9fbd-c8cc40df7d22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74e6e7cb-dc2a-4415-ae20-1573ff8836b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_90663f13-bdea-49ae-9480-f45efa86e5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0eac8aa6-0f09-436a-8629-5f7028184b40">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65fa9ac4-a534-448f-8cd0-c38ac7424048">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4ff2d05a-6222-4638-9733-1eef61762494">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6820822a-c4d6-4729-90de-29b9def7cf36">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a93a36f6-3a25-4c76-9cd9-78c3d42fbdde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e472adfe-10a1-4a92-b3bd-7b5b5ed2486b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_83cf789e-d6e9-41de-b519-aa03739f45f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6d58856-e665-4d79-98f5-afd84db54f69">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_784d6612-2600-4426-92e4-7027acffd95f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13896b4e-3e41-420f-b862-a0a3d21ceb96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_666c7a62-6e20-490a-a1c0-cbfb3c7436a9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ff7ed84-33d3-43ab-8376-70a048059152">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_14854eba-847f-49b3-8e20-ca94a2f5b9d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a9b204ab-1f6e-425f-90cf-898fcd1a7407">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed504220-d7be-48d7-9805-32d3e3c0e5d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c227f1c0-e34a-4741-8d9f-fac803867ef7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fb64a662-23fa-4075-9a28-e41e6adf1d71">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2d83d0ac-c4b2-47de-a28e-ab512147e83d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7cda8444-ab66-4c14-87f1-12402e45c61f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0c737ad7-aec2-4180-a72f-d72e244d844a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_133ac243-cbba-47fe-9390-45cbdb008ccb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_872f7b3c-5276-4ce6-b962-0d8b25432d94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_189e8e34-f99f-4574-9f08-b8b440464c4b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_67cb191e-4133-42e0-add2-607ec93ac3bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fb848d85-ce2a-4998-bc42-c56e2faaa553">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_992ea9eb-ce43-4464-a1d3-194fbc6b4ba3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_677076a2-8d3d-4f6b-a22d-43b9d496a2de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e60eb085-3818-4f34-93dc-e7c38e532bfa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6c0b212b-ce81-4c15-929a-40cc841586ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2bc7d3b4-6640-49a4-bebd-48161c16bf96">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_287c3a3a-9ab4-42be-abe8-142a3b70bf16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_277a94a1-0bcc-44ec-8db1-eb5021c13cab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5a7c9d0-d63d-4e0e-9bf5-95a77cf9cc84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e70d7203-74eb-4383-8a46-da218ed8dce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0614cd6-77e6-463b-98ec-e93ffcba4e75">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2e905378-e9c1-4fca-b4a0-c5acf1066973">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99e9719d-ed7b-49f5-b9ed-f4ed85e139ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_37e88aeb-098a-41fc-9e1a-52baadb16798">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cd243800-375f-4158-9a2e-e99a8b0a8977">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffc28114-bb4e-476b-9411-5930ed3c523d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_acbd5f5d-d985-46d8-9b39-51c1ec77654c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_8a8f2b10-d625-4291-bbb2-c1fc90c3d4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f23c38bc-87bc-4431-9393-a0cc4d3170c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fa31a3b-1cdd-4926-98eb-7e35a81b18bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9f3c2261-ef07-49ba-b884-bebd1494fb51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b045d88-1984-4a69-bbf1-f50f6b1ed6ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a38fd34c-89a5-4c12-84f2-09fbd8009033">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_edbf147e-3aa0-4d6f-b4e9-39601d31597e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a58f4ab-dc05-48bb-9b39-3cb5f45fd2e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d8bf36f7-97e0-42ad-864f-2f2edcb88bfe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2323e83d-47dc-40de-a144-16eb4e03305b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e3c11ea-49cb-4716-9818-5c12949903b8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_87f4fdd0-5e5d-42bf-97b2-4cff37d86182">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb9b8e19-399f-4574-822d-52b132b2a422">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02522a83-995b-4bcd-b3e9-375364be6b0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_798b3459-1bef-4fc3-8355-fdf9bf179a3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_43a027cb-d98c-4ca4-9d54-5af8fe884f01">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b7c12a36-2bc3-4fab-9d03-d242fdc47304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_95306b19-c314-4249-9726-7ef3f94e0d01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5ca2305f-ff10-4b1d-b5ac-044bb4c10f74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_78b67db8-75de-4d10-a3d3-fd218675b991">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3c76d6e4-2822-44a0-a623-695a0e7f9d3a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4e202178-e806-4523-a1bd-f93869911a50">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dfe9440b-926f-4cce-bf8c-a8f6d487a36f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_33626ba5-36b3-474a-a6c7-2c281ff87ec4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e6e2210-e273-4be6-95f9-5688af27f518">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4ee8789c-7502-4fe5-90a1-6e73dc9c505e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6133f8b6-0bde-45e5-8f0f-028ebdcf5e51">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ad218d74-0a8e-4012-8e2f-0e4b7a336d27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c1e52ca-76a7-4811-a892-befb669f3507">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_18fd6434-e78f-46b5-82c2-d3ebc9a988de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e648bb24-7214-4a6a-b0a5-a9fe6b8b61b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_94d3e68e-9865-4ec2-b05e-248a8bdc3d1a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_101f17cf-add4-42aa-b827-9fcee3063868">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_93711071-4cf8-4adf-86ec-c6a32d98f266">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_64cca2a6-8c18-4f0e-a042-fee853c9f2fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_180895e9-b096-458c-8c97-9c4a72ce7baf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f9420713-0860-41dd-8ba4-9afeb786243f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_61f2d29b-5e0d-45e1-8dd8-d0420e496f28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71cfb5dc-ba9d-408e-b18a-81f2094e2f7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_17ee7463-034c-4288-8bc7-137ac0a633f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1322195a-a94f-471d-97a1-36aaa5291e6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_01b1f9cb-d4c6-49b9-8308-a4fe08646434">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ab4438b3-f56e-46e0-8d20-4e4129be3372">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f297db3a-e6df-4def-8490-9c3a9b21c27b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_890cc6c9-ad70-4730-a9b0-cdf9c5cac5ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f8c6fcf8-d0e6-4535-a745-c08a0054f3ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dcba6d8b-5108-43ce-a5fc-b36e4b065d9f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_52753638-c365-4f1c-81f0-f9fb6fb0d58e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5ba74212-2d31-402a-b2b0-f3634b0fb61c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6c87a5c7-5bef-41a5-962c-12bd1cf3d6a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2bf5b977-f2d6-46aa-a673-2f66e395b78b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ef3a0e9c-40ac-4a1e-a041-86f72e7d5b7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e5e0a7a8-420f-4cff-b55b-e6e139165aa5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_13ed373b-2943-4988-ad54-980c97b6289f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d6452b62-9209-4e95-b4c8-b3f87293609d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e679a526-99fb-4b23-b39c-566137ce3f75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8a4eb8a9-a1a9-4251-bf2b-4f8c975cf86e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1a9bf8bd-6672-4e21-b8bb-e9e91f34e994">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_294557d1-3730-4819-8d03-96456f3fb912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e2daf53-4341-4911-980f-3022b8066b06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7fc0c8a-db70-4c61-b04e-6169c45e6742">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b83a5d31-4ee4-4219-98c9-aaf54ed1f572">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_16af6b93-4e31-4e18-a77a-e4539fbbc6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_766b42c3-ce28-41e3-bbfc-786e84c88654">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18029036-faee-43a5-8a1c-6439d7404892">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2d90918a-2664-43ab-ba72-50862a4cba1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5fc88920-3f1a-4427-8110-f4bc8a88aaf8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1768cfd7-5909-4887-8b25-fc3e38b59dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0147f1f9-332e-4e9d-a8d9-e49d4605f776">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_866002ce-f7f8-46ce-921d-f83f33ee8d46">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9226ad6a-e864-4c79-a107-ac6669389ece">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3fa8af05-471c-4f84-9804-2364ab4d0142">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33f8e378-97b4-4f9d-9b3f-be0fa08c737b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6abb7518-e189-477e-bebd-3b47fbf2925f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_08dbcd9f-0cb1-478b-9d54-9251d09fd380">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6c00c6b-4fb8-42b9-aa43-be4aedf68d8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_395ebb43-da61-4761-9bd9-015b17860fc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b177b6cc-2918-4ee8-a5f2-bd619448a2ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c167ce0a-7228-4516-973a-d0267c640bbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9224a58f-f44c-4dad-95f9-d57b2f19fdfb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_009bd855-5a73-40a8-b2db-4147028f51e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d617fbd2-7202-4dd8-8747-bcef9c2c5304">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3b667f9d-2ac9-4b00-b8ec-120472c203a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_39552eb2-2347-493b-a342-36112dd61761">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ca73dc61-46db-48cd-b6ac-020490792c8b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f12e678-c7ef-46bb-93dc-bd6c4fae421e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3635c9b3-b303-457e-8e50-6af4bf971c81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ed3d1d8-306c-4634-9e74-e55ce4231da4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5431f42a-4340-4948-81f8-b6dc1d46bd85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a549c145-0195-47ab-9ea4-77c6d452a452">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e8510213-3fae-44cd-8c15-4af0efd3142f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff76ff5b-f84d-4bfc-b06f-19f833592c4e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a8b52eaa-13cb-4ac3-a2e7-fced09e07ce7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9de60e0d-f60f-4269-b79b-392086bc26e9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7954e8ef-e8fa-45c9-a1ed-cc05cb0e38a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_11316af2-1bf8-40c3-a347-97344c20ad02">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50f7ffe9-6211-4a14-a182-778413891848">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_87540be5-5b92-4ea2-bc7d-5b3a26a87c91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f97ece6f-a45e-4473-8e6a-44a98b809134">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4c02fc72-0dd4-4386-9b66-933757038c0b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_867a6bed-e19c-48e8-a2f3-1926d9616bd3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_02bf56b6-a3a2-4fab-bf0b-44e24794fd3b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ecf22d39-597b-4818-b5a8-c31e0720bfc5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ced36e4b-41e8-4728-b496-b75bab9931a4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_34ba3909-aa3e-4d0b-a427-063609b352eb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf9be7ff-0016-4672-9459-a0b1516a2101">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3227f4eb-27db-4eb2-969a-3af0b573b8be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_22693f43-01c5-4cc4-87d4-61d6b5fc763d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0cd4e84e-7059-4b13-9285-4e8f4c356a2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6640ed22-d3ed-4ece-8619-61a1d5d51798">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e7ea311-332e-47d7-b933-6c6df5c31f77">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bca5d88c-41fb-4e64-ae21-d1cc14551a8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ab93ba3-8eef-4341-82ab-71ab7e39fa30">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e6e188b5-450f-4a43-86af-ba5bcfd661ee">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f2bcad28-b999-4f20-bacd-724c9f78c298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cdca876b-026f-48e4-8bef-c9b1dcf12eb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9c318374-62a4-4ff7-9cb1-d9a784db08dd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ca11ec26-3b01-4bf9-84db-24ac4f0248d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8705133d-cdf1-4be9-b24f-e9b2e676a388">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b540bd1e-385f-4dbb-9e2b-56ddb1eb21d3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a47fb97d-2d7b-4251-9f17-312b1e07eac5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_18a57444-1e35-48a3-a599-55c7a6e7af15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ebe2f330-1adb-431a-aeee-4a6a21167603">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4c70b357-5014-42b6-a0ee-fec1c2469a8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a01662c5-96de-418f-91a5-b16db1b66c81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_87c006b7-bb18-4a80-80da-0eb053d7b15a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f276409-96e1-405c-9e75-4d9fccc8bf87">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_034ec4b5-bd8c-4a92-99a2-1f730be3f002">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_bfc273d8-d57c-4ca6-a117-69a5e0ecb2d6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_392cef6c-b0ef-4cb7-a61b-d92b77e1f8b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82bd5ada-01e6-4702-b2bc-43685a564dca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e0203b79-c207-44ec-a455-1076786151ea">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2957eef7-ef17-4284-8b72-885290a5d4c2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb554827-e2b3-4174-8618-2fac9fb13cae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_68ca1c46-e3bc-4281-a44c-882106869b58">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_081ff2d8-2c7f-4dea-b78a-d67d6abc4db8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d02ad0d1-25fe-4737-9c11-d7409abb063b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8be185ca-2d62-4f9c-8e1e-caab88cc2025">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9664ae2d-68fa-4059-9ffb-473fe2c0cd86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9284884-794f-4ee0-8ef3-402a142e0bdf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_857587f3-78c0-4084-ad11-e09272976390">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_432d7e6b-c2e8-444f-b028-b234d1ef1e88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9a5b57d1-932a-4f96-8583-89781b773ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf0a0c29-48a3-41b7-bf37-d440fd41eba2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1a7e0964-17b7-46d6-8d1a-268c8cdf3e64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23d6d5b0-ace1-4f4b-865e-5a827364f543">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3ef890e7-a6b1-4294-85e1-3fb193760bde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_63fb9c11-e256-4e10-8312-fdfe2385c71d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc21f7b2-afe6-482f-af4f-92fd14b5abfd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad6c979f-657b-4e73-ba68-257d15d08a72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9990ad7d-38f1-4620-b15c-019273d58f41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c87e7e5-b2a7-40c8-98fb-101f3db6c73e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b79df498-dcfe-4fa8-b694-04d76cfe87b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6a676aa7-4dd9-446d-986d-794ce499f297">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f1f0e9e5-3f7f-4a7a-b8e0-3dad27794a06">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1e9770c9-db90-45bf-84af-be3839c382c5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a7565f8a-903e-4b04-91ee-dce04a6097a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2eb48637-02e4-4857-bf33-7421a2bd903e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5cbe4d57-0c5a-4e3d-8104-c43f35f3b8c0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe00b674-5c44-4794-9a2b-525f35f7f13a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_038e4bd6-fe6e-48cd-8b3b-8617fcf53b16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b8f4ab56-0cae-479f-b994-a089285bf453">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_84fc5009-d32e-48a7-8fa4-0a892b95543d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f170f287-d4c0-4aa8-bb8a-be6a691759fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f1173766-06ad-455b-8adf-663574665ef2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cbde89f5-f08e-478a-8a73-f1203842d380">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26c96fbe-07bb-454b-bafe-0b66e0d91779">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_66f5f987-6746-4ddf-8291-e079aae6f88f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1d1abd8a-4a75-450b-9814-efee70c1f00e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f7203f60-7692-4edd-919e-212721c83323">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_314d2ba4-7d01-4433-866f-7ed52d8c266f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e1c9ddf7-9f1e-46a2-b210-fcc7a90dd361">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e781a75-395c-4675-b1c9-8090f7136a9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d88cc96-bf93-4569-aaa9-b85447f5d6b1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5e012982-8c5b-49fe-a915-9984a9844629">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_99f7bda1-69e0-474c-b2ef-27c28b95a477">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21a9a1e4-817d-4f3c-a06a-88c050bd8a01">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a461b809-62d4-448d-8596-070fbc82bcd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_88c1f50f-7065-428a-a48e-3955c95e0a83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3633500c-289a-447f-84ea-ee2adf5d8f06">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0fb79a27-0296-460e-96bf-344c9748e998">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_320e4ca8-bc24-41ca-89e8-88fb69a20780">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d52c596-f3b5-4ce2-ad1f-c662b2590caf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f0c87d80-0936-4412-8a9b-c023ac69a7c8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_46f656f6-4f2e-402e-93de-2f4de8fe6b6b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_86fe6bb9-d204-429d-8827-606b790a951a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65a6018d-1102-48c8-bad8-c5a8effaff81">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fb4c745-f703-47ce-8de2-bfbbcaeaafc8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cc383940-5969-4abf-92be-59f7730681f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_56a02474-3467-4c31-80c7-4c1d43af0cbc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_1e7c81ed-90ef-4fff-9d64-df1dbba18891">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_270bc494-7c22-455b-a3e0-e1c31732dfc0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0da6b145-a096-4b6a-8359-91e83a938787">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8ef5af20-1c4b-49a2-8110-1d688fa10a75">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b698233d-7707-4afc-a8c4-ef3860860220">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2d5eb8c-d2e4-461a-a3c6-af74b86875b6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_067b340d-de06-4c93-b738-322c9e63f326">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_884b6d2f-b17f-47ab-b894-29709041ea27">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_175d59cd-5dbb-4625-981c-cb434b49c02e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d7701a0d-bdd9-4f72-b55d-db2c6b054614">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b1fe23e9-b568-46d1-9b05-3976637f31cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aab9f87e-3481-4ad1-9af4-85bab1baad21">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dc158be9-9c3d-46f8-894a-bfda40b4e8d2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a8f056b-8c01-4df9-9819-6fb78eee91e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8d3637a3-ce8e-4969-a955-19e3a93f2460">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb458537-8f24-43a4-9114-692c0daec131">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e806f44d-97f4-44e3-8726-a61f5883335b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0a7c0188-4d39-4dd3-8004-9b473b22b3b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f71a10a7-44bc-463d-abb6-e483dc630541">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2e8ced2-7ebb-4a01-a1e4-55f059b92fa4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d2f6cea0-e313-41ad-96f5-87800121a518">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ad72c6b-d938-497c-8618-859b5d3e5884">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f1cf396-8d86-4e6f-a52d-e1af86772ceb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3251f608-0688-4dc4-9dc8-e3091bdac7ff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8fd3fc61-31a0-43bd-b0c6-cafdd829679a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3fbbd787-319f-444d-a059-3a5536c03ff8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b7f797d-4bd2-4df1-9cc2-a888aec7662d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d2eb25c9-57ff-4877-a01d-57ad4b5ad6ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7f8d3ac3-bcdf-4d13-afbf-63bf24e38d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1342fe65-f28a-4ae6-97ac-46ffc8b6ea76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b546ffa7-d00d-44d4-b9b0-f2a6dc043c97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_486326b9-4614-40ef-b499-57360c1454e3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_65e01f10-db8a-405d-96f2-ecb2436ea1bb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_173fb145-6c85-4837-8c26-642a031183cb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39748ac4-8994-41ef-86ad-aa593876e300">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8feab797-7f0e-4657-8282-79c8b499523a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a5838d0b-841c-4085-876f-1356e29461b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_66238552-d9de-4b1b-9b46-7f3d2f028039">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ce8a387e-0ea0-425c-ac7a-1e5dbe93e6f8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_28e4a7ba-04a3-4c8e-9d98-9b47f86b7ec9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dff8a9f5-f6be-4746-a6cf-9e0fb46ef3a6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dd48faee-7455-4f0f-8f4a-77e7491becc4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_50ef0e35-d57a-446f-a4d2-2c9554e2d57e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e0f1d46-62c3-4360-90a8-bff00e7cf60e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b424c2b7-3a7f-497f-80c7-0a30f96676fc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a833d30d-19f5-4e6b-9f91-19343a3ef516">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_95506cd3-1c3d-4793-89f9-65cb4c8dbe8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3991ca5b-3c5e-4b1e-a604-17fc2269d13b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bb0b6e1d-6cc9-4cc1-91eb-2548f3a71765">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_df182f4d-e0de-492d-a328-0043b36cc033">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_21bf0113-445f-4a34-9358-bf53c533c485">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80a0e5c9-61fa-4204-b743-9351bb56ed69">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_632eb5a9-9e2d-4eaa-a7b2-00d881f0b85a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b386a96a-0e25-40f1-acd0-e6db2ead045b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_10196086-9e19-44bb-b597-102575b853e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b6bb26-e66c-4d36-b242-8da8298dfbcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_40fa729e-1cbc-40e8-9150-07e62aeff0b3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b2ae2b3-068b-4f40-b89c-183060300298">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_233b7c4f-1118-4246-b7b4-8ffb83cea2d7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47c6c1b2-0598-4985-ac70-ea6696ec5bc0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ec420356-2092-46dd-bd46-319011559d7f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ffdebe6f-5731-427d-a69f-bb6a72a5842c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8b6b8c7a-4fe0-488e-a01a-1e14170230d8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_516c7e02-238e-4cd1-9e09-495bdeb37206">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_97ca2a83-900c-40db-b703-573ca798e017">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f2026e7a-6ae4-4e02-9429-3d7c0044c104">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_16daa926-0bcb-48ee-9fbd-f92fda0d41f7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8c0d4db3-6da2-4152-bef0-416b2d5b0f7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c08f3b3b-a1c8-409a-90e4-8a48873e7d62">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c24c9829-f820-487d-9ff7-f9d743f2bc6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01815773-3d66-4ea9-a4b5-7e3bc5e21bea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_11eb003e-8feb-491c-aab0-f4290351e574">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_3fc6d901-d47c-45b8-932c-9503f5e191e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_346ad448-e260-4eb5-ad22-909cf41d55e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0aa15e9b-4db7-4647-80f3-6faffbbed9af">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e186c8cf-20ad-49f0-8181-cebfb9de7644">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2695dfad-50df-46b7-a2f9-455baf0a39eb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ccb801e0-67da-49ea-9ae8-eb6b74fd3796">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_518c2ad8-6722-49fb-aeba-027b9834fa12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_768736df-6aba-4013-a7fe-5a4d2415efc7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c98ae667-4b00-438c-a4e8-11eaac1449fe">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_aa48cfef-d128-4b07-a145-71146779f621">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dad66b7c-ead5-4597-b4bf-97239b0854d3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_571e8263-08c1-4586-a8e7-327d1f5ff2be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c344c2f7-1f7a-485e-ba0d-980abab192a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac2bbd87-5d42-4fff-967c-30d4052d4a0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d381ddfa-6e11-4efa-b898-c5d0ecdda246">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a14bcea2-8848-4ed2-8671-6e9c1db7b38f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7eee8ba0-c290-4cc6-9b99-cc978ad4a55f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b660b46b-f89e-44ba-a2f2-5f7ce2e38699">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5f5a225e-9d00-494d-90ec-44352d98d4e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ba7b635c-3031-40ea-8907-63881e80b42c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c94e6b68-da6c-43d1-94fd-09ad60c74134">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6fc20583-c9d8-48f1-833c-e332515ccb72">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9ff1d968-f352-433c-91e4-2086b875b068">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6f57e0ec-227b-48ba-8a55-8b1792a44c7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4caf17b-3b80-4f50-84cf-3c9800262e53">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_750abbc2-9c8f-478b-967e-5bca6ccb6649">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_d877c8a9-ebf3-4468-9bf5-bd35e802914d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3dbdb1b4-0575-43d8-ac61-faf72cb621a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1b858452-c35d-428a-8b4b-90f21ad07836">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_aa7083b1-1a9b-4973-84b9-df7487d7f4aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b4462db5-e42e-40fb-827a-196a16d123c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_df2d3e44-0edf-416c-98ab-3efbaf98a66c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_64b2c7d7-d7b7-4c1c-9f86-b1adea0698d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff2f1d3e-8f67-47c6-8e9a-dbd477da2acb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_b75cd36a-7f05-4fe3-af88-ff32fe39e6dc">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_0897b098-e2d5-483b-a708-28f47c435413">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc31b2ff-8ba5-43f8-947a-2f11dd26492b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_69d4e272-32f2-46ff-a0ee-95358129563a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fe46cdb5-2ea1-4fcb-b508-6ca5aa09db3d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_69d1ccd2-3730-4278-99bf-9ca956be4401">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aa397ea5-dffe-475a-86f9-d00d21ac01e2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25cee9f9-9bef-42be-b860-ab3beead7814">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f441e1ff-6bae-4314-98bd-5b1689de1b2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4ada9951-1e02-4889-8745-f13dc4148ad6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ed408729-5a92-4002-8a8f-ae384ce3620a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_688fc72b-057d-4a98-98c3-f962aeaa22d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_347aaee1-bd55-40a5-99e9-fa9bdc3a9ff6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3e50ea0b-e624-4ac7-8e6a-29876963b392">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a6f1e5e9-d979-47a3-83d4-817003628745">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e5318967-afcc-4fcc-b0de-d5f2522a95a6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8082da6f-11ee-4cba-96f9-5258414b720d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4e704656-b276-46da-b8cc-b757bc42fabb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_e9f91b69-a29b-44ea-aa0f-cff86ee80320">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5adebd33-20e8-4c94-b02c-d9033c3a891a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ad86e83d-6334-4dd8-b642-b4c16d65329a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c96e50b9-ea15-4421-b6c8-bd9c9158a69a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f43dae36-6df4-46ba-9dc2-01543e80e0c3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b8b0b9a9-af8b-41d2-a4f8-940637e63f70">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b345e74a-9570-4cb9-9a59-928390e3dc44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_17abdb92-0180-4bcf-8ae7-dd923630f360">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0b78ffaa-9859-4658-af17-c8d355633556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9acb676e-054f-4e61-b60d-3371c3320b52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e9315b98-af75-40bb-bf8e-05bd03d43db5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9dfeeaef-5c49-4c2c-97b1-03876970bee4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36d76f23-8e75-492b-8f9d-4d68d2dab71c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_a6a076be-4135-4592-85cf-1f22fb0528a0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c6fcfb68-394c-4c29-9cef-9e41fdeeee26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_420cad1e-e8fd-47fc-a747-b9032181f6c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4b664adb-6099-4a04-a498-dc33ba0fd5b5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_39cf2a82-5f62-4cef-9bd1-1af4f783291a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a7eaeea7-ce64-4a47-86ac-0eec8c65c8aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4fa594a2-56ff-41fa-aaf3-c9491755b684">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_00865800-7a32-4d63-91f6-88217af4743d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a0b0cafd-9ee4-41aa-ad86-965a7e4a00bb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_287ea6e7-a365-4038-b8d7-d7f01677255b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_dd5768e1-dc34-4e62-b9ed-bc8ffcdc0000">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f383c35-5d1f-410b-a60d-d67e1f48f646">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_679919d3-fc46-4791-b7d8-8a87d0bfbb91">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_835c00ee-21be-46df-98ff-e6cc1cfabd3c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0434708a-79d9-4740-b697-2bfbd525260d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ed1043ac-f6fb-4f30-8a2f-177e4fdcb26b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_cafaa7fd-26d1-4609-8186-f9af8022be4b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d43e0f0a-5253-41b4-9e43-ef864af5b857">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e3d02781-552d-4bbd-952c-f753034b5ece">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_46c8e67a-37d6-4498-a6e1-148ad0fcf682">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_74a95e4a-dc88-479c-8aa2-fc194cc595ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8d27fc6e-5da0-4d89-8d93-8bbee127638d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_17cb9e95-1fb1-4fad-95bc-9cb4cb1eabd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_36a6b0d1-4103-414f-98f3-14009ce91e9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1286c4ed-c414-4282-af59-91af27cb856c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9b591b30-bfd2-49b3-9bd5-4eb808638a99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_38733a74-2927-4247-8fe6-065cd9fdf7de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_abe5f6b0-6e09-41d8-b326-685828bb5fe9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_57e7e6c3-e0a6-4ac3-a0e3-392e749b3dd4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_40d166e5-8a94-461c-96be-c7b40c9b0c26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_159904f5-dc85-438e-adb2-0f7accdab22e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_2eb9abb5-9566-4c1c-9e11-c2f6ee115cef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ba08c29-26cc-4706-ac27-26692aac8c88">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c7d6536-ea8d-4b7b-be12-6be542b1db2e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d62d7e5-64c4-4d08-8a84-543433b71491">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff03ac62-f2e0-4beb-a79e-447a8dbcf53c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0b729ff6-e8d4-40a8-a250-8546f9d43ff9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d917556d-7af8-4d62-912f-cee8779b78ba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57df35dc-cdbf-498c-a3d5-7f5da2618ba2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3e47bb0d-8a7d-4e68-bab4-e4b55c2be04c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_09b5337b-759c-4cda-b09e-fc2131692bfe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6554fd18-1d49-48eb-88d8-289134c6e932">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_1baf8007-34b4-410a-bd34-21ba83f132e8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ea887338-df13-41c6-81c8-10ddf6501626">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dbf3737-7c17-4e23-b698-a6231fc95c9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7cf25bb9-e5be-466a-9eda-76d00e20aead">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_181c1a17-a777-4729-8e13-5d427ad49c94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7bad0622-8a66-4e8c-ad40-dc0a25bf0123">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_73e5d2d1-d756-4b50-8069-e663130f1816">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fc6296a5-b265-47cf-b634-c8e0e8fff1d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90364382-c1c6-4471-850f-7ebf7e718070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d3ba7162-1168-4478-97a5-1f522aab0b8d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_34818fdb-09a6-4567-be70-0bfe57e6cba5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dea346f3-01e8-4b63-bbe3-5aeea6ea9129">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_d0e08d7a-7d6a-4cb3-8a77-447b121443cf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d8569a51-3dcb-49ee-95e1-193d570db5be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ccffd22-4277-4a42-9dc9-86b270a0f291">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4e8f404b-ad7e-4684-bc52-e3464e34ee79">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fa3678ca-1dd0-4be0-aac6-a5cf857e7d60">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_19bb3455-dba7-4049-8350-9fc3c29ff4cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4274888e-6e49-4d9e-9563-b483331f8424">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_80fa1756-f607-4448-ad06-dd7b5e69ec38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ac383d2-d853-4b4e-b0af-171813d0b7aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ff8e4c1c-ad07-489e-ba11-43217dd68dad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e8d3d915-6065-4890-943e-4cf5c69a97a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_563b8841-aa4b-4bf2-a54f-8f069829f070">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5f1203b6-43c0-44bf-ba48-25564bbefef9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_57a42edc-5e05-4604-b596-f01ab114f5c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd023497-58d7-4396-8f9d-a9bd364f8c86">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_45d740ad-e86f-40d0-9008-fd671acbef6b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_33c8f510-825b-4689-a374-f96650937c33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe2c5d47-fa92-41ec-b454-3cb1c878437e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9f9f2dc0-6618-4f8f-a284-22aa15d23fb7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4cfe03e9-7d00-4eb7-be53-4b443d69703a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a26ae26e-b636-4503-ab26-2f5946d511a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0759a425-647a-4247-b66b-26357a147542">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a6ae1641-50f7-45be-9833-bf04ddcf7697">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6cc414f9-05d7-45a2-a19e-958faed12395">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_eda4be62-674c-4d62-bec3-33bf3bdd6294">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a241b4fe-ce93-46b3-ba20-126ed4574adf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_43fdad08-fd5a-4f4a-8ae4-296ea3184087">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0d653c1-85b7-4edb-b412-90836f207efd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a897e54e-1f4e-49f0-a8b8-d1b79c28413a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b3d8eb66-45fc-4b9c-9206-5b87bd362315">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_bffd0293-189f-4b46-9e82-f8951326d01d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bda2a584-06ba-4aa3-8af1-945d6ad9829d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26b37c45-5751-4c50-862e-d2f811623bd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e9f123e-b540-4391-833f-84e5f9b7e63f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8911f118-6ed7-4424-b8e1-a6885482ddbf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3da39f62-762a-4533-9485-f1849e5f8812">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dffdb415-95a8-496a-ad1a-93cdeb444fae">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d7ed6624-d332-4a9a-a96b-b31bcb1ef24c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7ccb6edb-253e-4e1d-85da-c68ef40f59a1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_aa063f2e-1205-4d1a-a549-3ccc5b31e65d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_443775ac-c8ba-4e4d-a91f-d1926ba21744">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8ef85f09-3622-4a12-87bf-fefcecc01e4a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_28b3e895-483c-478d-a5a3-7b9d7c9e11f3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a0244ab3-80e5-4c20-b201-a142d50e6ec1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c8e0d41-008e-48dc-af1e-e988941e71ac">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c0ba9bc8-9cb8-41f9-be4e-a8f6184e1432">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4e958ea-f50c-472b-8c35-9b2a606d4310">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4d0edeee-fb82-46ff-9ad7-8937813fd4a7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf4393c0-21c2-4e35-b330-c1acda2647ba">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_72627757-688f-4752-a751-c9e2bd554d2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a3d5e8cc-be34-4d4a-a586-ce582737826b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10180352-5b41-43e5-8bab-bbd40fc3053b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_10313794-08ff-4455-90e6-a439d474d0ca">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_22ac1bc2-c0f8-4d04-897f-c24e25f28f4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aad73b40-3e9c-40ac-834d-4c0243a5c334">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f492ecb1-1a65-4013-99f8-49edc9d7d556">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_307df982-5918-4ad2-8c83-1cbc9b7906ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31cfec00-6695-4126-b60a-98c4cd7132e8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cf36442f-8f07-4110-aecd-1c7124608dd2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_53e398ff-d48d-4e1b-acf0-be0965777d35">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4615f36c-51ee-4eb0-945c-d57636d7fbb3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_db7be977-a065-4bb0-8b27-d44e0a6cac16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3c3bbfbe-faab-4429-8c29-799f941f9add">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ed71bbb4-203f-42dc-8a01-e3b144ea8ddc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_54cc9d2a-325e-4545-a35c-d322e006a8d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_5731482a-7053-4716-866b-ab26f39cad97">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_aea5de0b-5724-497a-b712-f813e6c55462">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_350e99eb-81c8-4938-9014-f14d16cc0989">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a83373ad-d7a8-400b-9d4d-cf7a0dac3d73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_030a749a-f8db-4c51-a67f-571efd180ab0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6fe0f5c1-8319-4dc7-ac10-643c4d4ac0c4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3105ff97-c823-4905-b049-f467bc8e0810">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d4658ae-163f-40e5-ab58-754de44a9565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f655fe14-241f-462d-9fb3-a58dd791a31b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_97da8dc3-3290-45e8-92ae-a01611dc0b76">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_513211dc-4e13-49b8-b8f9-8a062e6136e2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4bdb83ed-36d7-4e74-9e77-1237f7695622">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f605145-f6fd-4665-9672-8fef199d1592">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7e8c477a-837a-416a-8283-44318182f678">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_47b201ba-930a-423f-b4be-a71805471077">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a4bae3a8-84d1-40fd-b83c-a9bf8c206d9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2c6145b2-effe-4953-9f32-2e49388dca38">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fbbaea94-c6b8-4492-99c4-08893180b6e1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4decc4c0-9950-4fdc-8682-dca579e200cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f851b27-33f3-45f3-aefb-2c134479e2ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b061adbe-26eb-4721-a6c9-e78026e0f915">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b79434bc-5187-4184-a806-7a39037a7640">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b395e7f-bd27-41ce-a590-eeb60a5f502b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee96be74-4d86-4eb1-9150-2d594bfcfe1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4d08a684-cdcb-484a-a767-03b10f4ada7f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8cb24cba-8dff-4ef9-9ba5-dbdb086e77e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_706e83b8-c1de-43d0-bafd-57766513c62e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f468d841-1bf6-470e-85d4-55d34fab8bff">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_a78dbd51-f64b-4abf-9154-3c138316e279">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_90c04b95-703a-4bae-82b8-7edf3075aa24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f193bd8f-badf-4600-82ac-f212d1f33534">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_340082f1-db9c-446d-97df-80e45aa0058b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3e33fc23-0e6a-411e-b0eb-67b1271cf383">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89c3d444-cf42-4e48-9825-96160ba9895f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_71f8df70-c805-42fc-9a09-c9527e6f8175">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_09c871ac-e7a9-40ac-9580-ed616b994397">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d6a25879-018d-46a3-82a7-81b9b99b609c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_cf08be5d-b85e-46be-9378-6eb35540e070">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6398ff9b-368e-4aa0-9a7b-8d9a2d095835">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_98a94e93-5272-46b4-85ed-7a173200852f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6e87b2c5-e7b5-428a-b836-5e55a23693a1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_05d6e5c3-2268-437e-829c-9e9107a18dba">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7951c520-ccd7-46b8-a3a5-fd879cd12257">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6adbd31d-0c80-48ec-84d6-000aac8d9a85">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:ControlArea rdf:about="#_1f9ecd81-e069-4040-bd64-f34b0fac3a60">
+    <cim:ControlArea.netInterchange>210</cim:ControlArea.netInterchange>
+  </cim:ControlArea>
+    <cim:Terminal rdf:about="#_65a95678-1819-43cd-94d2-a03756822725">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5c96df9d-39fa-46fe-a424-7b3e50184f79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c6a1e49-17b2-46fc-8e32-c95dec33eba8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+</rdf:RDF>


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When there are incompatible modes of LCC Converter Stations during CGMES import, an exception about HVDC type is thrown.


**What is the new behavior (if this is a feature change)?**
When there are incompatible modes of LCC Converter Stations during CGMES import, the mode of the converter station 2 is ignored.


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
