### PR TITLE
Proposal to fix issue #1136 (regulating terminal is at busbar section)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ install.cfg
 .factorypath
 .project
 .factorypath
+.checkstyle
 org.eclipse.core.resources.prefs
 org.eclipse.jdt.core.prefs
 org.eclipse.m2e.core.prefs

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalRefTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalRefTest.java
@@ -6,9 +6,24 @@
  */
 package com.powsybl.iidm.xml;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 
+import com.powsybl.iidm.export.ExportOptions;
+import com.powsybl.iidm.network.BusbarSection;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Substation;
+import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.iidm.network.TopologyLevel;
+import com.powsybl.iidm.network.VoltageLevel;
+
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
@@ -19,5 +34,97 @@ public class TerminalRefTest extends AbstractXmlConverterTest {
     public void roundTripTest() throws IOException {
         roundTripAllVersionnedXmlTest("terminalRef.xiidm");
         roundTripAllVersionnedXmlTest("regulatingTerminal.xml");
+    }
+
+    @Test
+    public void testTerminalRefBusbarSection() {
+        // Check that a regulation that points to a busbar section is properly
+        // exported when IIDM XML topology level is configured as bus-breaker or bus-branch
+
+        Network network = createNetworkWithRegulatingTerminalToBusbarSection();
+
+        Network networkBusBreaker = exportImport(network, TopologyLevel.BUS_BREAKER);
+        checkGeneratorWasRegulatingBusbarSection(networkBusBreaker);
+
+        Network networkBusBranch = exportImport(network, TopologyLevel.BUS_BRANCH);
+        checkGeneratorWasRegulatingBusbarSection(networkBusBranch);
+    }
+
+    private Network exportImport(Network network, TopologyLevel topologyLevel) {
+        ExportOptions options = new ExportOptions();
+        options.setTopologyLevel(topologyLevel);
+        Path path = fileSystem.getPath("/terminalRefBusBarSection" + topologyLevel + ".xiidm");
+        NetworkXml.write(network, options, path);
+        Network network2 = NetworkXml.read(path);
+        return network2;
+    }
+
+    private static void checkGeneratorWasRegulatingBusbarSection(Network network) {
+        // Check the generator is regulating the only bus at high voltage
+        Terminal thv = network.getTwoWindingsTransformer("tx1").getTerminal1();
+        Terminal treg = network.getGenerator("g1").getRegulatingTerminal();
+        assertEquals(thv, treg);
+    }
+
+    private static Network createNetworkWithRegulatingTerminalToBusbarSection() {
+        Network network = Network.create("terminal-ref-busbarsection", "test")
+            .setCaseDate(DateTime.parse("2020-02-03T12:33:26.208+01:00"));
+
+        Substation s1 = network.newSubstation()
+            .setId("s1")
+            .setCountry(Country.ES)
+            .add();
+        VoltageLevel vlhv = s1.newVoltageLevel()
+            .setId("vlhv")
+            .setNominalV(400)
+            .setTopologyKind(TopologyKind.NODE_BREAKER)
+            .add();
+        VoltageLevel vlg = s1.newVoltageLevel()
+            .setId("vlg")
+            .setNominalV(16)
+            .setTopologyKind(TopologyKind.NODE_BREAKER)
+            .add();
+        vlhv.getNodeBreakerView().setNodeCount(2);
+        BusbarSection busbarSection = vlhv.getNodeBreakerView().newBusbarSection()
+            .setId("bbhv")
+            .setNode(0)
+            .add();
+        vlhv.getNodeBreakerView().newSwitch()
+            .setId("brhv")
+            .setNode1(0)
+            .setNode2(1)
+            .setKind(SwitchKind.BREAKER)
+            .add();
+        vlg.getNodeBreakerView().setNodeCount(2);
+        vlg.newGenerator()
+            .setId("g1")
+            .setNode(0)
+            .setMinP(0)
+            .setMaxP(100)
+            .setTargetP(10)
+            .setVoltageRegulatorOn(true)
+            .setTargetV(400)
+            .setRegulatingTerminal(busbarSection.getTerminal())
+            .add();
+        vlg.getNodeBreakerView().newSwitch()
+            .setId("brg")
+            .setNode1(0)
+            .setNode2(1)
+            .setKind(SwitchKind.BREAKER)
+            .add();
+        s1.newTwoWindingsTransformer()
+            .setId("tx1")
+            .setVoltageLevel1("vlhv")
+            .setVoltageLevel2("vlg")
+            .setNode1(1)
+            .setNode2(1)
+            .setR(10)
+            .setX(1)
+            .setG(0)
+            .setB(0)
+            .setRatedU1(400)
+            .setRatedU2(16)
+            .add();
+        return network;
     }
 }


### PR DESCRIPTION
Signed-off-by: Luma Zamarreño <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
A proposal to fix #1136 with the following approach:
When exporting a node-breaker network to bus-breaker or bus-branch topology levels, terminal references that point to busbar sections (elements that are only available at node-breaker level) are changed by references to the current bus of the regulating terminal, obtained from the proper topology view. 

