### PR TITLE
CGMES regulating controls: targetDeadband is optional

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMapping.java
@@ -71,7 +71,9 @@ public class RegulatingControlMapping {
             this.topologicalNode = p.getId("topologicalNode");
             this.enabled = p.asBoolean("enabled", true);
             this.targetValue = p.asDouble("targetValue");
-            this.targetDeadband = p.asDouble("targetDeadband", Double.NaN);
+            // targetDeadband is optional in CGMES,
+            // If not explicitly given it should be interpreted as zero
+            this.targetDeadband = p.asDouble("targetDeadband", 0);
         }
 
         void setCorrectlySet(boolean okSet) {


### PR DESCRIPTION
Signed-off-by: Luma Zamarreño <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
For CGMES regulating controls, `targetDeadband` is optional. But a value is required in IIDM.

**What is the new behavior (if this is a feature change)?**
When a CGMES regulating control is missing the `targetDeadband` attribute, its value is interpreted as zero for IIDM.

