### PR TITLE
Add setMetadata to AppStorage interface

### DIFF
--- a/afs/afs-mapdb-storage/pom.xml
+++ b/afs/afs-mapdb-storage/pom.xml
@@ -67,6 +67,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/afs/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
+++ b/afs/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
@@ -449,6 +449,23 @@ public class MapDbAppStorage implements AppStorage {
     }
 
     @Override
+    public void setMetadata(String nodeId, NodeGenericMetadata metadata) {
+        UUID nodeUuid = checkNodeId(nodeId);
+        NodeInfo nodeInfo = getNodeInfo(nodeId);
+        nodeInfo.getGenericMetadata().getDoubles().clear();
+        nodeInfo.getGenericMetadata().getStrings().clear();
+        nodeInfo.getGenericMetadata().getInts().clear();
+        nodeInfo.getGenericMetadata().getBooleans().clear();
+        if (metadata != null) {
+            nodeInfo.getGenericMetadata().getDoubles().putAll(metadata.getDoubles());
+            nodeInfo.getGenericMetadata().getStrings().putAll(metadata.getStrings());
+            nodeInfo.getGenericMetadata().getInts().putAll(metadata.getInts());
+            nodeInfo.getGenericMetadata().getBooleans().putAll(metadata.getBooleans());
+        }
+        nodeInfoMap.put(nodeUuid, nodeInfo);
+    }
+
+    @Override
     public void renameNode(String nodeId, String name) {
         UUID nodeUuid = checkNodeId(nodeId);
         NodeInfo nodeInfo = getNodeInfo(nodeId);

--- a/afs/afs-mapdb-storage/src/test/java/com/powsybl/afs/mapdb/storage/MapDbAppStorageTest.java
+++ b/afs/afs-mapdb-storage/src/test/java/com/powsybl/afs/mapdb/storage/MapDbAppStorageTest.java
@@ -18,4 +18,5 @@ public class MapDbAppStorageTest extends AbstractAppStorageTest {
     protected AppStorage createStorage() {
         return MapDbAppStorage.createMem("mem");
     }
+
 }

--- a/afs/afs-storage-api/pom.xml
+++ b/afs/afs-storage-api/pom.xml
@@ -75,6 +75,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorage.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorage.java
@@ -14,7 +14,6 @@ import java.io.OutputStream;
 import java.util.*;
 
 /**
- *
  * A storage which maintains data for an application file system. This is a low level object,
  * and should not be used by users of the AFS API, but only when extending the AFS API
  * with a new storage implementation or new file types for example.
@@ -22,7 +21,6 @@ import java.util.*;
  * <p>
  * An AppStorage implements low level methods to walk through a filesystem and to write and read data from this filesystem.
  * It relies on nodes uniquely identified by and ID.
- *
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -42,6 +40,16 @@ public interface AppStorage extends AutoCloseable {
      * The new node is by default inconsistent, {@link #setConsistent(String nodeId)} method should explicitly be called to set it consistent.
      */
     NodeInfo createNode(String parentNodeId, String name, String nodePseudoClass, String description, int version, NodeGenericMetadata genericMetadata);
+
+    /**
+     * Update a node metadata
+     *
+     * @param nodeId          id of the node
+     * @param genericMetadata new metadata that will override previous ones
+     */
+    default void setMetadata(String nodeId, NodeGenericMetadata genericMetadata) {
+        throw new PowsyblException("Not implemented");
+    }
 
     boolean isWritable(String nodeId);
 

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/DefaultListenableAppStorage.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/DefaultListenableAppStorage.java
@@ -60,6 +60,12 @@ public class DefaultListenableAppStorage extends ForwardingAppStorage implements
     }
 
     @Override
+    public void setMetadata(String nodeId, NodeGenericMetadata genericMetadata) {
+        super.setMetadata(nodeId, genericMetadata);
+        addEvent(new NodeMetadataUpdated(nodeId, genericMetadata));
+    }
+
+    @Override
     public void setDescription(String nodeId, String description) {
         super.setDescription(nodeId, description);
         addEvent(new NodeDescriptionUpdated(nodeId, description));

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/ForwardingAppStorage.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/ForwardingAppStorage.java
@@ -48,6 +48,11 @@ public class ForwardingAppStorage implements AppStorage {
     }
 
     @Override
+    public void setMetadata(String nodeId, NodeGenericMetadata genericMetadata) {
+        storage.setMetadata(nodeId, genericMetadata);
+    }
+
+    @Override
     public boolean isWritable(String nodeId) {
         return storage.isWritable(nodeId);
     }

--- a/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeMetadataUpdated.java
+++ b/afs/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeMetadataUpdated.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.afs.storage.events;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.powsybl.afs.storage.NodeGenericMetadata;
+
+import java.util.Objects;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class NodeMetadataUpdated extends NodeEvent {
+
+    @JsonProperty("metadata")
+    private final NodeGenericMetadata metadata;
+
+    @JsonCreator
+    public NodeMetadataUpdated(@JsonProperty("id") String id,
+                               @JsonProperty("metadata") NodeGenericMetadata metadata) {
+        super(id, NodeEventType.NODE_DESCRIPTION_UPDATED);
+        this.metadata = Objects.requireNonNull(metadata);
+    }
+
+    public NodeGenericMetadata getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, metadata);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof NodeMetadataUpdated) {
+            NodeMetadataUpdated other = (NodeMetadataUpdated) obj;
+            return id.equals(other.id) && Objects.equals(metadata, other.metadata);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeMetadataUpdated(id=" + id + ", metadata=" + metadata + ")";
+    }
+}

--- a/afs/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
+++ b/afs/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
@@ -539,15 +539,18 @@ public abstract class AbstractAppStorageTest {
         testUpdateNodeMetadata(rootFolderInfo);
     }
 
-    private void testUpdateNodeMetadata(NodeInfo rootFolderInfo) {
+    private void testUpdateNodeMetadata(NodeInfo rootFolderInfo) throws InterruptedException {
         NodeGenericMetadata metadata = new NodeGenericMetadata();
         NodeInfo node = storage.createNode(rootFolderInfo.getId(), "testNode", "unkownFile", "", 0, cloneMetadata(metadata));
         storage.flush();
 
         checkMetadataEquality(metadata, node.getGenericMetadata());
+        discardEvents(17);
 
         try {
             storage.setMetadata(node.getId(), cloneMetadata(metadata));
+            storage.flush();
+            assertEventStack(new NodeMetadataUpdated(node.getId(), metadata));
         } catch (PowsyblException e) {
             assertThat(e).hasMessage("Not implemented");
             return;
@@ -557,26 +560,35 @@ public abstract class AbstractAppStorageTest {
         assertThat(node.getGenericMetadata().getStrings().keySet().size()).isEqualTo(0);
 
         storage.setMetadata(node.getId(), cloneMetadata(metadata));
+        storage.flush();
+        assertEventStack(new NodeMetadataUpdated(node.getId(), metadata));
         node = storage.getNodeInfo(node.getId());
         checkMetadataEquality(metadata, node.getGenericMetadata());
 
         metadata.setBoolean("test1", true);
         storage.setMetadata(node.getId(), cloneMetadata(metadata));
+        storage.flush();
+        assertEventStack(new NodeMetadataUpdated(node.getId(), metadata));
         node = storage.getNodeInfo(node.getId());
         checkMetadataEquality(metadata, node.getGenericMetadata());
 
         metadata.getStrings().remove("test");
         metadata.setDouble("test2", 0.1);
         storage.setMetadata(node.getId(), cloneMetadata(metadata));
+        storage.flush();
+        assertEventStack(new NodeMetadataUpdated(node.getId(), metadata));
         node = storage.getNodeInfo(node.getId());
         checkMetadataEquality(metadata, node.getGenericMetadata());
 
         metadata.setInt("test3", 1);
         storage.setMetadata(node.getId(), cloneMetadata(metadata));
+        storage.flush();
+        assertEventStack(new NodeMetadataUpdated(node.getId(), metadata));
         node = storage.getNodeInfo(node.getId());
         checkMetadataEquality(metadata, node.getGenericMetadata());
 
         storage.deleteNode(node.getId());
+        storage.flush();
     }
 
     private void checkMetadataEquality(NodeGenericMetadata source, NodeGenericMetadata target) {

--- a/afs/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
+++ b/afs/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
@@ -12,7 +12,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.powsybl.afs.storage.events.*;
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.datasource.DataSource;
 import com.powsybl.timeseries.*;
 import org.junit.After;
@@ -172,9 +171,9 @@ public abstract class AbstractAppStorageTest {
         NodeInfo testDataInfo = storage.createNode(testFolderInfo.getId(), "data", DATA_FILE_CLASS, "", 0, new NodeGenericMetadata());
         NodeInfo testData2Info = storage.createNode(testFolderInfo.getId(), "data2", DATA_FILE_CLASS, "", 0,
                 new NodeGenericMetadata().setString("s1", "v1")
-                        .setDouble("d1", 1d)
-                        .setInt("i1", 2)
-                        .setBoolean("b1", false));
+                                         .setDouble("d1", 1d)
+                                         .setInt("i1", 2)
+                                         .setBoolean("b1", false));
         NodeInfo testData3Info = storage.createNode(testFolderInfo.getId(), "data3", DATA_FILE_CLASS, "", 0, new NodeGenericMetadata());
 
         storage.setConsistent(testDataInfo.getId());
@@ -184,11 +183,11 @@ public abstract class AbstractAppStorageTest {
 
         // check events
         assertEventStack(new NodeCreated(testDataInfo.getId(), testFolderInfo.getId()),
-                new NodeCreated(testData2Info.getId(), testFolderInfo.getId()),
-                new NodeCreated(testData3Info.getId(), testFolderInfo.getId()),
-                new NodeConsistent(testDataInfo.getId()),
-                new NodeConsistent(testData2Info.getId()),
-                new NodeConsistent(testData3Info.getId()));
+                     new NodeCreated(testData2Info.getId(), testFolderInfo.getId()),
+                     new NodeCreated(testData3Info.getId(), testFolderInfo.getId()),
+                     new NodeConsistent(testDataInfo.getId()),
+                     new NodeConsistent(testData2Info.getId()),
+                     new NodeConsistent(testData3Info.getId()));
 
         // check info are correctly stored even with metadata
         assertEquals(testData2Info, storage.getNodeInfo(testData2Info.getId()));
@@ -244,7 +243,7 @@ public abstract class AbstractAppStorageTest {
 
         // check event
         assertEventStack(new DependencyAdded(testDataInfo.getId(), "mylink"),
-                new BackwardDependencyAdded(testData2Info.getId(), "mylink"));
+                         new BackwardDependencyAdded(testData2Info.getId(), "mylink"));
 
         // check dependency state
         assertEquals(ImmutableSet.of(new NodeDependency("mylink", testData2Info)), storage.getDependencies(testDataInfo.getId()));
@@ -258,7 +257,7 @@ public abstract class AbstractAppStorageTest {
 
         // check event
         assertEventStack(new DependencyAdded(testDataInfo.getId(), "mylink2"),
-                new BackwardDependencyAdded(testData2Info.getId(), "mylink2"));
+                         new BackwardDependencyAdded(testData2Info.getId(), "mylink2"));
 
         assertEquals(ImmutableSet.of(new NodeDependency("mylink", testData2Info), new NodeDependency("mylink2", testData2Info)), storage.getDependencies(testDataInfo.getId()));
         assertEquals(ImmutableSet.of(testDataInfo), storage.getBackwardDependencies(testData2Info.getId()));
@@ -269,7 +268,7 @@ public abstract class AbstractAppStorageTest {
 
         // check event
         assertEventStack(new DependencyRemoved(testDataInfo.getId(), "mylink2"),
-                new BackwardDependencyRemoved(testData2Info.getId(), "mylink2"));
+                         new BackwardDependencyRemoved(testData2Info.getId(), "mylink2"));
 
         assertEquals(ImmutableSet.of(new NodeDependency("mylink", testData2Info)), storage.getDependencies(testDataInfo.getId()));
         assertEquals(ImmutableSet.of(testDataInfo), storage.getBackwardDependencies(testData2Info.getId()));
@@ -365,10 +364,10 @@ public abstract class AbstractAppStorageTest {
 
         // 13) create double time series
         TimeSeriesMetadata metadata1 = new TimeSeriesMetadata("ts1",
-                TimeSeriesDataType.DOUBLE,
-                ImmutableMap.of("var1", "value1"),
-                RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-01-01T01:15:00Z"),
-                        Duration.ofMinutes(15)));
+                                                              TimeSeriesDataType.DOUBLE,
+                                                              ImmutableMap.of("var1", "value1"),
+                                                              RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-01-01T01:15:00Z"),
+                                                                                            Duration.ofMinutes(15)));
         storage.createTimeSeries(testData2Info.getId(), metadata1);
         storage.flush();
 
@@ -386,8 +385,8 @@ public abstract class AbstractAppStorageTest {
         assertTrue(storage.getTimeSeriesMetadata(testData3Info.getId(), Sets.newHashSet("ts1")).isEmpty());
 
         // 14) add data to double time series
-        storage.addDoubleTimeSeriesData(testData2Info.getId(), 0, "ts1", Arrays.asList(new UncompressedDoubleDataChunk(2, new double[]{1d, 2d}),
-                new UncompressedDoubleDataChunk(5, new double[]{3d})));
+        storage.addDoubleTimeSeriesData(testData2Info.getId(), 0, "ts1", Arrays.asList(new UncompressedDoubleDataChunk(2, new double[] {1d, 2d}),
+                                                                                       new UncompressedDoubleDataChunk(5, new double[] {3d})));
         storage.flush();
 
         // check event
@@ -400,17 +399,17 @@ public abstract class AbstractAppStorageTest {
         // check double time series data query
         Map<String, List<DoubleDataChunk>> doubleTimeSeriesData = storage.getDoubleTimeSeriesData(testData2Info.getId(), Sets.newHashSet("ts1"), 0);
         assertEquals(1, doubleTimeSeriesData.size());
-        assertEquals(Arrays.asList(new UncompressedDoubleDataChunk(2, new double[]{1d, 2d}),
-                new UncompressedDoubleDataChunk(5, new double[]{3d})),
-                doubleTimeSeriesData.get("ts1"));
+        assertEquals(Arrays.asList(new UncompressedDoubleDataChunk(2, new double[] {1d, 2d}),
+                                   new UncompressedDoubleDataChunk(5, new double[] {3d})),
+                     doubleTimeSeriesData.get("ts1"));
         assertTrue(storage.getDoubleTimeSeriesData(testData3Info.getId(), Sets.newHashSet("ts1"), 0).isEmpty());
 
         // 15) create a second string time series
         TimeSeriesMetadata metadata2 = new TimeSeriesMetadata("ts2",
-                TimeSeriesDataType.STRING,
-                ImmutableMap.of(),
-                RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-01-01T01:15:00Z"),
-                        Duration.ofMinutes(15)));
+                                                              TimeSeriesDataType.STRING,
+                                                              ImmutableMap.of(),
+                                                              RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-01-01T01:15:00Z"),
+                                                                                            Duration.ofMinutes(15)));
         storage.createTimeSeries(testData2Info.getId(), metadata2);
         storage.flush();
 
@@ -423,8 +422,8 @@ public abstract class AbstractAppStorageTest {
         assertEquals(1, metadataList.size());
 
         // 16) add data to double time series
-        storage.addStringTimeSeriesData(testData2Info.getId(), 0, "ts2", Arrays.asList(new UncompressedStringDataChunk(2, new String[]{"a", "b"}),
-                new UncompressedStringDataChunk(5, new String[]{"c"})));
+        storage.addStringTimeSeriesData(testData2Info.getId(), 0, "ts2", Arrays.asList(new UncompressedStringDataChunk(2, new String[] {"a", "b"}),
+                                                                                       new UncompressedStringDataChunk(5, new String[] {"c"})));
         storage.flush();
 
         // check event
@@ -433,9 +432,9 @@ public abstract class AbstractAppStorageTest {
         // check string time series data query
         Map<String, List<StringDataChunk>> stringTimeSeriesData = storage.getStringTimeSeriesData(testData2Info.getId(), Sets.newHashSet("ts2"), 0);
         assertEquals(1, stringTimeSeriesData.size());
-        assertEquals(Arrays.asList(new UncompressedStringDataChunk(2, new String[]{"a", "b"}),
-                new UncompressedStringDataChunk(5, new String[]{"c"})),
-                stringTimeSeriesData.get("ts2"));
+        assertEquals(Arrays.asList(new UncompressedStringDataChunk(2, new String[] {"a", "b"}),
+                                   new UncompressedStringDataChunk(5, new String[] {"c"})),
+                     stringTimeSeriesData.get("ts2"));
 
         // 17) clear time series
         storage.clearTimeSeries(testData2Info.getId());
@@ -547,14 +546,9 @@ public abstract class AbstractAppStorageTest {
         checkMetadataEquality(metadata, node.getGenericMetadata());
         discardEvents(17);
 
-        try {
-            storage.setMetadata(node.getId(), cloneMetadata(metadata));
-            storage.flush();
-            assertEventStack(new NodeMetadataUpdated(node.getId(), metadata));
-        } catch (PowsyblException e) {
-            assertThat(e).hasMessage("Not implemented");
-            return;
-        }
+        storage.setMetadata(node.getId(), cloneMetadata(metadata));
+        storage.flush();
+        assertEventStack(new NodeMetadataUpdated(node.getId(), metadata));
 
         metadata.setString("test", "test");
         assertThat(node.getGenericMetadata().getStrings().keySet().size()).isEqualTo(0);
@@ -619,5 +613,4 @@ public abstract class AbstractAppStorageTest {
         clone.getDoubles().putAll(metadata.getDoubles());
         return clone;
     }
-
 }

--- a/afs/afs-ws/afs-ws-server/pom.xml
+++ b/afs/afs-ws/afs-ws-server/pom.xml
@@ -65,6 +65,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
             <scope>test</scope>

--- a/afs/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/AppStorageServer.java
+++ b/afs/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/AppStorageServer.java
@@ -113,6 +113,19 @@ public class AppStorageServer {
         return Response.ok().entity(newNodeInfo).build();
     }
 
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("fileSystems/{fileSystemName}/nodes/{nodeId}/metadata")
+    @ApiOperation (value = "Update node's metadata")
+    @ApiResponses (value = {@ApiResponse(code = 200, message = ""), @ApiResponse(code = 500, message = "Error")})
+    public Response setMetadata(@ApiParam(value = "File system name") @PathParam("fileSystemName") String fileSystemName,
+                                              @ApiParam(value = "Node ID") @PathParam("nodeId") String nodeId,
+                                              @ApiParam(value = "Node Meta Data") NodeGenericMetadata nodeMetadata) {
+        AppStorage storage = appDataBean.getStorage(fileSystemName);
+        storage.setMetadata(nodeId, nodeMetadata);
+        return Response.ok().build();
+    }
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("fileSystems/{fileSystemName}/nodes/{nodeId}/parent")

--- a/afs/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/RemoteAppStorage.java
+++ b/afs/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/RemoteAppStorage.java
@@ -335,6 +335,31 @@ public class RemoteAppStorage implements AppStorage {
     }
 
     @Override
+    public void setMetadata(String nodeId, NodeGenericMetadata genericMetadata) {
+        Objects.requireNonNull(nodeId);
+        Objects.requireNonNull(genericMetadata);
+
+        // flush buffer to keep change order
+        changeBuffer.flush();
+
+        LOGGER.debug("setMetadata(fileSystemName={}, nodeId={}, genericMetadata={})", fileSystemName, nodeId, genericMetadata);
+
+        Response response = webTarget.path("fileSystems/{fileSystemName}/nodes/{nodeId}/metadata")
+                .resolveTemplate(FILE_SYSTEM_NAME, fileSystemName)
+                .resolveTemplate(NODE_ID, nodeId)
+                .request(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .header(HttpHeaders.CONTENT_ENCODING, "gzip")
+                .acceptEncoding("gzip")
+                .put(Entity.json(genericMetadata));
+        try {
+            checkOk(response);
+        } finally {
+            response.close();
+        }
+    }
+
+    @Override
     public List<NodeInfo> getChildNodes(String nodeId) {
         Objects.requireNonNull(nodeId);
 


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
Once a node is created, its metadata can't be updated


**What is the new behavior (if this is a feature change)?**
Node's metadata can be updated


**Other information**:
This has been added to reuse the generic metadata already implemented concepts in order to implement features like file tagging, or executions dates history, ...

