### PR TITLE
Fix how to merge two dangling lines in a tie line.

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -956,10 +956,10 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
             l.half2.name = dl2.getName();
             l.half2.r = dl2.getR();
             l.half2.x = dl2.getX();
-            l.half2.g1 = dl2.getG();
-            l.half2.g2 = 0;
-            l.half2.b1 = dl2.getB();
-            l.half2.b2 = 0;
+            l.half2.g2 = dl2.getG();
+            l.half2.g1 = 0;
+            l.half2.b2 = dl2.getB();
+            l.half2.b1 = 0;
             l.half2.xnodeP = dl2.getP0();
             l.half2.xnodeQ = dl2.getQ0();
             l.limits1 = dl1.getCurrentLimits();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TieLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TieLineImpl.java
@@ -235,7 +235,7 @@ class TieLineImpl extends LineImpl implements TieLine {
 
     @Override
     public double getG1() {
-        return half1.getG1() + half2.getG1();
+        return half1.getG1() + half1.getG2();
     }
 
     @Override
@@ -245,7 +245,7 @@ class TieLineImpl extends LineImpl implements TieLine {
 
     @Override
     public double getB1() {
-        return half1.getB1() + half2.getB1();
+        return half1.getB1() + half1.getB2();
     }
 
     @Override
@@ -255,7 +255,7 @@ class TieLineImpl extends LineImpl implements TieLine {
 
     @Override
     public double getG2() {
-        return half1.getG2() + half2.getG2();
+        return half2.getG1() + half2.getG2();
     }
 
     @Override
@@ -265,7 +265,7 @@ class TieLineImpl extends LineImpl implements TieLine {
 
     @Override
     public double getB2() {
-        return half1.getB2() + half2.getB2();
+        return half2.getB1() + half2.getB2();
     }
 
     @Override

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLineTest.java
@@ -340,10 +340,10 @@ public abstract class AbstractLineTest {
         assertEquals("hl2", tieLine.getHalf2().getId());
         assertEquals(r + r2, tieLine.getR(), 0.0);
         assertEquals(x + x2, tieLine.getX(), 0.0);
-        assertEquals(hl1g1 + hl2g1, tieLine.getG1(), 0.0);
-        assertEquals(hl1g2 + hl2g2, tieLine.getG2(), 0.0);
-        assertEquals(hl1b1 + hl2b1, tieLine.getB1(), 0.0);
-        assertEquals(hl1b2 + hl2b2, tieLine.getB2(), 0.0);
+        assertEquals(hl1g1 + hl1g2, tieLine.getG1(), 0.0);
+        assertEquals(hl2g1 + hl2g2, tieLine.getG2(), 0.0);
+        assertEquals(hl1b1 + hl1b2, tieLine.getB1(), 0.0);
+        assertEquals(hl2b1 + hl2b2, tieLine.getB2(), 0.0);
 
         // invalid set line characteristics on tieLine
         try {


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <atilloy@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No, but the issue was raised during the functional validation of the merging view compared to the classical merging of IIDM networks.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

The shunt admittance treatement of a line that is the result of the merging of 2 dangling lines in the classical merging of 2 IIDM networks. In details:
- Nothing change for the first half line ;
- For the second half line, only g2 and b2 are set from the second dangling line values of G and B ;

The getters of B1, G1, B2 and G2 of a `TieLine` have been corrected too. Now B1 and G1 only depend on the first half line and B2 and G2 only depend on the second half line.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
