### PR TITLE
Add UndirectedGraph.vertexExists(node) method + NodeBreakerView.getOptionalTerminal(node)

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Writer;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Stream;
 
@@ -437,11 +438,20 @@ public interface VoltageLevel extends Container<VoltageLevel> {
 
         /**
          * Get the terminal corresponding to the {@param node}.
-         * May return null.
          *
          * @throws com.powsybl.commons.PowsyblException if node is not found.
          */
         Terminal getTerminal(int node);
+
+        /**
+         * Get the terminal corresponding to the {@param node} if the {@param node} is valid.
+         * Return an empty optional if no existing terminal corresponds to {@param node}.
+         *
+         * @throws com.powsybl.commons.PowsyblException if node is not valid.
+         */
+        default Optional<Terminal> getOptionalTerminal(int node) {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Get the first terminal corresponding to the {@param switchId}.

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -594,6 +594,14 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
+        public Optional<Terminal> getOptionalTerminal(int node) {
+            if (graph.vertexExists(node)) {
+                return Optional.ofNullable(graph.getVertexObject(node));
+            }
+            return Optional.empty();
+        }
+
+        @Override
         public Terminal getTerminal1(String switchId) {
             return getTerminal(getNode1(switchId));
         }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerTest.java
@@ -162,12 +162,15 @@ public abstract class AbstractNodeBreakerTest {
     }
 
     @Test
-    public void connectDisconnect() {
+    public void connectDisconnectRemove() {
         Network network = createNetwork();
+        VoltageLevel.NodeBreakerView topo = network.getVoltageLevel("VL").getNodeBreakerView();
         Load l = network.getLoad("L");
         Generator g = network.getGenerator("G");
 
         // generator is connected, load is disconnected
+        assertTrue(topo.getOptionalTerminal(2).isPresent());
+        assertTrue(topo.getOptionalTerminal(3).isPresent());
         assertNotNull(g.getTerminal().getBusView().getBus());
         assertNull(l.getTerminal().getBusView().getBus());
         assertTrue(g.getTerminal().isConnected());
@@ -177,6 +180,7 @@ public abstract class AbstractNodeBreakerTest {
         assertTrue(l.getTerminal().connect());
 
         // check load is connected
+        assertTrue(topo.getOptionalTerminal(2).isPresent());
         assertNotNull(l.getTerminal().getBusView().getBus());
         assertTrue(l.getTerminal().isConnected());
 
@@ -184,8 +188,16 @@ public abstract class AbstractNodeBreakerTest {
         g.getTerminal().disconnect();
 
         // check generator is disconnected
+        assertTrue(topo.getOptionalTerminal(3).isPresent());
         assertNull(g.getTerminal().getBusView().getBus());
         assertFalse(g.getTerminal().isConnected());
+
+        // remove generator
+        g.remove();
+        topo.removeSwitch("B2");
+
+        // check generator is removed
+        assertFalse(topo.getOptionalTerminal(3).isPresent());
     }
 
     private static Bus getBus(Injection i) {

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
@@ -40,6 +40,14 @@ public interface UndirectedGraph<V, E> {
     }
 
     /**
+     * Check if a specified vertex exists.
+     * This method throws a {@link com.powsybl.commons.PowsyblException} if the vertex index is invalid (negative).
+     */
+    default boolean vertexExists(int v) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Remove the specified vertex and notify the {@link UndirectedGraphListener}s.
      * This method throws a {@link com.powsybl.commons.PowsyblException} if the vertex doesn't exist or if an edge is connected to this vertex.
      *

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraphImpl.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraphImpl.java
@@ -150,6 +150,14 @@ public class UndirectedGraphImpl<V, E> implements UndirectedGraph<V, E> {
     }
 
     @Override
+    public boolean vertexExists(int v) {
+        if (v < 0) {
+            throw new PowsyblException("Invalid vertex " + v);
+        }
+        return v < vertices.size() && vertices.get(v) != null;
+    }
+
+    @Override
     public V removeVertex(int v) {
         checkVertex(v);
         for (Edge<E> e : edges) {

--- a/math/src/test/java/com/powsybl/math/graph/UndirectedGraphImplTest.java
+++ b/math/src/test/java/com/powsybl/math/graph/UndirectedGraphImplTest.java
@@ -10,9 +10,6 @@ import com.powsybl.commons.PowsyblException;
 import gnu.trove.list.array.TIntArrayList;
 import org.junit.After;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,6 +21,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -435,5 +434,18 @@ public class UndirectedGraphImplTest {
         graph.addEdge(0, 1, "Edge 1");
         graph.addEdge(1, 2, "Edge 2");
         assertArrayEquals(new String[] {"Edge 1", "Edge 2"}, graph.getEdgeObjectStream().toArray());
+    }
+
+    @Test
+    public void testVertexExists() {
+        try {
+            graph.vertexExists(-1);
+            fail();
+        } catch (PowsyblException e) {
+            assertEquals("Invalid vertex -1", e.getMessage());
+        }
+        assertFalse(graph.vertexExists(0));
+        graph.addVertex();
+        assertTrue(graph.vertexExists(0));
     }
 }


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No



**What kind of change does this PR introduce?** 
Feature



**What is the current behavior?**
If a node in `NodeBreakerView` does not have an attached network component, the methode `getTerminal(node)` throws an exception. 



**What is the new behavior (if this is a feature change)?**
The method `getOptionalTerminal` now exists and can return an empty Optional if there is no attached network component to a valid node.


**Does this PR introduce a breaking change or deprecate an API?**
No


**Other information**:

Linked to #1233 
