### PR TITLE
Merging view : remove useless stacktrace

### DIFF
--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingNetworkListener.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingNetworkListener.java
@@ -15,16 +15,16 @@ import com.powsybl.iidm.network.NetworkListener;
 public class MergingNetworkListener implements NetworkListener {
     @Override
     public void onCreation(final Identifiable identifiable) {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
+        // Not implemented yet !
     }
 
     @Override
     public void onRemoval(final Identifiable identifiable) {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
+        // Not implemented yet !
     }
 
     @Override
     public void onUpdate(final Identifiable identifiable, final String attribute, final Object oldValue, final Object newValue) {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
+        // Not implemented yet !
     }
 }


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Remove a lot of stacktrace printing from mergingview tests logs


**What is the current behavior?** *(You can also link to an open issue here)*
A lot of stacktrace is printed during mergingview tests logs


**What is the new behavior (if this is a feature change)?**
All stacktrace are removed from mergingview tests logs


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
