### PR TITLE
align isTransformer s logic to createBranches line and transformer de…

### DIFF
--- a/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
+++ b/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
@@ -138,7 +138,7 @@ public class IeeeCdfImporter implements Importer {
     }
 
     private static boolean isTransformer(IeeeCdfBranch ieeeCdfBranch) {
-        return ieeeCdfBranch.getType() != IeeeCdfBranch.Type.TRANSMISSION_LINE || ieeeCdfBranch.getFinalTurnsRatio() != 0;
+        return ieeeCdfBranch.getType() != null && (ieeeCdfBranch.getType() != IeeeCdfBranch.Type.TRANSMISSION_LINE || ieeeCdfBranch.getFinalTurnsRatio() != 0);
     }
 
     private static void createSubstationMapping(IeeeCdfModel ieeeCdfModel, ContainersMapping containersMapping) {

--- a/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee9cdf.xiidm
+++ b/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee9cdf.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="ieee9cdf" caseDate="2009-04-26T00:00:00.000Z" forecastDistance="0" sourceFormat="IEEE-CDF">
-    <iidm:substation id="S1">
+    <iidm:substation id="S5">
         <iidm:voltageLevel id="VL1" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
                 <iidm:bus id="B1" name="BUS-1   100" v="1.04" angle="0.0"/>
@@ -9,6 +9,18 @@
                 <iidm:minMaxReactiveLimits minQ="-99990.0" maxQ="999900.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL4" nominalV="1.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B4" name="BUS-4   100" v="1.025" angle="-2.216"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="T4-1-0" r="0.0" x="5.76E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B1" connectableBus2="B1" voltageLevelId2="VL1">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="S1">
         <iidm:voltageLevel id="VL2" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
                 <iidm:bus id="B2" name="BUS-2   100" v="1.025" angle="9.28"/>
@@ -17,6 +29,18 @@
                 <iidm:minMaxReactiveLimits minQ="-99990.0" maxQ="999900.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL7" nominalV="1.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B7" name="BUS-7   100" v="1.025" angle="3.7197"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="T7-2-0" r="0.0" x="6.25E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B7" connectableBus1="B7" voltageLevelId1="VL7" bus2="B2" connectableBus2="B2" voltageLevelId2="VL2">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="S3">
         <iidm:voltageLevel id="VL3" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
                 <iidm:bus id="B3" name="BUS-3   100" v="1.025" angle="4.6647"/>
@@ -25,54 +49,40 @@
                 <iidm:minMaxReactiveLimits minQ="-99990.0" maxQ="999900.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL4" nominalV="1.0" topologyKind="BUS_BREAKER">
+        <iidm:voltageLevel id="VL9" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="B4" name="BUS-4   100" v="1.025" angle="-2.216"/>
+                <iidm:bus id="B9" name="BUS-9   100" v="1.032" angle="1.9667"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="T9-3-0" r="0.0" x="5.86E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B9" connectableBus1="B9" voltageLevelId1="VL9" bus2="B3" connectableBus2="B3" voltageLevelId2="VL3">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="S6">
         <iidm:voltageLevel id="VL5" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
                 <iidm:bus id="B5" name="BUS-5   100" v="0.995" angle="-3.988"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B5-L" loadType="UNDEFINED" p0="125.0" q0="50.0" bus="B5" connectableBus="B5"/>
         </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S2">
         <iidm:voltageLevel id="VL6" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
                 <iidm:bus id="B6" name="BUS-6   100" v="1.012" angle="-3.687"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B6-L" loadType="UNDEFINED" p0="90.0" q0="30.0" bus="B6" connectableBus="B6"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL7" nominalV="1.0" topologyKind="BUS_BREAKER">
-            <iidm:busBreakerTopology>
-                <iidm:bus id="B7" name="BUS-7   100" v="1.025" angle="3.7197"/>
-            </iidm:busBreakerTopology>
-        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S4">
         <iidm:voltageLevel id="VL8" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
                 <iidm:bus id="B8" name="BUS-8   100" v="1.015" angle="0.7275"/>
             </iidm:busBreakerTopology>
             <iidm:load id="B8-L" loadType="UNDEFINED" p0="100.0" q0="35.0" bus="B8" connectableBus="B8"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL9" nominalV="1.0" topologyKind="BUS_BREAKER">
-            <iidm:busBreakerTopology>
-                <iidm:bus id="B9" name="BUS-9   100" v="1.032" angle="1.9667"/>
-            </iidm:busBreakerTopology>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="T4-1-0" r="0.0" x="5.76E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B1" connectableBus2="B1" voltageLevelId2="VL1">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="false">
-                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
-            </iidm:ratioTapChanger>
-        </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="T7-2-0" r="0.0" x="6.25E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B7" connectableBus1="B7" voltageLevelId1="VL7" bus2="B2" connectableBus2="B2" voltageLevelId2="VL2">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="false">
-                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
-            </iidm:ratioTapChanger>
-        </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="T9-3-0" r="0.0" x="5.86E-4" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" bus1="B9" connectableBus1="B9" voltageLevelId1="VL9" bus2="B3" connectableBus2="B3" voltageLevelId2="VL3">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="false">
-                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
-            </iidm:ratioTapChanger>
-        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="L7-8-0" r="8.5E-5" x="7.199999999999999E-4" g1="0.0" b1="7.449999999999999" g2="0.0" b2="7.449999999999999" bus1="B7" connectableBus1="B7" voltageLevelId1="VL7" bus2="B8" connectableBus2="B8" voltageLevelId2="VL8"/>
     <iidm:line id="L9-8-0" r="1.19E-4" x="0.001008" g1="0.0" b1="10.45" g2="0.0" b2="10.45" bus1="B9" connectableBus1="B9" voltageLevelId1="VL9" bus2="B8" connectableBus2="B8" voltageLevelId2="VL8"/>


### PR DESCRIPTION
…tection logic

Signed-off-by: Christian Biasuzzi <christian.biasuzzi@techrain.eu>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
ieee-cdf importer: when an IeeeCdfBranch's type is not set (e.g. because the type attribute is empty in the cdf file),  the branch is considered as a transformer, in the topological analysis to identify substations.  However, the code that created lines and transformers (method createBranches) consider that branch as a line.





**What is the new behavior (if this is a feature change)?**
changed the transformer detector so that it behaves consistently with the createBranches method's logic  (i.e.  when the when an IeeeCdfBranch's type is not set, it's a line)



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
