### PR TITLE
fix #1004; log message only should be shown for two windings transformer

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/RatioTapChangerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/RatioTapChangerConversion.java
@@ -175,7 +175,7 @@ public class RatioTapChangerConversion extends AbstractIdentifiedObjectConversio
 
     private void addStepsFromStepVoltageIncrement(RatioTapChangerAdder rtca) {
         boolean rtcAtSide1 = rtcAtSide1();
-        if (LOG.isDebugEnabled() && rtcAtSide1) {
+        if (LOG.isDebugEnabled() && rtcAtSide1 && tx2 != null) {
             LOG.debug(
                 "Transformer {} ratio tap changer moved from side 2 to side 1, impedance/admittance corrections",
                 tx2.getId());


### PR DESCRIPTION
Signed-off-by: Luma Zamarreño <zamarrenolm@aia.es>

fix #1004.

The log message about ratio tap changer being moved only applies to two windings transformers. 

If the transformer related to the ratio tap changer is a three windings transformer the log message does not apply.