### PR TITLE
Modify the sensitivity API to allow for post-contingency sensitivity analyses

### DIFF
--- a/sensitivity-api/pom.xml
+++ b/sensitivity-api/pom.xml
@@ -93,6 +93,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-contingency-api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/sensitivity-api/pom.xml
+++ b/sensitivity-api/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>powsybl-loadflow-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-contingency-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -92,12 +97,6 @@
             <artifactId>powsybl-iidm-impl</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-contingency-api</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputation.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputation.java
@@ -7,6 +7,7 @@
 package com.powsybl.sensitivity;
 
 import com.powsybl.commons.Versionable;
+import com.powsybl.contingency.ContingenciesProvider;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -17,7 +18,7 @@ import java.util.concurrent.CompletableFuture;
  *     Sensitivity computation is used to assess the impact of a small modification
  *     of a network variables on the value of network functions.
  *     This computation can be assimilated to a partial derivative computed on a given
- *     network state.
+ *     network state and on that state modified based on a list of contingencies, if specified.
  * </p>
  * <p>
  *     PTDFs used in Flowbased methodology for example are sensitivity computation
@@ -28,12 +29,24 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface SensitivityComputation extends Versionable {
     /**
-     * Run an asynchronous sensitivity computation job using given parameters and input provider
+     * Run an asynchronous systematic sensitivity computation job using given parameters and input provider
+     *
+     * @param factorsProvider sensitivity factors provider for the computation
+     * @param contingenciesProvider contingencies provider for the computation
+     * @param workingStateId id of the network base state for the computation
+     * @param sensiParameters sensitivity computation parameters
+     * @return the sensitivity computation results in N and N-1
+     */
+    CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, ContingenciesProvider contingenciesProvider, String workingStateId, SensitivityComputationParameters sensiParameters);
+
+
+    /**
+     * Run an asynchronous single sensitivity computation job using given parameters and input provider
      *
      * @param factorsProvider sensitivity factors provider for the computation
      * @param workingStateId id of the network base state for the computation
      * @param sensiParameters sensitivity computation parameters
-     * @return the sensitivity computation results
+     * @return the sensitivity computation results on the given situation
      */
     CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, String workingStateId, SensitivityComputationParameters sensiParameters);
 

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputation.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputation.java
@@ -39,7 +39,7 @@ public interface SensitivityComputation extends Versionable {
     CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, String workingStateId, SensitivityComputationParameters sensiParameters);
 
     /**
-     * Run an asynchronous systematic sensitivity computation job using given parameters and input provider
+     * Run an asynchronous sensitivity analysis job using given parameters and input provider
      *
      * @param factorsProvider sensitivity factors provider for the computation
      * @param contingenciesProvider contingencies provider for the computation

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputation.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputation.java
@@ -29,18 +29,6 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface SensitivityComputation extends Versionable {
     /**
-     * Run an asynchronous systematic sensitivity computation job using given parameters and input provider
-     *
-     * @param factorsProvider sensitivity factors provider for the computation
-     * @param contingenciesProvider contingencies provider for the computation
-     * @param workingStateId id of the network base state for the computation
-     * @param sensiParameters sensitivity computation parameters
-     * @return the sensitivity computation results in N and N-1
-     */
-    CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, ContingenciesProvider contingenciesProvider, String workingStateId, SensitivityComputationParameters sensiParameters);
-
-
-    /**
      * Run an asynchronous single sensitivity computation job using given parameters and input provider
      *
      * @param factorsProvider sensitivity factors provider for the computation
@@ -50,4 +38,16 @@ public interface SensitivityComputation extends Versionable {
      */
     CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, String workingStateId, SensitivityComputationParameters sensiParameters);
 
+    /**
+     * Run an asynchronous systematic sensitivity computation job using given parameters and input provider
+     *
+     * @param factorsProvider sensitivity factors provider for the computation
+     * @param contingenciesProvider contingencies provider for the computation
+     * @param workingStateId id of the network base state for the computation
+     * @param sensiParameters sensitivity computation parameters
+     * @return the sensitivity computation results in N and N-1
+     */
+    default CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, ContingenciesProvider contingenciesProvider, String workingStateId, SensitivityComputationParameters sensiParameters) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 }

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
@@ -9,21 +9,30 @@ package com.powsybl.sensitivity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * Sensitivity computation results
  *
  * <p>
- *     Mainly composed of the list of sensitivity values
+ *     Mainly composed of the lists of sensitivity values in N, and optionally in N-1
  * </p>
+ *
+ * A single sensitivity computation should return, besides its status and some stats on the
+ * computation itself, all the sensitivity values for each factor (combination of a monitoredBranch and a specific
+ * equipment or group of equipments). The HADES2 sensitivity provider used with Powsybl offers the
+ * possibility to calculate the sensitivity on a set of contingencies besides the N state. It is a kind of
+ * systematic sensitivity computation where the computation is launched only once, but the solver itself
+ * modifies the matrix for each state of the network to output a full set of results.
+ * In the sensitivity API, at the moment it has been allowed to provide a list of contingencies as an optional input,
+ * which then triggers such a one-run systematic sensitivity computation.
+ * The full set of results then consists of :
+ *  - the list of sensitivity values in N
+ *  - the lists of sensitivity values for each N-1 situation
+ *  - some metadata (status, stats, logs)
+ * TODO: provide a systematic sensitivity API on the basis of the security-analysis API
+ *
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  * @see SensitivityValue
  */
@@ -41,23 +50,34 @@ public class SensitivityComputationResults {
     @JsonProperty("values")
     private final List<SensitivityValue> sensitivityValues;
 
+    @JsonProperty("contingencies present")
+    private final boolean contingenciesPresent;
+
+    @JsonProperty("contingencies values")
+    private final Map<String, List<SensitivityValue>> sensitivityValuesContingencies;
+
     /**
      * Hades2 sensitivity computation results
      *
      * @param ok true if the computation succeeded, false otherwise
      * @param metrics map of metrics about the computation
      * @param logs computation logs
-     * @param values result values of the senstivity computation. Must be non null.
+     * @param sensitivityValues result values of the senstivity computation in N
+     * @param sensitivityValuesContingencies result values of the senstivity computation on contingencies
      */
     @JsonCreator
     public SensitivityComputationResults(@JsonProperty("ok") boolean ok,
                                          @JsonProperty("metrics") Map<String, String> metrics,
                                          @JsonProperty("logs") String logs,
-                                         @JsonProperty("values") List<SensitivityValue> values) {
+                                         @JsonProperty("values") List<SensitivityValue> sensitivityValues,
+                                         @JsonProperty("contingencies present") boolean contingenciesPresent,
+                                         @JsonProperty("contingencyId values") Map<String, List<SensitivityValue>> sensitivityValuesContingencies) {
         this.ok = ok;
         this.metrics = Objects.requireNonNull(metrics);
         this.logs = Objects.requireNonNull(logs);
-        this.sensitivityValues = Objects.requireNonNull(values);
+        this.sensitivityValues = Objects.requireNonNull(sensitivityValues);
+        this.contingenciesPresent = contingenciesPresent;
+        this.sensitivityValuesContingencies = sensitivityValuesContingencies;
     }
 
     /**
@@ -89,44 +109,45 @@ public class SensitivityComputationResults {
     }
 
     /**
-     * Get a collection of all the sensitivity values.
+     * Get a collection of all the sensitivity values in state N.
      *
-     * @return a collection of all the sensitivity values.
+     * @return a collection of all the sensitivity values in state N.
      */
     public Collection<SensitivityValue> getSensitivityValues() {
         return Collections.unmodifiableCollection(sensitivityValues);
     }
 
+
     /**
-     * Get a collection of all the sensitivity values associated with given function.
+     * Get a collection of all the sensitivity values associated with given function in state N.
      *
      * @param function sensitivity function
-     * @return a collection of all the sensitivity values associated with given function
+     * @return a collection of all the sensitivity values associated with given function in state N.
      */
     public Collection<SensitivityValue> getSensitivityValuesByFunction(SensitivityFunction function) {
         return sensitivityValues.stream().filter(sensitivityValue -> sensitivityValue.getFactor().getFunction().equals(function)).collect(Collectors.toList());
     }
 
     /**
-     * Get a collection of all the sensitivity values associated with given variable
+     * Get a collection of all the sensitivity values associated with given variable in state N.
      *
      * @param variable sensitivity variable
-     * @return a collection of all the sensitivity values associated with given variable
+     * @return a collection of all the sensitivity values associated with given variable in state N.
      */
     public Collection<SensitivityValue> getSensitivityValuesByVariable(SensitivityVariable variable) {
         return sensitivityValues.stream().filter(sensitivityValue -> sensitivityValue.getFactor().getVariable().equals(variable)).collect(Collectors.toList());
     }
 
     /**
-     * Get the sensitivity value associated with given function and given variable
+     * Get the sensitivity value associated with given function and given variable in state N.
      *
      * @param function sensitivity function
      * @param variable sensitivity variable
-     * @return the sensitivity value associated with given function and given variable
+     * @return the sensitivity value associated with given function and given variable in state N.
      */
     public SensitivityValue getSensitivityValue(SensitivityFunction function, SensitivityVariable variable) {
         Optional<SensitivityValue> returnValue = sensitivityValues.stream().filter(sensitivityValue -> sensitivityValue.getFactor().getFunction().equals(function)
-            && sensitivityValue.getFactor().getVariable().equals(variable)).findAny();
+                && sensitivityValue.getFactor().getVariable().equals(variable)).findAny();
         if (!returnValue.isPresent()) {
             throw new NoSuchElementException(String.format("Sensitivity value not found for function %s and variable %s.", function.getId(), variable.getId()));
         }
@@ -134,10 +155,10 @@ public class SensitivityComputationResults {
     }
 
     /**
-     * Get the sensitivity value associated with given factor
+     * Get the sensitivity value associated with given factor in state N.
      *
      * @param factor sensitivity factor
-     * @return the sensitivity value associated with given function and given variable
+     * @return the sensitivity value associated with given function and given variable in state N.
      */
     public SensitivityValue getSensitivityValue(SensitivityFactor factor) {
         Optional<SensitivityValue> returnValue = sensitivityValues.stream().filter(sensitivityValue -> sensitivityValue.getFactor().equals(factor)).findAny();
@@ -145,5 +166,94 @@ public class SensitivityComputationResults {
             throw new NoSuchElementException(String.format("Sensitivity value not found for function %s and variable %s.", factor.getFunction().getId(), factor.getVariable().getId()));
         }
         return returnValue.get();
+    }
+
+    /**
+     * Get the status of the presence of contingencies
+     *
+     * @return true if the computation contains contingencies, false otherwise
+     */
+    public boolean contingenciesArePresent() {
+        return contingenciesPresent;
+    }
+
+    /**
+     * Get a collection of all the sensitivity values for all contingencies.
+     *
+     * @return a collection of all the sensitivity values for all contingencies.
+     */
+    public Map<String, List<SensitivityValue>> getSensitivityValuesContingencies() {
+        return sensitivityValuesContingencies;
+    }
+
+    /**
+     * Get a collection of all the sensitivity values for a contingency.
+     *
+     * @return a collection of all the sensitivity values for a given contingency.
+     */
+    public Collection<SensitivityValue> getSensitivityValuesContingency(String contingencyId) {
+        return Collections.unmodifiableCollection(sensitivityValuesContingencies.get(contingencyId));
+    }
+
+    /**
+     * Get a collection of all the sensitivity values associated with given function
+     * for a specific contingency.
+     *
+     * @param function sensitivity function
+     * @param contingencyId the ID of the considered contingency
+     * @return a collection of all the sensitivity values associated with given function for the given contingencyId
+     */
+    public Collection<SensitivityValue> getSensitivityValuesByFunction(SensitivityFunction function, String contingencyId) {
+        return sensitivityValuesContingencies.get(contingencyId).stream().filter(sensitivityValue -> sensitivityValue.getFactor().getFunction().equals(function)).collect(Collectors.toList());
+    }
+
+    /**
+     * Get a collection of all the sensitivity values associated with given variable
+     * for a specific contingency.
+     *
+     * @param variable sensitivity variable
+     * @param contingencyId the ID of the considered contingency
+     * @return a collection of all the sensitivity values associated with given variable
+     */
+    public Collection<SensitivityValue> getSensitivityValuesByVariable(SensitivityVariable variable, String contingencyId) {
+        return sensitivityValuesContingencies.get(contingencyId).stream().filter(sensitivityValue -> sensitivityValue.getFactor().getVariable().equals(variable)).collect(Collectors.toList());
+    }
+
+    /**
+     * Get the sensitivity value associated with given function and given variable for a specific contingency.
+     *
+     * @param function sensitivity function
+     * @param variable sensitivity variable
+     * @param contingencyId the ID of the considered contingency
+     * @return the sensitivity value associated with given function and given variable
+     */
+    public SensitivityValue getSensitivityValue(SensitivityFunction function, SensitivityVariable variable, String contingencyId) {
+        Optional<SensitivityValue> returnValue;
+        returnValue = sensitivityValuesContingencies.get(contingencyId).stream().filter(sensitivityValue -> sensitivityValue.getFactor().getFunction().equals(function)
+                && sensitivityValue.getFactor().getVariable().equals(variable)).findAny();
+        if (!returnValue.isPresent()) {
+            throw new NoSuchElementException(String.format("Sensitivity value not found for function %s and variable %s at contingencyId %s.", function.getId(), variable.getId(), contingencyId));
+        }
+        return returnValue.get();
+    }
+
+    /**
+     * Get the sensitivity value associated with given factor for a specific contingency
+     *
+     * @param factor sensitivity factor
+     * @param contingencyId the ID of the considered contingency
+     * @return the sensitivity value associated with given function and given variable
+     */
+    public SensitivityValue getSensitivityValue(SensitivityFactor factor, String contingencyId) {
+        Optional<SensitivityValue> returnValue;
+        returnValue = sensitivityValuesContingencies.get(contingencyId).stream().filter(sensitivityValue -> sensitivityValue.getFactor().equals(factor)).findAny();
+        if (!returnValue.isPresent()) {
+            throw new NoSuchElementException(String.format("Sensitivity value not found for function %s and variable %s.", factor.getFunction().getId(), factor.getVariable().getId()));
+        }
+        return returnValue.get();
+    }
+
+    public static SensitivityComputationResults empty() {
+        return new SensitivityComputationResults(false, Collections.emptyMap(), "", Collections.emptyList(), false, Collections.emptyMap());
     }
 }

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 public class SensitivityComputationResults {
 
     private static final String VALUE_NOT_FOUND = "Sensitivity value not found for function %s and variable %s.";
+    private static final String VALUE_NOT_FOUND_CONTINGENCY = "Sensitivity value not found for function %s and variable %s at contingencyId %s.";
 
     @JsonProperty("ok")
     private final boolean ok;
@@ -225,7 +226,7 @@ public class SensitivityComputationResults {
                 .filter(sensitivityValue -> sensitivityValue.getFactor().getFunction().equals(function)
                         && sensitivityValue.getFactor().getVariable().equals(variable))
                 .findFirst()
-                .orElseThrow(() -> new NoSuchElementException(String.format("Sensitivity value not found for function %s and variable %s at contingencyId %s.", function.getId(), variable.getId(), contingencyId)));
+                .orElseThrow(() -> new NoSuchElementException(String.format(VALUE_NOT_FOUND_CONTINGENCY, function.getId(), variable.getId(), contingencyId)));
     }
 
     /**

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
@@ -22,12 +22,12 @@ import java.util.stream.Collectors;
  * A single sensitivity computation should return, besides its status and some stats on the
  * computation itself, all the sensitivity values for each factor (combination of a monitoredBranch and a specific
  * equipment or group of equipments). The HADES2 sensitivity provider used with Powsybl offers the
- * possibility to calculate the sensitivity on a set of contingencies besides the N state. It is a kind of
- * systematic sensitivity computation where the computation is launched only once, but the solver itself
+ * possibility to calculate the sensitivity on a set of contingencies besides the N state.
+ * The computation is launched only once, but the solver itself
  * modifies the matrix for each state of the network to output a full set of results.
- * In the sensitivity API, at the moment it has been allowed to provide a list of contingencies as an optional input,
- * which then triggers such a one-run systematic sensitivity computation.
- * The full set of results then consists of :
+ * In the sensitivity API, it has been allowed to provide a list of contingencies as an optional input,
+ * which then triggers such a sensitivity analysis.
+ * The full set of results consists of :
  *  - the list of sensitivity values in N
  *  - the lists of sensitivity values for each N-1 situation
  *  - some metadata (status, stats, logs)

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
@@ -31,12 +31,13 @@ import java.util.stream.Collectors;
  *  - the list of sensitivity values in N
  *  - the lists of sensitivity values for each N-1 situation
  *  - some metadata (status, stats, logs)
- * TODO: provide a systematic sensitivity API on the basis of the security-analysis API
  *
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  * @see SensitivityValue
  */
 public class SensitivityComputationResults {
+
+    private static final String VALUE_NOT_FOUND = "Sensitivity value not found for function %s and variable %s.";
 
     @JsonProperty("ok")
     private final boolean ok;
@@ -149,7 +150,7 @@ public class SensitivityComputationResults {
         Optional<SensitivityValue> returnValue = sensitivityValues.stream().filter(sensitivityValue -> sensitivityValue.getFactor().getFunction().equals(function)
                 && sensitivityValue.getFactor().getVariable().equals(variable)).findAny();
         if (!returnValue.isPresent()) {
-            throw new NoSuchElementException(String.format("Sensitivity value not found for function %s and variable %s.", function.getId(), variable.getId()));
+            throw new NoSuchElementException(String.format(VALUE_NOT_FOUND, function.getId(), variable.getId()));
         }
         return returnValue.get();
     }
@@ -163,7 +164,7 @@ public class SensitivityComputationResults {
     public SensitivityValue getSensitivityValue(SensitivityFactor factor) {
         Optional<SensitivityValue> returnValue = sensitivityValues.stream().filter(sensitivityValue -> sensitivityValue.getFactor().equals(factor)).findAny();
         if (!returnValue.isPresent()) {
-            throw new NoSuchElementException(String.format("Sensitivity value not found for function %s and variable %s.", factor.getFunction().getId(), factor.getVariable().getId()));
+            throw new NoSuchElementException(String.format(VALUE_NOT_FOUND, factor.getFunction().getId(), factor.getVariable().getId()));
         }
         return returnValue.get();
     }
@@ -184,15 +185,6 @@ public class SensitivityComputationResults {
      */
     public Map<String, List<SensitivityValue>> getSensitivityValuesContingencies() {
         return sensitivityValuesContingencies;
-    }
-
-    /**
-     * Get a collection of all the sensitivity values for a contingency.
-     *
-     * @return a collection of all the sensitivity values for a given contingency.
-     */
-    public Collection<SensitivityValue> getSensitivityValuesContingency(String contingencyId) {
-        return Collections.unmodifiableCollection(sensitivityValuesContingencies.get(contingencyId));
     }
 
     /**
@@ -248,7 +240,7 @@ public class SensitivityComputationResults {
         Optional<SensitivityValue> returnValue;
         returnValue = sensitivityValuesContingencies.get(contingencyId).stream().filter(sensitivityValue -> sensitivityValue.getFactor().equals(factor)).findAny();
         if (!returnValue.isPresent()) {
-            throw new NoSuchElementException(String.format("Sensitivity value not found for function %s and variable %s.", factor.getFunction().getId(), factor.getVariable().getId()));
+            throw new NoSuchElementException(String.format(VALUE_NOT_FOUND, factor.getFunction().getId(), factor.getVariable().getId()));
         }
         return returnValue.get();
     }

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationTool.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationTool.java
@@ -142,11 +142,9 @@ public class SensitivityComputationTool implements Tool {
         SensitivityFactorsProvider factorsProvider = factorsProviderFactory.create(sensitivityFactorsFile);
 
         SensitivityComputationResults result;
-
         if (line.hasOption(CONTINGENCIES_FILE_OPTION)) {
             ContingenciesProviderFactory contingenciesProviderFactory = defaultConfig.newFactoryImpl(ContingenciesProviderFactory.class);
-            Path contingenciesFile = context.getFileSystem().getPath(line.getOptionValue(CONTINGENCIES_FILE_OPTION));
-            ContingenciesProvider contingenciesProvider = contingenciesProviderFactory.create(contingenciesFile);
+            ContingenciesProvider contingenciesProvider = contingenciesProviderFactory.create(context.getFileSystem().getPath(line.getOptionValue(CONTINGENCIES_FILE_OPTION)));
             result = sensitivityComputation.run(factorsProvider, contingenciesProvider, workingStateId, params).join();
         } else {
             result = sensitivityComputation.run(factorsProvider, workingStateId, params).join();

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationTool.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationTool.java
@@ -9,6 +9,8 @@ package com.powsybl.sensitivity;
 import com.google.auto.service.AutoService;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.config.ComponentDefaultConfig;
+import com.powsybl.contingency.ContingenciesProvider;
+import com.powsybl.contingency.ContingenciesProviderFactory;
 import com.powsybl.iidm.import_.ImportConfig;
 import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.Network;
@@ -41,6 +43,7 @@ public class SensitivityComputationTool implements Tool {
     private static final String OUTPUT_FORMAT_OPTION = "output-format";
     private static final String SKIP_POSTPROC_OPTION = "skip-postproc";
     private static final String FACTORS_FILE_OPTION = "factors-file";
+    private static final String CONTINGENCIES_FILE_OPTION = "contingencies-file";
 
     @Override
     public Command getCommand() {
@@ -74,6 +77,11 @@ public class SensitivityComputationTool implements Tool {
                         .hasArg()
                         .argName("FILE")
                         .required()
+                        .build());
+                options.addOption(Option.builder().longOpt(CONTINGENCIES_FILE_OPTION)
+                        .desc("contingencies input file path")
+                        .hasArg()
+                        .argName("FILE")
                         .build());
                 options.addOption(Option.builder().longOpt(OUTPUT_FILE_OPTION)
                         .desc("sensitivity computation results output path")
@@ -132,7 +140,17 @@ public class SensitivityComputationTool implements Tool {
         String workingStateId = network.getVariantManager().getWorkingVariantId();
         SensitivityFactorsProviderFactory factorsProviderFactory = defaultConfig.newFactoryImpl(SensitivityFactorsProviderFactory.class);
         SensitivityFactorsProvider factorsProvider = factorsProviderFactory.create(sensitivityFactorsFile);
-        SensitivityComputationResults result = sensitivityComputation.run(factorsProvider, workingStateId, params).join();
+
+        SensitivityComputationResults result;
+
+        if (line.hasOption(CONTINGENCIES_FILE_OPTION)) {
+            ContingenciesProviderFactory contingenciesProviderFactory = defaultConfig.newFactoryImpl(ContingenciesProviderFactory.class);
+            Path contingenciesFile = context.getFileSystem().getPath(line.getOptionValue(CONTINGENCIES_FILE_OPTION));
+            ContingenciesProvider contingenciesProvider = contingenciesProviderFactory.create(contingenciesFile);
+            result = sensitivityComputation.run(factorsProvider, contingenciesProvider, workingStateId, params).join();
+        } else {
+            result = sensitivityComputation.run(factorsProvider, workingStateId, params).join();
+        }
 
         if (!result.isOk()) {
             context.getErrorStream().println("Initial state divergence");

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporter.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporter.java
@@ -45,7 +45,7 @@ public class CsvSensitivityComputationResultExporter implements SensitivityCompu
 
     @Override
     public String getComment() {
-        return "Export a systematic sensitivity computation result in CSV format";
+        return "Export a sensitivity analysis result in CSV format";
     }
 
     @Override

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporter.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporter.java
@@ -63,6 +63,24 @@ public class CsvSensitivityComputationResultExporter implements SensitivityCompu
                     throw new UncheckedIOException(e);
                 }
             });
+            if (result.contingenciesArePresent()) {
+                result.getSensitivityValuesContingencies().forEach((contId, sensitivityValues) -> {
+                    sensitivityValues.forEach(sensitivityValue -> {
+                        try {
+                            formatter.writeCell("Contingency " + contId);
+                            formatter.writeCell(sensitivityValue.getFactor().getVariable().getId());
+                            formatter.writeCell(sensitivityValue.getFactor().getVariable().getName());
+                            formatter.writeCell(sensitivityValue.getFactor().getFunction().getId());
+                            formatter.writeCell(sensitivityValue.getFactor().getFunction().getName());
+                            formatter.writeCell(sensitivityValue.getVariableReference());
+                            formatter.writeCell(sensitivityValue.getFunctionReference());
+                            formatter.writeCell(sensitivityValue.getValue());
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
+                });
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporter.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporter.java
@@ -9,6 +9,7 @@ package com.powsybl.sensitivity.converter;
 import com.google.auto.service.AutoService;
 import com.powsybl.commons.io.table.*;
 import com.powsybl.sensitivity.SensitivityComputationResults;
+import com.powsybl.sensitivity.SensitivityValue;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -26,6 +27,17 @@ public class CsvSensitivityComputationResultExporter implements SensitivityCompu
 
     private static final char CSV_SEPARATOR = ',';
 
+    private void writeCells(TableFormatter formatter, SensitivityValue sensitivityValue, String state) throws IOException {
+        formatter.writeCell(state);
+        formatter.writeCell(sensitivityValue.getFactor().getVariable().getId());
+        formatter.writeCell(sensitivityValue.getFactor().getVariable().getName());
+        formatter.writeCell(sensitivityValue.getFactor().getFunction().getId());
+        formatter.writeCell(sensitivityValue.getFactor().getFunction().getName());
+        formatter.writeCell(sensitivityValue.getVariableReference());
+        formatter.writeCell(sensitivityValue.getFunctionReference());
+        formatter.writeCell(sensitivityValue.getValue());
+    }
+
     @Override
     public String getFormat() {
         return "CSV";
@@ -33,7 +45,7 @@ public class CsvSensitivityComputationResultExporter implements SensitivityCompu
 
     @Override
     public String getComment() {
-        return "Export a security analysis result in CSV format";
+        return "Export a systematic sensitivity computation result in CSV format";
     }
 
     @Override
@@ -51,35 +63,19 @@ public class CsvSensitivityComputationResultExporter implements SensitivityCompu
                 new Column("SensitivityValue"))) {
             result.getSensitivityValues().forEach(sensitivityValue -> {
                 try {
-                    formatter.writeCell("State N");
-                    formatter.writeCell(sensitivityValue.getFactor().getVariable().getId());
-                    formatter.writeCell(sensitivityValue.getFactor().getVariable().getName());
-                    formatter.writeCell(sensitivityValue.getFactor().getFunction().getId());
-                    formatter.writeCell(sensitivityValue.getFactor().getFunction().getName());
-                    formatter.writeCell(sensitivityValue.getVariableReference());
-                    formatter.writeCell(sensitivityValue.getFunctionReference());
-                    formatter.writeCell(sensitivityValue.getValue());
+                    writeCells(formatter, sensitivityValue, "State N");
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
             });
             if (result.contingenciesArePresent()) {
-                result.getSensitivityValuesContingencies().forEach((contId, sensitivityValues) -> {
-                    sensitivityValues.forEach(sensitivityValue -> {
-                        try {
-                            formatter.writeCell("Contingency " + contId);
-                            formatter.writeCell(sensitivityValue.getFactor().getVariable().getId());
-                            formatter.writeCell(sensitivityValue.getFactor().getVariable().getName());
-                            formatter.writeCell(sensitivityValue.getFactor().getFunction().getId());
-                            formatter.writeCell(sensitivityValue.getFactor().getFunction().getName());
-                            formatter.writeCell(sensitivityValue.getVariableReference());
-                            formatter.writeCell(sensitivityValue.getFunctionReference());
-                            formatter.writeCell(sensitivityValue.getValue());
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
-                    });
-                });
+                result.getSensitivityValuesContingencies().forEach((contId, sensitivityValues) -> sensitivityValues.forEach(sensitivityValue -> {
+                    try {
+                        writeCells(formatter, sensitivityValue, "Contingency " + contId);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }));
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/SensitivityComputationResultExporter.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/SensitivityComputationResultExporter.java
@@ -30,7 +30,7 @@ public interface SensitivityComputationResultExporter {
     String getComment();
 
     /**
-     * Export a result of a sensitivity computation
+     * Export a result of a sensitivity computation without contingency
      *
      * @param result The result of the sensitivity computation
      * @param writer The writer used for the export

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/SensitivityComputationResultExporter.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/converter/SensitivityComputationResultExporter.java
@@ -30,7 +30,7 @@ public interface SensitivityComputationResultExporter {
     String getComment();
 
     /**
-     * Export a result of a sensitivity computation without contingency
+     * Export a result of a sensitivity computation
      *
      * @param result The result of the sensitivity computation
      * @param writer The writer used for the export

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMock.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMock.java
@@ -7,6 +7,8 @@
 package com.powsybl.sensitivity.mock;
 
 import com.powsybl.computation.ComputationManager;
+import com.powsybl.contingency.ContingenciesProvider;
+import com.powsybl.contingency.Contingency;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.sensitivity.SensitivityComputation;
 import com.powsybl.sensitivity.SensitivityComputationFactory;
@@ -17,6 +19,7 @@ import com.powsybl.sensitivity.SensitivityValue;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -25,10 +28,23 @@ public class SensitivityComputationFactoryMock implements SensitivityComputation
     public SensitivityComputation create(Network network, ComputationManager computationManager, int priority) {
         return new SensitivityComputation() {
             @Override
-            public CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, String workingStateId, SensitivityComputationParameters sensiParameters) {
-                List<SensitivityValue> sensitivityValues = factorsProvider.getFactors(network).stream().map(factor -> new SensitivityValue(factor, Math.random(), Math.random(), Math.random())).collect(Collectors.toList());
-                SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValues);
+            public CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, ContingenciesProvider contingenciesProvider, String workingStateId, SensitivityComputationParameters sensiParameters) {
+                List<SensitivityValue> sensitivityValuesN = factorsProvider.getFactors(network).stream().map(factor -> new SensitivityValue(factor, Math.random(), Math.random(), Math.random())).collect(Collectors.toList());
+                Map<String, List<SensitivityValue>> sensitivityValuesContingencies = Collections.emptyMap();
+                SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValuesN, false, sensitivityValuesContingencies);
                 return CompletableFuture.completedFuture(results);
+            }
+
+            @Deprecated
+            @Override
+            public CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, String workingStateId, SensitivityComputationParameters sensiParameters) {
+                final ContingenciesProvider contingenciesProvider = new ContingenciesProvider() {
+                    @Override
+                    public List<Contingency> getContingencies(Network network) {
+                        return null;
+                    }
+                };
+                return run(factorsProvider, contingenciesProvider, workingStateId, sensiParameters);
             }
 
             @Override

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMock.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMock.java
@@ -8,14 +8,8 @@ package com.powsybl.sensitivity.mock;
 
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.contingency.ContingenciesProvider;
-import com.powsybl.contingency.Contingency;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.sensitivity.SensitivityComputation;
-import com.powsybl.sensitivity.SensitivityComputationFactory;
-import com.powsybl.sensitivity.SensitivityComputationParameters;
-import com.powsybl.sensitivity.SensitivityComputationResults;
-import com.powsybl.sensitivity.SensitivityFactorsProvider;
-import com.powsybl.sensitivity.SensitivityValue;
+import com.powsybl.sensitivity.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -30,21 +24,19 @@ public class SensitivityComputationFactoryMock implements SensitivityComputation
             @Override
             public CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, ContingenciesProvider contingenciesProvider, String workingStateId, SensitivityComputationParameters sensiParameters) {
                 List<SensitivityValue> sensitivityValuesN = factorsProvider.getFactors(network).stream().map(factor -> new SensitivityValue(factor, Math.random(), Math.random(), Math.random())).collect(Collectors.toList());
-                Map<String, List<SensitivityValue>> sensitivityValuesContingencies = Collections.emptyMap();
-                SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValuesN, false, sensitivityValuesContingencies);
+                List<SensitivityValue> sensitivityValuesContingency = factorsProvider.getFactors(network).stream().map(factor -> new SensitivityValue(factor, Math.random(), Math.random(), Math.random())).collect(Collectors.toList());
+
+                Map<String, List<SensitivityValue>> sensitivityValuesContingencies = Collections.singletonMap(contingenciesProvider.getContingencies(network).get(0).getId(), sensitivityValuesContingency);
+                SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValuesN, true, sensitivityValuesContingencies);
                 return CompletableFuture.completedFuture(results);
             }
 
             @Deprecated
             @Override
             public CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, String workingStateId, SensitivityComputationParameters sensiParameters) {
-                final ContingenciesProvider contingenciesProvider = new ContingenciesProvider() {
-                    @Override
-                    public List<Contingency> getContingencies(Network network) {
-                        return null;
-                    }
-                };
-                return run(factorsProvider, contingenciesProvider, workingStateId, sensiParameters);
+                List<SensitivityValue> sensitivityValuesN = factorsProvider.getFactors(network).stream().map(factor -> new SensitivityValue(factor, Math.random(), Math.random(), Math.random())).collect(Collectors.toList());
+                SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValuesN, false, Collections.emptyMap());
+                return CompletableFuture.completedFuture(results);
             }
 
             @Override

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMock.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMock.java
@@ -31,7 +31,6 @@ public class SensitivityComputationFactoryMock implements SensitivityComputation
                 return CompletableFuture.completedFuture(results);
             }
 
-            @Deprecated
             @Override
             public CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, String workingStateId, SensitivityComputationParameters sensiParameters) {
                 List<SensitivityValue> sensitivityValuesN = factorsProvider.getFactors(network).stream().map(factor -> new SensitivityValue(factor, Math.random(), Math.random(), Math.random())).collect(Collectors.toList());

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMock.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMock.java
@@ -27,14 +27,14 @@ public class SensitivityComputationFactoryMock implements SensitivityComputation
                 List<SensitivityValue> sensitivityValuesContingency = factorsProvider.getFactors(network).stream().map(factor -> new SensitivityValue(factor, Math.random(), Math.random(), Math.random())).collect(Collectors.toList());
 
                 Map<String, List<SensitivityValue>> sensitivityValuesContingencies = Collections.singletonMap(contingenciesProvider.getContingencies(network).get(0).getId(), sensitivityValuesContingency);
-                SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValuesN, true, sensitivityValuesContingencies);
+                SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValuesN, sensitivityValuesContingencies);
                 return CompletableFuture.completedFuture(results);
             }
 
             @Override
             public CompletableFuture<SensitivityComputationResults> run(SensitivityFactorsProvider factorsProvider, String workingStateId, SensitivityComputationParameters sensiParameters) {
                 List<SensitivityValue> sensitivityValuesN = factorsProvider.getFactors(network).stream().map(factor -> new SensitivityValue(factor, Math.random(), Math.random(), Math.random())).collect(Collectors.toList());
-                SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValuesN, false, Collections.emptyMap());
+                SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValuesN, Collections.emptyMap());
                 return CompletableFuture.completedFuture(results);
             }
 

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationResultsTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationResultsTest.java
@@ -46,10 +46,10 @@ public class SensitivityComputationResultsTest {
 
     @Test
     public void isOk() {
-        SensitivityComputationResults resultsOk = new SensitivityComputationResults(true, Collections.emptyMap(), "", Collections.emptyList());
+        SensitivityComputationResults resultsOk = new SensitivityComputationResults(true, Collections.emptyMap(), "", Collections.emptyList(), false, Collections.emptyMap());
         assertTrue(resultsOk.isOk());
 
-        SensitivityComputationResults resultsNok = new SensitivityComputationResults(false, Collections.emptyMap(), "", Collections.emptyList());
+        SensitivityComputationResults resultsNok = new SensitivityComputationResults(false, Collections.emptyMap(), "", Collections.emptyList(), false, Collections.emptyMap());
         assertFalse(resultsNok.isOk());
     }
 
@@ -59,7 +59,7 @@ public class SensitivityComputationResultsTest {
         metrics.put("Key 1", "Val 1");
         metrics.put("Key 2", "Val 2");
         metrics.put("Key 3", "Val 3");
-        SensitivityComputationResults results = new SensitivityComputationResults(true, metrics, "", Collections.emptyList());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, metrics, "", Collections.emptyList(), false, Collections.emptyMap());
         assertEquals(metrics.size(), results.getMetrics().size());
         assertEquals("Val 1", results.getMetrics().get("Key 1"));
         assertEquals("Val 2", results.getMetrics().get("Key 2"));
@@ -69,14 +69,14 @@ public class SensitivityComputationResultsTest {
     @Test
     public void getLogs() {
         String logs = "I don't know half of you half as well as I should like; and I like less than half of you half as well as you deserve.";
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), logs, Collections.emptyList());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), logs, Collections.emptyList(), false, Collections.emptyMap());
         assertEquals(logs, results.getLogs());
     }
 
     @Test
     public void createResultsWithNullValues() {
         exception.expect(NullPointerException.class);
-        new SensitivityComputationResults(true, Collections.emptyMap(), "", null);
+        new SensitivityComputationResults(true, Collections.emptyMap(), "", null, false, Collections.emptyMap());
     }
 
     @Test
@@ -84,7 +84,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
         assertEquals(values.size(), results.getSensitivityValues().size());
     }
 
@@ -93,7 +93,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
         assertEquals(1, results.getSensitivityValuesByFunction(factorOk.getFunction()).size());
         assertEquals(1, results.getSensitivityValuesByFunction(factorNok.getFunction()).size());
     }
@@ -103,7 +103,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
         assertEquals(2, results.getSensitivityValuesByVariable(factorOk.getVariable()).size());
         assertEquals(2, results.getSensitivityValuesByVariable(factorNok.getVariable()).size());
     }
@@ -113,7 +113,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
 
         SensitivityFunction wrongFunction = Mockito.mock(SensitivityFunction.class);
         SensitivityVariable wrongVariable = Mockito.mock(SensitivityVariable.class);
@@ -126,7 +126,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
 
         SensitivityFactor wrongFactor = Mockito.mock(SensitivityFactor.class);
         Mockito.when(wrongFactor.getFunction()).thenReturn(Mockito.mock(SensitivityFunction.class));
@@ -140,10 +140,12 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
         assertSame(factorOk, results.getSensitivityValue(factorOk.getFunction(), factorOk.getVariable()).getFactor());
         assertSame(factorNok, results.getSensitivityValue(factorNok.getFunction(), factorNok.getVariable()).getFactor());
         assertSame(factorOk, results.getSensitivityValue(factorOk).getFactor());
         assertSame(factorNok, results.getSensitivityValue(factorNok).getFactor());
     }
+
+    //TODO: add more tests on the contingencies results
 }

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationResultsTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationResultsTest.java
@@ -46,10 +46,10 @@ public class SensitivityComputationResultsTest {
 
     @Test
     public void isOk() {
-        SensitivityComputationResults resultsOk = new SensitivityComputationResults(true, Collections.emptyMap(), "", Collections.emptyList(), false, Collections.emptyMap());
+        SensitivityComputationResults resultsOk = new SensitivityComputationResults(true, Collections.emptyMap(), "", Collections.emptyList(), Collections.emptyMap());
         assertTrue(resultsOk.isOk());
 
-        SensitivityComputationResults resultsNok = new SensitivityComputationResults(false, Collections.emptyMap(), "", Collections.emptyList(), false, Collections.emptyMap());
+        SensitivityComputationResults resultsNok = new SensitivityComputationResults(false, Collections.emptyMap(), "", Collections.emptyList(), Collections.emptyMap());
         assertFalse(resultsNok.isOk());
     }
 
@@ -59,7 +59,7 @@ public class SensitivityComputationResultsTest {
         metrics.put("Key 1", "Val 1");
         metrics.put("Key 2", "Val 2");
         metrics.put("Key 3", "Val 3");
-        SensitivityComputationResults results = new SensitivityComputationResults(true, metrics, "", Collections.emptyList(), false, Collections.emptyMap());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, metrics, "", Collections.emptyList(), Collections.emptyMap());
         assertEquals(metrics.size(), results.getMetrics().size());
         assertEquals("Val 1", results.getMetrics().get("Key 1"));
         assertEquals("Val 2", results.getMetrics().get("Key 2"));
@@ -69,14 +69,14 @@ public class SensitivityComputationResultsTest {
     @Test
     public void getLogs() {
         String logs = "I don't know half of you half as well as I should like; and I like less than half of you half as well as you deserve.";
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), logs, Collections.emptyList(), false, Collections.emptyMap());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), logs, Collections.emptyList(), Collections.emptyMap());
         assertEquals(logs, results.getLogs());
     }
 
     @Test
     public void createResultsWithNullValues() {
         exception.expect(NullPointerException.class);
-        new SensitivityComputationResults(true, Collections.emptyMap(), "", null, false, Collections.emptyMap());
+        new SensitivityComputationResults(true, Collections.emptyMap(), "", null, Collections.emptyMap());
     }
 
     @Test
@@ -84,7 +84,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, Collections.emptyMap());
         assertEquals(values.size(), results.getSensitivityValues().size());
     }
 
@@ -94,7 +94,7 @@ public class SensitivityComputationResultsTest {
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
         Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, valuesContingency);
         assertEquals(valuesContingency.get("Contingency").size(), results.getSensitivityValuesContingencies().get("Contingency").size());
     }
 
@@ -103,7 +103,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, Collections.emptyMap());
         assertEquals(1, results.getSensitivityValuesByFunction(factorOk.getFunction()).size());
         assertEquals(1, results.getSensitivityValuesByFunction(factorNok.getFunction()).size());
     }
@@ -114,7 +114,7 @@ public class SensitivityComputationResultsTest {
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
         Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, valuesContingency);
         assertEquals(1, results.getSensitivityValuesByFunction(factorOk.getFunction(), "Contingency").size());
         assertEquals(1, results.getSensitivityValuesByFunction(factorNok.getFunction(), "Contingency").size());
     }
@@ -124,7 +124,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, Collections.emptyMap());
         assertEquals(2, results.getSensitivityValuesByVariable(factorOk.getVariable()).size());
         assertEquals(2, results.getSensitivityValuesByVariable(factorNok.getVariable()).size());
     }
@@ -135,7 +135,7 @@ public class SensitivityComputationResultsTest {
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
         Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, valuesContingency);
         assertEquals(2, results.getSensitivityValuesByVariable(factorOk.getVariable(), "Contingency").size());
         assertEquals(2, results.getSensitivityValuesByVariable(factorNok.getVariable(), "Contingency").size());
     }
@@ -145,7 +145,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, Collections.emptyMap());
 
         SensitivityFunction wrongFunction = Mockito.mock(SensitivityFunction.class);
         SensitivityVariable wrongVariable = Mockito.mock(SensitivityVariable.class);
@@ -159,7 +159,7 @@ public class SensitivityComputationResultsTest {
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
         Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, valuesContingency);
 
         SensitivityFunction wrongFunction = Mockito.mock(SensitivityFunction.class);
         SensitivityVariable wrongVariable = Mockito.mock(SensitivityVariable.class);
@@ -172,7 +172,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, Collections.emptyMap());
 
         SensitivityFactor wrongFactor = Mockito.mock(SensitivityFactor.class);
         Mockito.when(wrongFactor.getFunction()).thenReturn(Mockito.mock(SensitivityFunction.class));
@@ -187,7 +187,7 @@ public class SensitivityComputationResultsTest {
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
         Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, valuesContingency);
 
         SensitivityFactor wrongFactor = Mockito.mock(SensitivityFactor.class);
         Mockito.when(wrongFactor.getFunction()).thenReturn(Mockito.mock(SensitivityFunction.class));
@@ -201,7 +201,7 @@ public class SensitivityComputationResultsTest {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, Collections.emptyMap());
         assertSame(factorOk, results.getSensitivityValue(factorOk.getFunction(), factorOk.getVariable()).getFactor());
         assertSame(factorNok, results.getSensitivityValue(factorNok.getFunction(), factorNok.getVariable()).getFactor());
         assertSame(factorOk, results.getSensitivityValue(factorOk).getFactor());
@@ -214,7 +214,7 @@ public class SensitivityComputationResultsTest {
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
         values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
         Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
-        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, valuesContingency);
         assertSame(factorOk, results.getSensitivityValue(factorOk.getFunction(), factorOk.getVariable(), "Contingency").getFactor());
         assertSame(factorNok, results.getSensitivityValue(factorNok.getFunction(), factorNok.getVariable(), "Contingency").getFactor());
         assertSame(factorOk, results.getSensitivityValue(factorOk, "Contingency").getFactor());

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationResultsTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationResultsTest.java
@@ -89,6 +89,16 @@ public class SensitivityComputationResultsTest {
     }
 
     @Test
+    public void getSensitivityValuesContingency() {
+        List<SensitivityValue> values = new ArrayList<>();
+        values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
+        values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
+        Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        assertEquals(valuesContingency.get("Contingency").size(), results.getSensitivityValuesContingencies().get("Contingency").size());
+    }
+
+    @Test
     public void getSensitivityValuesByFunction() {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
@@ -96,6 +106,17 @@ public class SensitivityComputationResultsTest {
         SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, false, Collections.emptyMap());
         assertEquals(1, results.getSensitivityValuesByFunction(factorOk.getFunction()).size());
         assertEquals(1, results.getSensitivityValuesByFunction(factorNok.getFunction()).size());
+    }
+
+    @Test
+    public void getSensitivityValuesByFunctionContingency() {
+        List<SensitivityValue> values = new ArrayList<>();
+        values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
+        values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
+        Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        assertEquals(1, results.getSensitivityValuesByFunction(factorOk.getFunction(), "Contingency").size());
+        assertEquals(1, results.getSensitivityValuesByFunction(factorNok.getFunction(), "Contingency").size());
     }
 
     @Test
@@ -109,6 +130,17 @@ public class SensitivityComputationResultsTest {
     }
 
     @Test
+    public void getSensitivityValuesByVariableContingency() {
+        List<SensitivityValue> values = new ArrayList<>();
+        values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
+        values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
+        Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        assertEquals(2, results.getSensitivityValuesByVariable(factorOk.getVariable(), "Contingency").size());
+        assertEquals(2, results.getSensitivityValuesByVariable(factorNok.getVariable(), "Contingency").size());
+    }
+
+    @Test
     public void getNonExistingSensitivityValueByFunctionAndVariable() {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
@@ -119,6 +151,20 @@ public class SensitivityComputationResultsTest {
         SensitivityVariable wrongVariable = Mockito.mock(SensitivityVariable.class);
         exception.expect(NoSuchElementException.class);
         results.getSensitivityValue(wrongFunction, wrongVariable);
+    }
+
+    @Test
+    public void getNonExistingSensitivityValueByFunctionAndVariableContingency() {
+        List<SensitivityValue> values = new ArrayList<>();
+        values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
+        values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
+        Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+
+        SensitivityFunction wrongFunction = Mockito.mock(SensitivityFunction.class);
+        SensitivityVariable wrongVariable = Mockito.mock(SensitivityVariable.class);
+        exception.expect(NoSuchElementException.class);
+        results.getSensitivityValue(wrongFunction, wrongVariable, "Contingency");
     }
 
     @Test
@@ -136,6 +182,21 @@ public class SensitivityComputationResultsTest {
     }
 
     @Test
+    public void getNonExistingSensitivityValueByFactorContingency() {
+        List<SensitivityValue> values = new ArrayList<>();
+        values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
+        values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
+        Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+
+        SensitivityFactor wrongFactor = Mockito.mock(SensitivityFactor.class);
+        Mockito.when(wrongFactor.getFunction()).thenReturn(Mockito.mock(SensitivityFunction.class));
+        Mockito.when(wrongFactor.getVariable()).thenReturn(Mockito.mock(SensitivityVariable.class));
+        exception.expect(NoSuchElementException.class);
+        results.getSensitivityValue(wrongFactor, "Contingency");
+    }
+
+    @Test
     public void getSensitivityValue() {
         List<SensitivityValue> values = new ArrayList<>();
         values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
@@ -147,5 +208,16 @@ public class SensitivityComputationResultsTest {
         assertSame(factorNok, results.getSensitivityValue(factorNok).getFactor());
     }
 
-    //TODO: add more tests on the contingencies results
+    @Test
+    public void getSensitivityValueContingency() {
+        List<SensitivityValue> values = new ArrayList<>();
+        values.add(new SensitivityValue(factorOk, Double.NaN, Double.NaN, Double.NaN));
+        values.add(new SensitivityValue(factorNok, Double.NaN, Double.NaN, Double.NaN));
+        Map<String, List<SensitivityValue>> valuesContingency = Collections.singletonMap("Contingency", values);
+        SensitivityComputationResults results = new SensitivityComputationResults(true, Collections.emptyMap(), "", values, true, valuesContingency);
+        assertSame(factorOk, results.getSensitivityValue(factorOk.getFunction(), factorOk.getVariable(), "Contingency").getFactor());
+        assertSame(factorNok, results.getSensitivityValue(factorNok.getFunction(), factorNok.getVariable(), "Contingency").getFactor());
+        assertSame(factorOk, results.getSensitivityValue(factorOk, "Contingency").getFactor());
+        assertSame(factorNok, results.getSensitivityValue(factorNok, "Contingency").getFactor());
+    }
 }

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationToolTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationToolTest.java
@@ -38,12 +38,13 @@ public class SensitivityComputationToolTest extends AbstractToolTest {
 
     @Override
     public void assertCommand() {
-        assertCommand(tool.getCommand(), COMMAND_NAME, 7, 2);
+        assertCommand(tool.getCommand(), COMMAND_NAME, 8, 2);
         assertOption(tool.getCommand().getOptions(), "case-file", true, true);
         assertOption(tool.getCommand().getOptions(), "output-file", false, true);
         assertOption(tool.getCommand().getOptions(), "output-format", false, true);
         assertOption(tool.getCommand().getOptions(), "factors-file", true, true);
         assertOption(tool.getCommand().getOptions(), "skip-postproc", false, false);
+        assertOption(tool.getCommand().getOptions(), "contingencies-file", false, true);
     }
 
     @Test

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporterTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporterTest.java
@@ -17,9 +17,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -40,8 +38,9 @@ public class CsvSensitivityComputationResultExporterTest extends AbstractConvert
         factors.forEach(factor -> {
             sensitivityValues.add(new SensitivityValue(factor, 0, 0, 0));
         });
+        Map<String, List<SensitivityValue>> sensitivityValuesContingency = Collections.singletonMap("Contingency", sensitivityValues);
         // create result
-        return new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValues, false, Collections.emptyMap());
+        return new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValues, true, sensitivityValuesContingency);
     }
 
     public void writeCsv(SensitivityComputationResults results, Path path) {
@@ -56,6 +55,6 @@ public class CsvSensitivityComputationResultExporterTest extends AbstractConvert
 
     @Test
     public void testComment() {
-        assertEquals("Export a security analysis result in CSV format", SensitivityComputationResultExporters.getExporter("CSV").getComment());
+        assertEquals("Export a systematic sensitivity computation result in CSV format", SensitivityComputationResultExporters.getExporter("CSV").getComment());
     }
 }

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporterTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporterTest.java
@@ -41,7 +41,7 @@ public class CsvSensitivityComputationResultExporterTest extends AbstractConvert
             sensitivityValues.add(new SensitivityValue(factor, 0, 0, 0));
         });
         // create result
-        return new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValues);
+        return new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValues, false, Collections.emptyMap());
     }
 
     public void writeCsv(SensitivityComputationResults results, Path path) {

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporterTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporterTest.java
@@ -40,7 +40,7 @@ public class CsvSensitivityComputationResultExporterTest extends AbstractConvert
         });
         Map<String, List<SensitivityValue>> sensitivityValuesContingency = Collections.singletonMap("Contingency", sensitivityValues);
         // create result
-        return new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValues, true, sensitivityValuesContingency);
+        return new SensitivityComputationResults(true, Collections.emptyMap(), "", sensitivityValues, sensitivityValuesContingency);
     }
 
     public void writeCsv(SensitivityComputationResults results, Path path) {

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporterTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/converter/CsvSensitivityComputationResultExporterTest.java
@@ -55,6 +55,6 @@ public class CsvSensitivityComputationResultExporterTest extends AbstractConvert
 
     @Test
     public void testComment() {
-        assertEquals("Export a systematic sensitivity computation result in CSV format", SensitivityComputationResultExporters.getExporter("CSV").getComment());
+        assertEquals("Export a sensitivity analysis result in CSV format", SensitivityComputationResultExporters.getExporter("CSV").getComment());
     }
 }

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMockTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMockTest.java
@@ -8,12 +8,7 @@ package com.powsybl.sensitivity.mock;
 
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.sensitivity.JsonSensitivityFactorsProvider;
-import com.powsybl.sensitivity.SensitivityComputation;
-import com.powsybl.sensitivity.SensitivityComputationFactory;
-import com.powsybl.sensitivity.SensitivityComputationParameters;
-import com.powsybl.sensitivity.SensitivityComputationResults;
-import com.powsybl.sensitivity.SensitivityFactorsProvider;
+import com.powsybl.sensitivity.*;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -26,16 +21,17 @@ public class SensitivityComputationFactoryMockTest {
         SensitivityComputationFactory factory = new SensitivityComputationFactoryMock();
         SensitivityComputation computation = factory.create(Mockito.mock(Network.class), Mockito.mock(ComputationManager.class), 0);
 
-        SensitivityFactorsProvider provider = new JsonSensitivityFactorsProvider(SensitivityComputationFactoryMockTest.class.getResourceAsStream("/sensitivityFactorsExample.json"));
+        SensitivityFactorsProvider factorsProvider = new JsonSensitivityFactorsProvider(SensitivityComputationFactoryMockTest.class.getResourceAsStream("/sensitivityFactorsExample.json"));
+        //TODO: add a test with a list of contingencies
         assertEquals("Sensitivity computation mock", computation.getName());
         SensitivityComputationResults results = computation.run(
-                provider,
+                factorsProvider,
                 "any",
                 Mockito.mock(SensitivityComputationParameters.class)
         ).join();
 
         assertNotNull(results);
         assertTrue(results.isOk());
-        assertEquals(provider.getFactors(Mockito.mock(Network.class)).size(), results.getSensitivityValues().size());
+        assertEquals(factorsProvider.getFactors(Mockito.mock(Network.class)).size(), results.getSensitivityValues().size());
     }
 }

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMockTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/mock/SensitivityComputationFactoryMockTest.java
@@ -6,11 +6,21 @@
  */
 package com.powsybl.sensitivity.mock;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.computation.ComputationManager;
+import com.powsybl.contingency.ContingenciesProvider;
+import com.powsybl.contingency.Contingency;
+import com.powsybl.contingency.json.ContingencyJsonModule;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.sensitivity.*;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 
@@ -22,7 +32,6 @@ public class SensitivityComputationFactoryMockTest {
         SensitivityComputation computation = factory.create(Mockito.mock(Network.class), Mockito.mock(ComputationManager.class), 0);
 
         SensitivityFactorsProvider factorsProvider = new JsonSensitivityFactorsProvider(SensitivityComputationFactoryMockTest.class.getResourceAsStream("/sensitivityFactorsExample.json"));
-        //TODO: add a test with a list of contingencies
         assertEquals("Sensitivity computation mock", computation.getName());
         SensitivityComputationResults results = computation.run(
                 factorsProvider,
@@ -32,6 +41,44 @@ public class SensitivityComputationFactoryMockTest {
 
         assertNotNull(results);
         assertTrue(results.isOk());
+        assertFalse(results.contingenciesArePresent());
         assertEquals(factorsProvider.getFactors(Mockito.mock(Network.class)).size(), results.getSensitivityValues().size());
+    }
+
+    @Test
+    public void createSystematicMock() throws IOException {
+        SensitivityComputationFactory factory = new SensitivityComputationFactoryMock();
+        SensitivityComputation computation = factory.create(Mockito.mock(Network.class), Mockito.mock(ComputationManager.class), 0);
+
+        // Read sensitivity factors from a JSON file
+        SensitivityFactorsProvider factorsProvider = new JsonSensitivityFactorsProvider(SensitivityComputationFactoryMockTest.class.getResourceAsStream("/sensitivityFactorsExample.json"));
+
+        // Read one contingency from a JSON file
+        ContingenciesProvider contingenciesProvider = network -> {
+            try (InputStream is = SensitivityComputationFactoryMockTest.class.getResourceAsStream("/contingency.json")) {
+                ObjectMapper objectMapper = JsonUtil.createObjectMapper();
+                ContingencyJsonModule module = new ContingencyJsonModule();
+                objectMapper.registerModule(module);
+
+                return Collections.singletonList(objectMapper.readValue(is, Contingency.class));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+
+        // Check the consistency of the results
+        assertEquals("Sensitivity computation mock", computation.getName());
+        SensitivityComputationResults results = computation.run(
+                factorsProvider,
+                contingenciesProvider,
+                "any",
+                Mockito.mock(SensitivityComputationParameters.class)
+        ).join();
+
+        assertNotNull(results);
+        assertTrue(results.isOk());
+        assertEquals(factorsProvider.getFactors(Mockito.mock(Network.class)).size(), results.getSensitivityValues().size());
+        assertTrue(results.contingenciesArePresent());
+        assertEquals(contingenciesProvider.getContingencies(Mockito.mock(Network.class)).size(), results.getSensitivityValuesContingencies().keySet().size());
     }
 }

--- a/sensitivity-api/src/test/resources/contingency.json
+++ b/sensitivity-api/src/test/resources/contingency.json
@@ -1,0 +1,33 @@
+{
+  "id" : "contingency",
+  "elements" : [ {
+    "id" : "NHV1_NHV2_2",
+    "type" : "BRANCH",
+    "voltageLevelId" : "VLHV1"
+  }, {
+    "id" : "NHV1_NHV2_1",
+    "type" : "BRANCH"
+  }, {
+    "id" : "HVDC1",
+    "type" : "HVDC_LINE"
+  }, {
+    "id" : "HVDC1",
+    "type" : "HVDC_LINE",
+    "voltageLevelId" : "VL1"
+  }, {
+    "id" : "GEN",
+    "type" : "GENERATOR"
+  }, {
+    "id" : "SC",
+    "type" : "SHUNT_COMPENSATOR"
+  }, {
+    "id" : "SVC",
+    "type" : "STATIC_VAR_COMPENSATOR"
+  }, {
+    "id" : "BBS1",
+    "type" : "BUSBAR_SECTION"
+  } ],
+  "extensions" : {
+    "dummy-extension" : { }
+  }
+}

--- a/sensitivity-api/src/test/resources/resultsExport.json
+++ b/sensitivity-api/src/test/resources/resultsExport.json
@@ -98,5 +98,7 @@
     "value" : 1.25,
     "functionReference" : 2.12,
     "variableReference" : 15.2
-  } ]
+  } ],
+  "contingencies present" : false,
+  "contingencies values" : null
 }

--- a/sensitivity-api/src/test/resources/resultsExport.json
+++ b/sensitivity-api/src/test/resources/resultsExport.json
@@ -99,6 +99,5 @@
     "functionReference" : 2.12,
     "variableReference" : 15.2
   } ],
-  "contingencies present" : false,
-  "contingencies values" : null
+  "contingenciesValues" : { }
 }

--- a/sensitivity-api/src/test/resources/sensitivity-results.csv
+++ b/sensitivity-api/src/test/resources/sensitivity-results.csv
@@ -2,3 +2,6 @@ Variant,VariableId,VariableName,FunctionId,FunctionName,VariableRefValue,Functio
 State N,FFR1AA1 _generator,FFR1AA1 _generator,BBE1AA1  BBE2AA1  1,BBE1AA1  BBE2AA1  1,0.00000,0.00000,0.00000
 State N,FFR2AA1 _generator,FFR2AA1 _generator,BBE1AA1  BBE2AA1  1,BBE1AA1  BBE2AA1  1,0.00000,0.00000,0.00000
 State N,FFR3AA1 _generator,FFR3AA1 _generator,BBE1AA1  BBE2AA1  1,BBE1AA1  BBE2AA1  1,0.00000,0.00000,0.00000
+Contingency Contingency,FFR1AA1 _generator,FFR1AA1 _generator,BBE1AA1  BBE2AA1  1,BBE1AA1  BBE2AA1  1,0.00000,0.00000,0.00000
+Contingency Contingency,FFR2AA1 _generator,FFR2AA1 _generator,BBE1AA1  BBE2AA1  1,BBE1AA1  BBE2AA1  1,0.00000,0.00000,0.00000
+Contingency Contingency,FFR3AA1 _generator,FFR3AA1 _generator,BBE1AA1  BBE2AA1  1,BBE1AA1  BBE2AA1  1,0.00000,0.00000,0.00000


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** 
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
New feature: modification of the sensitivity api to make it possible to perform post-contingency sensitivity analyses based on Hades2. The HADES2 sensitivity provider used with Powsybl offers the possibility to calculate the sensitivity on a set of contingencies besides the N state. The computation is launched only once, but the solver itself modifies the matrix for each state of the network to output a full set of results. 

**What is the current behavior?**
At the moment it is only possible to run single sensitivity analyses through Powsybl. It returns, besides its status and some stats on the computation itself, all the sensitivity values for each factor (combination of a monitoredBranch and a specific equipment or group of equipments) on the network in state N.

**What is the new behavior (if this is a feature change)?**
With this change it is possible to run sensitivity analyses on state N and post-contingency states, based on the Hades2 provider, by passing a list of contingencies as an additional argument. It runs a single calculation, but that calculation will compute the sensitivity factors for the N state and on a set of N-1 network states. The full set of results then consists of :
- the list of sensitivity values in N
- the lists of sensitivity values for each N-1 situation
- some metadata (status, stats, logs)