### PR TITLE
Add nodeBreakerView.hasAttachedEquipment(node) method + Ensure an IIDM node number is valid before trying to use it in CGMES conversion

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
@@ -184,7 +184,7 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
                 return;
             }
             LOG.warn(
-                "Can't find a calculated Bus to set Voltage, Angle, but found a configured Bus {}. Connectivity node {}",
+                "Can't find a bus from the Bus View to set Voltage and Angle, we use the bus {} from the Bus/Breaker view. Connectivity node {}",
                 bus, id);
         }
         setVoltageAngle(bus);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
@@ -7,6 +7,7 @@
 
 package com.powsybl.cgmes.conversion.elements;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import org.slf4j.Logger;
@@ -68,34 +69,34 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
         String substationName = "boundary";
         String vlName = "boundary";
         return context.network()
-                .newSubstation()
-                .setId(context.namingStrategy().getId("Substation", substationId))
-                .setName(substationName)
-                // TODO(mathbagu): Country should be optional. This will be done in another PR.
-                // A non-null country code must be set
-                // This is an arbitrary country code, Bangladesh code BD also matches with
-                // BounDary
-                .setCountry(boundaryCountryCode())
-                .add()
-                .newVoltageLevel()
-                .setId(context.namingStrategy().getId("VoltageLevel", vlId))
-                .setName(vlName)
-                .setNominalV(nominalVoltage)
-                .setTopologyKind(context.nodeBreaker() ? TopologyKind.NODE_BREAKER : TopologyKind.BUS_BREAKER)
-                .add();
+            .newSubstation()
+            .setId(context.namingStrategy().getId("Substation", substationId))
+            .setName(substationName)
+            // TODO(mathbagu): Country should be optional. This will be done in another PR.
+            // A non-null country code must be set
+            // This is an arbitrary country code, Bangladesh code BD also matches with
+            // BounDary
+            .setCountry(boundaryCountryCode())
+            .add()
+            .newVoltageLevel()
+            .setId(context.namingStrategy().getId("VoltageLevel", vlId))
+            .setName(vlName)
+            .setNominalV(nominalVoltage)
+            .setTopologyKind(context.nodeBreaker() ? TopologyKind.NODE_BREAKER : TopologyKind.BUS_BREAKER)
+            .add();
     }
 
     private Country boundaryCountryCode() {
         // Selection of country code when ENTSO-E extensions are present
         return CountryConversion.fromIsoCode(p.getLocal("fromEndIsoCode"))
-                .orElseGet(() -> CountryConversion.fromIsoCode(p.getLocal("toEndIsoCode"))
-                        .orElseGet(() -> {
-                            String countryCodes = String.format("Country. ISO codes %s %s",
-                                    p.getLocal("fromEndIsoCode"),
-                                    p.getLocal("toEndIsoCode"));
-                            ignored(countryCodes);
-                            return null;
-                        }));
+            .orElseGet(() -> CountryConversion.fromIsoCode(p.getLocal("toEndIsoCode"))
+                .orElseGet(() -> {
+                    String countryCodes = String.format("Country. ISO codes %s %s",
+                        p.getLocal("fromEndIsoCode"),
+                        p.getLocal("toEndIsoCode"));
+                    ignored(countryCodes);
+                    return null;
+                }));
     }
 
     @Override
@@ -167,6 +168,10 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
         VoltageLevel.NodeBreakerView topo = vl.getNodeBreakerView();
         String connectivityNode = id;
         int iidmNode = context.nodeMapping().iidmNodeForConnectivityNode(connectivityNode, vl);
+        if (!iidmNodeIsValid(topo, iidmNode)) {
+            LOG.error("ConnectivityNode {} with voltage and angle is not valid in IIDM", connectivityNode);
+            return;
+        }
         // To obtain a bus for which we want to set voltage:
         // If there no Terminal at this IIDM node,
         // then find from it the first connected node with a Terminal
@@ -186,10 +191,17 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
                 return;
             }
             LOG.warn(
-                    "Can't find a calculated Bus to set Voltage, Angle, but found a configured Bus {}. Connectivity node {}",
-                    bus, id);
+                "Can't find a calculated Bus to set Voltage, Angle, but found a configured Bus {}. Connectivity node {}",
+                bus, id);
         }
         setVoltageAngle(bus);
+    }
+
+    private boolean iidmNodeIsValid(VoltageLevel.NodeBreakerView topo, int iidmNode) {
+        // A node is valid only if it has some equipment attached
+        // The list of valid nodes is obtained from the node-breaker view
+        // We assume the returned list is sorted
+        return Arrays.binarySearch(topo.getNodes(), iidmNode) >= 0;
     }
 
     private VoltageLevel voltageLevel() {
@@ -214,19 +226,19 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
         // against the topology present in the CGMES model
         if (context.config().createBusbarSectionForEveryConnectivityNode()) {
             BusbarSection bus = nbv.newBusbarSection()
-                    .setId(context.namingStrategy().getId("Bus", id))
-                    .setName(context.namingStrategy().getName("Bus", name))
-                    .setNode(iidmNode)
-                    .add();
+                .setId(context.namingStrategy().getId("Bus", id))
+                .setName(context.namingStrategy().getName("Bus", name))
+                .setNode(iidmNode)
+                .add();
             LOG.debug("    BusbarSection added at node {} : {} {} : {}", iidmNode, id, name, bus);
         }
     }
 
     private void newBus(VoltageLevel voltageLevel) {
         Bus bus = voltageLevel.getBusBreakerView().newBus()
-                .setId(context.namingStrategy().getId("Bus", id))
-                .setName(context.namingStrategy().getName("Bus", name))
-                .add();
+            .setId(context.namingStrategy().getId("Bus", id))
+            .setName(context.namingStrategy().getName("Bus", name))
+            .add();
         if (checkValidVoltageAngle(bus)) {
             setVoltageAngle(bus);
         }
@@ -238,13 +250,13 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
         boolean valid = valid(v, angle);
         if (!valid) {
             String reason = String.format(
-                    "v = %f, angle = %f. Node %s",
-                    v,
-                    angle,
-                    id);
+                "v = %f, angle = %f. Node %s",
+                v,
+                angle,
+                id);
             String location = bus == null
-                    ? "No bus"
-                    : String.format("Bus %s, Substation %s, Voltage level %s",
+                ? "No bus"
+                : String.format("Bus %s, Substation %s, Voltage level %s",
                     bus.getId(),
                     bus.getVoltageLevel().getSubstation().getNameOrId(),
                     bus.getVoltageLevel().getNameOrId());

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -454,6 +454,15 @@ public interface VoltageLevel extends Container<VoltageLevel> {
         }
 
         /**
+         * Check if a {@link Connectable}, a {@link Switch} or an {@link InternalConnection} is attached to the given node.
+         *
+         * @throws com.powsybl.commons.PowsyblException if node is not valid
+         */
+        default boolean hasAttachedEquipment(int node) {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
          * Get the first terminal corresponding to the {@param switchId}.
          * May return null.
          *

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -373,6 +373,16 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
+        public Optional<Terminal> getOptionalTerminal(int node) {
+            throw createNotSupportedBusBreakerTopologyException();
+        }
+
+        @Override
+        public boolean hasAttachedEquipment(int node) {
+            throw createNotSupportedBusBreakerTopologyException();
+        }
+
+        @Override
         public Terminal getTerminal1(String switchId) {
             throw createNotSupportedBusBreakerTopologyException();
         }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -602,6 +602,11 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
+        public boolean hasAttachedEquipment(int node) {
+            return graph.vertexExists(node);
+        }
+
+        @Override
         public Terminal getTerminal1(String switchId) {
             return getTerminal(getNode1(switchId));
         }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VoltageLevelAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VoltageLevelAdapter.java
@@ -15,6 +15,7 @@ import java.io.PrintStream;
 import java.io.Writer;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -221,6 +222,16 @@ class VoltageLevelAdapter extends AbstractIdentifiableAdapter<VoltageLevel> impl
         @Override
         public Terminal getTerminal(final int node) {
             return getIndex().getTerminal(getDelegate().getTerminal(node));
+        }
+
+        @Override
+        public Optional<Terminal> getOptionalTerminal(final int node) {
+            return getDelegate().getOptionalTerminal(node).map(t -> getIndex().getTerminal(t));
+        }
+
+        @Override
+        public boolean hasAttachedEquipment(final  int node) {
+            return getDelegate().hasAttachedEquipment(node);
         }
 
         @Override


### PR DESCRIPTION
Signed-off-by: Luma Zamarreño <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix for conversion of isolated connectivity nodes in CGMES.

**What is the current behavior?** *(You can also link to an open issue here)*
CGMES data contains an isolated connectivity node (no terminals attached to it, no related equipment).
Space for the connectivity node is reserved at IIDM node-breaker graph (a vertex is reserved).
During the conversion, the reserved vertex is never used (no equipment is attached to it).
After all equipment has been converted, voltages and angles from SV are put on the resulting IIDM data.
The CGMES SV data contains voltage and angle values for the connectivity node.
But the corresponding node in IIDM node-breaker graph is not valid.
An exception is raised.

**What is the new behavior (if this is a feature change)?**
Before trying to use the node from IIDM node-breaker graph, it is verified that the node number is valid.
To do it, we check that the nodes returned by the node-breaker view in IIDM contain the node number reserved.
There is no severe performance penalty on adding the check. It has been tested on a network with more than 14000 values for voltages. Without the check, all voltages and angles were set in 1400 ms. After adding the check, the cost is 1600 ms. 
