### PR TITLE
Fix SecurityAnalysisImpl in mode concurrent

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisResultBuilder.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisResultBuilder.java
@@ -8,6 +8,7 @@ package com.powsybl.security;
 
 import com.google.common.collect.ImmutableList;
 import com.powsybl.contingency.Contingency;
+import com.powsybl.iidm.network.Network;
 import com.powsybl.security.interceptors.RunningContext;
 import com.powsybl.security.interceptors.SecurityAnalysisInterceptor;
 
@@ -26,7 +27,7 @@ import java.util.*;
 public class SecurityAnalysisResultBuilder {
 
     private final LimitViolationFilter filter;
-    private final RunningContext context;
+    private RunningContext context;
     private final List<SecurityAnalysisInterceptor> interceptors;
 
     // Below are volatile objects used for building the actual complete result
@@ -70,6 +71,13 @@ public class SecurityAnalysisResultBuilder {
         }
 
         currentBuilder = new PreContingencyResultBuilder();
+        return this;
+    }
+
+    SecurityAnalysisResultBuilder preContingency(LimitViolationsResult precontingencyResult, String precontVariantId) {
+        this.preContingencyResult = Objects.requireNonNull(precontingencyResult);
+        Network network = context.getNetwork();
+        context = new RunningContext(network, precontVariantId);
         return this;
     }
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisTest.java
@@ -11,6 +11,7 @@ import com.google.common.jimfs.Jimfs;
 import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.computation.ComputationManager;
+import com.powsybl.computation.ComputationResourcesStatus;
 import com.powsybl.contingency.BranchContingency;
 import com.powsybl.contingency.ContingenciesProvider;
 import com.powsybl.contingency.Contingency;
@@ -75,6 +76,9 @@ public class SecurityAnalysisTest {
             .add();
 
         ComputationManager computationManager = Mockito.mock(ComputationManager.class);
+        ComputationResourcesStatus status = Mockito.mock(ComputationResourcesStatus.class);
+        Mockito.when(status.getAvailableCores()).thenReturn(1);
+        Mockito.when(computationManager.getResourcesStatus()).thenReturn(status);
         Executor executor = Runnable::run;
         Mockito.when(computationManager.getExecutor()).thenReturn(executor);
 


### PR DESCRIPTION
1. Pre-allocate variants in single thread.
2. Each worker runs LF in its own variants.
3. Variant is re-used by override clone().
4. Modify the builder.

Signed-off-by: yichen88 <tang.yichenyves@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#1097 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
