### PR TITLE
Ensure that voltageLevel.getConnectables() and associated return collections of distinct elements

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.network.impl;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
 import com.powsybl.iidm.network.*;
 
 import java.util.List;
@@ -123,11 +124,12 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     }
 
     @Override
-    public <T extends Connectable> FluentIterable<T> getConnectables(Class<T> clazz) {
+    public <T extends Connectable> Iterable<T> getConnectables(Class<T> clazz) {
         Iterable<Terminal> terminals = getTerminals();
         return FluentIterable.from(terminals)
                 .transform(Terminal::getConnectable)
-                .filter(clazz);
+                .filter(clazz)
+                .toSet();
     }
 
     @Override
@@ -135,29 +137,32 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
         return getTerminalStream()
                 .map(Terminal::getConnectable)
                 .filter(clazz::isInstance)
-                .map(clazz::cast);
+                .map(clazz::cast)
+                .distinct();
     }
 
     @Override
     public <T extends Connectable> int getConnectableCount(Class<T> clazz) {
-        return getConnectables(clazz).size();
+        return Ints.checkedCast(getConnectableStream(clazz).count());
     }
 
     @Override
-    public FluentIterable<Connectable> getConnectables() {
+    public Iterable<Connectable> getConnectables() {
         return FluentIterable.from(getTerminals())
-                .transform(Terminal::getConnectable);
+                .transform(Terminal::getConnectable)
+                .toSet();
     }
 
     @Override
     public Stream<Connectable> getConnectableStream() {
         return getTerminalStream()
-                .map(Terminal::getConnectable);
+                .map(Terminal::getConnectable)
+                .distinct();
     }
 
     @Override
     public int getConnectableCount() {
-        return getConnectables().size();
+        return Ints.checkedCast(getConnectableStream().count());
     }
 
     @Override

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -181,12 +181,12 @@ public abstract class AbstractNetworkTest {
 
         // Check notification done
         verify(mockedListener, times(1))
-               .onElementAdded(busCalc, "properties[" + key + "]", value);
+                .onElementAdded(busCalc, "properties[" + key + "]", value);
         // Check no notification on same property
         String value2 = "ValueTest2";
         busCalc.setProperty(key, value2);
         verify(mockedListener, times(1))
-               .onElementReplaced(busCalc, "properties[" + key + "]", value, value2);
+                .onElementReplaced(busCalc, "properties[" + key + "]", value, value2);
         // Check no notification on same property
         busCalc.setProperty(key, value2);
         verifyNoMoreInteractions(mockedListener);
@@ -326,6 +326,27 @@ public abstract class AbstractNetworkTest {
         Function<Stream<? extends Identifiable>, Set<String>> mapperSet = stream -> stream.map(Identifiable::getId).collect(Collectors.toSet());
 
         Network network = EurostagTutorialExample1Factory.create();
+        String nhv1nhv1 = "NHV1_NHV1";
+        network.getVoltageLevel(VLHV1).getBusBreakerView()
+                .newBus()
+                .setId("NHV1_bis")
+                .add();
+        network.getSubstation("P1").newTwoWindingsTransformer()
+                .setId(nhv1nhv1)
+                .setVoltageLevel1(VLHV1)
+                .setBus1("NHV1")
+                .setConnectableBus1("NHV1")
+                .setRatedU1(380)
+                .setVoltageLevel2(VLHV1)
+                .setBus2("NHV1_bis")
+                .setConnectableBus2("NHV1_bis")
+                .setRatedU2(400.0)
+                .setR(0.24 / 1300 * (38 * 38))
+                .setX(Math.sqrt(10 * 10 - 0.24 * 0.24) / 1300 * (38 * 38))
+                .setG(0.0)
+                .setB(0.0)
+                .add();
+
         assertEquals(Arrays.asList("P1", "P2"), mapper.apply(network.getSubstationStream()));
         assertEquals(network.getSubstationCount(), network.getSubstationStream().count());
         assertEquals(Arrays.asList(NHV1_NHV2_1, NHV1_NHV2_2), mapper.apply(network.getLineStream()));
@@ -336,18 +357,23 @@ public abstract class AbstractNetworkTest {
         assertEquals(Arrays.asList(VLGEN, VLHV1), mapper.apply(network.getSubstation("P1").getVoltageLevelStream()));
         assertEquals(Arrays.asList(VLHV2, VLLOAD), mapper.apply(network.getSubstation("P2").getVoltageLevelStream()));
 
-        assertEquals(Arrays.asList("NGEN", "NHV1", "NHV2", "NLOAD"), mapper.apply(network.getBusBreakerView().getBusStream()));
+        assertEquals(Arrays.asList("NGEN", "NHV1", "NHV1_bis", "NHV2", "NLOAD"), mapper.apply(network.getBusBreakerView().getBusStream()));
         assertEquals(Collections.singletonList("NGEN"), mapper.apply(network.getVoltageLevel(VLGEN).getBusBreakerView().getBusStream()));
-        assertEquals(Collections.singletonList("NHV1"), mapper.apply(network.getVoltageLevel(VLHV1).getBusBreakerView().getBusStream()));
+        assertEquals(Arrays.asList("NHV1", "NHV1_bis"), mapper.apply(network.getVoltageLevel(VLHV1).getBusBreakerView().getBusStream()));
         assertEquals(Collections.singletonList("NHV2"), mapper.apply(network.getVoltageLevel(VLHV2).getBusBreakerView().getBusStream()));
         assertEquals(Collections.singletonList("NLOAD"), mapper.apply(network.getVoltageLevel(VLLOAD).getBusBreakerView().getBusStream()));
 
-        assertEquals(Arrays.asList(NGEN_NHV1, NHV2_NLOAD), mapper.apply(network.getTwoWindingsTransformerStream()));
-        assertEquals(network.getTwoWindingsTransformerCount(), network.getTwoWindingsTransformerStream().count());
-        assertEquals(Collections.singleton(NGEN_NHV1), mapperSet.apply(network.getSubstation("P1").getTwoWindingsTransformerStream()));
-        assertEquals(Collections.singleton(NHV2_NLOAD), mapperSet.apply(network.getSubstation("P2").getTwoWindingsTransformerStream()));
+        assertEquals(Arrays.asList(NHV1_NHV2_1, NHV1_NHV2_2, NGEN_NHV1, nhv1nhv1), mapper.apply(network.getVoltageLevel(VLHV1).getConnectableStream()));
+        assertEquals(network.getVoltageLevel(VLHV1).getConnectableCount(), network.getVoltageLevel(VLHV1).getConnectableStream().count());
 
-        assertEquals(Arrays.asList(NHV1_NHV2_1, NHV1_NHV2_2, NGEN_NHV1, NHV2_NLOAD), mapper.apply(network.getBranchStream()));
+        assertEquals(Arrays.asList(NGEN_NHV1, NHV2_NLOAD, nhv1nhv1), mapper.apply(network.getTwoWindingsTransformerStream()));
+        assertEquals(network.getTwoWindingsTransformerCount(), network.getTwoWindingsTransformerStream().count());
+        assertEquals(Arrays.asList(NGEN_NHV1, nhv1nhv1), mapper.apply(network.getSubstation("P1").getTwoWindingsTransformerStream()));
+        assertEquals(Collections.singleton(NHV2_NLOAD), mapperSet.apply(network.getSubstation("P2").getTwoWindingsTransformerStream()));
+        assertEquals(Arrays.asList(NGEN_NHV1, nhv1nhv1), mapper.apply(network.getVoltageLevel(VLHV1).getConnectableStream(TwoWindingsTransformer.class)));
+        assertEquals(network.getVoltageLevel(VLHV1).getConnectableCount(TwoWindingsTransformer.class), network.getVoltageLevel(VLHV1).getConnectableStream(TwoWindingsTransformer.class).count());
+
+        assertEquals(Arrays.asList(NHV1_NHV2_1, NHV1_NHV2_2, NGEN_NHV1, NHV2_NLOAD, nhv1nhv1), mapper.apply(network.getBranchStream()));
         assertEquals(network.getBranchCount(), network.getBranchStream().count());
 
         assertEquals(Collections.emptyList(), mapper.apply(network.getThreeWindingsTransformerStream()));
@@ -375,7 +401,7 @@ public abstract class AbstractNetworkTest {
         assertEquals(Collections.singletonList("GEN"), mapper.apply(bus.getGeneratorStream()));
         bus = network.getVoltageLevel(VLHV1).getBusView().getBus("VLHV1_0");
         assertEquals(Arrays.asList(NHV1_NHV2_1, NHV1_NHV2_2), mapper.apply(bus.getLineStream()));
-        assertEquals(Collections.singletonList(NGEN_NHV1), mapper.apply(bus.getTwoWindingsTransformerStream()));
+        assertEquals(Arrays.asList(NGEN_NHV1, nhv1nhv1), mapper.apply(bus.getTwoWindingsTransformerStream()));
         bus = network.getVoltageLevel(VLHV2).getBusView().getBus("VLHV2_0");
         assertEquals(Collections.singletonList(NHV2_NLOAD), mapper.apply(bus.getTwoWindingsTransformerStream()));
         bus = network.getVoltageLevel(VLLOAD).getBusView().getBus("VLLOAD_0");


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?**
`voltageLevel.getConnectables()` and `voltageLevel.getConnectableStream()` do not check if they have duplicates in their respective returned iterable and stream.


**What is the new behavior (if this is a feature change)?**
The returned iterable and stream contain distinct elements.


**Does this PR introduce a breaking change or deprecate an API?** 
No


**Other information**:
It generated issues in voltage level with an internal transformer (for example) which:
- is not forbidden
- has been seen to happen by @agnesLeroy during UCTE imports
