### PR TITLE
Allow to choose the name of the default iidm implementation instead o…

### DIFF
--- a/action/action-dsl/pom.xml
+++ b/action/action-dsl/pom.xml
@@ -113,6 +113,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/action/action-util/pom.xml
+++ b/action/action-util/pom.xml
@@ -92,6 +92,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/commons/src/main/java/com/powsybl/commons/config/PlatformConfigNamedProvider.java
+++ b/commons/src/main/java/com/powsybl/commons/config/PlatformConfigNamedProvider.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.commons.config;
+
+import com.powsybl.commons.PowsyblException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * A provider that can be loaded by by Java's ServiceLoader based on its name
+ * present in an entry in the PlatformConfig.
+ *
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+public interface PlatformConfigNamedProvider {
+
+    /**
+     * Get the name.
+     *
+     * @return the name
+     */
+    String getName();
+
+    /**
+     * Get the Provider name used for identifying this provider in the
+     * PlatformConfig. Defaults to getName(). Override this method only if getName() is
+     * already implemented and returns the wrong name.
+     *
+     * @return the name
+     */
+    default String getPlatformConfigName() {
+        return getName();
+    }
+
+    /**
+     * A utility class to find providers in the {@link PlatformConfig} by their
+     * names configured in standard fields. the find* methods use the standard
+     * fields while the find*BackwardsCompatible methods also look in the legacy
+     * fields.
+     *
+     * @author Jon harper <jon.harper at rte-france.com>
+     * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+     */
+    static final class Finder {
+
+        private Finder() {
+        }
+
+        private static final String DEFAULT_SERVICE_IMPL_NAME_PROPERTY = "default-impl-name";
+        private static final String LEGACY_SERVICE_IMPL_NAME_PROPERTY = "default";
+
+        /**
+         * Find the default provider configured in the standard field of
+         * {@code moduleName} in {@code platformConfig} among the {@code providers}
+         * arguments based on its name.
+         *
+         * @return the provider
+         */
+        public static <T extends PlatformConfigNamedProvider> T findDefault(String moduleName,
+                List<T> providers, PlatformConfig platformConfig) {
+            return find(null, moduleName, Arrays.asList(DEFAULT_SERVICE_IMPL_NAME_PROPERTY),
+                    providers, platformConfig);
+        }
+
+        /**
+         * Find the provider among the {@code providers} based on its {@code name}, or
+         * if {@code name} is null find the default provider like @{link findDefault}
+         *
+         * @return the provider
+         */
+        public static <T extends PlatformConfigNamedProvider> T find(String name, String moduleName,
+                List<T> providers, PlatformConfig platformConfig) {
+            return find(name, moduleName, Arrays.asList(DEFAULT_SERVICE_IMPL_NAME_PROPERTY),
+                    providers, platformConfig);
+        }
+
+        /**
+         * Find the default provider configured in the standard field or the legacy
+         * field of {@code moduleName} in {@code platformConfig} among the
+         * {@code providers} arguments based on its name.
+         *
+         * @deprecated Use {@link #findDefault} instead
+         *
+         * @return the provider
+         */
+        @Deprecated
+        public static <T extends PlatformConfigNamedProvider> T findDefaultBackwardsCompatible(
+                String moduleName, List<T> providers, PlatformConfig platformConfig) {
+            return find(null, moduleName, Arrays.asList(DEFAULT_SERVICE_IMPL_NAME_PROPERTY,
+                    LEGACY_SERVICE_IMPL_NAME_PROPERTY), providers, platformConfig);
+        }
+
+        /**
+         * Find the provider among the {@code providers} based on its {@code name}, or
+         * if {@code name} is null find the default provider like @{link
+         * findDefaultBackwardsCompatible}
+         *
+         * @deprecated Use {@link #find} instead
+         *
+         * @return the provider
+         */
+        @Deprecated
+        public static <T extends PlatformConfigNamedProvider> T findBackwardsCompatible(String name,
+                String moduleName, List<T> providers, PlatformConfig platformConfig) {
+            return find(name, moduleName, Arrays.asList(DEFAULT_SERVICE_IMPL_NAME_PROPERTY,
+                    LEGACY_SERVICE_IMPL_NAME_PROPERTY), providers, platformConfig);
+        }
+
+        private static Optional<String> getOptionalFirstProperty(ModuleConfig moduleConfig,
+                List<String> propertyNames) {
+            return propertyNames.stream().map(moduleConfig::getOptionalStringProperty)
+                    .filter(Optional::isPresent).map(Optional::get).findFirst();
+        }
+
+        private static <T extends PlatformConfigNamedProvider> T find(String name,
+                String moduleName, List<String> propertyNames, List<T> providers,
+                PlatformConfig platformConfig) {
+            Objects.requireNonNull(providers);
+            Objects.requireNonNull(platformConfig);
+
+            if (providers.isEmpty()) {
+                throw new PowsyblException("No " + moduleName + " providers found");
+            }
+
+            // if no implementation name is provided through the API we look for information
+            // in platform configuration
+            String finalName = name != null ? name
+                    : platformConfig.getOptionalModuleConfig(moduleName)
+                            .flatMap(mc -> getOptionalFirstProperty(mc, propertyNames))
+                            .orElse(null);
+            T provider;
+            if (providers.size() == 1 && finalName == null) {
+                // no information to select the implementation but only one provider, so we can
+                // use it by default
+                // (that is be the most common use case)
+                provider = providers.get(0);
+            } else {
+                if (providers.size() > 1 && finalName == null) {
+                    // several providers and no information to select which one to choose, we can
+                    // only throw
+                    // an exception
+                    List<String> loadFlowNames = providers.stream()
+                            .map(PlatformConfigNamedProvider::getPlatformConfigName)
+                            .collect(Collectors.toList());
+                    throw new PowsyblException(
+                            "Several loadflow implementations found (" + loadFlowNames
+                                    + "), you must add configuration to select the implementation");
+                }
+                provider = providers.stream()
+                        .filter(p -> p.getPlatformConfigName().equals(finalName)).findFirst()
+                        .orElseThrow(() -> new PowsyblException(
+                                "Loadflow '" + finalName + "' not found"));
+            }
+
+            return provider;
+        }
+
+    }
+
+}

--- a/commons/src/test/java/com/powsybl/commons/config/PlatformConfigNamedProviderTest.java
+++ b/commons/src/test/java/com/powsybl/commons/config/PlatformConfigNamedProviderTest.java
@@ -34,8 +34,14 @@ public class PlatformConfigNamedProviderTest {
 
     private static final String DEFAULT_IMPL_NAME_PROPERTY = "default-impl-name";
 
-    private static final ImmutableList<TestProvider> MULTIPLE_PROVIDERS = ImmutableList
-            .of(new TestProvider("a"), new TestProvider(GOOD_NAME), new TestProvider("c"));
+    private static final ImmutableList<PlatformConfigNamedProvider> MULTIPLE_PROVIDERS = ImmutableList
+            .of(new TestProvider("a"), new TestProvider(GOOD_NAME),
+                    new TestProvider("c"));
+
+    private static final ImmutableList<String> DEFAULT_PROPERTY_LIST = ImmutableList
+            .of(DEFAULT_IMPL_NAME_PROPERTY, LEGACY_IMPL_NAME_PROPERTY);
+    private static final ImmutableList<String> LEGACY_PROPERTY_LIST = ImmutableList
+            .of(DEFAULT_IMPL_NAME_PROPERTY, LEGACY_IMPL_NAME_PROPERTY);
 
     private static final String MODULE = "module";
 
@@ -69,24 +75,24 @@ public class PlatformConfigNamedProviderTest {
     @Test(expected = PowsyblException.class)
     public void testDefaultNoProvider() {
         // case without any provider, an exception is expected
-        PlatformConfigNamedProvider.Finder.findDefault(MODULE, ImmutableList.of(),
-                platformConfig);
+        PlatformConfigNamedProvider.Finder.find(null, MODULE, ImmutableList.of(),
+                ImmutableList.of(), platformConfig, PlatformConfigNamedProvider.class);
     }
 
     @Test
     public void testOneProvider() {
         // case with multiple providers without any config
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .findDefault(MODULE, ImmutableList.of(new TestProvider("b")),
-                        platformConfig);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder.find(
+                null, MODULE, ImmutableList.of(), ImmutableList.of(new TestProvider("b")),
+                platformConfig, PlatformConfigNamedProvider.class);
         assertEquals(GOOD_NAME, provider.getName());
     }
 
     @Test(expected = PowsyblException.class)
     public void testDefaultTwoProviders() {
         // case with 2 providers without any config, an exception is expected
-        PlatformConfigNamedProvider.Finder.findDefault(MODULE, MULTIPLE_PROVIDERS,
-                platformConfig);
+        PlatformConfigNamedProvider.Finder.find(null, MODULE, ImmutableList.of(),
+                MULTIPLE_PROVIDERS, platformConfig, PlatformConfigNamedProvider.class);
     }
 
     @Test
@@ -95,8 +101,8 @@ public class PlatformConfigNamedProviderTest {
         // use in platform config
         platformConfig.createModuleConfig(MODULE)
                 .setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, GOOD_NAME);
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .findDefault(MODULE, MULTIPLE_PROVIDERS, platformConfig);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder.find(
+                null, MODULE, DEFAULT_PROPERTY_LIST, MULTIPLE_PROVIDERS, platformConfig, PlatformConfigNamedProvider.class);
         assertEquals(GOOD_NAME, provider.getName());
     }
 
@@ -106,47 +112,24 @@ public class PlatformConfigNamedProviderTest {
         // provider.
         platformConfig.createModuleConfig(MODULE)
                 .setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, BAD_NAME);
-        PlatformConfigNamedProvider.Finder.findDefault(MODULE,
-                ImmutableList.of(new TestProvider("a")), platformConfig);
+        PlatformConfigNamedProvider.Finder.find(null, MODULE, DEFAULT_PROPERTY_LIST,
+                ImmutableList.of(new TestProvider("a")), platformConfig, PlatformConfigNamedProvider.class);
     }
 
     @Test
     public void testNamedMultipleProviders() {
         // case with multiple providers and specifying programmatically
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .find(GOOD_NAME, MODULE, MULTIPLE_PROVIDERS, platformConfig);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder.find(
+                GOOD_NAME, MODULE, DEFAULT_PROPERTY_LIST, MULTIPLE_PROVIDERS,
+                platformConfig, PlatformConfigNamedProvider.class);
         assertEquals(GOOD_NAME, provider.getName());
     }
 
     @Test(expected = PowsyblException.class)
     public void testBadNamedMultipleProviders() {
         // case with multiple providers and specifying programmatically with an error
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .find(BAD_NAME, MODULE, MULTIPLE_PROVIDERS, platformConfig);
-    }
-
-    @Test(expected = PowsyblException.class)
-    public void testDefaultNoProviderBackwardsCompatible() {
-        // case without any provider, an exception is expected
-        PlatformConfigNamedProvider.Finder.findDefaultBackwardsCompatible(MODULE,
-                ImmutableList.of(), platformConfig);
-    }
-
-    @Test
-    public void testOneProviderBackwardsCompatible() {
-        // case with multiple providers without any config
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .findDefaultBackwardsCompatible(MODULE,
-                        ImmutableList.of(new TestProvider("b")),
-                        platformConfig);
-        assertEquals(GOOD_NAME, provider.getName());
-    }
-
-    @Test(expected = PowsyblException.class)
-    public void testDefaultTwoProvidersBackwardsCompatible() {
-        // case with 2 providers without any config, an exception is expected
-        PlatformConfigNamedProvider.Finder.findDefaultBackwardsCompatible(MODULE,
-                MULTIPLE_PROVIDERS, platformConfig);
+        PlatformConfigNamedProvider.Finder.find(BAD_NAME, MODULE, ImmutableList.of(),
+                MULTIPLE_PROVIDERS, platformConfig, PlatformConfigNamedProvider.class);
     }
 
     @Test
@@ -155,9 +138,8 @@ public class PlatformConfigNamedProviderTest {
         // use in platform config in backwards compatible mode with the new property
         platformConfig.createModuleConfig(MODULE)
                 .setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, GOOD_NAME);
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .findDefaultBackwardsCompatible(MODULE, MULTIPLE_PROVIDERS,
-                        platformConfig);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder.find(
+                null, MODULE, LEGACY_PROPERTY_LIST, MULTIPLE_PROVIDERS, platformConfig, PlatformConfigNamedProvider.class);
         assertEquals(GOOD_NAME, provider.getName());
     }
 
@@ -167,18 +149,32 @@ public class PlatformConfigNamedProviderTest {
         // use in platform config in backwards compatible mode with the old property
         platformConfig.createModuleConfig(MODULE)
                 .setStringProperty(LEGACY_IMPL_NAME_PROPERTY, GOOD_NAME);
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .findDefaultBackwardsCompatible(MODULE, MULTIPLE_PROVIDERS,
-                        platformConfig);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder.find(
+                null, MODULE, LEGACY_PROPERTY_LIST, MULTIPLE_PROVIDERS, platformConfig, PlatformConfigNamedProvider.class);
         assertEquals(GOOD_NAME, provider.getName());
     }
 
     @Test
-    public void testNamedMultipleProvidersBackwardsCompatible() {
-        // case with multiple providers and specifying programmatically
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .findBackwardsCompatible(GOOD_NAME, MODULE, MULTIPLE_PROVIDERS, platformConfig);
+    public void testDefaultMultipleProvidersPlatformConfigBackwardsCompatiblePriority1() {
+        // case with multiple providers without any config but specifying which one to
+        // use in platform config in backwards compatible mode with the new property
+        MapModuleConfig moduleConfig = platformConfig.createModuleConfig(MODULE);
+        moduleConfig.setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, GOOD_NAME);
+        moduleConfig.setStringProperty(LEGACY_IMPL_NAME_PROPERTY, BAD_NAME);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder.find(
+                null, MODULE, LEGACY_PROPERTY_LIST, MULTIPLE_PROVIDERS, platformConfig, PlatformConfigNamedProvider.class);
         assertEquals(GOOD_NAME, provider.getName());
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testDefaultMultipleProvidersPlatformConfigBackwardsCompatiblePriority2() {
+        // case with multiple providers without any config but specifying which one to
+        // use in platform config in backwards compatible mode with the new property
+        MapModuleConfig moduleConfig = platformConfig.createModuleConfig(MODULE);
+        moduleConfig.setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, BAD_NAME);
+        moduleConfig.setStringProperty(LEGACY_IMPL_NAME_PROPERTY, GOOD_NAME);
+        PlatformConfigNamedProvider.Finder.find(
+                null, MODULE, LEGACY_PROPERTY_LIST, MULTIPLE_PROVIDERS, platformConfig, PlatformConfigNamedProvider.class);
     }
 
     @Test(expected = PowsyblException.class)
@@ -187,9 +183,8 @@ public class PlatformConfigNamedProviderTest {
         // use in platform config with error
         platformConfig.createModuleConfig(MODULE)
                 .setStringProperty(LEGACY_IMPL_NAME_PROPERTY, BAD_NAME);
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .findDefaultBackwardsCompatible(MODULE,
-                        ImmutableList.of(new TestProvider("a")), platformConfig);
+        PlatformConfigNamedProvider.Finder.find(null, MODULE, LEGACY_PROPERTY_LIST,
+                ImmutableList.of(new TestProvider("a")), platformConfig, PlatformConfigNamedProvider.class);
     }
 
     @Test(expected = PowsyblException.class)
@@ -198,17 +193,9 @@ public class PlatformConfigNamedProviderTest {
         // use in platform config with error
         platformConfig.createModuleConfig(MODULE)
                 .setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, BAD_NAME);
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .findDefaultBackwardsCompatible(MODULE,
-                        ImmutableList.of(new TestProvider("a")), platformConfig);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder.find(
+                null, MODULE, LEGACY_PROPERTY_LIST,
+                ImmutableList.of(new TestProvider("a")), platformConfig, PlatformConfigNamedProvider.class);
     }
 
-    @Test(expected = PowsyblException.class)
-    public void testBadNamedMultipleProvidersBackwardsCompatible() {
-        // case with 1 provider with config but with a name that is not the one of
-        // provider.
-        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
-                .findBackwardsCompatible(BAD_NAME, MODULE,
-                        ImmutableList.of(new TestProvider("a")), platformConfig);
-    }
 }

--- a/commons/src/test/java/com/powsybl/commons/config/PlatformConfigNamedProviderTest.java
+++ b/commons/src/test/java/com/powsybl/commons/config/PlatformConfigNamedProviderTest.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.commons.config;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.PowsyblException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+public class PlatformConfigNamedProviderTest {
+
+    private static final String BAD_NAME = "xxxx";
+
+    private static final String LEGACY_IMPL_NAME_PROPERTY = "default";
+
+    private static final String GOOD_NAME = "b";
+
+    private static final String DEFAULT_IMPL_NAME_PROPERTY = "default-impl-name";
+
+    private static final ImmutableList<TestProvider> MULTIPLE_PROVIDERS = ImmutableList
+            .of(new TestProvider("a"), new TestProvider(GOOD_NAME), new TestProvider("c"));
+
+    private static final String MODULE = "module";
+
+    private FileSystem fileSystem;
+
+    private InMemoryPlatformConfig platformConfig;
+
+    @Before
+    public void setUp() {
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
+        platformConfig = new InMemoryPlatformConfig(fileSystem);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        fileSystem.close();
+    }
+
+    private static class TestProvider implements PlatformConfigNamedProvider {
+        String name;
+
+        public TestProvider(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testDefaultNoProvider() {
+        // case without any provider, an exception is expected
+        PlatformConfigNamedProvider.Finder.findDefault(MODULE, ImmutableList.of(),
+                platformConfig);
+    }
+
+    @Test
+    public void testOneProvider() {
+        // case with multiple providers without any config
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .findDefault(MODULE, ImmutableList.of(new TestProvider("b")),
+                        platformConfig);
+        assertEquals(GOOD_NAME, provider.getName());
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testDefaultTwoProviders() {
+        // case with 2 providers without any config, an exception is expected
+        PlatformConfigNamedProvider.Finder.findDefault(MODULE, MULTIPLE_PROVIDERS,
+                platformConfig);
+    }
+
+    @Test
+    public void testDefaultMultipleProvidersPlatformConfig() {
+        // case with multiple providers without any config but specifying which one to
+        // use in platform config
+        platformConfig.createModuleConfig(MODULE)
+                .setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, GOOD_NAME);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .findDefault(MODULE, MULTIPLE_PROVIDERS, platformConfig);
+        assertEquals(GOOD_NAME, provider.getName());
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testOneProviderAndMistakeInPlatformConfig() {
+        // case with 1 provider with config but with a name that is not the one of
+        // provider.
+        platformConfig.createModuleConfig(MODULE)
+                .setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, BAD_NAME);
+        PlatformConfigNamedProvider.Finder.findDefault(MODULE,
+                ImmutableList.of(new TestProvider("a")), platformConfig);
+    }
+
+    @Test
+    public void testNamedMultipleProviders() {
+        // case with multiple providers and specifying programmatically
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .find(GOOD_NAME, MODULE, MULTIPLE_PROVIDERS, platformConfig);
+        assertEquals(GOOD_NAME, provider.getName());
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testBadNamedMultipleProviders() {
+        // case with multiple providers and specifying programmatically with an error
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .find(BAD_NAME, MODULE, MULTIPLE_PROVIDERS, platformConfig);
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testDefaultNoProviderBackwardsCompatible() {
+        // case without any provider, an exception is expected
+        PlatformConfigNamedProvider.Finder.findDefaultBackwardsCompatible(MODULE,
+                ImmutableList.of(), platformConfig);
+    }
+
+    @Test
+    public void testOneProviderBackwardsCompatible() {
+        // case with multiple providers without any config
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .findDefaultBackwardsCompatible(MODULE,
+                        ImmutableList.of(new TestProvider("b")),
+                        platformConfig);
+        assertEquals(GOOD_NAME, provider.getName());
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testDefaultTwoProvidersBackwardsCompatible() {
+        // case with 2 providers without any config, an exception is expected
+        PlatformConfigNamedProvider.Finder.findDefaultBackwardsCompatible(MODULE,
+                MULTIPLE_PROVIDERS, platformConfig);
+    }
+
+    @Test
+    public void testDefaultMultipleProvidersPlatformConfigBackwardsCompatible1() {
+        // case with multiple providers without any config but specifying which one to
+        // use in platform config in backwards compatible mode with the new property
+        platformConfig.createModuleConfig(MODULE)
+                .setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, GOOD_NAME);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .findDefaultBackwardsCompatible(MODULE, MULTIPLE_PROVIDERS,
+                        platformConfig);
+        assertEquals(GOOD_NAME, provider.getName());
+    }
+
+    @Test
+    public void testDefaultMultipleProvidersPlatformConfigBackwardsCompatible2() {
+        // case with multiple providers without any config but specifying which one to
+        // use in platform config in backwards compatible mode with the old property
+        platformConfig.createModuleConfig(MODULE)
+                .setStringProperty(LEGACY_IMPL_NAME_PROPERTY, GOOD_NAME);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .findDefaultBackwardsCompatible(MODULE, MULTIPLE_PROVIDERS,
+                        platformConfig);
+        assertEquals(GOOD_NAME, provider.getName());
+    }
+
+    @Test
+    public void testNamedMultipleProvidersBackwardsCompatible() {
+        // case with multiple providers and specifying programmatically
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .findBackwardsCompatible(GOOD_NAME, MODULE, MULTIPLE_PROVIDERS, platformConfig);
+        assertEquals(GOOD_NAME, provider.getName());
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testOneProviderAndMistakeInPlatformConfigBackwardsCompatible1() {
+        // case with multiple providers without any config but specifying which one to
+        // use in platform config with error
+        platformConfig.createModuleConfig(MODULE)
+                .setStringProperty(LEGACY_IMPL_NAME_PROPERTY, BAD_NAME);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .findDefaultBackwardsCompatible(MODULE,
+                        ImmutableList.of(new TestProvider("a")), platformConfig);
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testOneProviderAndMistakeInPlatformConfigBackwardsCompatible2() {
+        // case with multiple providers without any config but specifying which one to
+        // use in platform config with error
+        platformConfig.createModuleConfig(MODULE)
+                .setStringProperty(DEFAULT_IMPL_NAME_PROPERTY, BAD_NAME);
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .findDefaultBackwardsCompatible(MODULE,
+                        ImmutableList.of(new TestProvider("a")), platformConfig);
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void testBadNamedMultipleProvidersBackwardsCompatible() {
+        // case with 1 provider with config but with a name that is not the one of
+        // provider.
+        PlatformConfigNamedProvider provider = PlatformConfigNamedProvider.Finder
+                .findBackwardsCompatible(BAD_NAME, MODULE,
+                        ImmutableList.of(new TestProvider("a")), platformConfig);
+    }
+}

--- a/contingency/contingency-api/pom.xml
+++ b/contingency/contingency-api/pom.xml
@@ -90,6 +90,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/contingency/contingency-dsl/pom.xml
+++ b/contingency/contingency-dsl/pom.xml
@@ -72,6 +72,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/dynamic-simulation/dynamic-simulation-api/src/main/java/com/powsybl/dynamicsimulation/DynamicSimulation.java
+++ b/dynamic-simulation/dynamic-simulation-api/src/main/java/com/powsybl/dynamicsimulation/DynamicSimulation.java
@@ -9,13 +9,12 @@ package com.powsybl.dynamicsimulation;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.Versionable;
 import com.powsybl.commons.config.PlatformConfig;
+import com.powsybl.commons.config.PlatformConfigNamedProvider;
 import com.powsybl.commons.util.ServiceLoaderCache;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.computation.local.LocalComputationManager;
@@ -93,48 +92,13 @@ public final class DynamicSimulation {
     }
 
     public static Runner find(String name) {
-        return find(name, PROVIDERS_SUPPLIERS.get(), PlatformConfig.defaultConfig());
+        return new Runner(PlatformConfigNamedProvider.Finder.findBackwardsCompatible(name,
+                "dynamic-simulation", PROVIDERS_SUPPLIERS.get(),
+                PlatformConfig.defaultConfig()));
     }
 
     public static Runner find() {
         return find(null);
-    }
-
-    public static Runner find(String name, List<DynamicSimulationProvider> providers, PlatformConfig platformConfig) {
-        Objects.requireNonNull(providers);
-        Objects.requireNonNull(platformConfig);
-
-        if (providers.isEmpty()) {
-            throw new PowsyblException("No dynamic simulation providers found");
-        }
-
-        // if no dynamic simulation implementation name is provided through the API we
-        // look for information in platform configuration
-        String dynamicSimulatorName = name != null ? name
-            : platformConfig.getOptionalModuleConfig("dynamic-simulation")
-                .flatMap(mc -> mc.getOptionalStringProperty("default"))
-                .orElse(null);
-        DynamicSimulationProvider provider;
-        if (providers.size() == 1 && dynamicSimulatorName == null) {
-            // no information to select the implementation but only one provider, so we can
-            // use it by default (that is be the most common use case)
-            provider = providers.get(0);
-        } else {
-            if (providers.size() > 1 && dynamicSimulatorName == null) {
-                // several providers and no information to select which one to choose, we can
-                // only throw an exception
-                List<String> dynamicSimulatorNames = providers.stream().map(DynamicSimulationProvider::getName)
-                    .collect(Collectors.toList());
-                throw new PowsyblException("Several dynamic simulation implementations found (" + dynamicSimulatorNames
-                    + "), you must add configuration to select the implementation");
-            }
-            provider = providers.stream()
-                .filter(p -> p.getName().equals(dynamicSimulatorName))
-                .findFirst()
-                .orElseThrow(() -> new PowsyblException("Dynamic simulation '" + dynamicSimulatorName + "' not found"));
-        }
-
-        return new Runner(provider);
     }
 
     public static CompletableFuture<DynamicSimulationResult> runAsync(Network network, String workingStateId,

--- a/dynamic-simulation/dynamic-simulation-api/src/main/java/com/powsybl/dynamicsimulation/DynamicSimulation.java
+++ b/dynamic-simulation/dynamic-simulation-api/src/main/java/com/powsybl/dynamicsimulation/DynamicSimulation.java
@@ -6,16 +6,12 @@
  */
 package com.powsybl.dynamicsimulation;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.powsybl.commons.Versionable;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.config.PlatformConfigNamedProvider;
-import com.powsybl.commons.util.ServiceLoaderCache;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.network.Network;
@@ -27,9 +23,6 @@ public final class DynamicSimulation {
 
     private DynamicSimulation() {
     }
-
-    private static final Supplier<List<DynamicSimulationProvider>> PROVIDERS_SUPPLIERS = Suppliers
-        .memoize(() -> new ServiceLoaderCache<>(DynamicSimulationProvider.class).getServices());
 
     public static class Runner implements Versionable {
 
@@ -93,7 +86,7 @@ public final class DynamicSimulation {
 
     public static Runner find(String name) {
         return new Runner(PlatformConfigNamedProvider.Finder.findBackwardsCompatible(name,
-                "dynamic-simulation", PROVIDERS_SUPPLIERS.get(),
+                "dynamic-simulation", DynamicSimulationProvider.class,
                 PlatformConfig.defaultConfig()));
     }
 

--- a/dynamic-simulation/dynamic-simulation-api/src/main/java/com/powsybl/dynamicsimulation/DynamicSimulationProvider.java
+++ b/dynamic-simulation/dynamic-simulation-api/src/main/java/com/powsybl/dynamicsimulation/DynamicSimulationProvider.java
@@ -9,13 +9,14 @@ package com.powsybl.dynamicsimulation;
 import java.util.concurrent.CompletableFuture;
 
 import com.powsybl.commons.Versionable;
+import com.powsybl.commons.config.PlatformConfigNamedProvider;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>
  */
-public interface DynamicSimulationProvider extends Versionable {
+public interface DynamicSimulationProvider extends Versionable, PlatformConfigNamedProvider {
 
     CompletableFuture<DynamicSimulationResult> run(Network network, ComputationManager computationManager, String workingVariantId, DynamicSimulationParameters parameters);
 

--- a/dynamic-simulation/dynamic-simulation-api/src/test/java/com/powsybl/dynamicsimulation/DynamicSimulationTest.java
+++ b/dynamic-simulation/dynamic-simulation-api/src/test/java/com/powsybl/dynamicsimulation/DynamicSimulationTest.java
@@ -8,23 +8,14 @@ package com.powsybl.dynamicsimulation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
-import java.io.IOException;
-import java.nio.file.FileSystem;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
-import com.powsybl.commons.PowsyblException;
-import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManager;
@@ -34,92 +25,36 @@ import com.powsybl.iidm.network.VariantManager;
  */
 public class DynamicSimulationTest {
 
-    private FileSystem fileSystem;
-
-    private InMemoryPlatformConfig platformConfig;
-
     private Network network;
-
-    private VariantManager variantManager;
 
     private ComputationManager computationManager;
 
     @Before
     public void setUp() {
-        fileSystem = Jimfs.newFileSystem(Configuration.unix());
-        platformConfig = new InMemoryPlatformConfig(fileSystem);
         network = Mockito.mock(Network.class);
-        variantManager = Mockito.mock(VariantManager.class);
+        VariantManager variantManager = Mockito.mock(VariantManager.class);
         Mockito.when(network.getVariantManager()).thenReturn(variantManager);
         Mockito.when(variantManager.getWorkingVariantId()).thenReturn("v");
         computationManager = Mockito.mock(ComputationManager.class);
     }
 
-    @After
-    public void tearDown() throws IOException {
-        fileSystem.close();
-    }
-
     @Test
     public void testDefaultOneProvider() {
         // case with only one provider, no need for config
-        DynamicSimulation.Runner defaultDynamicSimulation = DynamicSimulation.find(null, ImmutableList.of(new DynamicSimulationProviderMock()), platformConfig);
+        DynamicSimulation.Runner defaultDynamicSimulation = DynamicSimulation.find();
         assertEquals("DynamicSimulationMock", defaultDynamicSimulation.getName());
         DynamicSimulationResult result = defaultDynamicSimulation.run(network, computationManager, new DynamicSimulationParameters());
         assertNotNull(result);
     }
 
     @Test
-    public void testAsyncDefaultOneProvider() {
+    public void testAsyncNamedProvider()
+            throws InterruptedException, ExecutionException {
         // case with only one provider, no need for config
-        DynamicSimulation.Runner defaultDynamicSimulation = DynamicSimulation.find(null, ImmutableList.of(new DynamicSimulationProviderMock()), platformConfig);
+        DynamicSimulation.Runner defaultDynamicSimulation = DynamicSimulation
+                .find("DynamicSimulationMock");
         assertEquals("DynamicSimulationMock", defaultDynamicSimulation.getName());
         CompletableFuture<DynamicSimulationResult> result = defaultDynamicSimulation.runAsync(network, computationManager, new DynamicSimulationParameters());
-        try {
-            assertNotNull(result.get());
-        } catch (InterruptedException | ExecutionException ignored) {
-        }
-    }
-
-    @Test
-    public void testDefaultTwoProviders() {
-        // case with 2 providers without any config, an exception is expected
-        try {
-            DynamicSimulation.find(null, ImmutableList.of(new DynamicSimulationProviderMock(), new AnotherDynamicSimulationProviderMock()), platformConfig);
-            fail();
-        } catch (PowsyblException ignored) {
-        }
-    }
-
-    @Test
-    public void testDefaultNoProvider() {
-        // case without any provider
-        try {
-            DynamicSimulation.find(null, ImmutableList.of(), platformConfig);
-            fail();
-        } catch (PowsyblException ignored) {
-        }
-    }
-
-    @Test
-    public void testTwoProviders() {
-        // case with 2 providers without any config but specifying which one to use programmatically
-        DynamicSimulation.Runner otherDynamicSimulation = DynamicSimulation.find("AnotherDynamicSimulationMock", ImmutableList.of(new DynamicSimulationProviderMock(), new AnotherDynamicSimulationProviderMock()), platformConfig);
-        assertEquals("AnotherDynamicSimulationMock", otherDynamicSimulation.getName());
-    }
-
-    @Test
-    public void testDefaultTwoProvidersPlatformConfig() {
-        // case with 2 providers without any config but specifying which one to use in platform config
-        platformConfig.createModuleConfig("dynamic-simulation").setStringProperty("default", "AnotherDynamicSimulationMock");
-        DynamicSimulation.Runner otherDynamicSimulation2 = DynamicSimulation.find(null, ImmutableList.of(new DynamicSimulationProviderMock(), new AnotherDynamicSimulationProviderMock()), platformConfig);
-        assertEquals("AnotherDynamicSimulationMock", otherDynamicSimulation2.getName());
-    }
-
-    @Test(expected = PowsyblException.class)
-    public void testOneProviderAndMistakeInPlatformConfig() {
-        // case with 1 provider with config but with a name that is not the one of provider.
-        platformConfig.createModuleConfig("dynamic-simulation").setStringProperty("default", "AnotherDynamicSimulationMock");
-        DynamicSimulation.find(null, ImmutableList.of(new DynamicSimulationProviderMock()), platformConfig);
+        assertNotNull(result.get());
     }
 }

--- a/entsoe-util/pom.xml
+++ b/entsoe-util/pom.xml
@@ -92,6 +92,12 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactory.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactory.java
@@ -6,13 +6,8 @@
  */
 package com.powsybl.iidm.network;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.config.PlatformConfigNamedProvider;
-import com.powsybl.commons.util.ServiceLoaderCache;
-
-import java.util.List;
 
 /**
  *
@@ -37,7 +32,7 @@ public interface NetworkFactory {
      */
     static NetworkFactory find(String name) {
         return PlatformConfigNamedProvider.Finder.find(
-                name, "network", Private.PROVIDERS_SUPPLIERS.get(),
+                name, "network", NetworkFactoryService.class,
                 PlatformConfig.defaultConfig())
                 .createNetworkFactory();
     }
@@ -59,15 +54,4 @@ public interface NetworkFactory {
         return findDefault().createNetwork(id, sourceFormat);
     }
 
-    /**
-     * @deprecated Do not use. Exists only to have private static state.
-     */
-    @Deprecated
-    static final class Private {
-        Private() { }
-
-        private static final Supplier<List<NetworkFactoryService>> PROVIDERS_SUPPLIERS = Suppliers
-                .memoize(() -> new ServiceLoaderCache<>(NetworkFactoryService.class)
-                        .getServices());
-    }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactoryService.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactoryService.java
@@ -6,11 +6,13 @@
  */
 package com.powsybl.iidm.network;
 
+import com.powsybl.commons.config.PlatformConfigNamedProvider;
+
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public interface NetworkFactoryService {
+public interface NetworkFactoryService extends PlatformConfigNamedProvider {
 
     /**
      * Get network factory name.

--- a/iidm/iidm-comparator/pom.xml
+++ b/iidm/iidm-comparator/pom.xml
@@ -46,6 +46,12 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/iidm/iidm-converter-api/pom.xml
+++ b/iidm/iidm-converter-api/pom.xml
@@ -87,6 +87,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/iidm/iidm-extensions/pom.xml
+++ b/iidm/iidm-extensions/pom.xml
@@ -86,6 +86,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/iidm/iidm-mergingview/pom.xml
+++ b/iidm/iidm-mergingview/pom.xml
@@ -74,6 +74,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/iidm/iidm-reducer/pom.xml
+++ b/iidm/iidm-reducer/pom.xml
@@ -59,6 +59,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/iidm/iidm-util/pom.xml
+++ b/iidm/iidm-util/pom.xml
@@ -77,6 +77,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
@@ -6,21 +6,16 @@
  */
 package com.powsybl.loadflow;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.Versionable;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.config.PlatformConfigNamedProvider;
-import com.powsybl.commons.util.ServiceLoaderCache;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.network.Network;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-
 
 /**
  * LoadFlow main API. It is a utility class (so with only static methods) used as an entry point for running
@@ -32,9 +27,6 @@ public final class LoadFlow {
 
     private LoadFlow() {
     }
-
-    private static final Supplier<List<LoadFlowProvider>> PROVIDERS_SUPPLIERS
-            = Suppliers.memoize(() -> new ServiceLoaderCache<>(LoadFlowProvider.class).getServices());
 
     /**
      * A loadflow runner is responsible for providing convenient methods on top of {@link LoadFlowProvider}:
@@ -104,7 +96,7 @@ public final class LoadFlow {
      */
     public static Runner find(String name) {
         return new Runner(PlatformConfigNamedProvider.Finder
-                .findBackwardsCompatible(name, "load-flow", PROVIDERS_SUPPLIERS.get(),
+                .findBackwardsCompatible(name, "load-flow", LoadFlowProvider.class,
                 PlatformConfig.defaultConfig()));
     }
 

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
@@ -7,6 +7,7 @@
 package com.powsybl.loadflow;
 
 import com.powsybl.commons.Versionable;
+import com.powsybl.commons.config.PlatformConfigNamedProvider;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 
@@ -17,7 +18,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public interface LoadFlowProvider extends Versionable {
+public interface LoadFlowProvider extends Versionable, PlatformConfigNamedProvider {
 
     /**
      * Run a loadflow on variant {@code workingVariantId} of {@code network} delegating external program execution to

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowTest.java
@@ -7,20 +7,15 @@
 
 package com.powsybl.loadflow;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
-import com.powsybl.commons.PowsyblException;
-import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManager;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.nio.file.FileSystem;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
@@ -29,80 +24,37 @@ import static org.junit.Assert.*;
  */
 public class LoadFlowTest {
 
-    private FileSystem fileSystem;
-
-    private InMemoryPlatformConfig platformConfig;
+    private static final String DEFAULT_PROVIDER_NAME = "LoadFlowMock";
 
     private Network network;
-
-    private VariantManager variantManager;
 
     private ComputationManager computationManager;
 
     @Before
     public void setUp() throws Exception {
-        fileSystem = Jimfs.newFileSystem(Configuration.unix());
-        platformConfig = new InMemoryPlatformConfig(fileSystem);
         network = Mockito.mock(Network.class);
-        variantManager = Mockito.mock(VariantManager.class);
+        VariantManager variantManager = Mockito.mock(VariantManager.class);
         Mockito.when(network.getVariantManager()).thenReturn(variantManager);
         Mockito.when(variantManager.getWorkingVariantId()).thenReturn("v");
         computationManager = Mockito.mock(ComputationManager.class);
     }
 
-    @After
-    public void tearDown() throws Exception {
-        fileSystem.close();
-    }
-
     @Test
-    public void testDefaultOneProvider() {
+    public void testDefaultProvider() {
         // case with only one provider, no need for config
-        LoadFlow.Runner defaultLoadFlow = LoadFlow.find(null, ImmutableList.of(new LoadFlowProviderMock()), platformConfig);
-        assertEquals("LoadFlowMock", defaultLoadFlow.getName());
-        LoadFlowResult result = defaultLoadFlow.run(network, computationManager, new LoadFlowParameters());
+        LoadFlow.Runner defaultLoadFlow = LoadFlow.find();
+        assertEquals(DEFAULT_PROVIDER_NAME, defaultLoadFlow.getName());
+        LoadFlowResult result = defaultLoadFlow.run(network, computationManager,
+                new LoadFlowParameters());
         assertNotNull(result);
     }
 
     @Test
-    public void testDefaultTwoProviders() {
-        // case with 2 providers without any config, an exception is expected
-        try {
-            LoadFlow.find(null, ImmutableList.of(new LoadFlowProviderMock(), new AnotherLoadFlowProviderMock()), platformConfig);
-            fail();
-        } catch (PowsyblException ignored) {
-        }
-    }
-
-    @Test
-    public void testDefaultNoProvider() {
-        // case without any provider
-        try {
-            LoadFlow.find(null, ImmutableList.of(), platformConfig);
-            fail();
-        } catch (PowsyblException ignored) {
-        }
-    }
-
-    @Test
-    public void testTwoProviders() {
-        // case with 2 providers without any config but specifying which one to use programmatically
-        LoadFlow.Runner otherLoadFlow = LoadFlow.find("AnotherLoadFlowMock", ImmutableList.of(new LoadFlowProviderMock(), new AnotherLoadFlowProviderMock()), platformConfig);
-        assertEquals("AnotherLoadFlowMock", otherLoadFlow.getName());
-    }
-
-    @Test
-    public void testDefaultTwoProvidersPlatformConfig() {
-        // case with 2 providers without any config but specifying which one to use in platform config
-        platformConfig.createModuleConfig("load-flow").setStringProperty("default", "AnotherLoadFlowMock");
-        LoadFlow.Runner otherLoadFlow2 = LoadFlow.find(null, ImmutableList.of(new LoadFlowProviderMock(), new AnotherLoadFlowProviderMock()), platformConfig);
-        assertEquals("AnotherLoadFlowMock", otherLoadFlow2.getName());
-    }
-
-    @Test(expected = PowsyblException.class)
-    public void testOneProviderAndMistakeInPlatformConfig() {
-        // case with 1 provider with config but with a name that is not the one of provider.
-        platformConfig.createModuleConfig("load-flow").setStringProperty("default", "AnotherLoadFlowMock");
-        LoadFlow.find(null, ImmutableList.of(new LoadFlowProviderMock()), platformConfig);
+    public void testAsyncNamedProvider() throws InterruptedException, ExecutionException {
+        // named provider
+        LoadFlow.Runner defaultLoadFlow = LoadFlow.find(DEFAULT_PROVIDER_NAME);
+        CompletableFuture<LoadFlowResult> result = defaultLoadFlow.runAsync(network,
+                computationManager, new LoadFlowParameters());
+        assertNotNull(result.get());
     }
 }


### PR DESCRIPTION
…f the hardcoded 'Default'

This allows other implementations to be used by code that is using the the iidm api without specifying the implementation. For examples, all the tests in iidm-impl.


Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The iidm implementation is chosen by serviceLoader.load.filter(name == "Default")


**What is the new behavior (if this is a feature change)?**
The iidm implementation is chosen by 
String defaultName = ... ;//from platformConfig iidm.default
serviceLoader.load.filter(name == defaultName)

If the iidm is module is not present, "Default" is used
if the iidm module is present and the "default" property is not present, an exception is thrown
if the iidm module is present and the default value is set to a missing implementation in the classpath an exception is thrown, 



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No


