### PR TITLE
afs-ext-base, enstoe-util: fix missing scope=test for jimfs

### DIFF
--- a/afs/afs-ext-base/pom.xml
+++ b/afs/afs-ext-base/pom.xml
@@ -71,6 +71,7 @@
         <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/entsoe-util/pom.xml
+++ b/entsoe-util/pom.xml
@@ -67,6 +67,7 @@
         <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/ucte/ucte-converter/pom.xml
+++ b/ucte/ucte-converter/pom.xml
@@ -66,6 +66,11 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
After this change, jimfs is no longer included in distribution-core

Note that in config-test, jimfs is still scope compile because it's not used
for the tests of the project, but for the project itself.

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
jimfs is included in distribution-core


**What is the new behavior (if this is a feature change)?**
jimfs is not included in distribution-core


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO

