### PR TITLE
Remove useless properties

### DIFF
--- a/loadflow/loadflow-scripting/pom.xml
+++ b/loadflow/loadflow-scripting/pom.xml
@@ -24,8 +24,6 @@
 
     <properties>
         <groovydoc.classifier>javadoc</groovydoc.classifier>
-        <groovydoc.groovyDocJavaSources>true</groovydoc.groovyDocJavaSources>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
     <build>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Plugin configuration


**What is the current behavior?** *(You can also link to an open issue here)*
The loadflow-scripting module contains only groovy code, so the maven-javadoc-plugin doesn't generate a javadoc jar, required by sonatype.
We fix this in a previous PR, but the documentation was not clear enough and I set two useless properties.


**What is the new behavior (if this is a feature change)?**
The two properties have been removed, but it doesn't change anything.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
