### PR TITLE
Optimize performance SPARQL query "terminals"

### DIFF
--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -166,8 +166,10 @@ OPTIONAL { GRAPH ?graphSV {
         a cim:SvPowerFlow ;
         cim:SvPowerFlow.Terminal ?Terminal ;
         cim:SvPowerFlow.p ?p ;
-        cim:SvPowerFlow.q ?q
-} OPTIONAL {?SvStatus
+        cim:SvPowerFlow.q ?q .
+}}
+OPTIONAL { GRAPH ?graphSV2 {
+    ?SvStatus
         a cim:SvStatus ;
         cim:SvStatus.ConductingEquipment ?ConductingEquipment ;
         cim:SvStatus.inService ?inService . 


### PR DESCRIPTION
Signed-off-by: Elena Kaltakova <kaltakovae@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Optimize performance of SPARQL query "terminals".


**What is the current behavior?** *(You can also link to an open issue here)*
Query "terminals" takes a lot of time for particular GRIDS. 


**What is the new behavior (if this is a feature change)?**
Enhanced syntax allows collect required data with minimal cost.


**Other information**:
A performance analysis has been made on the impact of the change made to the query. Test case time execution went from 26000 ms to 150 ms. Data collected by enhanced query is as required.
