### PR TITLE
Clean: getConnectableStream() is already distinct

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/StateVariablesAdder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/StateVariablesAdder.java
@@ -247,7 +247,6 @@ public class StateVariablesAdder {
         PropertyBags svStatus = new PropertyBags();
         network.getVoltageLevelStream()
             .flatMap(VoltageLevel::getConnectableStream)
-            .distinct()
             .forEach(c -> {
                 PropertyBag p = new PropertyBag(SV_SVSTATUS_PROPERTIES);
                 p.put(IN_SERVICE,


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Clean code: `voltageLevel.getConnectableStream()` return distinct since PR #1218, no need to check it twice
