### PR TITLE
add AbstractXmlConverterTest.getVersionedNetworkAsStream method in test

### DIFF
--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/AbstractXmlConverterTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/AbstractXmlConverterTest.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.export.ExportOptions;
 import com.powsybl.iidm.network.Network;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.function.BiConsumer;
@@ -24,9 +25,13 @@ public abstract class AbstractXmlConverterTest extends AbstractConverterTest {
         return "/V" + version.toString("_") + "/";
     }
 
+    protected InputStream getVersionedNetworkAsStream(String fileName, IidmXmlVersion version) {
+        return getClass().getResourceAsStream(getVersionDir(version) + fileName);
+    }
+
     protected void roundTripVersionnedXmlTest(String file, IidmXmlVersion... versions) throws IOException {
         for (IidmXmlVersion version : versions) {
-            roundTripXmlTest(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(version) + file)),
+            roundTripXmlTest(NetworkXml.read(getVersionedNetworkAsStream(file, version)),
                     writeAndValidate(version),
                     NetworkXml::validateAndRead,
                     getVersionDir(version) + file);

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
@@ -195,8 +195,8 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractXmlConverter
 
         // backward compatibility 1.0
         roundTripVersionnedXmlTest("eurostag-tutorial-example1-with-terminalMock-ext.xml", IidmXmlVersion.V_1_0);
-        roundTripXmlTest(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0)
-                        + "eurostag-tutorial-example1-with-terminalMock-ext.xml")),
+        roundTripXmlTest(NetworkXml.read(getVersionedNetworkAsStream("eurostag-tutorial-example1-with-terminalMock-ext.xml",
+                IidmXmlVersion.V_1_0)),
                 NetworkXml::writeAndValidate,
                 NetworkXml::validateAndRead,
                 getVersionDir(IidmXmlConstants.CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial-example1-with-terminalMock-ext.xml");
@@ -205,8 +205,7 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractXmlConverter
     @Test
     public void testNotLatestVersionTerminalExtension() throws IOException {
         // import XIIDM file with loadMock v1.2
-        Network network = NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_1) +
-                "eurostag-tutorial-example1-with-loadMockExt-1_2.xml"));
+        Network network = NetworkXml.read(getVersionedNetworkAsStream("eurostag-tutorial-example1-with-loadMockExt-1_2.xml", IidmXmlVersion.V_1_1));
 
         MemDataSource dataSource = new MemDataSource();
 
@@ -221,7 +220,7 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractXmlConverter
         try (InputStream is = new ByteArrayInputStream(dataSource.getData(null, "xiidm"))) {
             assertNotNull(is);
             // check that loadMock has been serialized in v1.1
-            compareXml(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_1) + "eurostag-tutorial-example1-with-loadMockExt-1_1.xml"),
+            compareXml(getVersionedNetworkAsStream("eurostag-tutorial-example1-with-loadMockExt-1_1.xml", IidmXmlVersion.V_1_1),
                     is);
         }
     }
@@ -232,7 +231,7 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractXmlConverter
         exception.expectMessage("IIDM-XML version of network (1.1)"
                 + " is not compatible with the loadMock extension's namespace URI.");
         // should fail while trying to import a file in IIDM-XML network version 1.1 and loadMock in v1.0 (not compatible)
-        NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_1) + "eurostag-tutorial-example1-with-bad-loadMockExt.xml"));
+        NetworkXml.read(getVersionedNetworkAsStream("eurostag-tutorial-example1-with-bad-loadMockExt.xml", IidmXmlVersion.V_1_1));
     }
 
     @Test
@@ -249,6 +248,6 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractXmlConverter
         exception.expect(PowsyblException.class);
         exception.expectMessage("IIDM-XML version of network (1.1) is not supported by the loadQux extension's XML serializer.");
         // should fail while trying to import a file in IIDM-XML network version 1.1 (not supported by loadQux extension)
-        NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_1) + "eurostag-tutorial-example1-with-bad-loadQuxExt.xml"));
+        NetworkXml.read(getVersionedNetworkAsStream("eurostag-tutorial-example1-with-bad-loadQuxExt.xml", IidmXmlVersion.V_1_1));
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/OptionalLoadTypeBugTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/OptionalLoadTypeBugTest.java
@@ -8,18 +8,17 @@ package com.powsybl.iidm.xml;
 
 import org.junit.Test;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class OptionalLoadTypeBugTest {
+public class OptionalLoadTypeBugTest extends AbstractXmlConverterTest {
 
     @Test
     public void shouldNotThrowNullPointerExceptionTest() {
-        assertNotNull(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0) + "optionalLoadTypeBug.xml")));
-        assertNotNull(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "optionalLoadTypeBug.xml")));
+        assertNotNull(NetworkXml.read(getVersionedNetworkAsStream("optionalLoadTypeBug.xml", IidmXmlVersion.V_1_0)));
+        assertNotNull(NetworkXml.read(getVersionedNetworkAsStream("optionalLoadTypeBug.xml", CURRENT_IIDM_XML_VERSION)));
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SimpleAnonymizerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SimpleAnonymizerTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.xml;
 
-import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.datasource.MemDataSource;
@@ -18,13 +17,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class SimpleAnonymizerTest extends AbstractConverterTest {
+public class SimpleAnonymizerTest extends AbstractXmlConverterTest {
 
     private void anonymisationTest(Network network) throws IOException {
         PlatformConfig platformConfig = new InMemoryPlatformConfig(fileSystem);
@@ -37,7 +35,7 @@ public class SimpleAnonymizerTest extends AbstractConverterTest {
 
         // check we have 2 files, the anonymized IIDM XML and a CSV mapping file and compare to anonymized reference files
         try (InputStream is = new ByteArrayInputStream(dataSource.getData(null, "xiidm"))) {
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial-example1-anonymized.xml"), is);
+            compareXml(getVersionedNetworkAsStream("eurostag-tutorial-example1-anonymized.xml", CURRENT_IIDM_XML_VERSION), is);
         }
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("_mapping", "csv"))) {
             compareTxt(getClass().getResourceAsStream("/eurostag-tutorial-example1-mapping.csv"), is);
@@ -57,7 +55,7 @@ public class SimpleAnonymizerTest extends AbstractConverterTest {
 
     @Test
     public void test() throws IOException {
-        anonymisationTest(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0) + "eurostag-tutorial-example1.xml")));
+        anonymisationTest(NetworkXml.read(getVersionedNetworkAsStream("eurostag-tutorial-example1.xml", IidmXmlVersion.V_1_0)));
 
         anonymisationTest(NetworkXmlTest.createEurostagTutorialExample1());
     }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
@@ -16,6 +16,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 
 /**
@@ -54,8 +55,7 @@ public class StaticVarCompensatorXmlTest extends AbstractXmlConverterTest {
         exception.expect(PowsyblException.class);
         exception.expectMessage("staticVarCompensator.regulatingTerminal is not supported for IIDM-XML version 1.0. " +
                 "IIDM-XML version should be >= 1.1");
-        NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0) +
-                "faultyRegulatingStaticVarCompensatorRoundTripRef.xml"));
+        NetworkXml.read(getVersionedNetworkAsStream("faultyRegulatingStaticVarCompensatorRoundTripRef.xml", IidmXmlVersion.V_1_0));
     }
 
     @Test

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXmlTest.java
@@ -41,7 +41,7 @@ public class ThreeWindingsTransformerXmlTest extends AbstractXmlConverterTest {
     public void faultyFileTest() {
         exception.expect(PowsyblException.class);
         exception.expectMessage("threeWindingsTransformer.ratedU0 is mandatory for IIDM-XML version 1.1. IIDM-XML version should be < 1.1");
-        NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_1) + "faultyThreeWindingsTransformerRoundTripRef.xml"));
+        NetworkXml.read(getVersionedNetworkAsStream("faultyThreeWindingsTransformerRoundTripRef.xml", IidmXmlVersion.V_1_1));
     }
 
     @Test

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TopologyLevelTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TopologyLevelTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.xml;
 
-import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.iidm.export.ExportOptions;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TopologyKind;
@@ -17,14 +16,13 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 
 /**
  * @author Teofil Calin Banc<teofil-calin.banc at rte-france.com>
  */
-public class TopologyLevelTest extends AbstractConverterTest {
+public class TopologyLevelTest extends AbstractXmlConverterTest {
 
     @Test
     public void testComparison() {
@@ -39,7 +37,7 @@ public class TopologyLevelTest extends AbstractConverterTest {
 
     @Test
     public void testConversion() throws IOException {
-        testConversion(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0) + "fictitiousSwitchRef.xml")));
+        testConversion(NetworkXml.read(getVersionedNetworkAsStream("fictitiousSwitchRef.xml", IidmXmlVersion.V_1_0)));
 
         testConversion(FictitiousSwitchFactory.create());
     }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLExporterTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLExporterTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.xml;
 
-import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.MultipleExtensionsTestNetworkFactory;
@@ -17,16 +16,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 
 /**
  * @author Chamseddine BENHAMED  <chamseddine.benhamed at rte-france.com>
  */
 
-public class XMLExporterTest extends AbstractConverterTest {
+public class XMLExporterTest extends AbstractXmlConverterTest {
 
-    public void exporterTest(Network network, String xiidmRef) throws IOException {
+    public void exporterTest(Network network, IidmXmlVersion version) throws IOException {
         Properties properties = new Properties();
         properties.put(XMLExporter.ANONYMISED, "false");
 
@@ -34,13 +32,12 @@ public class XMLExporterTest extends AbstractConverterTest {
         new XMLExporter().export(network, properties, dataSource);
         // check the exported file and compare it to iidm reference file
         try (InputStream is = new ByteArrayInputStream(dataSource.getData(null, "xiidm"))) {
-            compareXml(getClass().getResourceAsStream(xiidmRef), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions.xml", version), is);
         }
     }
 
     @Test
     public void exportTest() throws IOException {
-        exporterTest(MultipleExtensionsTestNetworkFactory.create(),
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions.xml");
+        exporterTest(MultipleExtensionsTestNetworkFactory.create(), CURRENT_IIDM_XML_VERSION);
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLImporterExporterBaseExtensionsTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLImporterExporterBaseExtensionsTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.xml;
 
-import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
@@ -22,7 +21,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 
@@ -30,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Chamseddine BENHAMED  <chamseddine.benhamed at rte-france.com>
  */
-public class XMLImporterExporterBaseExtensionsTest extends AbstractConverterTest {
+public class XMLImporterExporterBaseExtensionsTest extends AbstractXmlConverterTest {
 
     private void importExport(String directory) throws IOException {
         Properties exportProperties = new Properties();
@@ -52,11 +50,11 @@ public class XMLImporterExporterBaseExtensionsTest extends AbstractConverterTest
         new XMLExporter().export(network, exportProperties, dataSource);
         // check the base exported file and compare it to iidmBaseRef reference file
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("", "xiidm"))) {
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
         // check the exported extensions file and compare it to "multiple-extensions-ext.xiidm" reference file
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("-ext", "xiidm"))) {
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions-ext.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions-ext.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
     }
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLImporterLimitsTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLImporterLimitsTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.xml;
 
-import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.iidm.IidmImportExportMode;
 import com.powsybl.iidm.network.Network;
@@ -19,7 +18,6 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.Properties;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 
@@ -27,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Chamseddine BENHAMED  <chamseddine.benhamed at rte-france.com>
  */
-public class XMLImporterLimitsTest extends AbstractConverterTest {
+public class XMLImporterLimitsTest extends AbstractXmlConverterTest {
 
     private void importExport(Network network) throws IOException {
 
@@ -44,7 +42,7 @@ public class XMLImporterLimitsTest extends AbstractConverterTest {
         new XMLExporter().export(network, exportProperties, dataSource);
         // check the base exported file and compare it to iidmBaseRef reference file
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("", "xiidm"))) {
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
 
         XMLImporter importer;
@@ -63,6 +61,6 @@ public class XMLImporterLimitsTest extends AbstractConverterTest {
         importExport(MultipleExtensionsTestNetworkFactory.create());
 
         //backward compatibility 1.0
-        importExport(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0) + "multiple-extensions.xml")));
+        importExport(NetworkXml.read(getVersionedNetworkAsStream("multiple-extensions.xml", IidmXmlVersion.V_1_0)));
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterBaseExtensionsTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterBaseExtensionsTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.xml;
 
-import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.iidm.IidmImportExportMode;
 import com.powsybl.iidm.export.ExportOptions;
@@ -21,7 +20,6 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Properties;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -30,7 +28,7 @@ import static org.junit.Assert.assertNotNull;
  * @author Chamseddine BENHAMED  <chamseddine.benhamed at rte-france.com>
  */
 
-public class XmlExporterBaseExtensionsTest extends AbstractConverterTest {
+public class XmlExporterBaseExtensionsTest extends AbstractXmlConverterTest {
 
     private void exporterTestBaseExtensions(Network network) throws IOException {
         Properties exportProperties = new Properties();
@@ -42,18 +40,18 @@ public class XmlExporterBaseExtensionsTest extends AbstractConverterTest {
         // check the base exported file and compare it to iidmBaseRef reference file
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("", "xiidm"))) {
             assertNotNull(is);
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
         // check the exported extensions file and compare it to xiidmExtRef reference file
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("-ext", "xiidm"))) {
             assertNotNull(is);
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions-ext.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions-ext.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
     }
 
     @Test
     public void exportBaseExtensions() throws IOException {
-        exporterTestBaseExtensions(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0) + "multiple-extensions.xml")));
+        exporterTestBaseExtensions(NetworkXml.read(getVersionedNetworkAsStream("multiple-extensions.xml", IidmXmlVersion.V_1_0)));
         exporterTestBaseExtensions(MultipleExtensionsTestNetworkFactory.create());
     }
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterBaseOneExtensionPerFileTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterBaseOneExtensionPerFileTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.xml;
 
-import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.iidm.IidmImportExportMode;
 import com.powsybl.iidm.network.Network;
@@ -19,7 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -28,7 +26,7 @@ import static org.junit.Assert.assertNotNull;
  * @author Chamseddine BENHAMED  <chamseddine.benhamed at rte-france.com>
  */
 
-public class XmlExporterBaseOneExtensionPerFileTest extends AbstractConverterTest {
+public class XmlExporterBaseOneExtensionPerFileTest extends AbstractXmlConverterTest {
 
     private MemDataSource export(Network network, List<String> extensionsList) {
         Properties properties = new Properties();
@@ -46,17 +44,17 @@ public class XmlExporterBaseOneExtensionPerFileTest extends AbstractConverterTes
         // check the base exported file and compare it to iidmBaseRef reference file
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("", "xiidm"))) {
             assertNotNull(is);
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
 
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("-loadBar.xiidm"))) {
             assertNotNull(is);
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions-loadBar.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions-loadBar.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
 
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("-loadFoo.xiidm"))) {
             assertNotNull(is);
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions-loadFoo.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions-loadFoo.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
     }
 
@@ -77,7 +75,7 @@ public class XmlExporterBaseOneExtensionPerFileTest extends AbstractConverterTes
     @Test
     public void exportAllExtensionsTest() throws IOException {
         List<String> extensionsList = Arrays.asList("loadFoo", "loadBar");
-        exporterOneFilePerExtensionType(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0) + "multiple-extensions.xml")), extensionsList);
+        exporterOneFilePerExtensionType(NetworkXml.read(getVersionedNetworkAsStream("multiple-extensions.xml", IidmXmlVersion.V_1_0)), extensionsList);
         exporterOneFilePerExtensionType(MultipleExtensionsTestNetworkFactory.create(), extensionsList);
     }
 
@@ -86,18 +84,18 @@ public class XmlExporterBaseOneExtensionPerFileTest extends AbstractConverterTes
 
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("", "xiidm"))) {
             assertNotNull(is);
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial-example1.xml"), is);
+            compareXml(getVersionedNetworkAsStream("eurostag-tutorial-example1.xml", CURRENT_IIDM_XML_VERSION), is);
         }
 
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("-terminalMock.xiidm"))) {
             assertNotNull(is);
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial-example1-terminalMock.xml"), is);
+            compareXml(getVersionedNetworkAsStream("eurostag-tutorial-example1-terminalMock.xml", CURRENT_IIDM_XML_VERSION), is);
         }
     }
 
     @Test
     public void exportTerminalExtTest() throws IOException {
-        exportTerminalExtTest(NetworkXml.read(getClass().getResourceAsStream(getVersionDir(IidmXmlVersion.V_1_0) + "eurostag-tutorial-example1-with-terminalMock-ext.xml")));
+        exportTerminalExtTest(NetworkXml.read(getVersionedNetworkAsStream("eurostag-tutorial-example1-with-terminalMock-ext.xml", IidmXmlVersion.V_1_0)));
         exportTerminalExtTest(EurostagTutorialExample1Factory.createWithTerminalMockExt());
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterImporterBaseOneExtensionPerFileTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XmlExporterImporterBaseOneExtensionPerFileTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.xml;
 
-import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
@@ -27,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.*;
 
@@ -35,7 +33,7 @@ import static org.junit.Assert.*;
  * @author Chamseddine BENHAMED  <chamseddine.benhamed at rte-france.com>
  */
 
-public class XmlExporterImporterBaseOneExtensionPerFileTest extends AbstractConverterTest {
+public class XmlExporterImporterBaseOneExtensionPerFileTest extends AbstractXmlConverterTest {
 
     private static MemDataSource exportOneFilePerExtensionType(Network network, List<String> extensions) {
         Properties exportProperties = new Properties();
@@ -76,15 +74,15 @@ public class XmlExporterImporterBaseOneExtensionPerFileTest extends AbstractConv
 
         // check the base exported file and compare it to iidmBaseRef reference file
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("", "xiidm"))) {
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
 
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("-loadBar.xiidm"))) {
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions-loadBar.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions-loadBar.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
 
         try (InputStream is = new ByteArrayInputStream(dataSource.getData("-loadFoo.xiidm"))) {
-            compareXml(getClass().getResourceAsStream(getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions-loadFoo.xiidm"), is);
+            compareXml(getVersionedNetworkAsStream("multiple-extensions-loadFoo.xiidm", CURRENT_IIDM_XML_VERSION), is);
         }
 
         testImportMultipleExtensions(network, dataSource, extensions);


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?**
No

**What kind of change does this PR introduce?**
Feature: implement a new method that generates an input stream from a test resource XIIDM file



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
