### PR TITLE
Increase the timeout in ThreadInterruptedCompletableFutureTest

### DIFF
--- a/computation/src/test/java/com/powsybl/computation/ThreadInterruptedCompletableFutureTest.java
+++ b/computation/src/test/java/com/powsybl/computation/ThreadInterruptedCompletableFutureTest.java
@@ -20,16 +20,13 @@ public class ThreadInterruptedCompletableFutureTest {
     public void test() throws Exception {
         ThreadInterruptedCompletableFuture<?> foo = new ThreadInterruptedCompletableFuture<>();
         boolean[] result = new boolean[2];
-        Thread t = new Thread() {
-            @Override
-            public void run() {
-                result[0] = foo.cancel(true);
-                result[1] = Thread.currentThread().isInterrupted();
-            }
-        };
+        Thread t = new Thread(() -> {
+            result[0] = foo.cancel(true);
+            result[1] = Thread.currentThread().isInterrupted();
+        });
         t.start();
         t.interrupt();
-        t.join(100);
+        t.join(5000);
         assertFalse(result[0]);
         assertTrue(result[1]);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#1210 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The compilation fails randomly on windows worker since we enable compilation in multi-thread mode. The timeout to wait for the termination of the thread is too low comparing to the load of the worker.


**What is the new behavior (if this is a feature change)?**
We increase the timeout to 5s. In the worst case, the compilation will fail after 5 secondes, but it should be sufficient to avoid false positive


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
