### PR TITLE
Fix NullPointerException when removing a voltage level with internal …

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -1080,8 +1080,10 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
     private void removeAllSwitches() {
         for (SwitchImpl s : graph.getEdgesObject()) {
-            getNetwork().getIndex().remove(s);
-            getNetwork().getListeners().notifyRemoval(s);
+            if (s != null) {
+                getNetwork().getIndex().remove(s);
+                getNetwork().getListeners().notifyRemoval(s);
+            }
         }
         graph.removeAllEdges();
         switches.clear();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -1075,10 +1075,10 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
     @Override
     protected void removeTopology() {
-        removeAllSwitches();
+        removeAllEdges();
     }
 
-    private void removeAllSwitches() {
+    private void removeAllEdges() {
         for (SwitchImpl s : graph.getEdgesObject()) {
             if (s != null) {
                 getNetwork().getIndex().remove(s);

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerInternalConnectionsTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerInternalConnectionsTest.java
@@ -18,8 +18,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.powsybl.iidm.network.VoltageLevel.NodeBreakerView.InternalConnection;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -91,6 +90,17 @@ public abstract class AbstractNodeBreakerInternalConnectionsTest {
         assertEquals(2, vl.getNodeBreakerView().getInternalConnectionStream().filter(ic -> ic.getNode1() == 6 && ic.getNode2() == 3).count());
         vl.getNodeBreakerView().removeInternalConnections(6, 3);
         assertTrue(vl.getNodeBreakerView().getInternalConnectionStream().noneMatch(ic -> ic.getNode1() == 6 && ic.getNode2() == 3));
+    }
+
+    @Test
+    public void testRemoveVoltageLevelWithInternalConnectionsIssue() {
+        Network network = Network.create("testRemoveVoltageLevelWithInternalConnectionsIssue", "test");
+        InternalConnections all = new InternalConnections();
+        createNetwork(network, all);
+        network.getLine("L6").remove(); // needed to be allowed to remove the voltage level
+        // should not throw a null pointer exception anymore
+        network.getVoltageLevel(S5_10K_V).remove();
+        assertNull(network.getVoltageLevel(S5_10K_V));
     }
 
     private void createNetwork(Network network, InternalConnections internalConnections) {


### PR DESCRIPTION
…connections

Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
A NullPointerException is thrown when we remove a voltage level that contains internal connections. This is because internal connections are modeled as a edge with no switch object attached.


**What is the new behavior (if this is a feature change)?**
A null check of switch object of the edge has been added and we can now safely remove voltage levels with internal connections.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
