### PR TITLE
Allow to write IIDM-XML files in previous versions

### DIFF
--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/export/ExportOptions.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/export/ExportOptions.java
@@ -45,15 +45,15 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
     }
 
     public ExportOptions(boolean withBranchSV, boolean indent, boolean onlyMainCc, TopologyLevel topologyLevel, boolean throwExceptionIfExtensionNotFound) {
+        this(withBranchSV, indent, onlyMainCc, topologyLevel, throwExceptionIfExtensionNotFound, null);
+    }
+
+    public ExportOptions(boolean withBranchSV, boolean indent, boolean onlyMainCc, TopologyLevel topologyLevel, boolean throwExceptionIfExtensionNotFound, String version) {
         this.withBranchSV = withBranchSV;
         this.indent = indent;
         this.onlyMainCc = onlyMainCc;
         this.topologyLevel = Objects.requireNonNull(topologyLevel);
         this.throwExceptionIfExtensionNotFound = throwExceptionIfExtensionNotFound;
-    }
-
-    public ExportOptions(boolean withBranchSV, boolean indent, boolean onlyMainCc, TopologyLevel topologyLevel, boolean throwExceptionIfExtensionNotFound, String version) {
-        this(withBranchSV, indent, onlyMainCc, topologyLevel, throwExceptionIfExtensionNotFound);
         this.version = version;
     }
 

--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/export/ExportOptions.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/export/ExportOptions.java
@@ -39,6 +39,8 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
 
     private boolean throwExceptionIfExtensionNotFound = false;
 
+    private String version;
+
     public ExportOptions() {
     }
 
@@ -48,6 +50,11 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
         this.onlyMainCc = onlyMainCc;
         this.topologyLevel = Objects.requireNonNull(topologyLevel);
         this.throwExceptionIfExtensionNotFound = throwExceptionIfExtensionNotFound;
+    }
+
+    public ExportOptions(boolean withBranchSV, boolean indent, boolean onlyMainCc, TopologyLevel topologyLevel, boolean throwExceptionIfExtensionNotFound, String version) {
+        this(withBranchSV, indent, onlyMainCc, topologyLevel, throwExceptionIfExtensionNotFound);
+        this.version = version;
     }
 
     @Override
@@ -134,6 +141,15 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
 
     public ExportOptions setThrowExceptionIfExtensionNotFound(boolean throwException) {
         this.throwExceptionIfExtensionNotFound = throwException;
+        return this;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public ExportOptions setVersion(String version) {
+        this.version = version;
         return this;
     }
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
@@ -161,18 +161,10 @@ public abstract class AbstractConnectableXml<T extends Connectable, A extends Id
         adder.add();
     }
 
-    /**
-     * @deprecated Use {@link #writeCurrentLimits(Integer, CurrentLimits, XMLStreamWriter, IidmXmlVersion)} instead.
-     */
-    @Deprecated
     public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer) throws XMLStreamException {
         writeCurrentLimits(index, limits, writer, IidmXmlConstants.CURRENT_IIDM_XML_VERSION);
     }
 
-    /**
-     * @deprecated Use {@link #writeCurrentLimits(Integer, CurrentLimits, XMLStreamWriter, String, IidmXmlVersion)} instead.
-     */
-    @Deprecated
     public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer, String nsUri) throws XMLStreamException {
         writeCurrentLimits(index, limits, writer, nsUri, IidmXmlConstants.CURRENT_IIDM_XML_VERSION);
     }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
@@ -15,9 +15,7 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 import java.util.function.Supplier;
 
-import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
 /**
- *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public abstract class AbstractConnectableXml<T extends Connectable, A extends IdentifiableAdder<A>, P extends Container> extends AbstractIdentifiableXml<T, A, P> {
@@ -55,7 +53,7 @@ public abstract class AbstractConnectableXml<T extends Connectable, A extends Id
 
     private static void writeNode(Integer index, Terminal t, NetworkXmlWriterContext context) throws XMLStreamException {
         context.getWriter().writeAttribute(NODE + indexToString(index),
-            Integer.toString(t.getNodeBreakerView().getNode()));
+                Integer.toString(t.getNodeBreakerView().getNode()));
     }
 
     private static void writeBus(Integer index, Bus bus, Bus connectableBus, NetworkXmlWriterContext context) throws XMLStreamException {
@@ -139,7 +137,7 @@ public abstract class AbstractConnectableXml<T extends Connectable, A extends Id
         double p = XmlUtil.readOptionalDoubleAttribute(reader, "p" + indexToString(index));
         double q = XmlUtil.readOptionalDoubleAttribute(reader, "q" + indexToString(index));
         t.setP(p)
-            .setQ(q);
+                .setQ(q);
     }
 
     public static void readCurrentLimits(Integer index, Supplier<CurrentLimitsAdder> currentLimitOwner, XMLStreamReader reader) throws XMLStreamException {
@@ -153,23 +151,39 @@ public abstract class AbstractConnectableXml<T extends Connectable, A extends Id
                 double value = XmlUtil.readOptionalDoubleAttribute(reader, "value", Double.MAX_VALUE);
                 boolean fictitious = XmlUtil.readOptionalBoolAttribute(reader, "fictitious", false);
                 adder.beginTemporaryLimit()
-                    .setName(name)
-                    .setAcceptableDuration(acceptableDuration)
-                    .setValue(value)
-                    .setFictitious(fictitious)
-                    .endTemporaryLimit();
+                        .setName(name)
+                        .setAcceptableDuration(acceptableDuration)
+                        .setValue(value)
+                        .setFictitious(fictitious)
+                        .endTemporaryLimit();
             }
         });
         adder.add();
     }
 
+    /**
+     * @deprecated Use {@link #writeCurrentLimits(Integer, CurrentLimits, XMLStreamWriter, IidmXmlVersion)} instead.
+     */
+    @Deprecated
     public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer) throws XMLStreamException {
-        writeCurrentLimits(index, limits, writer, IIDM_URI);
+        writeCurrentLimits(index, limits, writer, IidmXmlConstants.CURRENT_IIDM_XML_VERSION);
     }
 
+    /**
+     * @deprecated Use {@link #writeCurrentLimits(Integer, CurrentLimits, XMLStreamWriter, String, IidmXmlVersion)} instead.
+     */
+    @Deprecated
     public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer, String nsUri) throws XMLStreamException {
+        writeCurrentLimits(index, limits, writer, nsUri, IidmXmlConstants.CURRENT_IIDM_XML_VERSION);
+    }
+
+    public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer, IidmXmlVersion version) throws XMLStreamException {
+        writeCurrentLimits(index, limits, writer, version.getNamespaceURI(), version);
+    }
+
+    public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer, String nsUri, IidmXmlVersion version) throws XMLStreamException {
         if (!Double.isNaN(limits.getPermanentLimit())
-            || !limits.getTemporaryLimits().isEmpty()) {
+                || !limits.getTemporaryLimits().isEmpty()) {
             if (limits.getTemporaryLimits().isEmpty()) {
                 writer.writeEmptyElement(nsUri, CURRENT_LIMITS + indexToString(index));
             } else {
@@ -177,7 +191,7 @@ public abstract class AbstractConnectableXml<T extends Connectable, A extends Id
             }
             XmlUtil.writeDouble("permanentLimit", limits.getPermanentLimit(), writer);
             for (CurrentLimits.TemporaryLimit tl : limits.getTemporaryLimits()) {
-                writer.writeEmptyElement(IIDM_URI, "temporaryLimit");
+                writer.writeEmptyElement(version.getNamespaceURI(), "temporaryLimit");
                 writer.writeAttribute("name", tl.getName());
                 XmlUtil.writeOptionalInt("acceptableDuration", tl.getAcceptableDuration(), Integer.MAX_VALUE, writer);
                 XmlUtil.writeOptionalDouble("value", tl.getValue(), Double.MAX_VALUE, writer);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
@@ -161,10 +161,18 @@ public abstract class AbstractConnectableXml<T extends Connectable, A extends Id
         adder.add();
     }
 
+    /**
+     * @deprecated Use {@link #writeCurrentLimits(Integer, CurrentLimits, XMLStreamWriter, IidmXmlVersion)} instead.
+     */
+    @Deprecated
     public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer) throws XMLStreamException {
         writeCurrentLimits(index, limits, writer, IidmXmlConstants.CURRENT_IIDM_XML_VERSION);
     }
 
+    /**
+     * @deprecated Use {@link #writeCurrentLimits(Integer, CurrentLimits, XMLStreamWriter, String, IidmXmlVersion)} instead.
+     */
+    @Deprecated
     public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer, String nsUri) throws XMLStreamException {
         writeCurrentLimits(index, limits, writer, nsUri, IidmXmlConstants.CURRENT_IIDM_XML_VERSION);
     }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
@@ -14,8 +14,6 @@ import com.powsybl.iidm.network.IdentifiableAdder;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
-
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -34,9 +32,9 @@ abstract class AbstractIdentifiableXml<T extends Identifiable, A extends Identif
     public final void write(T identifiable, P parent, NetworkXmlWriterContext context) throws XMLStreamException {
         boolean hasSubElements = hasSubElements(identifiable);
         if (hasSubElements || identifiable.hasProperty()) {
-            context.getWriter().writeStartElement(IIDM_URI, getRootElementName());
+            context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), getRootElementName());
         } else {
-            context.getWriter().writeEmptyElement(IIDM_URI, getRootElementName());
+            context.getWriter().writeEmptyElement(context.getVersion().getNamespaceURI(), getRootElementName());
         }
         context.getWriter().writeAttribute("id", context.getAnonymizer().anonymizeString(identifiable.getId()));
         if (!identifiable.getId().equals(identifiable.getName())) {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractNetworkXmlContext.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractNetworkXmlContext.java
@@ -9,6 +9,8 @@ package com.powsybl.iidm.xml;
 import com.powsybl.iidm.AbstractConverterContext;
 import com.powsybl.iidm.anonymizer.Anonymizer;
 
+import java.util.Objects;
+
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
  */
@@ -18,7 +20,7 @@ public abstract class AbstractNetworkXmlContext<T> extends AbstractConverterCont
 
     AbstractNetworkXmlContext(Anonymizer anonymizer, IidmXmlVersion version) {
         super(anonymizer);
-        this.version = version;
+        this.version = Objects.requireNonNull(version);
     }
 
     public IidmXmlVersion getVersion() {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractNetworkXmlContext.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractNetworkXmlContext.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.xml;
+
+import com.powsybl.iidm.AbstractConverterContext;
+import com.powsybl.iidm.anonymizer.Anonymizer;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public abstract class AbstractNetworkXmlContext<T> extends AbstractConverterContext<T> {
+
+    private final IidmXmlVersion version;
+
+    AbstractNetworkXmlContext(Anonymizer anonymizer, IidmXmlVersion version) {
+        super(anonymizer);
+        this.version = version;
+    }
+
+    public IidmXmlVersion getVersion() {
+        return version;
+    }
+}

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
@@ -13,6 +13,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import java.util.function.BiConsumer;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
@@ -13,11 +13,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import java.util.function.BiConsumer;
-
-import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
-
 /**
- *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 abstract class AbstractTransformerXml<T extends Connectable, A extends IdentifiableAdder<A>> extends AbstractConnectableXml<T, A, Substation> {
@@ -50,7 +46,7 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
     }
 
     protected static void writeRatioTapChanger(String name, RatioTapChanger rtc, NetworkXmlWriterContext context) throws XMLStreamException {
-        context.getWriter().writeStartElement(IIDM_URI, name);
+        context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), name);
         writeTapChanger(rtc, context.getWriter());
         context.getWriter().writeAttribute("loadTapChangingCapabilities", Boolean.toString(rtc.hasLoadTapChangingCapabilities()));
         if (rtc.hasLoadTapChangingCapabilities() || rtc.isRegulating()) {
@@ -64,7 +60,7 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
         }
         for (int p = rtc.getLowTapPosition(); p <= rtc.getHighTapPosition(); p++) {
             RatioTapChangerStep rtcs = rtc.getStep(p);
-            context.getWriter().writeEmptyElement(IIDM_URI, ELEM_STEP);
+            context.getWriter().writeEmptyElement(context.getVersion().getNamespaceURI(), ELEM_STEP);
             writeTapChangerStep(rtcs, context.getWriter());
         }
         context.getWriter().writeEndElement();
@@ -123,7 +119,7 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
     }
 
     protected static void writePhaseTapChanger(String name, PhaseTapChanger ptc, NetworkXmlWriterContext context) throws XMLStreamException {
-        context.getWriter().writeStartElement(IIDM_URI, name);
+        context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), name);
         writeTapChanger(ptc, context.getWriter());
         context.getWriter().writeAttribute("regulationMode", ptc.getRegulationMode().name());
         if (ptc.getRegulationMode() != PhaseTapChanger.RegulationMode.FIXED_TAP || !Double.isNaN(ptc.getRegulationValue())) {
@@ -137,7 +133,7 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
         }
         for (int p = ptc.getLowTapPosition(); p <= ptc.getHighTapPosition(); p++) {
             PhaseTapChangerStep ptcs = ptc.getStep(p);
-            context.getWriter().writeEmptyElement(IIDM_URI, ELEM_STEP);
+            context.getWriter().writeEmptyElement(context.getVersion().getNamespaceURI(), ELEM_STEP);
             writeTapChangerStep(ptcs, context.getWriter());
             XmlUtil.writeDouble("alpha", ptcs.getAlpha(), context.getWriter());
         }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/DanglingLineXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/DanglingLineXml.java
@@ -51,7 +51,7 @@ class DanglingLineXml extends AbstractConnectableXml<DanglingLine, DanglingLineA
     @Override
     protected void writeSubElements(DanglingLine dl, VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
         if (dl.getCurrentLimits() != null) {
-            writeCurrentLimits(null, dl.getCurrentLimits(), context.getWriter());
+            writeCurrentLimits(null, dl.getCurrentLimits(), context.getWriter(), context.getVersion());
         }
     }
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/IidmXmlConstants.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/IidmXmlConstants.java
@@ -15,8 +15,6 @@ public final class IidmXmlConstants {
 
     public static final IidmXmlVersion CURRENT_IIDM_XML_VERSION = IidmXmlVersion.V_1_1;
 
-    public static final String IIDM_URI = CURRENT_IIDM_XML_VERSION.getNamespaceURI();
-
     public static final String IIDM_PREFIX = "iidm";
 
     private IidmXmlConstants() {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/IidmXmlVersion.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/IidmXmlVersion.java
@@ -42,7 +42,7 @@ public enum IidmXmlVersion {
 
     public static IidmXmlVersion fromNamespaceURI(String namespaceURI) {
         String version = namespaceURI.substring(namespaceURI.lastIndexOf('/') + 1);
-        IidmXmlVersion v = of(version);
+        IidmXmlVersion v = of(version, "_");
         String namespaceUriV = v.getNamespaceURI();
         if (!namespaceURI.equals(namespaceUriV)) {
             throw new PowsyblException("Namespace " + namespaceURI + " is not supported. " +
@@ -51,9 +51,9 @@ public enum IidmXmlVersion {
         return v;
     }
 
-    public static IidmXmlVersion of(String version) {
+    public static IidmXmlVersion of(String version, String separator) {
         return Stream.of(IidmXmlVersion.values())
-                .filter(v -> version.equals(v.toString("_")))
+                .filter(v -> version.equals(v.toString(separator)))
                 .findFirst() // there can only be 0 or exactly 1 match
                 .orElseThrow(() -> new PowsyblException("Version " + version + " is not supported."));
     }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/LineXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/LineXml.java
@@ -52,10 +52,10 @@ class LineXml extends AbstractConnectableXml<Line, LineAdder, Network> {
     @Override
     protected void writeSubElements(Line l, Network n, NetworkXmlWriterContext context) throws XMLStreamException {
         if (l.getCurrentLimits1() != null) {
-            writeCurrentLimits(1, l.getCurrentLimits1(), context.getWriter());
+            writeCurrentLimits(1, l.getCurrentLimits1(), context.getWriter(), context.getVersion());
         }
         if (l.getCurrentLimits2() != null) {
-            writeCurrentLimits(2, l.getCurrentLimits2(), context.getWriter());
+            writeCurrentLimits(2, l.getCurrentLimits2(), context.getWriter(), context.getVersion());
         }
     }
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -240,7 +240,7 @@ public final class NetworkXml {
             if (!context.isExportedEquipment(identifiable) || extensions.isEmpty() || !options.hasAtLeastOneExtension(getExtensionsName(extensions))) {
                 continue;
             }
-            context.getExtensionsWriter().writeStartElement(IIDM_URI, EXTENSION_ELEMENT_NAME);
+            context.getExtensionsWriter().writeStartElement(context.getVersion().getNamespaceURI(), EXTENSION_ELEMENT_NAME);
             context.getExtensionsWriter().writeAttribute(ID, context.getAnonymizer().anonymizeString(identifiable.getId()));
             for (Extension<? extends Identifiable<?>> extension : extensions) {
                 if (options.withExtension(extension.getName())) {
@@ -260,11 +260,13 @@ public final class NetworkXml {
 
     private static XMLStreamWriter writeStartAttributes(OutputStream os, ExportOptions options) throws XMLStreamException {
         XMLStreamWriter writer;
+        IidmXmlVersion version = options.getVersion() == null ? IidmXmlConstants.CURRENT_IIDM_XML_VERSION : IidmXmlVersion.of(options.getVersion(), ".");
         writer = createXmlStreamWriter(options, os);
         writer.writeStartDocument(StandardCharsets.UTF_8.toString(), "1.0");
-        writer.setPrefix(IIDM_PREFIX, IIDM_URI);
-        writer.writeStartElement(IIDM_URI, NETWORK_ROOT_ELEMENT_NAME);
-        writer.writeNamespace(IIDM_PREFIX, IIDM_URI);
+        String namespaceUri = version.getNamespaceURI();
+        writer.setPrefix(IIDM_PREFIX, namespaceUri);
+        writer.writeStartElement(namespaceUri, NETWORK_ROOT_ELEMENT_NAME);
+        writer.writeNamespace(IIDM_PREFIX, namespaceUri);
         return writer;
     }
 
@@ -308,7 +310,7 @@ public final class NetworkXml {
                      BufferedOutputStream bos = new BufferedOutputStream(os)) {
                     XMLStreamWriter writer = initializeExtensionFileWriter(n, bos, options, name);
                     for (String id : ids) {
-                        writer.writeStartElement(IIDM_URI, EXTENSION_ELEMENT_NAME);
+                        writer.writeStartElement(context.getVersion().getNamespaceURI(), EXTENSION_ELEMENT_NAME);
                         writer.writeAttribute("id", context.getAnonymizer().anonymizeString(id));
                         context.setExtensionsWriter(writer);
                         writeExtension(n.getIdentifiable(id).getExtensionByName(name), context);
@@ -331,7 +333,8 @@ public final class NetworkXml {
         }
         BusFilter filter = BusFilter.create(n, options);
         Anonymizer anonymizer = options.isAnonymized() ? new SimpleAnonymizer() : null;
-        NetworkXmlWriterContext context = new NetworkXmlWriterContext(anonymizer, writer, options, filter);
+        IidmXmlVersion version = options.getVersion() == null ? IidmXmlConstants.CURRENT_IIDM_XML_VERSION : IidmXmlVersion.of(options.getVersion(), ".");
+        NetworkXmlWriterContext context = new NetworkXmlWriterContext(anonymizer, writer, options, filter, version);
         // Consider the network has been exported so its extensions will be written also
         context.addExportedEquipment(n);
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlReaderContext.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlReaderContext.java
@@ -38,6 +38,7 @@ public class NetworkXmlReaderContext extends AbstractNetworkXmlContext<ImportOpt
         super(anonymizer, version);
         this.reader = Objects.requireNonNull(reader);
         this.options = Objects.requireNonNull(options);
+        this.version = version;
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlReaderContext.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlReaderContext.java
@@ -8,7 +8,6 @@ package com.powsybl.iidm.xml;
 
 import com.powsybl.commons.extensions.ExtensionXmlSerializer;
 import com.powsybl.commons.xml.XmlReaderContext;
-import com.powsybl.iidm.AbstractConverterContext;
 import com.powsybl.iidm.anonymizer.Anonymizer;
 import com.powsybl.iidm.import_.ImportOptions;
 
@@ -21,7 +20,7 @@ import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class NetworkXmlReaderContext extends AbstractConverterContext<ImportOptions> implements XmlReaderContext {
+public class NetworkXmlReaderContext extends AbstractNetworkXmlContext<ImportOptions> implements XmlReaderContext {
 
     private final XMLStreamReader reader;
 
@@ -36,10 +35,9 @@ public class NetworkXmlReaderContext extends AbstractConverterContext<ImportOpti
     }
 
     public NetworkXmlReaderContext(Anonymizer anonymizer, XMLStreamReader reader, ImportOptions options, IidmXmlVersion version) {
-        super(anonymizer);
+        super(anonymizer, version);
         this.reader = Objects.requireNonNull(reader);
         this.options = Objects.requireNonNull(options);
-        this.version = Objects.requireNonNull(version);
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlReaderContext.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlReaderContext.java
@@ -27,7 +27,6 @@ public class NetworkXmlReaderContext extends AbstractNetworkXmlContext<ImportOpt
     private final List<Runnable> endTasks = new ArrayList<>();
     private final ImportOptions options;
 
-    private final IidmXmlVersion version;
     private final Set<String> extensionsNamespaceUri = new HashSet<>();
 
     public NetworkXmlReaderContext(Anonymizer anonymizer, XMLStreamReader reader) {
@@ -38,7 +37,6 @@ public class NetworkXmlReaderContext extends AbstractNetworkXmlContext<ImportOpt
         super(anonymizer, version);
         this.reader = Objects.requireNonNull(reader);
         this.options = Objects.requireNonNull(options);
-        this.version = version;
     }
 
     @Override
@@ -53,10 +51,6 @@ public class NetworkXmlReaderContext extends AbstractNetworkXmlContext<ImportOpt
     @Override
     public ImportOptions getOptions() {
         return options;
-    }
-
-    public IidmXmlVersion getVersion() {
-        return version;
     }
 
     public void buildExtensionNamespaceUriList(Stream<ExtensionXmlSerializer> providers) {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlWriterContext.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlWriterContext.java
@@ -8,7 +8,6 @@ package com.powsybl.iidm.xml;
 
 import com.powsybl.commons.xml.XmlWriterContext;
 import com.powsybl.iidm.anonymizer.Anonymizer;
-import com.powsybl.iidm.AbstractConverterContext;
 import com.powsybl.iidm.export.BusFilter;
 import com.powsybl.iidm.export.ExportOptions;
 import com.powsybl.iidm.network.Identifiable;
@@ -21,7 +20,7 @@ import java.util.Set;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class NetworkXmlWriterContext extends AbstractConverterContext<ExportOptions> implements XmlWriterContext {
+public class NetworkXmlWriterContext extends AbstractNetworkXmlContext<ExportOptions> implements XmlWriterContext {
 
     private final XMLStreamWriter writer;
     private XMLStreamWriter extensionsWriter;
@@ -29,13 +28,17 @@ public class NetworkXmlWriterContext extends AbstractConverterContext<ExportOpti
     private final BusFilter filter;
     private final Set<Identifiable> exportedEquipments;
 
-    NetworkXmlWriterContext(Anonymizer anonymizer, XMLStreamWriter writer, ExportOptions options, BusFilter filter) {
-        super(anonymizer);
+    NetworkXmlWriterContext(Anonymizer anonymizer, XMLStreamWriter writer, ExportOptions options, BusFilter filter, IidmXmlVersion version) {
+        super(anonymizer, version);
         this.writer = writer;
         this.options = options;
         this.filter = filter;
         this.extensionsWriter = writer;
         this.exportedEquipments = new HashSet<>();
+    }
+
+    NetworkXmlWriterContext(Anonymizer anonymizer, XMLStreamWriter writer, ExportOptions options, BusFilter filter) {
+        this(anonymizer, writer, options, filter, IidmXmlConstants.CURRENT_IIDM_XML_VERSION);
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewInternalConnectionXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewInternalConnectionXml.java
@@ -6,8 +6,6 @@
  */
 package com.powsybl.iidm.xml;
 
-import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
-
 import javax.xml.stream.XMLStreamException;
 
 import com.powsybl.commons.xml.XmlUtil;
@@ -26,7 +24,7 @@ public class NodeBreakerViewInternalConnectionXml {
     }
 
     protected void write(int node1, int node2, NetworkXmlWriterContext context) throws XMLStreamException {
-        context.getWriter().writeEmptyElement(IIDM_URI, getRootElementName());
+        context.getWriter().writeEmptyElement(context.getVersion().getNamespaceURI(), getRootElementName());
         context.getWriter().writeAttribute("node1", Integer.toString(node1));
         context.getWriter().writeAttribute("node2", Integer.toString(node2));
     }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/PropertiesXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/PropertiesXml.java
@@ -7,8 +7,6 @@
 
 package com.powsybl.iidm.xml;
 
-import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
-
 import javax.xml.stream.XMLStreamException;
 
 import com.powsybl.iidm.network.Identifiable;
@@ -27,7 +25,7 @@ public final class PropertiesXml {
         if (identifiable.hasProperty()) {
             for (String name : identifiable.getPropertyNames()) {
                 String value = identifiable.getProperty(name);
-                context.getWriter().writeEmptyElement(IIDM_URI, PROPERTY);
+                context.getWriter().writeEmptyElement(context.getVersion().getNamespaceURI(), PROPERTY);
                 context.getWriter().writeAttribute(NAME, name);
                 context.getWriter().writeAttribute(VALUE, value);
             }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ReactiveLimitsXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ReactiveLimitsXml.java
@@ -14,8 +14,6 @@ import com.powsybl.iidm.network.ReactiveLimitsHolder;
 
 import javax.xml.stream.XMLStreamException;
 
-import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
-
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */
@@ -32,9 +30,9 @@ public class ReactiveLimitsXml {
         switch (holder.getReactiveLimits().getKind()) {
             case CURVE:
                 ReactiveCapabilityCurve curve = holder.getReactiveLimits(ReactiveCapabilityCurve.class);
-                context.getWriter().writeStartElement(IIDM_URI, ELEM_REACTIVE_CAPABILITY_CURVE);
+                context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), ELEM_REACTIVE_CAPABILITY_CURVE);
                 for (ReactiveCapabilityCurve.Point point : curve.getPoints()) {
-                    context.getWriter().writeEmptyElement(IIDM_URI, "point");
+                    context.getWriter().writeEmptyElement(context.getVersion().getNamespaceURI(), "point");
                     XmlUtil.writeDouble("p", point.getP(), context.getWriter());
                     XmlUtil.writeDouble(ATTR_MIN_Q, point.getMinQ(), context.getWriter());
                     XmlUtil.writeDouble(ATTR_MAX_Q, point.getMaxQ(), context.getWriter());
@@ -44,7 +42,7 @@ public class ReactiveLimitsXml {
 
             case MIN_MAX:
                 MinMaxReactiveLimits limits = holder.getReactiveLimits(MinMaxReactiveLimits.class);
-                context.getWriter().writeEmptyElement(IIDM_URI, ELEM_MIN_MAX_REACTIVE_LIMITS);
+                context.getWriter().writeEmptyElement(context.getVersion().getNamespaceURI(), ELEM_MIN_MAX_REACTIVE_LIMITS);
                 XmlUtil.writeDouble(ATTR_MIN_Q, limits.getMinQ(), context.getWriter());
                 XmlUtil.writeDouble(ATTR_MAX_Q, limits.getMaxQ(), context.getWriter());
                 break;

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/StaticVarCompensatorXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/StaticVarCompensatorXml.java
@@ -49,10 +49,9 @@ public class StaticVarCompensatorXml extends AbstractConnectableXml<StaticVarCom
 
     @Override
     protected void writeSubElements(StaticVarCompensator svc, VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
-        if (!Objects.equals(svc, svc.getRegulatingTerminal().getConnectable())) {
-            IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, REGULATING_TERMINAL, IidmXmlVersion.V_1_1, context);
-            TerminalRefXml.writeTerminalRef(svc.getRegulatingTerminal(), context, REGULATING_TERMINAL);
-        }
+        IidmXmlUtil.assertMinimumVersionAndRunIfNotDefault(!Objects.equals(svc, svc.getRegulatingTerminal().getConnectable()),
+                ROOT_ELEMENT_NAME, REGULATING_TERMINAL, IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED,
+                IidmXmlVersion.V_1_1, context, () -> TerminalRefXml.writeTerminalRef(svc.getRegulatingTerminal(), context, REGULATING_TERMINAL));
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/StaticVarCompensatorXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/StaticVarCompensatorXml.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.xml;
 
+import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.network.StaticVarCompensator;
 import com.powsybl.iidm.network.StaticVarCompensatorAdder;
@@ -48,10 +49,16 @@ public class StaticVarCompensatorXml extends AbstractConnectableXml<StaticVarCom
     }
 
     @Override
-    protected void writeSubElements(StaticVarCompensator svc, VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
+    protected void writeSubElements(StaticVarCompensator svc, VoltageLevel vl, NetworkXmlWriterContext context) {
         IidmXmlUtil.assertMinimumVersionAndRunIfNotDefault(!Objects.equals(svc, svc.getRegulatingTerminal().getConnectable()),
                 ROOT_ELEMENT_NAME, REGULATING_TERMINAL, IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED,
-                IidmXmlVersion.V_1_1, context, () -> TerminalRefXml.writeTerminalRef(svc.getRegulatingTerminal(), context, REGULATING_TERMINAL));
+                IidmXmlVersion.V_1_1, context, () -> {
+                try {
+                    TerminalRefXml.writeTerminalRef(svc.getRegulatingTerminal(), context, REGULATING_TERMINAL);
+                } catch (XMLStreamException e) {
+                    throw new UncheckedXmlStreamException(e);
+                }
+            });
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/StaticVarCompensatorXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/StaticVarCompensatorXml.java
@@ -50,6 +50,7 @@ public class StaticVarCompensatorXml extends AbstractConnectableXml<StaticVarCom
     @Override
     protected void writeSubElements(StaticVarCompensator svc, VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
         if (!Objects.equals(svc, svc.getRegulatingTerminal().getConnectable())) {
+            IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, REGULATING_TERMINAL, IidmXmlVersion.V_1_1, context);
             TerminalRefXml.writeTerminalRef(svc.getRegulatingTerminal(), context, REGULATING_TERMINAL);
         }
     }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TerminalRefXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TerminalRefXml.java
@@ -13,15 +13,13 @@ import com.powsybl.iidm.network.*;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
-import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
-
 /**
  * @author Mathieu Bague <mathieu.bague@rte-france.com>
  */
 public final class TerminalRefXml {
 
     public static void writeTerminalRef(Terminal t, NetworkXmlWriterContext context, String elementName) throws XMLStreamException {
-        writeTerminalRef(t, context, IIDM_URI, elementName);
+        writeTerminalRef(t, context, context.getVersion().getNamespaceURI(), elementName);
     }
 
     public static void writeTerminalRef(Terminal t, NetworkXmlWriterContext context, String namespace, String elementName) throws XMLStreamException {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
@@ -22,6 +22,11 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
 
     static final String ROOT_ELEMENT_NAME = "threeWindingsTransformer";
 
+    private static final String RATIO_TAP_CHANGER_1 = "ratioTapChanger1";
+    private static final String PHASE_TAP_CHANGER_1 = "phaseTapChanger1";
+    private static final String PHASE_TAP_CHANGER_2 = "phaseTapChanger2";
+    private static final String PHASE_TAP_CHANGER_3 = "phaseTapChanger3";
+
     @Override
     protected String getRootElementName() {
         return ROOT_ELEMENT_NAME;
@@ -49,15 +54,20 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
         XmlUtil.writeDouble("ratedU1", twt.getLeg1().getRatedU(), context.getWriter());
         XmlUtil.writeDouble("r2", twt.getLeg2().getR(), context.getWriter());
         XmlUtil.writeDouble("x2", twt.getLeg2().getX(), context.getWriter());
-        XmlUtil.writeDouble("g2", twt.getLeg2().getG(), context.getWriter());
-        XmlUtil.writeDouble("b2", twt.getLeg2().getB(), context.getWriter());
+        IidmXmlUtil.writeDoubleAttributeFromMinimumVersion(ROOT_ELEMENT_NAME, "g2", twt.getLeg2().getG(), 0,
+                IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
+        IidmXmlUtil.writeDoubleAttributeFromMinimumVersion(ROOT_ELEMENT_NAME, "b2", twt.getLeg2().getB(), 0,
+                IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
         XmlUtil.writeDouble("ratedU2", twt.getLeg2().getRatedU(), context.getWriter());
         XmlUtil.writeDouble("r3", twt.getLeg3().getR(), context.getWriter());
         XmlUtil.writeDouble("x3", twt.getLeg3().getX(), context.getWriter());
-        XmlUtil.writeDouble("g3", twt.getLeg3().getG(), context.getWriter());
-        XmlUtil.writeDouble("b3", twt.getLeg3().getB(), context.getWriter());
+        IidmXmlUtil.writeDoubleAttributeFromMinimumVersion(ROOT_ELEMENT_NAME, "g3", twt.getLeg3().getG(), 0,
+                IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
+        IidmXmlUtil.writeDoubleAttributeFromMinimumVersion(ROOT_ELEMENT_NAME, "b3", twt.getLeg3().getB(), 0,
+                IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
         XmlUtil.writeDouble("ratedU3", twt.getLeg3().getRatedU(), context.getWriter());
-        XmlUtil.writeDouble("ratedU0", twt.getRatedU0(), context.getWriter());
+        IidmXmlUtil.writeDoubleAttributeFromMinimumVersion(ROOT_ELEMENT_NAME, "ratedU0", twt.getRatedU0(), twt.getLeg1().getRatedU(),
+                IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
         writeNodeOrBus(1, twt.getLeg1().getTerminal(), context);
         writeNodeOrBus(2, twt.getLeg2().getTerminal(), context);
         writeNodeOrBus(3, twt.getLeg3().getTerminal(), context);
@@ -70,11 +80,19 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
 
     @Override
     protected void writeSubElements(ThreeWindingsTransformer twt, Substation s, NetworkXmlWriterContext context) throws XMLStreamException {
+        IidmXmlUtil.assertMinimumVersionIfNotDefault(twt.getLeg1().getRatioTapChanger() != null, ROOT_ELEMENT_NAME, RATIO_TAP_CHANGER_1,
+                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
         writeRatioTapChanger(twt.getLeg1().getRatioTapChanger(), 1, context);
+        IidmXmlUtil.assertMinimumVersionIfNotDefault(twt.getLeg1().getPhaseTapChanger() != null, ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_1,
+                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
         writePhaseTapChanger(twt.getLeg1().getPhaseTapChanger(), 1, context);
         writeRatioTapChanger(twt.getLeg2().getRatioTapChanger(), 2, context);
+        IidmXmlUtil.assertMinimumVersionIfNotDefault(twt.getLeg2().getPhaseTapChanger() != null, ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_2,
+                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
         writePhaseTapChanger(twt.getLeg2().getPhaseTapChanger(), 2, context);
         writeRatioTapChanger(twt.getLeg3().getRatioTapChanger(), 3, context);
+        IidmXmlUtil.assertMinimumVersionIfNotDefault(twt.getLeg3().getPhaseTapChanger() != null, ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_3,
+                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
         writePhaseTapChanger(twt.getLeg3().getPhaseTapChanger(), 3, context);
         if (twt.getLeg1().getCurrentLimits() != null) {
             writeCurrentLimits(1, twt.getLeg1().getCurrentLimits(), context.getWriter(), context.getVersion());
@@ -155,13 +173,13 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
                     readCurrentLimits(3, tx.getLeg3()::newCurrentLimits, context.getReader());
                     break;
 
-                case "ratioTapChanger1":
-                    IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, "ratioTapChanger1", IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
+                case RATIO_TAP_CHANGER_1:
+                    IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, RATIO_TAP_CHANGER_1, IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
                     readRatioTapChanger(1, tx.getLeg1(), context);
                     break;
 
-                case "phaseTapChanger1":
-                    IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, "phaseTapChanger1", IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
+                case PHASE_TAP_CHANGER_1:
+                    IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_1, IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
                     readPhaseTapChanger(1, tx.getLeg1(), context);
                     break;
 
@@ -169,8 +187,8 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
                     readRatioTapChanger(2, tx.getLeg2(), context);
                     break;
 
-                case "phaseTapChanger2":
-                    IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, "phaseTapChanger2", IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
+                case PHASE_TAP_CHANGER_2:
+                    IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_2, IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
                     readPhaseTapChanger(2, tx.getLeg2(), context);
                     break;
 
@@ -178,8 +196,8 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
                     readRatioTapChanger(3, tx.getLeg3(), context);
                     break;
 
-                case "phaseTapChanger3":
-                    IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, "phaseTapChanger3", IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
+                case PHASE_TAP_CHANGER_3:
+                    IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_3, IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
                     readPhaseTapChanger(3, tx.getLeg3(), context);
                     break;
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
@@ -77,13 +77,13 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
         writeRatioTapChanger(twt.getLeg3().getRatioTapChanger(), 3, context);
         writePhaseTapChanger(twt.getLeg3().getPhaseTapChanger(), 3, context);
         if (twt.getLeg1().getCurrentLimits() != null) {
-            writeCurrentLimits(1, twt.getLeg1().getCurrentLimits(), context.getWriter());
+            writeCurrentLimits(1, twt.getLeg1().getCurrentLimits(), context.getWriter(), context.getVersion());
         }
         if (twt.getLeg2().getCurrentLimits() != null) {
-            writeCurrentLimits(2, twt.getLeg2().getCurrentLimits(), context.getWriter());
+            writeCurrentLimits(2, twt.getLeg2().getCurrentLimits(), context.getWriter(), context.getVersion());
         }
         if (twt.getLeg3().getCurrentLimits() != null) {
-            writeCurrentLimits(3, twt.getLeg3().getCurrentLimits(), context.getWriter());
+            writeCurrentLimits(3, twt.getLeg3().getCurrentLimits(), context.getWriter(), context.getVersion());
         }
     }
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
@@ -24,7 +24,9 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
 
     private static final String RATIO_TAP_CHANGER_1 = "ratioTapChanger1";
     private static final String PHASE_TAP_CHANGER_1 = "phaseTapChanger1";
+    private static final String RATIO_TAP_CHANGER_2 = "ratioTapChanger2";
     private static final String PHASE_TAP_CHANGER_2 = "phaseTapChanger2";
+    private static final String RATIO_TAP_CHANGER_3 = "ratioTapChanger3";
     private static final String PHASE_TAP_CHANGER_3 = "phaseTapChanger3";
 
     @Override
@@ -183,7 +185,7 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
                     readPhaseTapChanger(1, tx.getLeg1(), context);
                     break;
 
-                case "ratioTapChanger2":
+                case RATIO_TAP_CHANGER_2:
                     readRatioTapChanger(2, tx.getLeg2(), context);
                     break;
 
@@ -192,7 +194,7 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
                     readPhaseTapChanger(2, tx.getLeg2(), context);
                     break;
 
-                case "ratioTapChanger3":
+                case RATIO_TAP_CHANGER_3:
                     readRatioTapChanger(3, tx.getLeg3(), context);
                     break;
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TieLineXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TieLineXml.java
@@ -64,10 +64,10 @@ class TieLineXml extends AbstractConnectableXml<TieLine, TieLineAdder, Network> 
     @Override
     protected void writeSubElements(TieLine tl, Network n, NetworkXmlWriterContext context) throws XMLStreamException {
         if (tl.getCurrentLimits1() != null) {
-            writeCurrentLimits(1, tl.getCurrentLimits1(), context.getWriter());
+            writeCurrentLimits(1, tl.getCurrentLimits1(), context.getWriter(), context.getVersion());
         }
         if (tl.getCurrentLimits2() != null) {
-            writeCurrentLimits(2, tl.getCurrentLimits2(), context.getWriter());
+            writeCurrentLimits(2, tl.getCurrentLimits2(), context.getWriter(), context.getVersion());
         }
     }
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TwoWindingsTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TwoWindingsTransformerXml.java
@@ -61,10 +61,10 @@ class TwoWindingsTransformerXml extends AbstractTransformerXml<TwoWindingsTransf
             writePhaseTapChanger("phaseTapChanger", ptc, context);
         }
         if (twt.getCurrentLimits1() != null) {
-            writeCurrentLimits(1, twt.getCurrentLimits1(), context.getWriter());
+            writeCurrentLimits(1, twt.getCurrentLimits1(), context.getWriter(), context.getVersion());
         }
         if (twt.getCurrentLimits2() != null) {
-            writeCurrentLimits(2, twt.getCurrentLimits2(), context.getWriter());
+            writeCurrentLimits(2, twt.getCurrentLimits2(), context.getWriter(), context.getVersion());
         }
     }
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -11,8 +11,6 @@ import com.powsybl.iidm.network.*;
 
 import javax.xml.stream.XMLStreamException;
 
-import static com.powsybl.iidm.xml.IidmXmlConstants.IIDM_URI;
-
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -77,7 +75,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     }
 
     private void writeNodeBreakerTopology(VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
-        context.getWriter().writeStartElement(IIDM_URI, NODE_BREAKER_TOPOLOGY_ELEMENT_NAME);
+        context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), NODE_BREAKER_TOPOLOGY_ELEMENT_NAME);
         context.getWriter().writeAttribute("nodeCount", Integer.toString(vl.getNodeBreakerView().getNodeCount()));
         for (BusbarSection bs : vl.getNodeBreakerView().getBusbarSections()) {
             BusbarSectionXml.INSTANCE.write(bs, null, context);
@@ -96,7 +94,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     }
 
     private void writeBusBreakerTopology(VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
-        context.getWriter().writeStartElement(IIDM_URI, BUS_BREAKER_TOPOLOGY_ELEMENT_NAME);
+        context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), BUS_BREAKER_TOPOLOGY_ELEMENT_NAME);
         for (Bus b : vl.getBusBreakerView().getBuses()) {
             if (!context.getFilter().test(b)) {
                 continue;
@@ -115,7 +113,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     }
 
     private void writeBusBranchTopology(VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
-        context.getWriter().writeStartElement(IIDM_URI, BUS_BREAKER_TOPOLOGY_ELEMENT_NAME);
+        context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), BUS_BREAKER_TOPOLOGY_ELEMENT_NAME);
         for (Bus b : vl.getBusView().getBuses()) {
             if (!context.getFilter().test(b)) {
                 continue;

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/XMLExporter.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/XMLExporter.java
@@ -72,6 +72,7 @@ public class XMLExporter implements Exporter {
     public static final String EXPORT_MODE = "iidm.export.xml.export-mode";
     public static final String EXTENSIONS_LIST = "iidm.export.xml.extensions";
     public static final String SKIP_EXTENSIONS = "iidm.export.xml.skip-extensions";
+    public static final String VERSION = "iidm.export.xml.version";
 
     private static final Parameter INDENT_PARAMETER = new Parameter(INDENT, ParameterType.BOOLEAN, "Indent export output file", Boolean.TRUE);
     private static final Parameter WITH_BRANCH_STATE_VARIABLES_PARAMETER = new Parameter(WITH_BRANCH_STATE_VARIABLES, ParameterType.BOOLEAN, "Export network with branch state variables", Boolean.TRUE);
@@ -82,6 +83,7 @@ public class XMLExporter implements Exporter {
     private static final Parameter EXPORT_MODE_PARAMETER = new Parameter(EXPORT_MODE, ParameterType.STRING, "export each extension in a separate file", String.valueOf(IidmImportExportMode.UNIQUE_FILE));
     private static final Parameter EXTENSIONS_LIST_PARAMETER = new Parameter(EXTENSIONS_LIST, ParameterType.STRING_LIST, "The list of exported extensions", null);
     private static final Parameter SKIP_EXTENSIONS_PARAMETER = new Parameter(SKIP_EXTENSIONS, ParameterType.BOOLEAN, "Skip exporting the extensions", Boolean.FALSE);
+    private static final Parameter VERSION_PARAMETER = new Parameter(VERSION, ParameterType.STRING, "IIDM-XML version in which files will be generated", IidmXmlConstants.CURRENT_IIDM_XML_VERSION.toString("."));
     private final ParameterDefaultValueConfig defaultValueConfig;
 
     public XMLExporter() {
@@ -116,7 +118,8 @@ public class XMLExporter implements Exporter {
                 .setThrowExceptionIfExtensionNotFound(ConversionParameters.readBooleanParameter(getFormat(), parameters, THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER, defaultValueConfig))
                 .setMode(IidmImportExportMode.valueOf(ConversionParameters.readStringParameter(getFormat(), parameters, EXPORT_MODE_PARAMETER, defaultValueConfig)))
                 .setSkipExtensions(ConversionParameters.readBooleanParameter(getFormat(), parameters, SKIP_EXTENSIONS_PARAMETER, defaultValueConfig))
-                .setExtensions(ConversionParameters.readStringListParameter(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig) != null ? new HashSet<>(ConversionParameters.readStringListParameter(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig)) : null);
+                .setExtensions(ConversionParameters.readStringListParameter(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig) != null ? new HashSet<>(ConversionParameters.readStringListParameter(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig)) : null)
+                .setVersion(ConversionParameters.readStringParameter(getFormat(), parameters, VERSION_PARAMETER, defaultValueConfig));
         try {
             long startTime = System.currentTimeMillis();
             NetworkXml.write(network, options, dataSource, "xiidm");

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml.util;
 
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.xml.AbstractNetworkXmlContext;
 import com.powsybl.iidm.xml.IidmXmlVersion;
 import com.powsybl.iidm.xml.NetworkXmlReaderContext;
 
@@ -30,7 +31,7 @@ public final class IidmXmlUtil {
      * Assert that the context's IIDM-XML version equals or is more recent than a given IIDM-XML version.
      * If not, throw an exception with a given type of error message.
      */
-    public static void assertMinimumVersion(String rootElementName, String elementName, ErrorMessage type, IidmXmlVersion minVersion, NetworkXmlReaderContext context) {
+    public static <C extends AbstractNetworkXmlContext> void assertMinimumVersion(String rootElementName, String elementName, ErrorMessage type, IidmXmlVersion minVersion, C context) {
         if (context.getVersion().compareTo(minVersion) < 0) {
             throw new PowsyblException(rootElementName + "." + elementName + " is " + type.message + " for IIDM-XML version " + context.getVersion().toString(".") + ". " +
                     "IIDM-XML version should be >= " + minVersion.toString("."));
@@ -41,7 +42,7 @@ public final class IidmXmlUtil {
      * Assert that the context's IIDM-XML version is strictly older than a given IIDM-XML version.
      * If not, throw an exception with a given type of error message.
      */
-    public static void assertStrictMaximumVersion(String rootElementName, String elementName, ErrorMessage type, IidmXmlVersion maxVersion, NetworkXmlReaderContext context) {
+    public static <C extends AbstractNetworkXmlContext> void assertStrictMaximumVersion(String rootElementName, String elementName, ErrorMessage type, IidmXmlVersion maxVersion, C context) {
         if (context.getVersion().compareTo(maxVersion) >= 0) {
             throw new PowsyblException(rootElementName + "." + elementName + " is " + type.message + " for IIDM-XML version " + context.getVersion().toString(".") + ". " +
                     "IIDM-XML version should be < " + maxVersion.toString("."));

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
@@ -21,10 +21,6 @@ import java.util.Objects;
  */
 public final class IidmXmlUtil {
 
-    public interface IidmXmlRunnable {
-        void run() throws XMLStreamException;
-    }
-
     public enum ErrorMessage {
         NOT_SUPPORTED("not supported"),
         MANDATORY("mandatory"),
@@ -70,7 +66,7 @@ public final class IidmXmlUtil {
      */
     public static <C extends AbstractNetworkXmlContext> void assertMinimumVersionAndRunIfNotDefault(boolean valueIsNotDefault, String rootElementName,
                                                                                                     String elementName, ErrorMessage type, IidmXmlVersion minVersion,
-                                                                                                    C context, IidmXmlRunnable runnable) throws XMLStreamException {
+                                                                                                    C context, Runnable runnable) {
         if (valueIsNotDefault) {
             assertMinimumVersion(rootElementName, elementName, type, minVersion, context);
             runnable.run();

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
@@ -7,18 +7,29 @@
 package com.powsybl.iidm.xml.util;
 
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.xml.AbstractNetworkXmlContext;
 import com.powsybl.iidm.xml.IidmXmlVersion;
 import com.powsybl.iidm.xml.NetworkXmlReaderContext;
+import com.powsybl.iidm.xml.NetworkXmlWriterContext;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.Objects;
 
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
  */
 public final class IidmXmlUtil {
 
+    public interface IidmXmlRunnable {
+        void run() throws XMLStreamException;
+    }
+
     public enum ErrorMessage {
         NOT_SUPPORTED("not supported"),
-        MANDATORY("mandatory");
+        MANDATORY("mandatory"),
+        NOT_NULL_NOT_SUPPORTED("not null and not supported"),
+        NOT_DEFAULT_NOT_SUPPORTED("not defined as default and not supported");
 
         private String message;
 
@@ -39,6 +50,34 @@ public final class IidmXmlUtil {
     }
 
     /**
+     * Assert that the context's IIDM-XML version equals or is more recent than a given IIDM-XML version if the value of an attribute or the state of an equipment
+     * is not default (interpretable for previous versions).
+     * If not, throw an exception with a given type of error message.
+     */
+    public static <C extends AbstractNetworkXmlContext> void assertMinimumVersionIfNotDefault(boolean valueIsNotDefault, String rootElementName,
+                                                                                              String elementName, ErrorMessage type, IidmXmlVersion minVersion,
+                                                                                              C context) {
+        if (valueIsNotDefault) {
+            assertMinimumVersion(rootElementName, elementName, type, minVersion, context);
+        }
+    }
+
+    /**
+     * Assert that the context's IIDM-XML version equals or is more recent than a given IIDM-XML version if the value of an attribute or the state of an equipment
+     * is not default (interpretable for previous versions).
+     * If not, throw an exception with a given type of error message.
+     * If the value is not default and no exception has been thrown, run a given runnable.
+     */
+    public static <C extends AbstractNetworkXmlContext> void assertMinimumVersionAndRunIfNotDefault(boolean valueIsNotDefault, String rootElementName,
+                                                                                                    String elementName, ErrorMessage type, IidmXmlVersion minVersion,
+                                                                                                    C context, IidmXmlRunnable runnable) throws XMLStreamException {
+        if (valueIsNotDefault) {
+            assertMinimumVersion(rootElementName, elementName, type, minVersion, context);
+            runnable.run();
+        }
+    }
+
+    /**
      * Assert that the context's IIDM-XML version is strictly older than a given IIDM-XML version.
      * If not, throw an exception with a given type of error message.
      */
@@ -50,7 +89,7 @@ public final class IidmXmlUtil {
     }
 
     /**
-     * Read an attribute which is <b>mandatory</b> from a given minimum IIDM-XML version. <br>
+     * Read a double attribute which is <b>mandatory</b> from a given minimum IIDM-XML version. <br>
      * If the context's IIDM-XML version is strictly older than the given minimum IIDM-XML version, the attribute <b>should not exist</b> (else an exception is thrown).
      * In this case, return Double.NaN <br>
      * If the context's IIDM-XML version equals or is more recent than the given minimum IIDM-XML version, the attribute <b>must exist</b> (else an exception is thrown).
@@ -61,7 +100,7 @@ public final class IidmXmlUtil {
     }
 
     /**
-     * Read an attribute which is <b>mandatory</b> from a given minimum IIDM-XML version. <br>
+     * Read a double attribute which is <b>mandatory</b> from a given minimum IIDM-XML version. <br>
      * If the context's IIDM-XML version is strictly older than the given minimum IIDM-XML version, the attribute <b>should not exist</b> (else an exception is thrown).
      * In this case, return a given defaultValue. <br>
      * If the context's IIDM-XML version equals or is more recent than the given minimum IIDM-XML version, the attribute <b>must exist</b> (else an exception is thrown).
@@ -75,6 +114,20 @@ public final class IidmXmlUtil {
             assertStrictMaximumVersion(rootElementName, attributeName, ErrorMessage.MANDATORY, minVersion, context);
         }
         return attributeStr == null ? defaultValue : Double.valueOf(attributeStr);
+    }
+
+    /**
+     * Write a <b>mandatory</b> double attribute from a given minimum IIDM-XML version.<br>
+     * If the context's IIDM-XML version is strictly older than the given minimum IIDM-XML version, the attribute's value <b>should be default</b>
+     * (else an exception is thrown).
+     */
+    public static void writeDoubleAttributeFromMinimumVersion(String rootElementName, String attributeName, double value, double defaultValue,
+                                                              ErrorMessage type, IidmXmlVersion minVersion, NetworkXmlWriterContext context) throws XMLStreamException {
+        if (context.getVersion().compareTo(minVersion) >= 0) {
+            XmlUtil.writeDouble(attributeName, value, context.getWriter());
+        } else {
+            assertMinimumVersionIfNotDefault(!Objects.equals(value, defaultValue), rootElementName, attributeName, type, minVersion, context);
+        }
     }
 
     private IidmXmlUtil() {

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
@@ -191,7 +191,12 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractXmlConverter
         assertSame(loadXml.getTerminal(), terminalMockExtXml.getTerminal());
 
         // backward compatibility 1.0
-        roundTripVersionnedXmlTest("eurostag-tutorial-example1-with-terminalMock-ext.xml", IidmXmlVersion.V_1_0);
+        //roundTripVersionnedXmlTest("eurostag-tutorial-example1-with-terminalMock-ext.xml", IidmXmlVersion.V_1_0); // TODO add versions mechanism for extensions
+        roundTripXmlTest(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0)
+                        + "eurostag-tutorial-example1-with-terminalMock-ext.xml")),
+                NetworkXml::writeAndValidate,
+                NetworkXml::validateAndRead,
+                getVersionDir(IidmXmlConstants.CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial-example1-with-terminalMock-ext.xml");
     }
 
     @Test

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
@@ -16,8 +16,6 @@ import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 
 /**

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
@@ -61,7 +61,7 @@ public class StaticVarCompensatorXmlTest extends AbstractXmlConverterTest {
     @Test
     public void writeFaultyVersionRegulatingSvcFile() throws IOException {
         exception.expect(PowsyblException.class);
-        exception.expectMessage("staticVarCompensator.regulatingTerminal is not supported for IIDM-XML version 1.0. " +
+        exception.expectMessage("staticVarCompensator.regulatingTerminal is not defined as default and not supported for IIDM-XML version 1.0. " +
                 "IIDM-XML version should be >= 1.1");
         try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             NetworkXml.write(SvcTestCaseFactory.createWithRemoteRegulatingTerminal(), new ExportOptions().setVersion("1.0"), os);

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
@@ -7,13 +7,16 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.export.ExportOptions;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.SvcTestCaseFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 
@@ -49,12 +52,22 @@ public class StaticVarCompensatorXmlTest extends AbstractXmlConverterTest {
     }
 
     @Test
-    public void faultyVersionRegulatingSvcFile() {
+    public void readFaultyVersionRegulatingSvcFile() {
         exception.expect(PowsyblException.class);
         exception.expectMessage("staticVarCompensator.regulatingTerminal is not supported for IIDM-XML version 1.0. " +
                 "IIDM-XML version should be >= 1.1");
         NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0) +
                 "faultyRegulatingStaticVarCompensatorRoundTripRef.xml"));
+    }
+
+    @Test
+    public void writeFaultyVersionRegulatingSvcFile() throws IOException {
+        exception.expect(PowsyblException.class);
+        exception.expectMessage("staticVarCompensator.regulatingTerminal is not supported for IIDM-XML version 1.0. " +
+                "IIDM-XML version should be >= 1.1");
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            NetworkXml.write(SvcTestCaseFactory.createWithRemoteRegulatingTerminal(), new ExportOptions().setVersion("1.0"), os);
+        }
     }
 
     private static void addProperties(Network network) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No



**What kind of change does this PR introduce?**
Feature



**What is the current behavior?**
IIDM-XML files can only be written in current IIDM-XML version (i.e. 1.1)



**What is the new behavior (if this is a feature change)?**
IIDM-XML files can now be written in current and previous IIDM-XML versions (i.e. 1.0 and 1.1)


**Does this PR introduce a breaking change or deprecate an API?** 
No

**Other information:**
:warning: Network extensions **cannot** for the moment be written in previous versions, it will be implemented in another PR
