### PR TITLE
Handle switches missing equipment container in CGMES conversion

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.powsybl.cgmes.conversion.Context;
+import com.powsybl.cgmes.model.CgmesContainer;
 import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.LineAdder;
 import com.powsybl.iidm.network.SwitchKind;
@@ -93,7 +94,11 @@ public class SwitchConversion extends AbstractConductingEquipmentConversion {
     }
 
     private String switchVoltageLevelId() {
-        return context.cgmes().container(p.getId("EquipmentContainer")).voltageLevel();
+        CgmesContainer container = context.cgmes().container(p.getId("EquipmentContainer"));
+        if (container == null) {
+            LOG.error("Missing equipment container for switch {} {}", id, name);
+        }
+        return container == null ? null : container.voltageLevel();
     }
 
     private boolean convertToLowImpedanceLine() {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
@@ -103,17 +103,6 @@ public class SwitchConversion extends AbstractConductingEquipmentConversion {
 
     private boolean convertToLowImpedanceLine() {
         String vl = switchVoltageLevelId();
-        String vl1 = cgmesVoltageLevelId(1);
-        String vl2 = cgmesVoltageLevelId(2);
-        if (this.id.startsWith("_8e56ead3") && LOG.isInfoEnabled()) {
-            LOG.info("voltage levels for switch {}", this.id);
-            LOG.info("    vl  : {}", vl);
-            LOG.info("    vl1 : {}", vl1);
-            LOG.info("    vl2 : {}", vl2);
-            LOG.info("    cn1 : {}", nodeId(1));
-            LOG.info("    cn2 : {}", nodeId(2));
-            LOG.info("");
-        }
         return !cgmesVoltageLevelId(1).equals(vl) || !cgmesVoltageLevelId(2).equals(vl);
     }
 


### PR DESCRIPTION
Signed-off-by: Luma Zamarreño <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Equipment container for switch is required to decide if switch should be converted to a low impedance line during CGMES conversion. If equipment container referenced object does not exist in the CGMES model a null pointer exception is raised.
Switches are converted to low impedance lines when any of the voltage levels of the end points are different of the voltage level of the equipment container.

**What is the new behavior (if this is a feature change)?**
If the equipment container is not found, the voltage level of the equipment container can not be obtained. The result will be that the switch will be converted to a low impedance line in this situation.
An error is written in the log.
