### PR TITLE
Synchronize the SA result builder

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisImpl.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisImpl.java
@@ -111,20 +111,24 @@ public class SecurityAnalysisImpl extends AbstractSecurityAnalysis {
                                     .handleAsync((lfResult, throwable) -> {
                                         network.getVariantManager().setWorkingVariant(postContStateId);
 
-                                        resultBuilder.contingency(contingency)
-                                                .setComputationOk(lfResult.isOk());
-                                        violationDetector.checkAll(contingency, network, resultBuilder::addViolation);
-                                        resultBuilder.endContingency();
+                                        synchronized (resultBuilder) {
+                                            resultBuilder.contingency(contingency)
+                                                    .setComputationOk(lfResult.isOk());
+                                            violationDetector.checkAll(contingency, network, resultBuilder::addViolation);
+                                            resultBuilder.endContingency();
+                                        }
                                         network.getVariantManager().removeVariant(postContStateId);
 
                                         return null;
                                     }, computationManager.getExecutor());
                         }
                     } else {
-                        resultBuilder.preContingency()
-                                .setComputationOk(false)
-                                .endPreContingency()
-                                .build();
+                        synchronized (resultBuilder) {
+                            resultBuilder.preContingency()
+                                    .setComputationOk(false)
+                                    .endPreContingency()
+                                    .build();
+                        }
                         futures = new CompletableFuture[0];
                     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If you run a SA with `SecurityAnalysisImpl` in multi thread, you often have error saying that that it's not possible to create a contingency result because you are not if the good state. In fact the SecurityAnalysisResultBuilder is not thread-safe. 


**What is the new behavior (if this is a feature change)?**
We add the `synchronized` keyword around the builder to make result creation thread safe. In another PR, we will change the design of the SecurityAnalysisResultBuilder to make it thread-safe by design. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
