### PR TITLE
Remove skip-extension property

### DIFF
--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/AbstractOptions.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/AbstractOptions.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm;
 
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -29,7 +28,7 @@ public abstract class AbstractOptions<T> {
     }
 
     public boolean withNoExtension() {
-        return Optional.ofNullable(extensions).map(Set::isEmpty).orElse(false);
+        return extensions != null && extensions.isEmpty();
     }
 
     public  boolean withAllExtensions() {
@@ -49,7 +48,7 @@ public abstract class AbstractOptions<T> {
     }
 
     public  boolean withExtension(String extensionName) {
-        return withAllExtensions() || Optional.ofNullable(extensions).orElse(new HashSet<>()).contains(extensionName);
+        return withAllExtensions() || extensions.contains(extensionName);
     }
 
     public IidmImportExportMode getMode() {

--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/export/ExportOptions.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/export/ExportOptions.java
@@ -178,28 +178,4 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
     public Optional<String> getExtensionVersion(String extensionName) {
         return Optional.ofNullable(extensionsVersions.get(extensionName));
     }
-
-    /**
-     * @deprecated Use {@link #withNoExtension()} instead.
-     */
-    @Deprecated
-    public boolean isSkipExtensions() {
-        return withNoExtension();
-    }
-
-    /**
-     * @deprecated Use {@link #setExtensions(Set<String>)} instead.
-     * Pass an empty Set as parameter
-     */
-    @Deprecated
-    public ExportOptions setSkipExtensions(boolean skipExtensions) {
-        if (extensions != null) {
-            throw new PowsyblException("Contradictory behavior: you have already passed an extensions list");
-        }
-        if (skipExtensions) {
-            this.extensions = new HashSet<>();
-        }
-        return this;
-    }
-
 }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/XMLExporter.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/XMLExporter.java
@@ -77,7 +77,6 @@ public class XMLExporter implements Exporter {
     public static final String THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND = "iidm.export.xml.throw-exception-if-extension-not-found";
     public static final String EXPORT_MODE = "iidm.export.xml.export-mode";
     public static final String EXTENSIONS_LIST = "iidm.export.xml.extensions";
-    public static final String SKIP_EXTENSIONS = "iidm.export.xml.skip-extensions";
     public static final String VERSION = "iidm.export.xml.version";
 
     private static final Parameter INDENT_PARAMETER = new Parameter(INDENT, ParameterType.BOOLEAN, "Indent export output file", Boolean.TRUE);
@@ -88,7 +87,6 @@ public class XMLExporter implements Exporter {
     private static final Parameter THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER = new Parameter(THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND, ParameterType.BOOLEAN, "Throw exception if extension not found", Boolean.FALSE);
     private static final Parameter EXPORT_MODE_PARAMETER = new Parameter(EXPORT_MODE, ParameterType.STRING, "export each extension in a separate file", String.valueOf(IidmImportExportMode.UNIQUE_FILE));
     private static final Parameter EXTENSIONS_LIST_PARAMETER = new Parameter(EXTENSIONS_LIST, ParameterType.STRING_LIST, "The list of exported extensions", null);
-    private static final Parameter SKIP_EXTENSIONS_PARAMETER = new Parameter(SKIP_EXTENSIONS, ParameterType.BOOLEAN, "Skip exporting the extensions", Boolean.FALSE);
     private static final Parameter VERSION_PARAMETER = new Parameter(VERSION, ParameterType.STRING, "IIDM-XML version in which files will be generated", IidmXmlConstants.CURRENT_IIDM_XML_VERSION.toString("."));
     private final ParameterDefaultValueConfig defaultValueConfig;
 
@@ -123,7 +121,6 @@ public class XMLExporter implements Exporter {
                 .setTopologyLevel(TopologyLevel.valueOf(ConversionParameters.readStringParameter(getFormat(), parameters, TOPOLOGY_LEVEL_PARAMETER, defaultValueConfig)))
                 .setThrowExceptionIfExtensionNotFound(ConversionParameters.readBooleanParameter(getFormat(), parameters, THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER, defaultValueConfig))
                 .setMode(IidmImportExportMode.valueOf(ConversionParameters.readStringParameter(getFormat(), parameters, EXPORT_MODE_PARAMETER, defaultValueConfig)))
-                .setSkipExtensions(ConversionParameters.readBooleanParameter(getFormat(), parameters, SKIP_EXTENSIONS_PARAMETER, defaultValueConfig))
                 .setExtensions(ConversionParameters.readStringListParameter(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig) != null ? new HashSet<>(ConversionParameters.readStringListParameter(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig)) : null)
                 .setVersion(ConversionParameters.readStringParameter(getFormat(), parameters, VERSION_PARAMETER, defaultValueConfig));
         addExtensionsVersions(parameters, options);

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SkipExtensionTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SkipExtensionTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.iidm.xml;
+
+import com.powsybl.iidm.export.Exporters;
+import com.powsybl.iidm.network.Network;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+/**
+ * @author Mathieu Bague <mathieu.bague@rte-france.com>
+ */
+public class SkipExtensionTest extends AbstractXmlConverterTest {
+
+    @Test
+    public void testSkipExtension() throws IOException {
+        Network network = NetworkXml.read(getVersionedNetworkAsStream("multiple-extensions.xml", IidmXmlVersion.V_1_0));
+
+        Properties properties = new Properties();
+        properties.put(XMLExporter.EXTENSIONS_LIST, "");
+        properties.put(XMLExporter.VERSION, "1.0");
+
+        // Write the file
+        Path networkFile = tmpDir.resolve("noExtension.xiidm");
+        Exporters.export("XIIDM", network, properties, networkFile);
+
+        // Compare
+        compareXml(getVersionedNetworkAsStream("noExtension.xml", IidmXmlVersion.V_1_0), Files.newInputStream(networkFile));
+    }
+}

--- a/iidm/iidm-xml-converter/src/test/resources/V1_0/noExtension.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_0/noExtension.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="test" caseDate="2017-11-17T12:00:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="S" country="FR">
+        <iidm:voltageLevel id="VL" nominalV="20.0" lowVoltageLimit="15.0" highVoltageLimit="25.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="0.0" q0="0.0" bus="BUS" connectableBus="BUS"/>
+            <iidm:load id="LOAD2" loadType="UNDEFINED" p0="0.0" q0="0.0" bus="BUS" connectableBus="BUS"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If I set the `iidm.export.xml.skip-extensions` option, without setting the `iidm.export.xml.extensions` option, all the extension are written.


**What is the new behavior (if this is a feature change)?**
As this property have been flagged `Deprecated`, I remove this property to make the code less confusing.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
