### PR TITLE
Ext writer

### DIFF
--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeArea.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeArea.java
@@ -16,23 +16,16 @@ import java.util.Objects;
  */
 public class EntsoeArea extends AbstractExtension<Substation> {
 
-    private final Substation substation;
-
     private EntsoeGeographicalCode code;
 
     public EntsoeArea(Substation substation, EntsoeGeographicalCode code) {
-        this.substation = Objects.requireNonNull(substation);
+        super(substation);
         this.code = Objects.requireNonNull(code);
     }
 
     @Override
     public String getName() {
         return "entsoeArea";
-    }
-
-    @Override
-    public Substation getExtendable() {
-        return substation;
     }
 
     public EntsoeGeographicalCode getCode() {

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeAreaXmlSerializer.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeAreaXmlSerializer.java
@@ -29,7 +29,7 @@ public class EntsoeAreaXmlSerializer extends AbstractExtensionXmlSerializer<Subs
 
     @Override
     public void write(EntsoeArea country, XmlWriterContext context) throws XMLStreamException {
-        context.getWriter().writeCharacters(country.getCode().name());
+        context.getExtensionsWriter().writeCharacters(country.getCode().name());
     }
 
     @Override

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/MergedXnode.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/MergedXnode.java
@@ -16,8 +16,6 @@ import java.util.Objects;
  */
 public class MergedXnode extends AbstractExtension<Line> {
 
-    private final Line line;
-
     private float rdp; // r divider position 1 -> 2
 
     private float xdp; // x divider position 1 -> 2
@@ -38,7 +36,7 @@ public class MergedXnode extends AbstractExtension<Line> {
 
     public MergedXnode(Line line, float rdp, float xdp, double xnodeP1, double xnodeQ1, double xnodeP2, double xnodeQ2,
                        String line1Name, String line2Name, String code) {
-        this.line = Objects.requireNonNull(line);
+        super(line);
         this.rdp = checkDividerPosition(rdp);
         this.xdp = checkDividerPosition(xdp);
         this.xnodeP1 = checkPowerFlow(xnodeP1);
@@ -67,11 +65,6 @@ public class MergedXnode extends AbstractExtension<Line> {
     @Override
     public String getName() {
         return "mergedXnode";
-    }
-
-    @Override
-    public Line getExtendable() {
-        return line;
     }
 
     public float getRdp() {

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/MergedXnodeXmlSerializer.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/MergedXnodeXmlSerializer.java
@@ -29,13 +29,13 @@ public class MergedXnodeXmlSerializer extends AbstractExtensionXmlSerializer<Lin
 
     @Override
     public void write(MergedXnode xnode, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeFloat("rdp", xnode.getRdp(), context.getWriter());
-        XmlUtil.writeFloat("xdp", xnode.getXdp(), context.getWriter());
-        XmlUtil.writeDouble("xnodeP1", xnode.getXnodeP1(), context.getWriter());
-        XmlUtil.writeDouble("xnodeQ1", xnode.getXnodeQ1(), context.getWriter());
-        XmlUtil.writeDouble("xnodeP2", xnode.getXnodeP2(), context.getWriter());
-        XmlUtil.writeDouble("xnodeQ2", xnode.getXnodeQ2(), context.getWriter());
-        context.getWriter().writeAttribute("code", xnode.getCode());
+        XmlUtil.writeFloat("rdp", xnode.getRdp(), context.getExtensionsWriter());
+        XmlUtil.writeFloat("xdp", xnode.getXdp(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("xnodeP1", xnode.getXnodeP1(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("xnodeQ1", xnode.getXnodeQ1(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("xnodeP2", xnode.getXnodeP2(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("xnodeQ2", xnode.getXnodeQ2(), context.getExtensionsWriter());
+        context.getExtensionsWriter().writeAttribute("code", xnode.getCode());
     }
 
     @Override

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/Xnode.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/Xnode.java
@@ -16,23 +16,16 @@ import java.util.Objects;
  */
 public class Xnode extends AbstractExtension<DanglingLine> {
 
-    private final DanglingLine dl;
-
     private String code;
 
     public Xnode(DanglingLine dl, String code) {
-        this.dl = Objects.requireNonNull(dl);
+        super(dl);
         this.code = Objects.requireNonNull(code);
     }
 
     @Override
     public String getName() {
         return "xnode";
-    }
-
-    @Override
-    public DanglingLine getExtendable() {
-        return dl;
     }
 
     public String getCode() {

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/XnodeXmlSerializer.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/XnodeXmlSerializer.java
@@ -28,7 +28,7 @@ public class XnodeXmlSerializer extends AbstractExtensionXmlSerializer<DanglingL
 
     @Override
     public void write(Xnode xnode, XmlWriterContext context) throws XMLStreamException {
-        context.getWriter().writeAttribute("code", xnode.getCode());
+        context.getExtensionsWriter().writeAttribute("code", xnode.getCode());
     }
 
     @Override


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X ] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactor the ENTSO-E extension to use correctly the base class. Fix an issue in XML serializer also.


**What is the current behavior?** *(You can also link to an open issue here)*
The extendable is stored twice for entso-e extensions
The writer used during XML serialization is not the good one if we want to export them in a separate file.


**What is the new behavior (if this is a feature change)?**
It's now fixed!


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
