### PR TITLE
Set rdp to 0 when R1+R2 = 0 in mergedXnode (resp. xdp)

### DIFF
--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/MergedXnode.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/MergedXnode.java
@@ -49,7 +49,7 @@ public class MergedXnode extends AbstractExtension<Line> {
     }
 
     private static float checkDividerPosition(float dp) {
-        if (dp < 0f || dp > 1f) {
+        if (dp < 0f || dp > 1f || Double.isNaN(dp)) {
             throw new IllegalArgumentException("Invalid divider postion: " + dp);
         }
         return dp;

--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -815,8 +815,12 @@ public class UcteImporter implements Importer {
         String mergeLineId = dlAtSideOne.getId() + " + " + dlAtSideTwo.getId();
 
         // create XNODE merge extension
-        float rdp = (float) (dlAtSideOne.getR() / (dlAtSideOne.getR() + dlAtSideTwo.getR()));
-        float xdp = (float) (dlAtSideOne.getX() / (dlAtSideOne.getX() + dlAtSideTwo.getX()));
+        // In case R1 and R2 (resp. X1 and X2) are zero, rdp (resp. xdp) should be set to zero to recover
+        // R1 = 0 and R2 = 0 (resp. X1 = 0 and X2 = 0) when splitting the mergedXnode
+        double sumR = dlAtSideOne.getR() + dlAtSideTwo.getR();
+        double sumX = dlAtSideOne.getX() + dlAtSideTwo.getX();
+        float rdp = (sumR == 0.) ? (float) 0. : (float) (dlAtSideOne.getR() / sumR);
+        float xdp = (sumX == 0.) ? (float) 0. : (float) (dlAtSideOne.getX() / sumX);
         double xnodeP1 = dlAtSideOne.getP0();
         double xnodeQ1 = dlAtSideOne.getQ0();
         double xnodeP2 = dlAtSideTwo.getP0();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
This is a bug fix in the UCTE import/export feature.

**What is the current behavior?**
In a mergedXnode, rdp is calculated as R1/(R1+R2).
When R1+R2 = 0, rdp is thus NaN. When converting a UCTE network to IIDM, for a mergedXnode with R (or X) = 0 on both sides, rdp is not written because NaN values are not serialized.
When importing the generated xiidm file into Powsybl, since rdp is a required attribute, a nullPointerException is raised. This also holds for xdp.

**What is the new behavior (if this is a feature change)?**
With this change, when R1+R2 = 0, rdp is set to 0 (resp. xdp). This fixes the isssue mentionned above. Besides, when splitting the merged Xnode again, we recover R1 & R2 = 0 (resp. X).
