### PR TITLE
Add AbstractXmlConverterTest.getVersionedNetworkPath method

### DIFF
--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/AbstractXmlConverterTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/AbstractXmlConverterTest.java
@@ -25,8 +25,12 @@ public abstract class AbstractXmlConverterTest extends AbstractConverterTest {
         return "/V" + version.toString("_") + "/";
     }
 
+    public static String getVersionedNetworkPath(String fileName, IidmXmlVersion version) {
+        return getVersionDir(version) + fileName;
+    }
+
     protected InputStream getVersionedNetworkAsStream(String fileName, IidmXmlVersion version) {
-        return getClass().getResourceAsStream(getVersionDir(version) + fileName);
+        return getClass().getResourceAsStream(getVersionedNetworkPath(fileName, version));
     }
 
     protected void roundTripVersionnedXmlTest(String file, IidmXmlVersion... versions) throws IOException {
@@ -34,7 +38,7 @@ public abstract class AbstractXmlConverterTest extends AbstractConverterTest {
             roundTripXmlTest(NetworkXml.read(getVersionedNetworkAsStream(file, version)),
                     writeAndValidate(version),
                     NetworkXml::validateAndRead,
-                    getVersionDir(version) + file);
+                    getVersionedNetworkPath(file, version));
         }
     }
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/BatteryXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/BatteryXmlTest.java
@@ -23,7 +23,7 @@ public class BatteryXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(BatteryNetworkFactory.create(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "batteryRoundTripRef.xml");
+                getVersionedNetworkPath("batteryRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
 
         //backward compatibility 1.0
         roundTripVersionnedXmlTest("batteryRoundTripRef.xml", IidmXmlVersion.V_1_0);

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/EurostagXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/EurostagXmlTest.java
@@ -23,7 +23,7 @@ public class EurostagXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(EurostagTutorialExample1Factory.createWithLFResults(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial1-lf.xml");
+                getVersionedNetworkPath("eurostag-tutorial1-lf.xml", CURRENT_IIDM_XML_VERSION));
 
         //backward compatibility 1.0
         roundTripVersionnedXmlTest("eurostag-tutorial1-lf.xml", IidmXmlVersion.V_1_0);

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/FictitiousSwitchTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/FictitiousSwitchTest.java
@@ -23,7 +23,7 @@ public class FictitiousSwitchTest extends AbstractXmlConverterTest {
         roundTripXmlTest(FictitiousSwitchFactory.create(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "fictitiousSwitchRef.xml");
+                getVersionedNetworkPath("fictitiousSwitchRef.xml", CURRENT_IIDM_XML_VERSION));
 
         //backward compatibility 1.0
         roundTripVersionnedXmlTest("fictitiousSwitchRef.xml", IidmXmlVersion.V_1_0);

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/HvdcXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/HvdcXmlTest.java
@@ -23,7 +23,7 @@ public class HvdcXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(HvdcTestNetwork.createLcc(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "LccRoundTripRef.xml");
+                getVersionedNetworkPath("LccRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
 
         // backward compatibility 1.0
         roundTripVersionnedXmlTest("LccRoundTripRef.xml", IidmXmlVersion.V_1_0);
@@ -34,7 +34,7 @@ public class HvdcXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(HvdcTestNetwork.createVsc(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "VscRoundTripRef.xml");
+                getVersionedNetworkPath("VscRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
 
         // backward compatibility 1.0
         roundTripVersionnedXmlTest("VscRoundTripRef.xml", IidmXmlVersion.V_1_0);

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
@@ -78,7 +78,7 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractXmlConverter
         roundTripXmlTest(MultipleExtensionsTestNetworkFactory.create(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "multiple-extensions.xml");
+                getVersionedNetworkPath("multiple-extensions.xml", CURRENT_IIDM_XML_VERSION));
 
         // backward compatibility 1.0
         roundTripVersionnedXmlTest("multiple-extensions.xml", IidmXmlVersion.V_1_0);
@@ -187,7 +187,7 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractXmlConverter
         Network network2 = roundTripXmlTest(EurostagTutorialExample1Factory.createWithTerminalMockExt(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial-example1-with-terminalMock-ext.xml");
+                getVersionedNetworkPath("eurostag-tutorial-example1-with-terminalMock-ext.xml", CURRENT_IIDM_XML_VERSION));
         Load loadXml = network2.getLoad("LOAD");
         TerminalMockExt terminalMockExtXml = loadXml.getExtension(TerminalMockExt.class);
         assertNotNull(terminalMockExtXml);
@@ -199,7 +199,7 @@ public class IdentifiableExtensionXmlSerializerTest extends AbstractXmlConverter
                 IidmXmlVersion.V_1_0)),
                 NetworkXml::writeAndValidate,
                 NetworkXml::validateAndRead,
-                getVersionDir(IidmXmlConstants.CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial-example1-with-terminalMock-ext.xml");
+                getVersionedNetworkPath("eurostag-tutorial-example1-with-terminalMock-ext.xml", CURRENT_IIDM_XML_VERSION));
     }
 
     @Test

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
@@ -46,7 +46,7 @@ public class NetworkXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(createEurostagTutorialExample1(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial-example1.xml");
+                getVersionedNetworkPath("eurostag-tutorial-example1.xml", CURRENT_IIDM_XML_VERSION));
 
         // backward compatibility 1.0
         roundTripVersionnedXmlTest("eurostag-tutorial-example1.xml", IidmXmlVersion.V_1_0);

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NodeBreakerInternalConnectionsTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NodeBreakerInternalConnectionsTest.java
@@ -26,7 +26,7 @@ public class NodeBreakerInternalConnectionsTest extends AbstractXmlConverterTest
                 networkWithInternalConnections(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "internalConnections.xiidm");
+                getVersionedNetworkPath("internalConnections.xiidm", CURRENT_IIDM_XML_VERSION));
 
         // backward compatibility 1.0
         roundTripVersionnedXmlTest("internalConnections.xiidm", IidmXmlVersion.V_1_0);

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PhaseShifterXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PhaseShifterXmlTest.java
@@ -24,6 +24,6 @@ public class PhaseShifterXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(PhaseShifterTestCaseFactory.createWithTargetDeadband(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "phaseShifterRoundTripRef.xml");
+                getVersionedNetworkPath("phaseShifterRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ReactiveLimitsXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ReactiveLimitsXmlTest.java
@@ -25,6 +25,6 @@ public class ReactiveLimitsXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(ReactiveLimitsTestNetworkFactory.create(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "reactiveLimitsRoundTripRef.xml");
+                getVersionedNetworkPath("reactiveLimitsRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SimpleAnonymizerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SimpleAnonymizerTest.java
@@ -50,7 +50,7 @@ public class SimpleAnonymizerTest extends AbstractXmlConverterTest {
         roundTripXmlTest(network2,
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "eurostag-tutorial-example1.xml");
+                getVersionedNetworkPath("eurostag-tutorial-example1.xml", CURRENT_IIDM_XML_VERSION));
     }
 
     @Test

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
@@ -37,7 +37,7 @@ public class StaticVarCompensatorXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(network,
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "staticVarCompensatorRoundTripRef.xml");
+                getVersionedNetworkPath("staticVarCompensatorRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
     }
 
     @Test
@@ -47,7 +47,7 @@ public class StaticVarCompensatorXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(network,
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "regulatingStaticVarCompensatorRoundTripRef.xml");
+                getVersionedNetworkPath("regulatingStaticVarCompensatorRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
     }
 
     @Test

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXmlTest.java
@@ -34,7 +34,7 @@ public class ThreeWindingsTransformerXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(ThreeWindingsTransformerNetworkFactory.createWithCurrentLimits(),
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "threeWindingsTransformerRoundTripRef.xml");
+                getVersionedNetworkPath("threeWindingsTransformerRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class ThreeWindingsTransformerXmlTest extends AbstractXmlConverterTest {
         roundTripXmlTest(network,
                 NetworkXml::writeAndValidate,
                 NetworkXml::read,
-                getVersionDir(CURRENT_IIDM_XML_VERSION) + "completeThreeWindingsTransformerRoundTripRef.xml");
+                getVersionedNetworkPath("completeThreeWindingsTransformerRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
     }
 
     private void createPtc(PhaseTapChangerAdder adder) {

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TopologyLevelTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TopologyLevelTest.java
@@ -43,13 +43,16 @@ public class TopologyLevelTest extends AbstractXmlConverterTest {
     }
 
     private void testConversion(Network network) throws IOException {
-        writeXmlTest(network, TopologyLevelTest::writeNodeBreaker, getVersionDir(CURRENT_IIDM_XML_VERSION) + "fictitiousSwitchRef.xml");
+        writeXmlTest(network, TopologyLevelTest::writeNodeBreaker,
+                getVersionedNetworkPath("fictitiousSwitchRef.xml", CURRENT_IIDM_XML_VERSION));
 
         network.getSwitchStream().forEach(sw -> sw.setRetained(false));
         network.getSwitch("BJ").setRetained(true);
 
-        writeXmlTest(network, TopologyLevelTest::writeBusBreaker, getVersionDir(CURRENT_IIDM_XML_VERSION) + "fictitiousSwitchRef-bbk.xml");
-        writeXmlTest(network, TopologyLevelTest::writeBusBranch, getVersionDir(CURRENT_IIDM_XML_VERSION) + "fictitiousSwitchRef-bbr.xml");
+        writeXmlTest(network, TopologyLevelTest::writeBusBreaker,
+                getVersionedNetworkPath("fictitiousSwitchRef-bbk.xml", CURRENT_IIDM_XML_VERSION));
+        writeXmlTest(network, TopologyLevelTest::writeBusBranch,
+                getVersionedNetworkPath("fictitiousSwitchRef-bbr.xml", CURRENT_IIDM_XML_VERSION));
     }
 
     private static void writeNodeBreaker(Network network, Path path) {


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No



**What kind of change does this PR introduce?**
Feature: add an util method to retrieve as a string the path of a versioned network in the test resources.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
