### PR TITLE
Update modification date on object changes

### DIFF
--- a/afs/afs-core/src/main/java/com/powsybl/afs/ProjectFolder.java
+++ b/afs/afs-core/src/main/java/com/powsybl/afs/ProjectFolder.java
@@ -41,12 +41,14 @@ public class ProjectFolder extends ProjectNode implements FolderBase<ProjectNode
                 case NODE_CREATED:
                     if (getId().equals(((NodeCreated) event).getParentId())) {
                         listeners.notify(listener -> listener.childAdded(event.getId()));
+                        storage.updateModificationTime(info.getId());
                     }
                     break;
 
                 case NODE_REMOVED:
                     if (getId().equals(((NodeRemoved) event).getParentId())) {
                         listeners.notify(listener -> listener.childRemoved(event.getId()));
+                        storage.updateModificationTime(info.getId());
                     }
                     break;
 

--- a/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCase.java
+++ b/afs/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCase.java
@@ -42,6 +42,7 @@ public class VirtualCase extends ProjectFile implements ProjectCase {
     public void setCase(ProjectFile aCase) {
         Objects.requireNonNull(aCase);
         setDependencies(CASE_DEPENDENCY_NAME, Collections.singletonList(aCase));
+        storage.updateModificationTime(info.getId());
         projectCaseDependency.invalidate();
     }
 
@@ -52,6 +53,7 @@ public class VirtualCase extends ProjectFile implements ProjectCase {
     public void setScript(ModificationScript aScript) {
         Objects.requireNonNull(aScript);
         setDependencies(SCRIPT_DEPENDENCY_NAME, Collections.singletonList(aScript));
+        storage.updateModificationTime(info.getId());
         modificationScriptDependency.invalidate();
     }
 

--- a/contingency/contingency-afs/src/main/java/com/powsybl/contingency/afs/ContingencyStore.java
+++ b/contingency/contingency-afs/src/main/java/com/powsybl/contingency/afs/ContingencyStore.java
@@ -48,6 +48,7 @@ public class ContingencyStore extends ProjectFile implements ContingenciesProvid
         Objects.requireNonNull(contingencies);
         try (OutputStream os = storage.writeBinaryData(info.getId(), CONTINGENCY_LIST_JSON_NAME)) {
             objectMapper.writeValue(os, contingencies);
+            storage.updateModificationTime(info.getId());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/security-analysis/security-analysis-afs-local/src/main/java/com/powsybl/security/afs/local/LocalSecurityAnalysisRunningService.java
+++ b/security-analysis/security-analysis-afs-local/src/main/java/com/powsybl/security/afs/local/LocalSecurityAnalysisRunningService.java
@@ -78,6 +78,7 @@ public class LocalSecurityAnalysisRunningService implements SecurityAnalysisRunn
                         return null;
                     }).join();
         } finally {
+            runner.updateModificationTime();
             runner.stopTask(taskId);
         }
     }

--- a/security-analysis/security-analysis-afs/src/main/java/com/powsybl/security/afs/SecurityAnalysisRunner.java
+++ b/security-analysis/security-analysis-afs/src/main/java/com/powsybl/security/afs/SecurityAnalysisRunner.java
@@ -59,6 +59,7 @@ public class SecurityAnalysisRunner extends ProjectFile {
             throw new AfsException("Bad project case " + aCase.getClass());
         }
         setDependencies(CASE_DEPENDENCY_NAME, Collections.singletonList(aCase));
+        updateModificationTime();
         caseDependency.invalidate();
     }
 
@@ -75,6 +76,7 @@ public class SecurityAnalysisRunner extends ProjectFile {
             }
             setDependencies(CONTINGENCY_STORE_DEPENDENCY_NAME, Collections.singletonList(contingencyStore));
         }
+        updateModificationTime();
         contingencyStoreDependency.invalidate();
     }
 
@@ -133,5 +135,9 @@ public class SecurityAnalysisRunner extends ProjectFile {
     @Override
     public boolean mandatoryDependenciesAreMissing() {
         return !getCase().isPresent() || !getContingencyStore().isPresent();
+    }
+
+    public void updateModificationTime() {
+        storage.updateModificationTime(info.getId());
     }
 }


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
the modification date of the afs object isn't updated on object changes (content or dep changes)


**What is the new behavior (if this is a feature change)?**
the modification date is updated over various changes depending of the object type
