### PR TITLE
Fix SynchronousComponent buses filtering

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractComponentImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractComponentImpl.java
@@ -6,19 +6,21 @@
  */
 package com.powsybl.iidm.network.impl;
 
-import com.google.common.collect.Iterables;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Component;
 import com.powsybl.iidm.network.impl.util.Ref;
 
 import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-class ComponentImpl implements Component {
+abstract class AbstractComponentImpl implements Component {
 
     private final int num;
 
@@ -26,7 +28,7 @@ class ComponentImpl implements Component {
 
     private final Ref<NetworkImpl> networkRef;
 
-    ComponentImpl(int num, int size, Ref<NetworkImpl> networkRef) {
+    AbstractComponentImpl(int num, int size, Ref<NetworkImpl> networkRef) {
         this.num = num;
         this.size = size;
         this.networkRef = Objects.requireNonNull(networkRef);
@@ -44,11 +46,15 @@ class ComponentImpl implements Component {
 
     @Override
     public Iterable<Bus> getBuses() {
-        return Iterables.filter(networkRef.get().getBusView().getBuses(), bus -> bus.getConnectedComponent() == ComponentImpl.this);
+        return StreamSupport.stream(networkRef.get().getBusView().getBuses().spliterator(), false)
+                            .filter(filterOnThis())
+                            .collect(Collectors.toList());
     }
 
     @Override
     public Stream<Bus> getBusStream() {
-        return networkRef.get().getBusView().getBusStream().filter(bus -> bus.getConnectedComponent() == ComponentImpl.this);
+        return networkRef.get().getBusView().getBusStream().filter(filterOnThis());
     }
+
+    protected abstract Predicate<Bus> filterOnThis();
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractComponentImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractComponentImpl.java
@@ -47,14 +47,14 @@ abstract class AbstractComponentImpl implements Component {
     @Override
     public Iterable<Bus> getBuses() {
         return StreamSupport.stream(networkRef.get().getBusView().getBuses().spliterator(), false)
-                            .filter(filterOnThis())
+                            .filter(getBusPredicate())
                             .collect(Collectors.toList());
     }
 
     @Override
     public Stream<Bus> getBusStream() {
-        return networkRef.get().getBusView().getBusStream().filter(filterOnThis());
+        return networkRef.get().getBusView().getBusStream().filter(getBusPredicate());
     }
 
-    protected abstract Predicate<Bus> filterOnThis();
+    protected abstract Predicate<Bus> getBusPredicate();
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConnectedComponentImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConnectedComponentImpl.java
@@ -23,7 +23,7 @@ class ConnectedComponentImpl extends AbstractComponentImpl implements Component 
     }
 
     @Override
-    protected Predicate<Bus> filterOnThis() {
+    protected Predicate<Bus> getBusPredicate() {
         return bus -> bus.getConnectedComponent() == ConnectedComponentImpl.this;
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -773,14 +773,14 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
         }
     }
 
-    static final class SynchronousComponentsManager extends AbstractComponentsManager<ComponentImpl> {
+    static final class SynchronousComponentsManager extends AbstractComponentsManager<SynchronousComponentImpl> {
 
         private SynchronousComponentsManager(NetworkImpl network) {
             super(network);
         }
 
-        protected ComponentImpl createComponent(int num, int size) {
-            return new ComponentImpl(num, size, network.ref);
+        protected SynchronousComponentImpl createComponent(int num, int size) {
+            return new SynchronousComponentImpl(num, size, network.ref);
         }
 
         @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SynchronousComponentImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SynchronousComponentImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, All partners of the iTesla project (http://www.itesla-project.eu/consortium)
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -13,17 +13,16 @@ import com.powsybl.iidm.network.impl.util.Ref;
 import java.util.function.Predicate;
 
 /**
- *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Thomas ADAM <tadam at silicom.fr>
  */
-class ConnectedComponentImpl extends AbstractComponentImpl implements Component {
+class SynchronousComponentImpl extends AbstractComponentImpl implements Component {
 
-    ConnectedComponentImpl(int num, int size, Ref<NetworkImpl> networkRef) {
+    SynchronousComponentImpl(int num, int size, Ref<NetworkImpl> networkRef) {
         super(num, size, networkRef);
     }
 
     @Override
     protected Predicate<Bus> filterOnThis() {
-        return bus -> bus.getConnectedComponent() == ConnectedComponentImpl.this;
+        return bus -> bus.getSynchronousComponent() == SynchronousComponentImpl.this;
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SynchronousComponentImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SynchronousComponentImpl.java
@@ -22,7 +22,7 @@ class SynchronousComponentImpl extends AbstractComponentImpl implements Componen
     }
 
     @Override
-    protected Predicate<Bus> filterOnThis() {
+    protected Predicate<Bus> getBusPredicate() {
         return bus -> bus.getSynchronousComponent() == SynchronousComponentImpl.this;
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVscTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVscTest.java
@@ -81,7 +81,11 @@ public abstract class AbstractVscTest {
         assertSame(cs2, hvdcLine.getConverterStation(HvdcLine.Side.TWO));
 
         assertEquals(2, hvdcLine.getConverterStation1().getTerminal().getBusView().getBus().getConnectedComponent().getBusStream().count());
+        assertEquals(2, hvdcLine.getConverterStation1().getTerminal().getBusView().getBus().getConnectedComponent().getSize());
+        assertTrue(hvdcLine.getConverterStation1().getTerminal().getBusView().getBus().getConnectedComponent().getBuses().iterator().hasNext());
         assertEquals(1, hvdcLine.getConverterStation1().getTerminal().getBusView().getBus().getSynchronousComponent().getBusStream().count());
+        assertEquals(1, hvdcLine.getConverterStation1().getTerminal().getBusView().getBus().getSynchronousComponent().getSize());
+        assertTrue(hvdcLine.getConverterStation1().getTerminal().getBusView().getBus().getSynchronousComponent().getBuses().iterator().hasNext());
     }
 
     @Test

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVscTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVscTest.java
@@ -79,6 +79,9 @@ public abstract class AbstractVscTest {
         assertSame(cs1, hvdcLine.getConverterStation(HvdcLine.Side.ONE));
         assertSame(cs2, hvdcLine.getConverterStation2());
         assertSame(cs2, hvdcLine.getConverterStation(HvdcLine.Side.TWO));
+
+        assertEquals(2, hvdcLine.getConverterStation1().getTerminal().getBusView().getBus().getConnectedComponent().getBusStream().count());
+        assertEquals(1, hvdcLine.getConverterStation1().getTerminal().getBusView().getBus().getSynchronousComponent().getBusStream().count());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The class ConnectedComponentImpl do not improve/override to super class ComponentImpl
Into synchronous component the bus filter used is the same as connected component


**What is the new behavior (if this is a feature change)?**
Add new abstract method into ComponentImpl in order to define the filtering lambda in getBuses() & getBusStream
Add a new class SynchronousComponentImpl as ConnectedComponentImpl


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
