### PR TITLE
Delete node count

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/NodeMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/NodeMapping.java
@@ -84,10 +84,6 @@ public class NodeMapping {
         // If a previous value was stored, new value is computed with "sum" 1
         // We want a zero-based index, so -1 + ...
         int numNodes = voltageLevelNumNodes.merge(vl, 1, Integer::sum);
-        if (vl.getNodeBreakerView().getNodeCount() < numNodes) {
-            // +10 to avoid calling setNodeCount too many times
-            vl.getNodeBreakerView().setNodeCount(numNodes + 10);
-        }
         return numNodes - 1;
     }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -405,7 +405,7 @@ public interface VoltageLevel extends Container<VoltageLevel> {
         Stream<InternalConnection> getInternalConnectionStream();
 
         /**
-         * Remove <b>all</b> the internal connections between node1 and node2 if they exist.
+         * Remove <b>all</b> the internal connections between node1 and node2 (not orientated) if they exist.
          */
         default void removeInternalConnections(int node1, int node2) {
             throw new UnsupportedOperationException();

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -406,9 +406,9 @@ public interface VoltageLevel extends Container<VoltageLevel> {
         Stream<InternalConnection> getInternalConnectionStream();
 
         /**
-         * Remove the internal connection between node1 and node2 if it exists.
+         * Remove <b>all</b> the internal connections between node1 and node2 if they exist.
          */
-        default void removeInternalConnection(int node1, int node2) {
+        default void removeInternalConnections(int node1, int node2) {
             throw new UnsupportedOperationException();
         }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -360,18 +360,17 @@ public interface VoltageLevel extends Container<VoltageLevel> {
         /**
          * Get the count of used nodes (nodes attached to an equipment, a switch or an internal connection).
          *
-         * @deprecated Depending on your use case, use {@link #getMaximumNodeIndex()} or {@link #getNodeCapacity()}.
+         * @deprecated Use {@link #getMaximumNodeIndex()} instead.
          */
         @Deprecated
         default int getNodeCount() {
             throw new UnsupportedOperationException();
         }
 
+        /**
+         * Get the highest index of used nodes (i.e. attached to an equipment, a switch or an internal connection) in the voltage level.
+         */
         default int getMaximumNodeIndex() {
-            throw new UnsupportedOperationException();
-        }
-
-        default int getNodeCapacity() {
             throw new UnsupportedOperationException();
         }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -358,19 +358,27 @@ public interface VoltageLevel extends Container<VoltageLevel> {
         }
 
         /**
-         * Get the number of node.
+         * Get the count of used nodes (nodes attached to an equipment, a switch or an internal connection).
+         *
+         * @deprecated Depending on your use case, use {@link #getMaximumNodeIndex()} or {@link #getNodeCapacity()}.
          */
-        int getNodeCount();
+        @Deprecated
+        default int getNodeCount() {
+            throw new UnsupportedOperationException();
+        }
+
+        default int getMaximumNodeIndex() {
+            throw new UnsupportedOperationException();
+        }
+
+        default int getNodeCapacity() {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Get the list of nodes.
          */
         int[] getNodes();
-
-        /**
-         * Set the number of node.
-         */
-        NodeBreakerView setNodeCount(int count);
 
         /**
          * Get a builder to create a new switch.
@@ -396,6 +404,13 @@ public interface VoltageLevel extends Container<VoltageLevel> {
          * Get internal connection stream.
          */
         Stream<InternalConnection> getInternalConnectionStream();
+
+        /**
+         * Remove the internal connection between node1 and node2 if it exists.
+         */
+        default void removeInternalConnection(int node1, int node2) {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Get a builder to create a new breaker.
@@ -1035,5 +1050,4 @@ public interface VoltageLevel extends Container<VoltageLevel> {
      * @param writer a writer
      */
     void exportTopology(Writer writer) throws IOException;
-
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
@@ -64,7 +64,6 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         for (TerminalExt terminal : terminals) {
             VoltageLevelExt vl = terminal.getVoltageLevel();
             vl.detach(terminal);
-            vl.clean();
         }
         network.getListeners().notifyRemoval(this);
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -340,8 +340,8 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     @Override
     public Iterable<Terminal> getTerminals() {
         return FluentIterable.from(graph.getVerticesObj())
-                             .transformAndConcat(ConfiguredBus::getTerminals)
-                             .transform(Terminal.class::cast);
+                .transformAndConcat(ConfiguredBus::getTerminals)
+                .transform(Terminal.class::cast);
     }
 
     @Override
@@ -417,6 +417,11 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
         @Override
         public Stream<InternalConnection> getInternalConnectionStream() {
+            throw createNotSupportedBusBreakerTopologyException();
+        }
+
+        @Override
+        public void removeInternalConnections(int node1, int node2) {
             throw createNotSupportedBusBreakerTopologyException();
         }
 
@@ -705,7 +710,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         if (!(terminal instanceof BusTerminal)) {
             throw new ValidationException(terminal.getConnectable(),
                     "voltage level " + BusBreakerVoltageLevel.this.id + " has a bus/breaker topology"
-                    + ", a bus connection should be specified instead of a node connection");
+                            + ", a bus connection should be specified instead of a node connection");
         }
 
         // check connectable buses exist

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -361,11 +361,6 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public int getNodeCapacity() {
-            throw createNotSupportedBusBreakerTopologyException();
-        }
-
-        @Override
         public int[] getNodes() {
             throw createNotSupportedBusBreakerTopologyException();
         }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -356,17 +356,17 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     private final NodeBreakerViewExt nodeBreakerView = new NodeBreakerViewExt() {
 
         @Override
-        public int getNodeCount() {
+        public int getMaximumNodeIndex() {
+            throw createNotSupportedBusBreakerTopologyException();
+        }
+
+        @Override
+        public int getNodeCapacity() {
             throw createNotSupportedBusBreakerTopologyException();
         }
 
         @Override
         public int[] getNodes() {
-            throw createNotSupportedBusBreakerTopologyException();
-        }
-
-        @Override
-        public NodeBreakerView setNodeCount(int count) {
             throw createNotSupportedBusBreakerTopologyException();
         }
 
@@ -754,11 +754,6 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         });
         // remove the link terminal -> voltage level
         terminal.setVoltageLevel(null);
-    }
-
-    @Override
-    public void clean() {
-        // nothing to do
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -654,7 +654,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public void removeInternalConnection(int node1, int node2) {
+        public void removeInternalConnections(int node1, int node2) {
             int[] internalConnectionsToBeRemoved = Arrays.stream(graph.getEdges())
                     .filter(e -> graph.getEdgeObject(e) == null)
                     .filter(e -> graph.getEdgeVertex1(e) == node1 && graph.getEdgeVertex2(e) == node2)

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -166,6 +166,8 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             }
             SwitchImpl aSwitch = new SwitchImpl(NodeBreakerVoltageLevel.this, id, getName(), kind, open, retained, fictitious);
             getNetwork().getIndex().checkAndAdd(aSwitch);
+            graph.addVertexIfNotPresent(node1);
+            graph.addVertexIfNotPresent(node2);
             int e = graph.addEdge(node1, node2, aSwitch);
             switches.put(id, e);
             invalidateCache();
@@ -204,7 +206,8 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             if (node2 == null) {
                 throw new ValidationException(NodeBreakerVoltageLevel.this, "second connection node is not set");
             }
-
+            graph.addVertexIfNotPresent(node1);
+            graph.addVertexIfNotPresent(node2);
             graph.addEdge(node1, node2, null);
             invalidateCache();
         }
@@ -562,25 +565,28 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
     private final NodeBreakerViewExt nodeBreakerView = new NodeBreakerViewExt() {
 
+        /**
+         * @deprecated Depending on your use case, use {@link #getMaximumNodeIndex()} or {@link #getNodeCapacity()}.
+         */
         @Override
+        @Deprecated
         public int getNodeCount() {
             return graph.getVertexCount();
         }
 
         @Override
-        public int[] getNodes() {
-            return graph.getVertices();
+        public int getMaximumNodeIndex() {
+            return graph.getMaximumVertexIndex();
         }
 
         @Override
-        public NodeBreakerView setNodeCount(int count) {
-            int oldCount = graph.getVertexCount();
-            if (count > oldCount) {
-                for (int i = oldCount; i < count; i++) {
-                    graph.addVertex();
-                }
-            }
-            return this;
+        public int getNodeCapacity() {
+            return graph.getVertexCapacity();
+        }
+
+        @Override
+        public int[] getNodes() {
+            return graph.getVertices();
         }
 
         @Override
@@ -645,6 +651,21 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                             return graph.getEdgeVertex2(e);
                         }
                     });
+        }
+
+        @Override
+        public void removeInternalConnection(int node1, int node2) {
+            int[] internalConnectionsToBeRemoved = Arrays.stream(graph.getEdges())
+                    .filter(e -> graph.getEdgeObject(e) == null)
+                    .filter(e -> graph.getEdgeVertex1(e) == node1 && graph.getEdgeVertex2(e) == node2)
+                    .toArray();
+            if (internalConnectionsToBeRemoved.length == 0) {
+                throw new PowsyblException("Internal connection not found between " + node1 + " and " + node2);
+            }
+            for (int ic : internalConnectionsToBeRemoved) {
+                graph.removeEdge(ic);
+            }
+            clean();
         }
 
         @Override
@@ -879,6 +900,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             return;
         }
         int node = ((NodeTerminal) terminal).getNode();
+        graph.addVertexIfNotPresent(node);
         if (graph.getVertexObject(node) != null) {
             throw new ValidationException(terminal.getConnectable(),
                     "an equipment (" + graph.getVertexObject(node).getConnectable().getId()
@@ -906,10 +928,10 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
         // remove the link terminal -> voltage level
         terminal.setVoltageLevel(null);
+        clean();
     }
 
-    @Override
-    public void clean() {
+    private void clean() {
         GraphUtil.removeIsolatedVertices(graph);
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -566,7 +566,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     private final NodeBreakerViewExt nodeBreakerView = new NodeBreakerViewExt() {
 
         /**
-         * @deprecated Depending on your use case, use {@link #getMaximumNodeIndex()} or {@link #getNodeCapacity()}.
+         * @deprecated Use {@link #getMaximumNodeIndex()} instead.
          */
         @Override
         @Deprecated
@@ -576,12 +576,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
         @Override
         public int getMaximumNodeIndex() {
-            return graph.getMaximumVertexIndex();
-        }
-
-        @Override
-        public int getNodeCapacity() {
-            return graph.getVertexCapacity();
+            return graph.getVertexCapacity() - 1;
         }
 
         @Override
@@ -666,6 +661,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                 graph.removeEdge(ic);
             }
             clean();
+            invalidateCache();
         }
 
         @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -652,7 +652,8 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         public void removeInternalConnections(int node1, int node2) {
             int[] internalConnectionsToBeRemoved = Arrays.stream(graph.getEdges())
                     .filter(e -> graph.getEdgeObject(e) == null)
-                    .filter(e -> graph.getEdgeVertex1(e) == node1 && graph.getEdgeVertex2(e) == node2)
+                    .filter(e -> (graph.getEdgeVertex1(e) == node1 && graph.getEdgeVertex2(e) == node2) ||
+                            (graph.getEdgeVertex1(e) == node2 && graph.getEdgeVertex2(e) == node1))
                     .toArray();
             if (internalConnectionsToBeRemoved.length == 0) {
                 throw new PowsyblException("Internal connection not found between " + node1 + " and " + node2);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
@@ -50,8 +50,6 @@ interface VoltageLevelExt extends VoltageLevel, MultiVariantObject {
      */
     void detach(TerminalExt terminal);
 
-    void clean();
-
     boolean connect(TerminalExt terminal);
 
     boolean disconnect(TerminalExt terminal);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerCleanTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerCleanTest.java
@@ -6,7 +6,8 @@
  */
 package com.powsybl.iidm.network.impl;
 
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.test.NetworkTest1Factory;
 import org.junit.Test;
 
@@ -15,47 +16,43 @@ import static org.junit.Assert.*;
 public class NodeBreakerCleanTest {
 
     @Test
-    public void cleanTopology() {
+    public void removeSwitchAndCleanTopology() {
         Network network = NetworkTest1Factory.create();
 
-        VoltageLevelExt vl = (VoltageLevelExt) network.getVoltageLevel("voltageLevel1");
+        VoltageLevel vl = network.getVoltageLevel("voltageLevel1");
         assertNotNull(vl);
 
         VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
-        assertEquals(10, topo.getNodeCount());
-        vl.clean();
-
-        // Check useless nodes have been removed from the topology
-        assertEquals(6, topo.getNodeCount());
-    }
-
-    @Test
-    public void removeSwitch() {
-        Network network = NetworkTest1Factory.create();
-
-        VoltageLevelExt vl = (VoltageLevelExt) network.getVoltageLevel("voltageLevel1");
-        assertNotNull(vl);
-
-        VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
-        vl.clean();
-
-        // Check useless nodes have been removed from the topology
-        assertEquals(6, topo.getNodeCount());
+        assertEquals(6, topo.getMaximumNodeIndex());
+        assertEquals(7, topo.getNodeCapacity());
 
         assertNotNull(topo.getSwitch("load1Disconnector1"));
         assertNotNull(topo.getSwitch("load1Breaker1"));
+
+        // Remove the switches linked to an intermediate node (3)
         topo.removeSwitch("load1Disconnector1");
         topo.removeSwitch("load1Breaker1");
 
-        // Check the 2 switches and the intermediate node have been removed from the topology.
+        // Check the 2 switches and that the node capacity and maximum node index have not changed
         assertNull(topo.getSwitch("load1Disconnector1"));
         assertNull(topo.getSwitch("load1Breaker1"));
-        assertEquals(5, topo.getNodeCount());
+        assertEquals(6, topo.getMaximumNodeIndex());
+        assertEquals(7, topo.getNodeCapacity());
 
         assertNull(network.getSwitch("load1Disconnector1"));
         assertNull(network.getSwitch("load1Breaker1"));
         assertNull(network.getIdentifiable("load1Disconnector1"));
         assertNull(network.getIdentifiable("load1Breaker1"));
+
+        // Remove the switches linked to the maximum node (6)
+        topo.removeSwitch("generator1Disconnector1");
+        topo.removeSwitch("generator1Breaker1");
+
+        // Check the 2 switches and that the node capacity and maximum node index have changed
+        assertNull(topo.getSwitch("generator1Disconnector1"));
+        assertNull(topo.getSwitch("generator1Breaker1"));
+        assertEquals(5, topo.getMaximumNodeIndex());
+        assertEquals(6, topo.getNodeCapacity());
     }
 
 }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerCleanTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerCleanTest.java
@@ -24,7 +24,6 @@ public class NodeBreakerCleanTest {
 
         VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
         assertEquals(6, topo.getMaximumNodeIndex());
-        assertEquals(7, topo.getNodeCapacity());
 
         assertNotNull(topo.getSwitch("load1Disconnector1"));
         assertNotNull(topo.getSwitch("load1Breaker1"));
@@ -37,7 +36,6 @@ public class NodeBreakerCleanTest {
         assertNull(topo.getSwitch("load1Disconnector1"));
         assertNull(topo.getSwitch("load1Breaker1"));
         assertEquals(6, topo.getMaximumNodeIndex());
-        assertEquals(7, topo.getNodeCapacity());
 
         assertNull(network.getSwitch("load1Disconnector1"));
         assertNull(network.getSwitch("load1Breaker1"));
@@ -52,7 +50,6 @@ public class NodeBreakerCleanTest {
         assertNull(topo.getSwitch("generator1Disconnector1"));
         assertNull(topo.getSwitch("generator1Breaker1"));
         assertEquals(5, topo.getMaximumNodeIndex());
-        assertEquals(6, topo.getNodeCapacity());
     }
 
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VoltageLevelAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VoltageLevelAdapter.java
@@ -281,9 +281,19 @@ class VoltageLevelAdapter extends AbstractIdentifiableAdapter<VoltageLevel> impl
         // -------------------------------
         // Simple delegated methods ------
         // -------------------------------
+
+        /**
+         * @deprecated Use {@link #getMaximumNodeIndex()} instead.
+         */
         @Override
+        @Deprecated
         public int getNodeCount() {
             return getDelegate().getNodeCount();
+        }
+
+        @Override
+        public int getMaximumNodeIndex() {
+            return getDelegate().getMaximumNodeIndex();
         }
 
         @Override

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VoltageLevelAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VoltageLevelAdapter.java
@@ -292,12 +292,6 @@ class VoltageLevelAdapter extends AbstractIdentifiableAdapter<VoltageLevel> impl
         }
 
         @Override
-        public VoltageLevel.NodeBreakerView setNodeCount(final int count) {
-            getDelegate().setNodeCount(count);
-            return this;
-        }
-
-        @Override
         public int getInternalConnectionCount() {
             return getDelegate().getInternalConnectionCount();
         }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/VoltageLevelAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/VoltageLevelAdapterTest.java
@@ -319,9 +319,6 @@ public class VoltageLevelAdapterTest {
 
         final VoltageLevel.NodeBreakerView nbv = voltageLevelNB.getNodeBreakerView();
         assertTrue(nbv instanceof VoltageLevelAdapter.NodeBreakerViewAdapter);
-        nbv.setNodeCount(2);
-        assertEquals(2, nbv.getNodeCount());
-        assertEquals(2, nbv.getNodes().length);
 
         nbv.newInternalConnection()
                .setNode1(0)

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractCalculatedTopologyTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractCalculatedTopologyTest.java
@@ -122,7 +122,6 @@ public abstract class AbstractCalculatedTopologyTest {
                 .setNominalV(400f)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl1.getNodeBreakerView().setNodeCount(5);
         Substation s2 = network.newSubstation()
                 .setId("S2")
                 .setCountry(Country.FR)

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractEmptyCalculatedBusBugTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractEmptyCalculatedBusBugTest.java
@@ -29,7 +29,6 @@ public abstract class AbstractEmptyCalculatedBusBugTest {
                 .setNominalV(400.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl.getNodeBreakerView().setNodeCount(2);
         vl.getNodeBreakerView().newBreaker()
                 .setId("SW1")
                 .setNode1(0)
@@ -56,7 +55,6 @@ public abstract class AbstractEmptyCalculatedBusBugTest {
 
         VoltageLevel vl = network.getVoltageLevel("VL");
         vl.getNodeBreakerView()
-                .setNodeCount(3)
                 .newInternalConnection()
                 .setNode1(1)
                 .setNode2(2)

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMainConnectedComponentWithSwitchTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMainConnectedComponentWithSwitchTest.java
@@ -33,7 +33,6 @@ public abstract class AbstractMainConnectedComponentWithSwitchTest {
                 .setLowVoltageLimit(0.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl1.getNodeBreakerView().setNodeCount(3);
         vl1.getNodeBreakerView().newBusbarSection()
                 .setId("C")
                 .setNode(0)
@@ -65,7 +64,6 @@ public abstract class AbstractMainConnectedComponentWithSwitchTest {
                 .setLowVoltageLimit(0.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl2.getNodeBreakerView().setNodeCount(5);
         vl2.getNodeBreakerView().newBusbarSection()
                 .setId("H")
                 .setNode(0)

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractNetworkTest {
         assertSame(TopologyKind.NODE_BREAKER, voltageLevel1.getTopologyKind());
 
         NodeBreakerView topology1 = voltageLevel1.getNodeBreakerView();
-        assertEquals(10, topology1.getNodeCount());
+        assertEquals(7, topology1.getNodeCapacity());
         assertEquals(2, Iterables.size(topology1.getBusbarSections()));
         assertEquals(2, topology1.getBusbarSectionCount());
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractNetworkTest {
         assertSame(TopologyKind.NODE_BREAKER, voltageLevel1.getTopologyKind());
 
         NodeBreakerView topology1 = voltageLevel1.getNodeBreakerView();
-        assertEquals(7, topology1.getNodeCapacity());
+        assertEquals(6, topology1.getMaximumNodeIndex());
         assertEquals(2, Iterables.size(topology1.getBusbarSections()));
         assertEquals(2, topology1.getBusbarSectionCount());
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerDisconnectionDoublePathBugTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerDisconnectionDoublePathBugTest.java
@@ -28,7 +28,6 @@ public abstract class AbstractNodeBreakerDisconnectionDoublePathBugTest {
                 .setNominalV(400.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl.getNodeBreakerView().setNodeCount(10);
         vl.getNodeBreakerView().newBusbarSection()
                 .setId("BBS1")
                 .setNode(0)

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerInternalConnectionsTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerInternalConnectionsTest.java
@@ -1,5 +1,12 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.iidm.network.tck;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
@@ -12,7 +19,11 @@ import java.util.stream.Collectors;
 
 import static com.powsybl.iidm.network.VoltageLevel.NodeBreakerView.InternalConnection;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
 public abstract class AbstractNodeBreakerInternalConnectionsTest {
 
     private static final String S5_10K_V = "S5 10kV";
@@ -26,8 +37,8 @@ public abstract class AbstractNodeBreakerInternalConnectionsTest {
 
         assertEquals(6, vl.getNodeBreakerView().getInternalConnectionCount());
         List<InternalConnection> internalConnections = vl.getNodeBreakerView().getInternalConnectionStream().collect(Collectors.toList());
-        int[] expecteds1 = new int[] {7, 6, 4, 5, 9, 8 };
-        int[] expecteds2 = new int[] {0, 3, 3, 2, 2, 1 };
+        int[] expecteds1 = new int[]{7, 6, 4, 5, 9, 8};
+        int[] expecteds2 = new int[]{0, 3, 3, 2, 2, 1};
         assertEquals(expecteds1.length, expecteds2.length);
         for (int i = 0; i < expecteds1.length; i++) {
             assertEquals(expecteds1[i], internalConnections.get(i).getNode1());
@@ -49,6 +60,37 @@ public abstract class AbstractNodeBreakerInternalConnectionsTest {
         InternalConnections actual = findInternalConnections(vl);
         InternalConnections expected = all;
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testRemoveInternalConnections() {
+        Network network = Network.create("testTraversalInternalConnections", "test");
+        createNetwork(network, new InternalConnections());
+        VoltageLevel vl = network.getVoltageLevel(S5_10K_V);
+
+        // remove an existing internal connection
+        assertTrue(vl.getNodeBreakerView().getInternalConnectionStream().anyMatch(ic -> ic.getNode1() == 7 && ic.getNode2() == 0));
+        vl.getNodeBreakerView().removeInternalConnections(7, 0);
+        assertTrue(vl.getNodeBreakerView().getInternalConnectionStream().noneMatch(ic -> ic.getNode1() == 7 && ic.getNode2() == 0));
+
+        // remove a non-existing internal connection
+        boolean thrownException = false;
+        try {
+            vl.getNodeBreakerView().removeInternalConnections(6, 0);
+        } catch (PowsyblException e) {
+            assertEquals("Internal connection not found between 6 and 0", e.getMessage());
+            thrownException = true;
+        }
+        assertTrue(thrownException);
+
+        // remove multiple internal connections
+        vl.getNodeBreakerView().newInternalConnection()
+                .setNode1(6)
+                .setNode2(3)
+                .add();
+        assertEquals(2, vl.getNodeBreakerView().getInternalConnectionStream().filter(ic -> ic.getNode1() == 6 && ic.getNode2() == 3).count());
+        vl.getNodeBreakerView().removeInternalConnections(6, 3);
+        assertTrue(vl.getNodeBreakerView().getInternalConnectionStream().noneMatch(ic -> ic.getNode1() == 6 && ic.getNode2() == 3));
     }
 
     private void createNetwork(Network network, InternalConnections internalConnections) {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerInternalConnectionsTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerInternalConnectionsTest.java
@@ -61,7 +61,6 @@ public abstract class AbstractNodeBreakerInternalConnectionsTest {
                 .setNominalV(10.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl.getNodeBreakerView().setNodeCount(14);
         vl.getNodeBreakerView().newBusbarSection()
                 .setId("NODE13")
                 .setNode(0)
@@ -125,12 +124,11 @@ public abstract class AbstractNodeBreakerInternalConnectionsTest {
                 .setId("S4")
                 .setCountry(Country.FR)
                 .add();
-        VoltageLevel vl4 = s4.newVoltageLevel()
+        s4.newVoltageLevel()
                 .setId("S4 10kV")
                 .setNominalV(10.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl4.getNodeBreakerView().setNodeCount(1);
         network.newLine()
                 .setId("L6")
                 .setVoltageLevel1("S4 10kV")

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerTest.java
@@ -28,7 +28,6 @@ public abstract class AbstractNodeBreakerTest {
                 .setNominalV(400.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl.getNodeBreakerView().setNodeCount(10);
         vl.getNodeBreakerView().newBusbarSection()
                 .setId("BBS")
                 .setNode(0)
@@ -80,7 +79,6 @@ public abstract class AbstractNodeBreakerTest {
                 .add();
 
         vl1.getNodeBreakerView()
-                .setNodeCount(11)
                 .newBusbarSection()
                 .setId("B0")
                 .setNode(0)
@@ -154,8 +152,6 @@ public abstract class AbstractNodeBreakerTest {
                 .setRetained(true)
                 .add();
 
-        vl2.getNodeBreakerView()
-                .setNodeCount(1);
         vl2.newLoad()
                 .setId("L4")
                 .setNode(0)

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSwitchOpenCloseNodeBreakerTopoTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSwitchOpenCloseNodeBreakerTopoTest.java
@@ -29,7 +29,6 @@ public abstract class AbstractSwitchOpenCloseNodeBreakerTopoTest {
                 .setNominalV(400.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl.getNodeBreakerView().setNodeCount(10);
         vl.getNodeBreakerView().newBusbarSection()
                 .setId("BBS1")
                 .setNode(0)

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSwitchSetRetainedTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSwitchSetRetainedTest.java
@@ -28,7 +28,6 @@ public abstract class AbstractSwitchSetRetainedTest {
                 .setNominalV(400.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl.getNodeBreakerView().setNodeCount(10);
         vl.getNodeBreakerView().newBusbarSection()
                 .setId("BBS1")
                 .setNode(0)

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTopologyTraverserTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTopologyTraverserTest.java
@@ -32,7 +32,6 @@ public abstract class AbstractTopologyTraverserTest {
                 .setNominalV(400.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl1.getNodeBreakerView().setNodeCount(5);
         vl1.getNodeBreakerView().newBusbarSection()
                 .setId("BBS1")
                 .setNode(0)
@@ -78,7 +77,6 @@ public abstract class AbstractTopologyTraverserTest {
                 .setNominalV(400.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl2.getNodeBreakerView().setNodeCount(5);
         vl2.getNodeBreakerView().newBusbarSection()
                 .setId("BBS2")
                 .setNode(0)

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/FictitiousSwitchFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/FictitiousSwitchFactory.java
@@ -40,7 +40,6 @@ public final class FictitiousSwitchFactory {
                 .setLowVoltageLimit(0.0)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vlC.getNodeBreakerView().setNodeCount(5);
         BusbarSection busbarSectionD = vlC.getNodeBreakerView().newBusbarSection()
                 .setId("D")
                 .setName("E")
@@ -58,7 +57,6 @@ public final class FictitiousSwitchFactory {
                 .setHighVoltageLimit(245.00002)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vlN.getNodeBreakerView().setNodeCount(23);
         BusbarSection busbarSectionO = vlN.getNodeBreakerView().newBusbarSection()
                 .setId("O")
                 .setName("E")

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/HvdcTestNetwork.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/HvdcTestNetwork.java
@@ -53,7 +53,6 @@ public final class HvdcTestNetwork {
                 .setNominalV(400)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
-        vl2.getNodeBreakerView().setNodeCount(3);
         vl2.getNodeBreakerView().newBusbarSection()
                 .setId("BBS1")
                 .setName("BusbarSection")
@@ -180,7 +179,6 @@ public final class HvdcTestNetwork {
                 .setP(100.0)
                 .setQ(50.0);
         VoltageLevel vl2 = network.getVoltageLevel("VL2");
-        vl2.getNodeBreakerView().setNodeCount(7);
         vl2.getNodeBreakerView().newDisconnector()
                 .setId("DISC_BBS1_BK2")
                 .setName(DISCONNECTOR_NAME)

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NetworkTest1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NetworkTest1Factory.java
@@ -39,7 +39,6 @@ public final class NetworkTest1Factory {
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
         VoltageLevel.NodeBreakerView topology1 = voltageLevel1.getNodeBreakerView();
-        topology1.setNodeCount(10);
         BusbarSection voltageLevel1BusbarSection1 = topology1.newBusbarSection()
                 .setId("voltageLevel1BusbarSection1")
                 .setNode(0)

--- a/iidm/iidm-util/src/main/java/com/powsybl/iidm/network/util/NodeBreakerTopology.java
+++ b/iidm/iidm-util/src/main/java/com/powsybl/iidm/network/util/NodeBreakerTopology.java
@@ -72,7 +72,7 @@ public final class NodeBreakerTopology {
         int n = bb.getTerminal().getNodeBreakerView().getNode();
         VoltageLevel.NodeBreakerView topo = bb.getTerminal().getVoltageLevel().getNodeBreakerView();
 
-        int oldCount = topo.getNodeCount();
+        int oldCount = topo.getMaximumNodeIndex() + 1;
         topo.newDisconnector()
                 .setId(String.format("disconnector %s-%d", bb.getId(), oldCount))
                 .setNode1(n)

--- a/iidm/iidm-util/src/main/java/com/powsybl/iidm/network/util/NodeBreakerTopology.java
+++ b/iidm/iidm-util/src/main/java/com/powsybl/iidm/network/util/NodeBreakerTopology.java
@@ -73,7 +73,6 @@ public final class NodeBreakerTopology {
         VoltageLevel.NodeBreakerView topo = bb.getTerminal().getVoltageLevel().getNodeBreakerView();
 
         int oldCount = topo.getNodeCount();
-        topo.setNodeCount(oldCount + 2);
         topo.newDisconnector()
                 .setId(String.format("disconnector %s-%d", bb.getId(), oldCount))
                 .setNode1(n)

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -12,6 +12,8 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.util.Networks;
 import com.powsybl.iidm.xml.util.IidmXmlUtil;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.stream.XMLStreamException;
 import java.util.Map;
@@ -26,9 +28,11 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
 
     static final String ROOT_ELEMENT_NAME = "voltageLevel";
 
-    static final String NODE_BREAKER_TOPOLOGY_ELEMENT_NAME = "nodeBreakerTopology";
+    private static final Logger LOGGER = LoggerFactory.getLogger(VoltageLevelXml.class);
 
-    static final String BUS_BREAKER_TOPOLOGY_ELEMENT_NAME = "busBreakerTopology";
+    private static final String NODE_BREAKER_TOPOLOGY_ELEMENT_NAME = "nodeBreakerTopology";
+    private static final String BUS_BREAKER_TOPOLOGY_ELEMENT_NAME = "busBreakerTopology";
+    private static final String NODE_COUNT = "nodeCount";
 
     @Override
     protected String getRootElementName() {
@@ -82,7 +86,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
 
     private void writeNodeBreakerTopology(VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
         context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), NODE_BREAKER_TOPOLOGY_ELEMENT_NAME);
-        context.getWriter().writeAttribute("nodeCount", Integer.toString(vl.getNodeBreakerView().getNodeCount()));
+        IidmXmlUtil.writeIntAttributeUntilMaximumVersion(NODE_COUNT, vl.getNodeBreakerView().getNodeCapacity(), IidmXmlVersion.V_1_1, context);
         for (BusbarSection bs : vl.getNodeBreakerView().getBusbarSections()) {
             BusbarSectionXml.INSTANCE.write(bs, null, context);
         }
@@ -292,8 +296,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     }
 
     private void readNodeBreakerTopology(VoltageLevel vl, NetworkXmlReaderContext context) throws XMLStreamException {
-        int nodeCount = XmlUtil.readIntAttribute(context.getReader(), "nodeCount");
-        vl.getNodeBreakerView().setNodeCount(nodeCount);
+        IidmXmlUtil.runUntilMaximumVersion(IidmXmlVersion.V_1_1, context, () -> LOGGER.info("attribute " + NODE_BREAKER_TOPOLOGY_ELEMENT_NAME + ".nodeCount is ignored."));
         XmlUtil.readUntilEndElement(NODE_BREAKER_TOPOLOGY_ELEMENT_NAME, context.getReader(), () -> {
             switch (context.getReader().getLocalName()) {
                 case BusbarSectionXml.ROOT_ELEMENT_NAME:

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -86,7 +86,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
 
     private void writeNodeBreakerTopology(VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
         context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), NODE_BREAKER_TOPOLOGY_ELEMENT_NAME);
-        IidmXmlUtil.writeIntAttributeUntilMaximumVersion(NODE_COUNT, vl.getNodeBreakerView().getNodeCapacity(), IidmXmlVersion.V_1_1, context);
+        IidmXmlUtil.writeIntAttributeUntilMaximumVersion(NODE_COUNT, vl.getNodeBreakerView().getMaximumNodeIndex() + 1, IidmXmlVersion.V_1_1, context);
         for (BusbarSection bs : vl.getNodeBreakerView().getBusbarSections()) {
             BusbarSectionXml.INSTANCE.write(bs, null, context);
         }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
@@ -86,6 +86,15 @@ public final class IidmXmlUtil {
         }
     }
 
+    public static <C extends AbstractNetworkXmlContext> void assertMaximumVersionIfNotDefault(boolean valueIsNotDefault, String rootElementName,
+                                                                                              String elementName, ErrorMessage type, IidmXmlVersion maxVersion,
+                                                                                              C context, Runnable runnable) {
+        if (valueIsNotDefault) {
+            assertMaximumVersion(rootElementName, elementName, type, maxVersion, context);
+            runnable.run();
+        }
+    }
+
     /**
      * Assert that the context's IIDM-XML version is strictly older than a given IIDM-XML version.
      * If not, throw an exception with a given type of error message.
@@ -164,6 +173,12 @@ public final class IidmXmlUtil {
             write.run();
         } else {
             assertMinimumVersionIfNotDefault(isNotDefaultValue, rootElementName, attributeName, type, minVersion, context);
+        }
+    }
+
+    public static void writeIntAttributeUntilMaximumVersion(String attributeName, int value, IidmXmlVersion maxVersion, NetworkXmlWriterContext context) throws XMLStreamException {
+        if (context.getVersion().compareTo(maxVersion) <= 0) {
+            XmlUtil.writeInt(attributeName, value, context.getWriter());
         }
     }
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/util/IidmXmlUtil.java
@@ -86,15 +86,6 @@ public final class IidmXmlUtil {
         }
     }
 
-    public static <C extends AbstractNetworkXmlContext> void assertMaximumVersionIfNotDefault(boolean valueIsNotDefault, String rootElementName,
-                                                                                              String elementName, ErrorMessage type, IidmXmlVersion maxVersion,
-                                                                                              C context, Runnable runnable) {
-        if (valueIsNotDefault) {
-            assertMaximumVersion(rootElementName, elementName, type, maxVersion, context);
-            runnable.run();
-        }
-    }
-
     /**
      * Assert that the context's IIDM-XML version is strictly older than a given IIDM-XML version.
      * If not, throw an exception with a given type of error message.
@@ -176,6 +167,10 @@ public final class IidmXmlUtil {
         }
     }
 
+    /**
+     * Write a <b>mandatory</b> int attribute until a given maximum IIDM-XML version. <br>
+     * If the context's IIDM-XML version is strictly more recent than the given maximum IIDM-XML version, do nothing.
+     */
     public static void writeIntAttributeUntilMaximumVersion(String attributeName, int value, IidmXmlVersion maxVersion, NetworkXmlWriterContext context) throws XMLStreamException {
         if (context.getVersion().compareTo(maxVersion) <= 0) {
             XmlUtil.writeInt(attributeName, value, context.getWriter());

--- a/iidm/iidm-xml-converter/src/main/resources/xsd/iidm_V1_2.xsd
+++ b/iidm/iidm-xml-converter/src/main/resources/xsd/iidm_V1_2.xsd
@@ -108,7 +108,6 @@
             <xs:element name="internalConnection" minOccurs="0" maxOccurs="unbounded" type="iidm:InternalConnection"/>
             <xs:element name="bus" minOccurs="0" maxOccurs="unbounded" type="iidm:CalculatedBus"/>
         </xs:sequence>
-        <xs:attribute name="nodeCount" use="required" type="xs:int"/>
     </xs:complexType>
     <xs:complexType name="BusBreakerTopology">
         <xs:sequence>

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NodeBreakerInternalConnectionsTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NodeBreakerInternalConnectionsTest.java
@@ -46,7 +46,6 @@ public class NodeBreakerInternalConnectionsTest extends AbstractXmlConverterTest
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
         NodeBreakerView n1 = vl1.getNodeBreakerView();
-        n1.setNodeCount(5);
         vl1.newGenerator()
                 .setId("g1")
                 .setNode(0)
@@ -71,7 +70,6 @@ public class NodeBreakerInternalConnectionsTest extends AbstractXmlConverterTest
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
         NodeBreakerView n2 = vl2.getNodeBreakerView();
-        n2.setNodeCount(5);
         vl2.newLoad()
                 .setId("l2")
                 .setNode(0)

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ShuntCompensatorXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ShuntCompensatorXmlTest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
@@ -40,39 +40,35 @@ public class ShuntCompensatorXmlTest extends AbstractXmlConverterTest {
 
     @Test
     public void unsupportedReadTest() {
-        testForAllPreviousVersions(IidmXmlVersion.V_1_2, v -> assertTrue(read(v)));
+        testForAllPreviousVersions(IidmXmlVersion.V_1_2, this::read);
     }
 
     @Test
     public void unsupportedWriteTest() {
         Network network = ShuntTestCaseFactory.create();
-        testForAllPreviousVersions(IidmXmlVersion.V_1_2, v -> assertTrue(write(network, v.toString("."))));
+        testForAllPreviousVersions(IidmXmlVersion.V_1_2, v -> write(network, v.toString(".")));
     }
 
-    private boolean read(IidmXmlVersion version) {
-        boolean exceptionThrown = false;
+    private void read(IidmXmlVersion version) {
         try {
             NetworkXml.read(getVersionedNetworkAsStream("faultyShunt.xml", version));
+            fail();
         } catch (PowsyblException e) {
-            exceptionThrown = true;
             assertEquals("shunt.regulatingTerminal is not supported for IIDM-XML version " +
                             version.toString(".") + ". IIDM-XML version should be >= 1.2",
                     e.getMessage());
         }
-        return exceptionThrown;
     }
 
-    private boolean write(Network network, String version) {
-        boolean exceptionThrown = false;
+    private void write(Network network, String version) {
         try {
             ExportOptions options = new ExportOptions().setVersion(version);
             NetworkXml.write(network, options, tmpDir.resolve("/fail.xml"));
+            fail();
         } catch (PowsyblException e) {
-            exceptionThrown = true;
             assertEquals("shunt.voltageRegulatorOn is not defined as default and not supported for IIDM-XML version " +
                             version + ". IIDM-XML version should be >= 1.2",
                     e.getMessage());
         }
-        return exceptionThrown;
     }
 }

--- a/iidm/iidm-xml-converter/src/test/resources/V1_1/faultyThreeWindingsTransformerRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_1/faultyThreeWindingsTransformerRoundTripRef.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_1" id="three-windings-transformer" caseDate="2018-03-05T13:30:30.486+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="SUBSTATION" country="FR">
+        <iidm:voltageLevel id="VL_132" nominalV="132.0" lowVoltageLimit="118.8" highVoltageLimit="145.2" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS_132" v="133.584" angle="-9.62"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN_132" energySource="OTHER" minP="0.0" maxP="140.0" voltageRegulatorOn="true" targetP="7.2" targetV="135.0" bus="BUS_132" connectableBus="BUS_132">
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL_33" nominalV="33.0" lowVoltageLimit="29.7" highVoltageLimit="36.3" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS_33" v="34.881" angle="-15.24"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD_33" loadType="UNDEFINED" p0="11.2" q0="7.5" bus="BUS_33" connectableBus="BUS_33" p="11.2" q="7.5"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL_11" nominalV="11.0" lowVoltageLimit="9.9" highVoltageLimit="12.1" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS_11" v="11.781" angle="-15.24"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD_11" loadType="UNDEFINED" p0="0.0" q0="-10.6" bus="BUS_11" connectableBus="BUS_11" p="0.0" q="-10.6"/>
+        </iidm:voltageLevel>
+        <iidm:threeWindingsTransformer id="3WT" r1="17.424" x1="1.7424" g1="0.00573921028466483" b1="5.73921028466483E-4" ratedU1="132.0" r2="1.089" x2="0.1089" g2="0.0" b2="0.0" ratedU2="33.0" r3="0.121" x3="0.0121" g3="0.0" b3="0.0" ratedU3="11.0" bus1="BUS_132" connectableBus1="BUS_132" voltageLevelId1="VL_132" bus2="BUS_33" connectableBus2="BUS_33" voltageLevelId2="VL_33" bus3="BUS_11" connectableBus3="BUS_11" voltageLevelId3="VL_11">
+            <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulating="true" targetV="33.0">
+                <iidm:terminalRef id="LOAD_33"/>
+                <iidm:step r="0.9801" x="0.09801" g="0.08264462809917356" b="0.008264462809917356" rho="0.9"/>
+                <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
+                <iidm:step r="1.1979" x="0.11979" g="0.10101010101010101" b="0.0101010101010101" rho="1.1"/>
+            </iidm:ratioTapChanger2>
+            <iidm:ratioTapChanger3 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="false" targetV="11.0">
+                <iidm:terminalRef id="LOAD_11"/>
+                <iidm:step r="0.1089" x="0.01089" g="0.8264462809917356" b="0.08264462809917356" rho="0.9"/>
+                <iidm:step r="0.121" x="0.0121" g="0.8264462809917356" b="0.08264462809917356" rho="1.0"/>
+                <iidm:step r="0.1331" x="0.01331" g="0.9090909090909092" b="0.09090909090909093" rho="1.1"/>
+            </iidm:ratioTapChanger3>
+            <iidm:currentLimits1 permanentLimit="1000.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="1200.0"/>
+                <iidm:temporaryLimit name="10'" acceptableDuration="600" value="1400.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="100.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="120.0"/>
+                <iidm:temporaryLimit name="10'" acceptableDuration="600" value="140.0"/>
+            </iidm:currentLimits2>
+            <iidm:currentLimits3 permanentLimit="10.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="12.0"/>
+                <iidm:temporaryLimit name="10'" acceptableDuration="600" value="14.0"/>
+            </iidm:currentLimits3>
+        </iidm:threeWindingsTransformer>
+    </iidm:substation>
+</iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/LccRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/LccRoundTripRef.xml
@@ -12,7 +12,7 @@
     </iidm:substation>
     <iidm:substation id="S2" country="FR">
         <iidm:voltageLevel id="VL2" nominalV="400.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology nodeCount="7">
+            <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="BBS1" name="BusbarSection" node="0"/>
                 <iidm:switch id="DISC_BBS1_BK1" name="Disconnector" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="BK1" name="Breaker" kind="BREAKER" retained="true" open="false" node1="1" node2="2"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/VscRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/VscRoundTripRef.xml
@@ -15,7 +15,7 @@
     </iidm:substation>
     <iidm:substation id="S2" country="FR">
         <iidm:voltageLevel id="VL2" nominalV="400.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology nodeCount="3">
+            <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="BBS1" name="BusbarSection" node="0"/>
                 <iidm:switch id="DISC_BBS1_BK1" name="Disconnector" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="BK1" name="Breaker" kind="BREAKER" retained="true" open="false" node1="1" node2="2"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/fictitiousSwitchRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/fictitiousSwitchRef.xml
@@ -2,7 +2,7 @@
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="fictitious" caseDate="2017-06-25T17:43:00.000+01:00" forecastDistance="0" sourceFormat="test">
     <iidm:substation id="A" country="FR">
         <iidm:voltageLevel id="C" nominalV="225.0" lowVoltageLimit="0.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology nodeCount="5">
+            <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="D" name="E" node="0"/>
                 <iidm:switch id="F" name="G" kind="DISCONNECTOR" retained="false" open="false" fictitious="true" node1="0" node2="1"/>
                 <iidm:switch id="H" name="I" kind="DISCONNECTOR" retained="false" open="false" fictitious="true" node1="0" node2="3"/>
@@ -12,7 +12,7 @@
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="N" nominalV="225.0" lowVoltageLimit="220.0" highVoltageLimit="245.00002" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology nodeCount="23">
+            <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="O" name="E" node="0"/>
                 <iidm:busbarSection id="P" name="Q" node="1"/>
                 <iidm:switch id="R" name="S" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="19"/>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_2/internalConnections.xiidm
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_2/internalConnections.xiidm
@@ -2,7 +2,7 @@
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="internal-connections" caseDate="2018-11-08T12:33:26.208+01:00" forecastDistance="0" sourceFormat="test">
     <iidm:substation id="s1" country="ES">
         <iidm:voltageLevel id="vl1" nominalV="400.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology nodeCount="5">
+            <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="b1" node="2"/>
                 <iidm:switch id="br1" kind="BREAKER" retained="false" open="false" node1="1" node2="2"/>
                 <iidm:internalConnection node1="0" node2="1"/>
@@ -15,7 +15,7 @@
     </iidm:substation>
     <iidm:substation id="s2" country="ES">
         <iidm:voltageLevel id="vl2" nominalV="400.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology nodeCount="5">
+            <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="b2" node="2"/>
                 <iidm:switch id="br2" kind="BREAKER" retained="false" open="false" node1="1" node2="2"/>
                 <iidm:internalConnection node1="0" node2="1"/>

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
@@ -33,6 +33,13 @@ public interface UndirectedGraph<V, E> {
     int addVertex();
 
     /**
+     * If the specified vertex does not exist or is null, create it and notify the {@link UndirectedGraphListener}
+     */
+    default void addVertexIfNotPresent(int v) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Remove the specified vertex and notify the {@link UndirectedGraphListener}s.
      * This method throws a {@link com.powsybl.commons.PowsyblException} if the vertex doesn't exist or if an edge is connected to this vertex.
      *
@@ -48,6 +55,10 @@ public interface UndirectedGraph<V, E> {
      * @return the number of vertices.
      */
     int getVertexCount();
+
+    default int getMaximumVertexIndex() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Create an edge between the two specified vertices and notify the {@link UndirectedGraphListener}s.

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
@@ -49,16 +49,12 @@ public interface UndirectedGraph<V, E> {
     V removeVertex(int v);
 
     /**
-     * Return the number of vertices.
+     * Return the number of non-null vertices.
      * As the contiguity of vertices is not mandatory, the number of vertices can be less than the highest vertex index.
      *
      * @return the number of vertices.
      */
     int getVertexCount();
-
-    default int getMaximumVertexIndex() {
-        throw new UnsupportedOperationException();
-    }
 
     /**
      * Create an edge between the two specified vertices and notify the {@link UndirectedGraphListener}s.

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraphImpl.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraphImpl.java
@@ -11,6 +11,7 @@ import com.google.common.collect.FluentIterable;
 import com.powsybl.commons.PowsyblException;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.list.linked.TIntLinkedList;
+import gnu.trove.set.hash.TIntHashSet;
 
 import java.io.PrintStream;
 import java.util.*;
@@ -97,7 +98,7 @@ public class UndirectedGraphImpl<V, E> implements UndirectedGraph<V, E> {
 
     private final Lock adjacencyListCacheLock = new ReentrantLock();
 
-    private final TIntLinkedList availableVertices = new TIntLinkedList();
+    private final TIntHashSet availableVertices = new TIntHashSet();
 
     private final TIntLinkedList removedEdges = new TIntLinkedList();
 
@@ -120,9 +121,10 @@ public class UndirectedGraphImpl<V, E> implements UndirectedGraph<V, E> {
         int v;
         if (availableVertices.isEmpty()) {
             v = vertices.size();
-            vertices.add(new Vertex<V>());
+            vertices.add(new Vertex<>());
         } else {
-            v = availableVertices.removeAt(0);
+            v = availableVertices.iterator().next();
+            availableVertices.remove(v);
         }
         invalidateAdjacencyList();
         notifyListener();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
fix #781 
fix #1118 

**What kind of change does this PR introduce?**
Bug fix

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
In this proposition, I kept the same behaviour for `NodeBreakerVoltageLevel.cleanTopology()` than `NodeBreakerVoltageLevel.clean()` used to have **with the same issues**: hence, when the topology is cleaned and intermediate nodes are removed, they cannot be used again e.g. if a node/breaker voltage level only used nodes 1, 2 and 4 and is cleaned, attempting to use node 3 will throw a `PowsyblException` with the message `Vertex 3 not found`. Is this the behavior we want?
