### PR TITLE
Add methods in the shunt compensator adapter of the merging view

### DIFF
--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ShuntCompensatorAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ShuntCompensatorAdapter.java
@@ -81,7 +81,8 @@ public class ShuntCompensatorAdapter extends AbstractInjectionAdapter<ShuntCompe
 
     @Override
     public ShuntCompensator setVoltageRegulatorOn(boolean voltageRegulatorOn) {
-        return getDelegate().setVoltageRegulatorOn(voltageRegulatorOn);
+        getDelegate().setVoltageRegulatorOn(voltageRegulatorOn);
+        return this;
     }
 
     @Override
@@ -91,7 +92,8 @@ public class ShuntCompensatorAdapter extends AbstractInjectionAdapter<ShuntCompe
 
     @Override
     public ShuntCompensator setTargetV(double targetV) {
-        return getDelegate().setTargetV(targetV);
+        getDelegate().setTargetV(targetV);
+        return this;
     }
 
     @Override
@@ -101,7 +103,8 @@ public class ShuntCompensatorAdapter extends AbstractInjectionAdapter<ShuntCompe
 
     @Override
     public ShuntCompensator setTargetDeadband(double targetDeadband) {
-        return getDelegate().setTargetDeadband(targetDeadband);
+        getDelegate().setTargetDeadband(targetDeadband);
+        return this;
     }
 
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ShuntCompensatorAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ShuntCompensatorAdapter.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.mergingview;
 
 import com.powsybl.iidm.network.ShuntCompensator;
+import com.powsybl.iidm.network.Terminal;
 
 /**
  * @author Thomas Adam <tadam at silicom.fr>
@@ -57,4 +58,50 @@ public class ShuntCompensatorAdapter extends AbstractInjectionAdapter<ShuntCompe
     public double getCurrentB() {
         return getDelegate().getCurrentB();
     }
+
+    @Override
+    public Terminal getRegulatingTerminal() {
+        return getIndex().getTerminal(getDelegate().getRegulatingTerminal());
+    }
+
+    @Override
+    public ShuntCompensator setRegulatingTerminal(Terminal regulatingTerminal) {
+        Terminal terminal = regulatingTerminal;
+        if (terminal instanceof TerminalAdapter) {
+            terminal = ((TerminalAdapter) terminal).getDelegate();
+        }
+        getDelegate().setRegulatingTerminal(terminal);
+        return this;
+    }
+
+    @Override
+    public boolean isVoltageRegulatorOn() {
+        return getDelegate().isVoltageRegulatorOn();
+    }
+
+    @Override
+    public ShuntCompensator setVoltageRegulatorOn(boolean voltageRegulatorOn) {
+        return getDelegate().setVoltageRegulatorOn(voltageRegulatorOn);
+    }
+
+    @Override
+    public double getTargetV() {
+        return getDelegate().getTargetV();
+    }
+
+    @Override
+    public ShuntCompensator setTargetV(double targetV) {
+        return getDelegate().setTargetV(targetV);
+    }
+
+    @Override
+    public double getTargetDeadband() {
+        return getDelegate().getTargetDeadband();
+    }
+
+    @Override
+    public ShuntCompensator setTargetDeadband(double targetDeadband) {
+        return getDelegate().setTargetDeadband(targetDeadband);
+    }
+
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ShuntCompensatorAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ShuntCompensatorAdapterTest.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.mergingview;
 
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ShuntCompensator;
+import com.powsybl.iidm.network.Terminal;
 import com.powsybl.iidm.network.test.HvdcTestNetwork;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,9 +57,34 @@ public class ShuntCompensatorAdapterTest {
         double b = shuntCExpected.getbPerSection();
         assertEquals(b, shuntCActual.getbPerSection(), 0.0d);
         assertTrue(shuntCActual.setbPerSection(++b) instanceof ShuntCompensatorAdapter);
+        assertEquals(shuntCExpected.getbPerSection(), shuntCActual.getbPerSection(), 0.0d);
+
+        double currentB = shuntCExpected.getCurrentB();
+        assertEquals(currentB, shuntCActual.getCurrentB(), 0.0d);
+        assertTrue(shuntCActual.setbPerSection(++currentB) instanceof ShuntCompensatorAdapter);
         assertEquals(shuntCExpected.getCurrentB(), shuntCActual.getCurrentB(), 0.0d);
+
+        Terminal terminal = mergingView.getLccConverterStation("C1").getTerminal();
+        assertTrue(shuntCActual.setRegulatingTerminal(terminal) instanceof ShuntCompensatorAdapter);
+        assertSame(terminal, shuntCActual.getRegulatingTerminal());
+
+        double targetV = shuntCExpected.getTargetV();
+        assertEquals(targetV, shuntCActual.getTargetV(), 0.0d);
+        assertTrue(shuntCActual.setTargetV(400) instanceof ShuntCompensatorAdapter);
+        assertEquals(shuntCExpected.getTargetV(), shuntCActual.getTargetV(), 0.0d);
+
+        double targetDeadband = shuntCExpected.getTargetDeadband();
+        assertEquals(targetDeadband, shuntCActual.getTargetDeadband(), 0.0d);
+        assertTrue(shuntCActual.setTargetDeadband(20) instanceof ShuntCompensatorAdapter);
+        assertEquals(shuntCExpected.getTargetDeadband(), shuntCActual.getTargetDeadband(), 0.0d);
+
+        boolean voltageRegulatorOn = shuntCExpected.isVoltageRegulatorOn();
+        assertEquals(voltageRegulatorOn, shuntCActual.isVoltageRegulatorOn());
+        assertTrue(shuntCActual.setVoltageRegulatorOn(!voltageRegulatorOn) instanceof ShuntCompensatorAdapter);
+        assertEquals(shuntCExpected.isVoltageRegulatorOn(), shuntCActual.isVoltageRegulatorOn());
 
         // Not implemented yet !
         TestUtil.notImplemented(shuntCActual::remove);
     }
 }
+    //pour les méthodes setComponentNumber de BusExt je peux les remonter dans Bus


### PR DESCRIPTION
It comes after the ShuntCompensator new API (IIDM version 1.2).

Signed-off-by: Anne Tilloy <atilloy@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

New API of ShuntCompensator (IIDM 1.2).

**What is the current behavior?** *(You can also link to an open issue here)*


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
