### PR TITLE
InternalConnectionAdder should not inherit from IdentifiableAdder

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -341,7 +341,7 @@ public interface VoltageLevel extends Container<VoltageLevel> {
 
         }
 
-        interface InternalConnectionAdder extends IdentifiableAdder<InternalConnectionAdder> {
+        interface InternalConnectionAdder {
 
             InternalConnectionAdder setNode1(int node1);
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -175,23 +175,13 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
     }
 
-    private final class InternalConnectionAdderImpl extends AbstractIdentifiableAdder<InternalConnectionAdderImpl> implements NodeBreakerView.InternalConnectionAdder {
+    private final class InternalConnectionAdderImpl implements NodeBreakerView.InternalConnectionAdder {
 
         private Integer node1;
 
         private Integer node2;
 
         private InternalConnectionAdderImpl() {
-        }
-
-        @Override
-        protected NetworkImpl getNetwork() {
-            return NodeBreakerVoltageLevel.this.getNetwork();
-        }
-
-        @Override
-        protected String getTypeDescription() {
-            return "InternalConnection";
         }
 
         @Override
@@ -209,10 +199,10 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         @Override
         public void add() {
             if (node1 == null) {
-                throw new ValidationException(this, "first connection node is not set");
+                throw new ValidationException(NodeBreakerVoltageLevel.this, "first connection node is not set");
             }
             if (node2 == null) {
-                throw new ValidationException(this, "second connection node is not set");
+                throw new ValidationException(NodeBreakerVoltageLevel.this, "second connection node is not set");
             }
 
             graph.addEdge(node1, node2, null);

--- a/iidm/iidm-tck/src/main/java/com/powsybl/iidm/network/tck/AbstractEmptyCalculatedBusBugTest.java
+++ b/iidm/iidm-tck/src/main/java/com/powsybl/iidm/network/tck/AbstractEmptyCalculatedBusBugTest.java
@@ -58,7 +58,6 @@ public abstract class AbstractEmptyCalculatedBusBugTest {
         vl.getNodeBreakerView()
                 .setNodeCount(3)
                 .newInternalConnection()
-                .setId("IC")
                 .setNode1(1)
                 .setNode2(2)
                 .add();


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
InternalConnectionAdder inherit from IdentifiableAdder while InternalConnection does not inherit from Identifiable.


**What is the new behavior (if this is a feature change)?**
InternalConnectionAdder does not inherit IdentifiableAdder anymore


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
