### PR TITLE
Obtain voltage level from terminal through node-breaker or bus-branch node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ install.cfg
 .factorypath
 .project
 .factorypath
+.checkstyle
 org.eclipse.core.resources.prefs
 org.eclipse.jdt.core.prefs
 org.eclipse.m2e.core.prefs

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/SubstationIdMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/SubstationIdMapping.java
@@ -108,7 +108,7 @@ public class SubstationIdMapping {
             CgmesTerminal t = context.cgmes().terminal(end.getId(CgmesNames.TERMINAL));
             String node = context.nodeBreaker() ? t.connectivityNode() : t.topologicalNode();
             if (node != null && !context.boundary().containsNode(node)) {
-                String sid = context.cgmes().substation(t);
+                String sid = context.cgmes().substation(t, context.nodeBreaker());
                 if (sid != null) {
                     substationsIds.add(context.namingStrategy().getId(CgmesNames.SUBSTATION, sid));
                 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
@@ -296,7 +296,7 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
             } else {
                 // cgmesVoltageLevelId may be null if terminal is contained in a Line
                 // (happens in boundaries)
-                cgmesVoltageLevelId = context.cgmes().voltageLevel(t);
+                cgmesVoltageLevelId = context.cgmes().voltageLevel(t, context.nodeBreaker());
             }
             if (cgmesVoltageLevelId != null) {
                 iidmVoltageLevelId = context.namingStrategy().getId("VoltageLevel",

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
@@ -206,7 +206,7 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
     }
 
     protected Substation substation() {
-        String sid = context.cgmes().substation(terminals[0].t);
+        String sid = context.cgmes().substation(terminals[0].t, context.nodeBreaker());
         return context.network().getSubstation(context.substationIdMapping().iidm(sid));
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SvInjectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SvInjectionConversion.java
@@ -72,13 +72,13 @@ public class SvInjectionConversion extends AbstractIdentifiedObjectConversion {
         Terminal associatedTerminal = context.terminalMapping().findFromTopologicalNode(topologicalNode);
         if (associatedTerminal == null) {
             cgmesTerminal = context.cgmes().terminal(context.terminalMapping().findCgmesTerminalFromTopologicalNode(topologicalNode));
-            if (cgmesTerminal == null || context.cgmes().voltageLevel(cgmesTerminal) == null) {
+            if (cgmesTerminal == null || context.cgmes().voltageLevel(cgmesTerminal, context.nodeBreaker()) == null) {
                 context.invalid(id,
                         String.format("The CGMES terminal and/or the voltage level associated to the topological node %slinked to the SV injection %s is missing",
                                 topologicalNode, id));
                 return false;
             }
-            voltageLevel = context.network().getVoltageLevel(context.cgmes().voltageLevel(cgmesTerminal));
+            voltageLevel = context.network().getVoltageLevel(context.cgmes().voltageLevel(cgmesTerminal, context.nodeBreaker()));
         } else {
             voltageLevel = associatedTerminal.getVoltageLevel();
         }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -116,7 +116,7 @@ public abstract class AbstractCgmesModel implements CgmesModel {
             cachedNodes = computeNodes();
         }
         String containerId = null;
-        String nodeId = nodeBreaker ? t.connectivityNode() : t.topologicalNode();
+        String nodeId = nodeBreaker && t.connectivityNode() != null ? t.connectivityNode() : t.topologicalNode();
         if (nodeId != null) {
             PropertyBag node = cachedNodes.get(nodeId);
             if (node != null) {

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -73,7 +73,7 @@ public abstract class AbstractCgmesModel implements CgmesModel {
 
     @Override
     public String substation(CgmesTerminal t) {
-        CgmesContainer c = container(t);
+        CgmesContainer c = container(t, true);
         if (c == null) {
             return null;
         }
@@ -81,8 +81,8 @@ public abstract class AbstractCgmesModel implements CgmesModel {
     }
 
     @Override
-    public String voltageLevel(CgmesTerminal t) {
-        CgmesContainer c = container(t);
+    public String voltageLevel(CgmesTerminal t, boolean nodeBreaker) {
+        CgmesContainer c = container(t, nodeBreaker);
         if (c == null) {
             return null;
         }
@@ -111,12 +111,12 @@ public abstract class AbstractCgmesModel implements CgmesModel {
         }
     }
 
-    private CgmesContainer container(CgmesTerminal t) {
+    private CgmesContainer container(CgmesTerminal t, boolean nodeBreaker) {
         if (cachedNodes == null) {
             cachedNodes = computeNodes();
         }
         String containerId = null;
-        String nodeId = t.connectivityNode() != null ? t.connectivityNode() : t.topologicalNode();
+        String nodeId = nodeBreaker ? t.connectivityNode() : t.topologicalNode();
         if (nodeId != null) {
             PropertyBag node = cachedNodes.get(nodeId);
             if (node != null) {

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -72,8 +72,8 @@ public abstract class AbstractCgmesModel implements CgmesModel {
     }
 
     @Override
-    public String substation(CgmesTerminal t) {
-        CgmesContainer c = container(t, true);
+    public String substation(CgmesTerminal t, boolean nodeBreaker) {
+        CgmesContainer c = container(t, nodeBreaker);
         if (c == null) {
             return null;
         }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -169,7 +169,7 @@ public interface CgmesModel {
 
     String substation(CgmesTerminal t);
 
-    String voltageLevel(CgmesTerminal t);
+    String voltageLevel(CgmesTerminal t, boolean nodeBreaker);
 
     CgmesContainer container(String containerId);
 

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -167,8 +167,20 @@ public interface CgmesModel {
 
     // TODO(Luma) refactoring node-breaker conversion temporal
 
-    String substation(CgmesTerminal t);
+    /**
+     * Obtain the substation of a given terminal.
+     *
+     * @param t the terminal
+     * @param nodeBreaker to determine the terminal container, use node-breaker connectivity information first
+     */
+    String substation(CgmesTerminal t, boolean nodeBreaker);
 
+    /**
+     * Obtain the voltage level grouping in which a given terminal is contained.
+     *
+     * @param t the terminal
+     * @param nodeBreaker to determine the terminal container, use node-breaker connectivity information first
+     */
     String voltageLevel(CgmesTerminal t, boolean nodeBreaker);
 
     CgmesContainer container(String containerId);

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModelFactory.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModelFactory.java
@@ -75,7 +75,7 @@ public final class CgmesModelFactory {
         for (PropertyBags tends : cgmes.groupedTransformerEnds().values()) {
             for (PropertyBag end : tends) {
                 CgmesTerminal t = cgmes.terminal(end.getId(CgmesNames.TERMINAL));
-                cgmes.substation(t);
+                cgmes.substation(t, isNodeBreaker);
                 if (isNodeBreaker) {
                     t.connectivityNode();
                 } else {

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
@@ -547,7 +547,7 @@ public final class FakeCgmesModel implements CgmesModel {
     }
 
     @Override
-    public String substation(CgmesTerminal t) {
+    public String substation(CgmesTerminal t, boolean nodeBreaker) {
         return null;
     }
 

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
@@ -552,7 +552,7 @@ public final class FakeCgmesModel implements CgmesModel {
     }
 
     @Override
-    public String voltageLevel(CgmesTerminal t) {
+    public String voltageLevel(CgmesTerminal t, boolean nodeBreaker) {
         return null;
     }
 


### PR DESCRIPTION
Signed-off-by: Luma Zamarreño <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
An equipment may belong to different voltage levels depending on the node used to find its container. Using the equipment `Terminal` node-breaker information (`ConnectivityNode`) we may find a voltage level different than the one found using bus-branch information (`TopologicalNode`).

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
When querying the CGMES model for the container of a given terminal, the client must specify the node to be used to find the container.
During conversion from CGMES to IIDM, the CGMES model will be queried based on the level that the conversion is being performed (as defined in the context).

**What is the current behavior?** *(You can also link to an open issue here)*
A model is described using node-breaker information. Bus-branch information is also provided (TP file). There is a load that _belongs_ to `VL1` if node-breaker information is used. But should be considered under `VL2` from bus-branch point of view.
The conversion is configured to run using bus-branch information.
The IIDM bus and connectable bus of the load where correctly mapped using bus-branch information, but the IIDM voltage level was incorrectly obtained based on node-breaker information.
As a result, when the IIDM load was added to the Network, an error was raised because the given bus for the load was not found in the IIDM voltage level used to create the load.

**What is the new behavior (if this is a feature change)?**
The problem is solved using the proper level of information to find the voltage level of the equipment, based on the level configured in the conversion.

