### PR TITLE
Fix Ucte element order code rule

### DIFF
--- a/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/UcteElementId.java
+++ b/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/UcteElementId.java
@@ -6,9 +6,6 @@
  */
 package com.powsybl.ucte.network;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.*;
 
 /**
@@ -17,10 +14,8 @@ import java.util.*;
  */
 public class UcteElementId implements Comparable<UcteElementId> {
 
-    private static final List<Character> ORDER_CODES = Arrays.asList('1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
+    private static final List<Character> ORDER_CODES = Arrays.asList('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
         'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '_', '-', '.', ' ');
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(UcteElementId.class);
 
     private final UcteNodeCode nodeCode1;
     private final UcteNodeCode nodeCode2;
@@ -118,7 +113,7 @@ public class UcteElementId implements Comparable<UcteElementId> {
     private static boolean isOrderCode(char orderCode) {
         /*
            Update to match modification on UCTE format
-           The new update is availble on the ENTSO-E website:
+           The new update is available on the ENTSO-E website:
            https://docstore.entsoe.eu/Documents/Publications/SOC/Continental_Europe/150420_quality_of_datasets_and_calculations_3rd_edition.pdf
          */
         return ORDER_CODES.contains(orderCode);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
0 is not allowed as an order code since #1128. Before this commit, 0 was allowed but a warning was displayed because it's valid regarding the UCTE-DEF format specification.
We now follow the ENTSO-E rules defined in [150420_quality_of_datasets_and_calculations_3rd_edition.pdf](https://docstore.entsoe.eu/Documents/Publications/SOC/Continental_Europe/150420_quality_of_datasets_and_calculations_3rd_edition.pdf)


**What is the new behavior (if this is a feature change)?**
0 is allowed as an order code


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
