### PR TITLE
Fix a bug during UCTE import when it only lacked the final character of a node line

### DIFF
--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
@@ -143,5 +143,12 @@ public class UcteImporterTest {
         Network network = new UcteImporter().importData(dataSource, null);
         assertEquals(1, network.getBusBreakerView().getBusStream().count());
     }
+
+    @Test
+    public void testEmptyLastCharacterOfLineImport() {
+        ResourceDataSource dataSource = new ResourceDataSource("lastCharacterIssue", new ResourceSet("/", "lastCharacterIssue.uct"));
+        Network network = new UcteImporter().importData(dataSource, null);
+        assertEquals(2, network.getBusBreakerView().getBusStream().count());
+    }
 }
 

--- a/ucte/ucte-converter/src/test/resources/lastCharacterIssue.uct
+++ b/ucte/ucte-converter/src/test/resources/lastCharacterIssue.uct
@@ -1,0 +1,12 @@
+##C 2007.05.01
+Test case for UCTE import issue in PowSyBl core package
+contact : sebastien.murgey@rte-france.com
+##N
+##ZES
+EHORTA21              0 0 122.66 3.96708       0       0       0       0       0       0       0                               N
+##ZBE
+BHORTA11              0 0 122.66 3.96708       0       0       0       0       0       0       0                               
+##L
+EHORTA21 BHORTA11 1 1      0 0.2000        0   5051
+##T
+##R

--- a/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/io/UcteRecordParser.java
+++ b/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/io/UcteRecordParser.java
@@ -73,7 +73,7 @@ class UcteRecordParser {
     }
 
     Character parseChar(int index) {
-        return line == null || index > line.length() ? null : line.charAt(index);
+        return line == null || index >= line.length() ? null : line.charAt(index);
     }
 
     Integer parseInt(int beginIndex, int endIndex) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
Currently, when a line is filled by empty space except last character in a UCTE file, an exception is thrown at file import.

**What is the new behavior (if this is a feature change)?**
No more exception thrown.
