### PR TITLE
Add missing license to dsl/pom.xml

### DIFF
--- a/dsl/pom.xml
+++ b/dsl/pom.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
"docs update"


**What is the current behavior?** *(You can also link to an open issue here)*
missing license to dsl/pom.xml


**What is the new behavior (if this is a feature change)?**
license added. the file dates from 2018 Sylvain Leclerc an RTE employee assigning copyright to RTE

