### PR TITLE
AbstractExtension, log the correct extandable in throw when reassigni…

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/extensions/AbstractExtension.java
+++ b/commons/src/main/java/com/powsybl/commons/extensions/AbstractExtension.java
@@ -29,7 +29,7 @@ public abstract class AbstractExtension<T> implements Extension<T> {
 
     public void setExtendable(T extendable) {
         if ((extendable != null) && (this.extendable != null) && (this.extendable != extendable)) {
-            throw new PowsyblException("Extension is already associated to the extendable " + extendable);
+            throw new PowsyblException("Extension is already associated to the extendable " + this.extendable);
         }
 
         this.extendable = extendable;


### PR DESCRIPTION
…ng extension

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Wrong extendable is logged in exception when setting the extendable twice 


**What is the new behavior (if this is a feature change)?**
Good extandable is logged


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
NO
