### PR TITLE
Fix PR #1155 to avoid breaking change in the sensitivity results constructor

### DIFF
--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
@@ -77,6 +77,17 @@ public class SensitivityComputationResults {
         this.sensitivityValuesContingencies = Optional.ofNullable(sensitivityValuesContingencies).map(Collections::unmodifiableMap).orElse(Collections.emptyMap());
     }
 
+    public SensitivityComputationResults(boolean ok,
+                                         Map<String, String> metrics,
+                                         String logs,
+                                         List<SensitivityValue> sensitivityValues) {
+        this.ok = ok;
+        this.metrics = Objects.requireNonNull(metrics);
+        this.logs = Objects.requireNonNull(logs);
+        this.sensitivityValues = Collections.unmodifiableList(Objects.requireNonNull(sensitivityValues));
+        this.sensitivityValuesContingencies = Collections.emptyMap();
+    }
+
     /**
      * Get the status of the sensitivity computation
      *

--- a/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
+++ b/sensitivity-api/src/main/java/com/powsybl/sensitivity/SensitivityComputationResults.java
@@ -81,11 +81,7 @@ public class SensitivityComputationResults {
                                          Map<String, String> metrics,
                                          String logs,
                                          List<SensitivityValue> sensitivityValues) {
-        this.ok = ok;
-        this.metrics = Objects.requireNonNull(metrics);
-        this.logs = Objects.requireNonNull(logs);
-        this.sensitivityValues = Collections.unmodifiableList(Objects.requireNonNull(sensitivityValues));
-        this.sensitivityValuesContingencies = Collections.emptyMap();
+        this(ok, metrics, logs, sensitivityValues, Collections.emptyMap());
     }
 
     /**

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationResultsTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/SensitivityComputationResultsTest.java
@@ -76,7 +76,7 @@ public class SensitivityComputationResultsTest {
     @Test
     public void createResultsWithNullValues() {
         exception.expect(NullPointerException.class);
-        new SensitivityComputationResults(true, Collections.emptyMap(), "", null, Collections.emptyMap());
+        new SensitivityComputationResults(true, Collections.emptyMap(), "", null);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
It just adds a constructor for the SensitivityComputationResults in order to avoid a breaking change in the API, caused by PR #1155.

