### PR TITLE
[WIP] Merging view step : remove methods implementation

### DIFF
--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractBranchAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractBranchAdapter.java
@@ -164,11 +164,8 @@ abstract class AbstractBranchAdapter<I extends Branch<I>> extends AbstractIdenti
         return getDelegate().getType();
     }
 
-    // -------------------------------
-    // Not implemented methods -------
-    // -------------------------------
     @Override
     public void remove() {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
+        getDelegate().remove();
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractHvdcConverterStationAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractHvdcConverterStationAdapter.java
@@ -64,11 +64,8 @@ abstract class AbstractHvdcConverterStationAdapter<I extends HvdcConverterStatio
         return getDelegate().getLossFactor();
     }
 
-    // -------------------------------
-    // Not implemented methods -------
-    // -------------------------------
     @Override
     public void remove() {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
+        getDelegate().remove();
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractInjectionAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractInjectionAdapter.java
@@ -42,11 +42,8 @@ abstract class AbstractInjectionAdapter<I extends Injection<I>> extends Abstract
         return getDelegate().getType();
     }
 
-    // -------------------------------
-    // Not implemented methods -------
-    // -------------------------------
     @Override
     public void remove() {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
+        getDelegate().remove();
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractTapChangerAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractTapChangerAdapter.java
@@ -101,11 +101,8 @@ abstract class AbstractTapChangerAdapter<P extends TapChanger<P, S>, S extends T
         return (P) this;
     }
 
-    // ------------------------------
-    // Not implemented methods ------
-    // ------------------------------
     @Override
     public void remove() {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
+        getDelegate().remove();
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/HvdcLineAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/HvdcLineAdapter.java
@@ -86,11 +86,8 @@ public class HvdcLineAdapter extends AbstractIdentifiableAdapter<HvdcLine> imple
         return this;
     }
 
-    // -------------------------------
-    // Not implemented methods -------
-    // -------------------------------
     @Override
     public void remove() {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
+        getDelegate().remove();
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergedLine.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergedLine.java
@@ -417,6 +417,8 @@ class MergedLine implements Line {
 
     @Override
     public void remove() {
+        // Remove this from MergingViewIndex
+        index.remove(dl1.getUcteXnodeCode());
         dl1.remove();
         dl2.remove();
     }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergedLine.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergedLine.java
@@ -415,14 +415,15 @@ class MergedLine implements Line {
         return (String) properties.setProperty(key, value);
     }
 
+    @Override
+    public void remove() {
+        dl1.remove();
+        dl2.remove();
+    }
+
     // -------------------------------
     // Not implemented methods -------
     // -------------------------------
-    @Override
-    public void remove() {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
-    }
-
     @Override
     public <E extends Extension<Line>> void addExtension(final Class<? super E> type, final E extension) {
         throw MergingView.NOT_IMPLEMENTED_EXCEPTION;

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingNetworkListener.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingNetworkListener.java
@@ -32,11 +32,17 @@ public class MergingNetworkListener implements NetworkListener {
 
     @Override
     public void onRemoval(final Identifiable identifiable) {
-        // Not implemented yet !
+        index.remove(identifiable);
     }
 
     @Override
     public void onUpdate(final Identifiable identifiable, final String attribute, final Object oldValue, final Object newValue) {
-        // Not implemented yet !
+        if (Objects.isNull(newValue)) {
+            if (attribute.contains("phaseTapChanger")) {
+                index.remove((PhaseTapChanger) oldValue);
+            } else if (attribute.contains("ratioTapChanger")) {
+                index.remove((RatioTapChanger) oldValue);
+            }
+        }
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingNetworkListener.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingNetworkListener.java
@@ -37,10 +37,10 @@ public class MergingNetworkListener implements NetworkListener {
 
     @Override
     public void onUpdate(final Identifiable identifiable, final String attribute, final Object oldValue, final Object newValue) {
-        if (Objects.isNull(newValue)) {
-            if (attribute.contains("phaseTapChanger")) {
+        if (Objects.nonNull(oldValue) && Objects.isNull(newValue)) {
+            if (oldValue instanceof PhaseTapChanger) {
                 index.remove((PhaseTapChanger) oldValue);
-            } else if (attribute.contains("ratioTapChanger")) {
+            } else if (oldValue instanceof RatioTapChanger) {
                 index.remove((RatioTapChanger) oldValue);
             }
         }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
@@ -672,7 +672,7 @@ public final class MergingView implements Network {
     @Override
     public DanglingLine getDanglingLine(final String id) {
         final DanglingLine dl = index.get(n -> n.getDanglingLine(id), index::getDanglingLine);
-        return index.isMerged(dl) ? dl : null;
+        return index.isMerged(dl) ? null : dl;
     }
 
     // HvdcLines
@@ -741,21 +741,25 @@ public final class MergingView implements Network {
         return variantManager;
     }
 
+    @Override
+    public void addListener(final NetworkListener listener) {
+        Objects.requireNonNull(listener, "Listener is null");
+        workingNetwork.addListener(listener);
+        index.getNetworkStream().forEach(n -> n.addListener(listener));
+    }
+
+    @Override
+    public void removeListener(final NetworkListener listener) {
+        Objects.requireNonNull(listener, "Listener is null");
+        workingNetwork.removeListener(listener);
+        index.getNetworkStream().forEach(n -> n.removeListener(listener));
+    }
+
     // -------------------------------
     // Not implemented methods -------
     // -------------------------------
     @Override
     public TieLineAdder newTieLine() {
-        throw NOT_IMPLEMENTED_EXCEPTION;
-    }
-
-    @Override
-    public void addListener(final NetworkListener listener) {
-        throw NOT_IMPLEMENTED_EXCEPTION;
-    }
-
-    @Override
-    public void removeListener(final NetworkListener listener) {
         throw NOT_IMPLEMENTED_EXCEPTION;
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
@@ -272,7 +272,11 @@ class MergingViewIndex {
     }
 
     boolean isMerged(final DanglingLine dl) {
-        return !mergedLineCached.containsKey(dl.getUcteXnodeCode());
+        boolean isMerged = false;
+        if (dl != null) {
+            isMerged = !mergedLineCached.containsKey(dl.getUcteXnodeCode());
+        }
+        return isMerged;
     }
 
     Collection<DanglingLine> getDanglingLines() {
@@ -466,5 +470,23 @@ class MergingViewIndex {
                     .filter(filter)
                     .findFirst()
                     .orElse(null);
+    }
+
+    void remove(final Identifiable toRemove) {
+        Objects.requireNonNull(toRemove, "Identifiable to remove is null");
+
+        if (toRemove instanceof DanglingLine) {
+            // if DanglingLine, check if MergedLine need to be removed
+            mergedLineCached.remove(((DanglingLine) toRemove).getUcteXnodeCode());
+        }
+        identifiableCached.remove(toRemove);
+    }
+
+    void remove(final PhaseTapChanger toRemove) {
+        ptcCached.remove(toRemove);
+    }
+
+    void remove(final RatioTapChanger toRemove) {
+        rtcCached.remove(toRemove);
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
@@ -272,18 +272,14 @@ class MergingViewIndex {
     }
 
     boolean isMerged(final DanglingLine dl) {
-        boolean isMerged = false;
-        if (dl != null) {
-            isMerged = !mergedLineCached.containsKey(dl.getUcteXnodeCode());
-        }
-        return isMerged;
+        return (dl != null) && mergedLineCached.containsKey(dl.getUcteXnodeCode());
     }
 
     Collection<DanglingLine> getDanglingLines() {
         // Search DanglingLine into merging & working networks
         return getNetworkStream()
                 .flatMap(Network::getDanglingLineStream)
-                .filter(this::isMerged)
+                .filter(dl -> !isMerged(dl))
                 .map(this::getDanglingLine)
                 .collect(Collectors.toList());
     }
@@ -480,6 +476,10 @@ class MergingViewIndex {
             mergedLineCached.remove(((DanglingLine) toRemove).getUcteXnodeCode());
         }
         identifiableCached.remove(toRemove);
+    }
+
+    void remove(final String ucteXnodeCode) {
+        mergedLineCached.remove(ucteXnodeCode);
     }
 
     void remove(final PhaseTapChanger toRemove) {

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapter.java
@@ -186,11 +186,8 @@ public class ThreeWindingsTransformerAdapter extends AbstractIdentifiableAdapter
         return getDelegate().getRatedU0();
     }
 
-    // -------------------------------
-    // Not implemented methods -------
-    // -------------------------------
     @Override
     public void remove() {
-        throw MergingView.NOT_IMPLEMENTED_EXCEPTION;
+        getDelegate().remove();
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VoltageLevelAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VoltageLevelAdapter.java
@@ -541,7 +541,7 @@ class VoltageLevelAdapter extends AbstractIdentifiableAdapter<VoltageLevel> impl
     @Override
     public Stream<DanglingLine> getDanglingLineStream() {
         return getDelegate().getDanglingLineStream()
-                            .filter(getIndex()::isMerged)
+                            .filter(dl -> !getIndex().isMerged(dl))
                             .map(getIndex()::getDanglingLine);
     }
 

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BatteryAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BatteryAdapterTest.java
@@ -28,10 +28,11 @@ public class BatteryAdapterTest {
     @Test
     public void testSetterGetter() {
         double delta = 0.0;
+        final String id = "BATEST";
         final VoltageLevel vlbat = mergingView.getVoltageLevel("vl1");
         final Battery battery = vlbat.newBattery()
-                                         .setId("BATEST")
-                                         .setName("BATEST")
+                                         .setId(id)
+                                         .setName(id)
                                          .setBus("busA")
                                          .setMaxP(9999.99d)
                                          .setMinP(-9999.99d)
@@ -40,11 +41,11 @@ public class BatteryAdapterTest {
                                          .setEnsureIdUnicity(true)
                                      .add();
 
-        assertSame(battery, mergingView.getBattery("BATEST"));
+        assertSame(battery, mergingView.getBattery(id));
         assertEquals(ConnectableType.BATTERY, battery.getType());
         assertTrue(battery instanceof BatteryAdapter);
         assertSame(mergingView, battery.getNetwork());
-        assertEquals("BATEST", battery.getId());
+        assertEquals(id, battery.getId());
         assertEquals(15.0d, battery.getP0(), delta);
         assertNotNull(battery.setP0(0.0d));
         assertEquals(0.0d, battery.getP0(), delta);
@@ -90,7 +91,7 @@ public class BatteryAdapterTest {
             assertNotNull(b);
         });
 
-        // Not implemented yet !
-        TestUtil.notImplemented(battery::remove);
+        battery.remove();
+        assertNull(mergingView.getBattery(id));
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusbarSectionAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusbarSectionAdapterTest.java
@@ -27,11 +27,12 @@ public class BusbarSectionAdapterTest {
 
     @Test
     public void testSetterGetter() {
+        final String id = "voltageLevel1BusbarSection1";
         final Network networkRef = NetworkTest1Factory.create();
         mergingView.merge(networkRef);
 
-        final BusbarSection expectedSJB = networkRef.getBusbarSection("voltageLevel1BusbarSection1");
-        final BusbarSection actualSJB   = mergingView.getBusbarSection("voltageLevel1BusbarSection1");
+        final BusbarSection expectedSJB = networkRef.getBusbarSection(id);
+        final BusbarSection actualSJB   = mergingView.getBusbarSection(id);
         assertNotNull(actualSJB);
         assertTrue(actualSJB instanceof BusbarSectionAdapter);
         assertSame(mergingView, actualSJB.getNetwork());
@@ -46,7 +47,7 @@ public class BusbarSectionAdapterTest {
         assertEquals(expectedSJB.getV(), actualSJB.getV(), 0.0d);
         assertEquals(expectedSJB.getAngle(), actualSJB.getAngle(), 0.0d);
 
-        // Not implemented yet !
-        TestUtil.notImplemented(actualSJB::remove);
+        actualSJB.remove();
+        assertNull(mergingView.getBusbarSection(id));
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/DanglingLineAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/DanglingLineAdapterTest.java
@@ -102,7 +102,7 @@ public class DanglingLineAdapterTest {
     @Test
     public void mergedDanglingLine() {
         mergingView.merge(noEquipNetwork);
-
+        final String id = "dl1 + dl2";
         final DanglingLine dl1 = createDanglingLine(mergingView, "vl1", "dl1", "dl1", 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, "code", "busA");
         assertNotNull(mergingView.getDanglingLine("dl1"));
         assertEquals(1, mergingView.getDanglingLineCount());
@@ -115,9 +115,9 @@ public class DanglingLineAdapterTest {
         // Check access to MergedLine
         assertEquals(1, mergingView.getLineCount());
         assertEquals(1, mergingView.getBranchCount());
-        final Line line = mergingView.getLine("dl1 + dl2");
-        assertSame(line, mergingView.getIdentifiable("dl1 + dl2"));
-        assertSame(line, mergingView.getBranch("dl1 + dl2"));
+        final Line line = mergingView.getLine(id);
+        assertSame(line, mergingView.getIdentifiable(id));
+        assertSame(line, mergingView.getBranch(id));
         assertSame(line, mergingView.getIdentifiable("dl1"));
         assertSame(line, mergingView.getIdentifiable("dl2"));
         assertTrue(line instanceof MergedLine);
@@ -156,8 +156,8 @@ public class DanglingLineAdapterTest {
         assertSame(currentLimits2, mergedLine.getCurrentLimits2());
         assertSame(currentLimits1, mergedLine.getCurrentLimits(Branch.Side.ONE));
         assertSame(currentLimits2, mergedLine.getCurrentLimits(Branch.Side.TWO));
-        assertEquals("dl1 + dl2", mergedLine.getId());
-        assertEquals("dl1 + dl2", mergedLine.getName());
+        assertEquals(id, mergedLine.getId());
+        assertEquals(id, mergedLine.getName());
         assertSame(mergedLine, mergedLine.setR(1.0d));
         assertEquals(dl1.getR() + dl2.getR(), mergedLine.getR(), 0.0d);
         assertSame(mergedLine, mergedLine.setX(2.0d));
@@ -196,7 +196,6 @@ public class DanglingLineAdapterTest {
         });
 
         // Not implemented yet !
-        TestUtil.notImplemented(mergedLine::remove);
         TestUtil.notImplemented(() -> mergedLine.addExtension(null, null));
         TestUtil.notImplemented(() -> mergedLine.getExtension(null));
         TestUtil.notImplemented(() -> mergedLine.getExtensionByName(""));
@@ -207,6 +206,22 @@ public class DanglingLineAdapterTest {
         thrown.expect(PowsyblException.class);
         thrown.expectMessage("No terminal connected to voltage level invalid");
         mergedLine.getTerminal("invalid");
+    }
+
+    @Test
+    public void removeMergedLine() {
+        mergingView.merge(noEquipNetwork);
+        final String id = "dl1 + dl2";
+        final DanglingLine dl1 = createDanglingLine(mergingView, "vl1", "dl1", "dl1", 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, "code", "busA");
+        final DanglingLine dl2 = createDanglingLine(mergingView, "vl2", "dl2", "dl2", 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, "code", "busB");
+        final Line line = mergingView.getLine(id);
+        // MergedLine
+        final MergedLine mergedLine = (MergedLine) line;
+
+        mergedLine.remove();
+        assertNull(mergingView.getLine(id));
+        assertNull(mergingView.getDanglingLine("dl1"));
+        assertNull(mergingView.getDanglingLine("dl2"));
     }
 
     @Test

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/GeneratorAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/GeneratorAdapterTest.java
@@ -109,7 +109,7 @@ public class GeneratorAdapterTest {
         assertTrue(generator.setRatedS(++ratedS) instanceof GeneratorAdapter);
         assertEquals(ratedS, generator.getRatedS(), delta);
 
-        // Not implemented yet !
-        TestUtil.notImplemented(generator::remove);
+        generator.remove();
+        assertNull(mergingView.getGenerator(id));
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/HvdcLineAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/HvdcLineAdapterTest.java
@@ -36,8 +36,9 @@ public class HvdcLineAdapterTest {
 
     @Test
     public void baseTests() {
-        final HvdcLine expectedLine = networkRef.getHvdcLine("L");
-        final HvdcLine lineAdapted = mergingView.getHvdcLine("L");
+        final String id = "L";
+        final HvdcLine expectedLine = networkRef.getHvdcLine(id);
+        final HvdcLine lineAdapted = mergingView.getHvdcLine(id);
         assertTrue(lineAdapted instanceof HvdcLineAdapter);
         assertSame(mergingView, lineAdapted.getNetwork());
 
@@ -73,8 +74,8 @@ public class HvdcLineAdapterTest {
         assertSame(lineAdapted.getConverterStation2().getId(), expectedLine.getConverterStation2().getId());
         assertSame(lineAdapted.getConverterStation2(), lineAdapted.getConverterStation(HvdcLine.Side.TWO));
 
-        // Test not implemented !
-        TestUtil.notImplemented(lineAdapted::remove);
+        lineAdapted.remove();
+        assertNull(mergingView.getHvdcLine(id));
     }
 
     @Test

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/LineAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/LineAdapterTest.java
@@ -40,7 +40,8 @@ public class LineAdapterTest {
 
     @Test
     public void testSetterGetter() {
-        final Line lineRef = networkRef.getLine("NHV1_NHV2_1");
+        final String id = "NHV1_NHV2_1";
+        final Line lineRef = networkRef.getLine(id);
         final Line lineAdapted = mergingView.getLine(lineRef.getId());
         // setter / getter
         assertTrue(lineAdapted instanceof LineAdapter);
@@ -101,8 +102,8 @@ public class LineAdapterTest {
         assertEquals(lineRef.getType(), lineAdapted.getType());
         assertEquals(lineRef.getTerminals().size(), lineAdapted.getTerminals().size());
 
-        // Not implemented yet !
-        TestUtil.notImplemented(lineAdapted::remove);
+        lineAdapted.remove();
+        assertNull(mergingView.getLine(id));
     }
 
     @Test
@@ -153,5 +154,11 @@ public class LineAdapterTest {
                                                       .setConnectableBus1("busA")
                                                       .setConnectableBus2("NBAT")
                                                   .add();
+        assertNotNull(lineOnBothNetwork);
+        assertSame(lineOnBothNetwork, mergingView.getLine("lineOnBothNetworkId"));
+
+        // Remove
+        lineOnBothNetwork.remove();
+        assertNull(mergingView.getLine("lineOnBothNetworkId"));
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/LoadAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/LoadAdapterTest.java
@@ -26,11 +26,12 @@ public class LoadAdapterTest {
 
     @Test
     public void testSetterGetter() {
+        final String id = "CE";
         Network networkRef = FictitiousSwitchFactory.create();
         mergingView.merge(networkRef);
 
-        final Load loadExpected = networkRef.getLoad("CE");
-        final Load loadActual = mergingView.getLoad("CE");
+        final Load loadExpected = networkRef.getLoad(id);
+        final Load loadActual = mergingView.getLoad(id);
         assertNotNull(loadActual);
         assertTrue(loadActual instanceof LoadAdapter);
         assertSame(mergingView, loadActual.getNetwork());
@@ -55,7 +56,7 @@ public class LoadAdapterTest {
         assertTrue(loadActual.setQ0(++q0) instanceof LoadAdapter);
         assertEquals(q0, loadActual.getQ0(), 0.0d);
 
-        // Not implemented yet !
-        TestUtil.notImplemented(loadActual::remove);
+        loadActual.remove();
+        assertNull(mergingView.getLoad(id));
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/MergingNetworkTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/MergingNetworkTest.java
@@ -195,9 +195,6 @@ public class MergingNetworkTest {
         // Not implemented yet !
         // Lines
         TestUtil.notImplemented(mergingView::newTieLine);
-        // Listeners
-        TestUtil.notImplemented(() -> mergingView.addListener(null));
-        TestUtil.notImplemented(() -> mergingView.removeListener(null));
     }
 
     @Test

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/PhaseTapChangerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/PhaseTapChangerAdapterTest.java
@@ -104,7 +104,7 @@ public class PhaseTapChangerAdapterTest {
         phaseTapChanger.setLowTapPosition(lowTapPosition);
         assertEquals(lowTapPosition, phaseTapChanger.getLowTapPosition());
 
-        // Not implemented yet !
-        TestUtil.notImplemented(phaseTapChanger::remove);
+        phaseTapChanger.remove();
+        assertNull(twt.getPhaseTapChanger());
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/RatioTapChangerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/RatioTapChangerAdapterTest.java
@@ -125,8 +125,7 @@ public class RatioTapChangerAdapterTest {
         step.setRho(stepRho);
         assertEquals(stepRho, step.getRho(), 0.0);
 
-        // Not implemented yet !
-        // remove
-        TestUtil.notImplemented(ratioTapChanger::remove);
+        ratioTapChanger.remove();
+        assertNull(twt.getRatioTapChanger());
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ShuntCompensatorAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ShuntCompensatorAdapterTest.java
@@ -27,11 +27,12 @@ public class ShuntCompensatorAdapterTest {
 
     @Test
     public void testSetterGetter() {
-        Network networkRef = HvdcTestNetwork.createLcc();
+        final String id = "C1_Filter1";
+        final Network networkRef = HvdcTestNetwork.createLcc();
         mergingView.merge(networkRef);
 
-        final ShuntCompensator shuntCExpected = networkRef.getShuntCompensator("C1_Filter1");
-        final ShuntCompensator shuntCActual   = mergingView.getShuntCompensator("C1_Filter1");
+        final ShuntCompensator shuntCExpected = networkRef.getShuntCompensator(id);
+        final ShuntCompensator shuntCActual   = mergingView.getShuntCompensator(id);
         assertNotNull(shuntCActual);
         assertTrue(shuntCActual instanceof ShuntCompensatorAdapter);
         assertSame(mergingView, shuntCActual.getNetwork());
@@ -58,7 +59,8 @@ public class ShuntCompensatorAdapterTest {
         assertTrue(shuntCActual.setbPerSection(++b) instanceof ShuntCompensatorAdapter);
         assertEquals(shuntCExpected.getCurrentB(), shuntCActual.getCurrentB(), 0.0d);
 
-        // Not implemented yet !
-        TestUtil.notImplemented(shuntCActual::remove);
+        shuntCActual.remove();
+        assertNull(mergingView.getShuntCompensator(id));
+        assertNull(networkRef.getShuntCompensator(id));
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/StaticVarCompensatorAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/StaticVarCompensatorAdapterTest.java
@@ -27,11 +27,12 @@ public class StaticVarCompensatorAdapterTest {
 
     @Test
     public void testSetterGetter() {
+        final String id = "SVC2";
         Network networkRef = SvcTestCaseFactory.createWithRemoteRegulatingTerminal();
         mergingView.merge(networkRef);
 
-        final StaticVarCompensator svcExpected = networkRef.getStaticVarCompensator("SVC2");
-        final StaticVarCompensator svcActual = mergingView.getStaticVarCompensator("SVC2");
+        final StaticVarCompensator svcExpected = networkRef.getStaticVarCompensator(id);
+        final StaticVarCompensator svcActual = mergingView.getStaticVarCompensator(id);
         assertNotNull(svcActual);
         assertTrue(svcActual instanceof StaticVarCompensatorAdapter);
         assertSame(mergingView, svcActual.getNetwork());
@@ -74,7 +75,8 @@ public class StaticVarCompensatorAdapterTest {
         assertTrue(svcActual.setRegulatingTerminal(mergingView.getLine("L1").getTerminal1()) instanceof StaticVarCompensatorAdapter);
         assertEquals(svcActual.getRegulatingTerminal(), mergingView.getLine("L1").getTerminal1());
 
-        // Not implemented yet !
-        TestUtil.notImplemented(svcActual::remove);
+        svcActual.remove();
+        assertNull(mergingView.getStaticVarCompensator(id));
+        assertNull(networkRef.getStaticVarCompensator(id));
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapterTest.java
@@ -28,7 +28,8 @@ public class ThreeWindingsTransformerAdapterTest {
 
     @Test
     public void testSetterGetter() {
-        final ThreeWindingsTransformer twt = mergingView.getThreeWindingsTransformer("3WT");
+        final String id = "3WT";
+        final ThreeWindingsTransformer twt = mergingView.getThreeWindingsTransformer(id);
         assertNotNull(twt);
         assertTrue(twt instanceof ThreeWindingsTransformerAdapter);
         assertSame(mergingView, twt.getNetwork());
@@ -132,7 +133,13 @@ public class ThreeWindingsTransformerAdapterTest {
         assertNotNull(leg3);
         assertTrue(leg3 instanceof AbstractAdapter);
 
-        // Not implemented yet !
-        TestUtil.notImplemented(twt::remove);
+        // Remove
+        leg1.getRatioTapChanger().remove();
+        assertNull(leg1.getRatioTapChanger());
+        leg2.getPhaseTapChanger().remove();
+        assertNull(leg2.getPhaseTapChanger());
+
+        twt.remove();
+        assertNull(mergingView.getThreeWindingsTransformer(id));
     }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapterTest.java
@@ -28,6 +28,7 @@ public class TwoWindingsTransformerAdapterTest {
 
     @Test
     public void testSetterGetter() {
+        final String id = "twt";
         final Substation substation = mergingView.getSubstation("sub");
 
         // adder
@@ -46,7 +47,7 @@ public class TwoWindingsTransformerAdapterTest {
                     .setConnectableBus2("busB")
                 .add();
         assertNotNull(twt);
-        assertSame(mergingView.getTwoWindingsTransformer("twt"), mergingView.getBranch("twt"));
+        assertSame(mergingView.getTwoWindingsTransformer(id), mergingView.getBranch(id));
         assertTrue(twt instanceof TwoWindingsTransformerAdapter);
         assertSame(mergingView, twt.getNetwork());
 
@@ -183,7 +184,8 @@ public class TwoWindingsTransformerAdapterTest {
         assertNull(twt.checkTemporaryLimits2());
         assertNull(twt.checkTemporaryLimits2(0.9f));
 
-        // Not implemented yet !
-        TestUtil.notImplemented(twt::remove);
+        // Remove
+        twt.remove();
+        assertNull(mergingView.getTwoWindingsTransformer(id));
     }
 }


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Implementation of remove methods from Connectable & HvdcLine interfaces in MergingView module.


**What is the current behavior?** *(You can also link to an open issue here)*
Remove methods from Connectable & HvdcLine interfaces in MergingView module is not implemented


**What is the new behavior (if this is a feature change)?**
Remove method from Connectable & HvdcLine interfaces in MergingView module is now implemented


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
