### PR TITLE
ExtensionProviders, add missing requireNonNull

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/extensions/ExtensionProviders.java
+++ b/commons/src/main/java/com/powsybl/commons/extensions/ExtensionProviders.java
@@ -35,6 +35,7 @@ public final class ExtensionProviders<T extends ExtensionProvider> {
     }
 
     private ExtensionProviders(Class<T> clazz) {
+        Objects.requireNonNull(clazz);
         providers = new ServiceLoaderCache<>(clazz).getServices().stream()
             .collect(Collectors.toMap(T::getExtensionName, e -> e));
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
Other constructors all require that the clazz argument is not null, but ExtensionProviders(clazz) doesn't


**What is the new behavior (if this is a feature change)?**
add missing requireNotNull


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO
