### PR TITLE
Add sub-network reduction predicate

### DIFF
--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/SubNetworkPredicate.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/SubNetworkPredicate.java
@@ -58,12 +58,12 @@ public class SubNetworkPredicate implements NetworkPredicate {
             }
 
             @Override
-            public void visitLine(Line line, Line.Side side) {
+            public void visitLine(Line line, Branch.Side side) {
                 visitBranch(line, side);
             }
 
             @Override
-            public void visitTwoWindingsTransformer(TwoWindingsTransformer transformer, TwoWindingsTransformer.Side side) {
+            public void visitTwoWindingsTransformer(TwoWindingsTransformer transformer, Branch.Side side) {
                 visitBranch(transformer, side);
             }
 

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/SubNetworkPredicate.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/SubNetworkPredicate.java
@@ -44,7 +44,7 @@ public class SubNetworkPredicate implements NetworkPredicate {
         voltageLevelIds.add(vl.getId());
 
         vl.visitEquipments(new DefaultTopologyVisitor() {
-            public void visitBranch(Branch branch, Branch.Side side) {
+            private void visitBranch(Branch branch, Branch.Side side) {
                 switch (side) {
                     case ONE:
                         traverse(branch.getTerminal2().getVoltageLevel(), depth + 1, maxDepth, voltageLevelIds);

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/SubNetworkPredicate.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/SubNetworkPredicate.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.*;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A network reducer predicate that allow reduction based on a center voltage level and all other voltage level neighbors
+ * within a specified depth.
+ *
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class SubNetworkPredicate implements NetworkPredicate {
+
+    private String voltageLevelId;
+
+    private int maxDepth;
+
+    private IdentifierNetworkPredicate delegate;
+
+    public SubNetworkPredicate(String voltageLevelId, int maxDepth) {
+        this.voltageLevelId = Objects.requireNonNull(voltageLevelId);
+        if (maxDepth < 0) {
+            throw new IllegalArgumentException("Invalid max depth value: " + maxDepth);
+        }
+        this.maxDepth = maxDepth;
+    }
+
+    private void init(Network network) {
+        if (delegate != null) {
+            return;
+        }
+        VoltageLevel vl = network.getVoltageLevel(voltageLevelId);
+        if (vl == null) {
+            throw new PowsyblException("Voltage level '" + voltageLevelId + "' not found");
+        }
+        Set<String> voltageLevelIds = new LinkedHashSet<>();
+        traverse(vl, 0, maxDepth, voltageLevelIds);
+        delegate = new IdentifierNetworkPredicate(voltageLevelIds);
+    }
+
+    private static void traverse(VoltageLevel vl, int depth, int maxDepth, Set<String> voltageLevelIds) {
+        if (voltageLevelIds.contains(vl.getId()) || depth > maxDepth) {
+            return;
+        }
+
+        voltageLevelIds.add(vl.getId());
+
+        vl.visitEquipments(new DefaultTopologyVisitor() {
+            public void visitBranch(Branch branch, Branch.Side side) {
+                switch (side) {
+                    case ONE:
+                        traverse(branch.getTerminal2().getVoltageLevel(), depth + 1, maxDepth, voltageLevelIds);
+                        break;
+                    case TWO:
+                        traverse(branch.getTerminal1().getVoltageLevel(), depth + 1, maxDepth, voltageLevelIds);
+                        break;
+                    default:
+                        throw new IllegalStateException("Unknown side: " + side);
+                }
+            }
+
+            @Override
+            public void visitLine(Line line, Line.Side side) {
+                visitBranch(line, side);
+            }
+
+            @Override
+            public void visitTwoWindingsTransformer(TwoWindingsTransformer transformer, TwoWindingsTransformer.Side side) {
+                visitBranch(transformer, side);
+            }
+
+            @Override
+            public void visitThreeWindingsTransformer(ThreeWindingsTransformer transformer, ThreeWindingsTransformer.Side side) {
+                switch (side) {
+                    case ONE:
+                        traverse(transformer.getLeg2().getTerminal().getVoltageLevel(), depth + 1, maxDepth, voltageLevelIds);
+                        traverse(transformer.getLeg3().getTerminal().getVoltageLevel(), depth + 1, maxDepth, voltageLevelIds);
+                        break;
+                    case TWO:
+                        traverse(transformer.getLeg1().getTerminal().getVoltageLevel(), depth + 1, maxDepth, voltageLevelIds);
+                        traverse(transformer.getLeg3().getTerminal().getVoltageLevel(), depth + 1, maxDepth, voltageLevelIds);
+                        break;
+                    case THREE:
+                        traverse(transformer.getLeg1().getTerminal().getVoltageLevel(), depth + 1, maxDepth, voltageLevelIds);
+                        traverse(transformer.getLeg2().getTerminal().getVoltageLevel(), depth + 1, maxDepth, voltageLevelIds);
+                        break;
+                    default:
+                        throw new IllegalStateException("Unknown side: " + side);
+                }
+            }
+        });
+    }
+
+    @Override
+    public boolean test(Substation substation) {
+        init(substation.getNetwork());
+        return delegate.test(substation);
+    }
+
+    @Override
+    public boolean test(VoltageLevel voltageLevel) {
+        init(voltageLevel.getNetwork());
+        return delegate.test(voltageLevel);
+    }
+}

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/SubNetworkPredicateTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/SubNetworkPredicateTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.reducer;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -31,16 +30,16 @@ public class SubNetworkPredicateTest {
 
     @Test
     public void testEsgTuto() {
-        NetworkPredicate predicate = new SubNetworkPredicate("VLHV1", 1);
         Network network = EurostagTutorialExample1Factory.create();
+        NetworkPredicate predicate = new SubNetworkPredicate(network.getVoltageLevel("VLHV1"), 1);
         assertEquals(Arrays.asList("P1", "P2"), network.getSubstationStream().filter(predicate::test).map(Identifiable::getId).collect(Collectors.toList()));
         assertEquals(Arrays.asList("VLGEN", "VLHV1", "VLHV2"), network.getVoltageLevelStream().filter(predicate::test).map(Identifiable::getId).collect(Collectors.toList()));
     }
 
     @Test
     public void test3wt() {
-        NetworkPredicate predicate = new SubNetworkPredicate("VL_132", 1);
         Network network = ThreeWindingsTransformerNetworkFactory.create();
+        NetworkPredicate predicate = new SubNetworkPredicate(network.getVoltageLevel("VL_132"), 1);
         assertEquals(Collections.singletonList("SUBSTATION"), network.getSubstationStream().filter(predicate::test).map(Identifiable::getId).collect(Collectors.toList()));
         assertEquals(Arrays.asList("VL_132", "VL_33", "VL_11"), network.getVoltageLevelStream().filter(predicate::test).map(Identifiable::getId).collect(Collectors.toList()));
     }
@@ -49,15 +48,7 @@ public class SubNetworkPredicateTest {
     public void shouldThrowInvalidMaxDepth() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Invalid max depth value: -2");
-        new SubNetworkPredicate("AA", -2);
-    }
-
-    @Test
-    public void shouldThrowVoltageLevelNotFound() {
-        thrown.expect(PowsyblException.class);
-        thrown.expectMessage("Voltage level 'AA' not found");
         Network network = EurostagTutorialExample1Factory.create();
-        NetworkPredicate predicate = new SubNetworkPredicate("AA", 1);
-        network.getVoltageLevelStream().forEach(predicate::test);
+        new SubNetworkPredicate(network.getVoltageLevel("VLHV1"), -2);
     }
 }

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/SubNetworkPredicateTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/SubNetworkPredicateTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class SubNetworkPredicateTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testEsgTuto() {
+        NetworkPredicate predicate = new SubNetworkPredicate("VLHV1", 1);
+        Network network = EurostagTutorialExample1Factory.create();
+        assertEquals(Arrays.asList("P1", "P2"), network.getSubstationStream().filter(predicate::test).map(Identifiable::getId).collect(Collectors.toList()));
+        assertEquals(Arrays.asList("VLGEN", "VLHV1", "VLHV2"), network.getVoltageLevelStream().filter(predicate::test).map(Identifiable::getId).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void test3wt() {
+        NetworkPredicate predicate = new SubNetworkPredicate("VL_132", 1);
+        Network network = ThreeWindingsTransformerNetworkFactory.create();
+        assertEquals(Collections.singletonList("SUBSTATION"), network.getSubstationStream().filter(predicate::test).map(Identifiable::getId).collect(Collectors.toList()));
+        assertEquals(Arrays.asList("VL_132", "VL_33", "VL_11"), network.getVoltageLevelStream().filter(predicate::test).map(Identifiable::getId).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void shouldThrowInvalidMaxDepth() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Invalid max depth value: -2");
+        new SubNetworkPredicate("AA", -2);
+    }
+
+    @Test
+    public void shouldThrowVoltageLevelNotFound() {
+        thrown.expect(PowsyblException.class);
+        thrown.expectMessage("Voltage level 'AA' not found");
+        Network network = EurostagTutorialExample1Factory.create();
+        NetworkPredicate predicate = new SubNetworkPredicate("AA", 1);
+        network.getVoltageLevelStream().forEach(predicate::test);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the new behavior (if this is a feature change)?**
A new predicate for network reduction is added. It allows to specify a center voltage level to keep and a voltage level depth to keep around the center voltage level.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
