### PR TITLE
Fix two issues in iterative proportional scalable scaling algorithm.

### DIFF
--- a/action/action-util/src/main/java/com/powsybl/action/util/ProportionalScalable.java
+++ b/action/action-util/src/main/java/com/powsybl/action/util/ProportionalScalable.java
@@ -119,7 +119,7 @@ class ProportionalScalable extends AbstractCompoundScalable {
             if (scalablePercentage.isSaturated()) {
                 scalablePercentage.setIterationPercentage(0);
             } else {
-                scalablePercentage.setIterationPercentage(scalablePercentage.getPercentage() / unsaturatedPercentagesSum * 100);
+                scalablePercentage.setIterationPercentage(scalablePercentage.getIterationPercentage() / unsaturatedPercentagesSum * 100);
             }
         });
     }
@@ -138,9 +138,10 @@ class ProportionalScalable extends AbstractCompoundScalable {
         double done = 0;
         for (ScalablePercentage scalablePercentage : scalablePercentageList) {
             Scalable s = scalablePercentage.getScalable();
-            double p = scalablePercentage.getIterationPercentage();
-            double doneOnScalable = s.scale(n, p / 100 * asked, scalingConvention);
-            if (Math.abs(doneOnScalable - p) > EPSILON) {
+            double iterationPercentage = scalablePercentage.getIterationPercentage();
+            double askedOnScalable = iterationPercentage / 100 * asked;
+            double doneOnScalable = s.scale(n, askedOnScalable, scalingConvention);
+            if (Math.abs(doneOnScalable - askedOnScalable) > EPSILON) {
                 scalablePercentage.setSaturated(true);
             }
             done += doneOnScalable;

--- a/action/action-util/src/test/java/com/powsybl/action/util/ScalableTest.java
+++ b/action/action-util/src/test/java/com/powsybl/action/util/ScalableTest.java
@@ -555,4 +555,20 @@ public class ScalableTest {
         }
     }
 
+    @Test
+    public void testProportionalScaleIterativeTwoSteps() {
+        double done = Scalable.proportional(Arrays.asList(70.f, 20.f, 10.f), Arrays.asList(g1, g2, g3), false).scale(network, 270.0);
+        assertEquals(181.0, done, 0.0);
+        assertEquals(100.0, network.getGenerator("g1").getTargetP(), 1e-3);
+        assertEquals(54, network.getGenerator("g2").getTargetP(), 1e-3);
+        assertEquals(27, network.getGenerator("g3").getTargetP(), 1e-3);
+
+        reset();
+        done = Scalable.proportional(Arrays.asList(70.f, 20.f, 10.f), Arrays.asList(g1, g2, g3), true).scale(network, 270.0);
+        assertEquals(270.0, done, 0.0);
+        assertEquals(100.0, network.getGenerator("g1").getTargetP(), 1e-3);
+        assertEquals(100.0, network.getGenerator("g2").getTargetP(), 1e-3);
+        assertEquals(70.0, network.getGenerator("g3").getTargetP(), 1e-3);
+    }
+
 }

--- a/action/action-util/src/test/java/com/powsybl/action/util/ScalableTest.java
+++ b/action/action-util/src/test/java/com/powsybl/action/util/ScalableTest.java
@@ -556,7 +556,7 @@ public class ScalableTest {
     }
 
     @Test
-    public void testProportionalScaleIterativeTwoSteps() {
+    public void testProportionalScaleIterativeThreeSteps() {
         double done = Scalable.proportional(Arrays.asList(70.f, 20.f, 10.f), Arrays.asList(g1, g2, g3), false).scale(network, 270.0);
         assertEquals(181.0, done, 0.0);
         assertEquals(100.0, network.getGenerator("g1").getTargetP(), 1e-3);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
Currently, iterative scaling algorithm on proportional scalable does not work as expected and can even throw assertion errors or consider non saturated scalables as saturated

**What is the new behavior (if this is a feature change)?**
Iterative scaling algorithm works as expected
