### PR TITLE
fromContinuous method rounds value (from SSH or SV) in CGMES import

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractObjectConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractObjectConversion.java
@@ -56,7 +56,8 @@ public abstract class AbstractObjectConversion {
         // and convert them to integers for IIDM.
         // We should consider storing these attributes in IIDM also as real numbers.
         // This method is used only to clearly identify the affected properties
-        return (int) value;
+        // The value is supposed to be rounded to the nearest integer
+        return (int) Math.round(value);
     }
 
     public boolean presentMandatoryProperty(String pname) {


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** 
No.


**What kind of change does this PR introduce?** 
Bug fix



**What is the current behavior?**
`fromContinuous` method truncates float value (from SSH or SV files) to int during CGMES import.



**What is the new behavior (if this is a feature change)?**
`fromContinuous` method rounds float value (from SSH or SV files) to int during CGMES import.


**Does this PR introduce a breaking change or deprecate an API?**
No

