### PR TITLE
Validations around HVDC lines in IIDM

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/DcLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/DcLineSegmentConversion.java
@@ -137,12 +137,12 @@ public class DcLineSegmentConversion extends AbstractIdentifiedObjectConversion 
             if (pAC1 != 0) {
                 return 1.2 * pAC1;
             }
-            return 1.2 * pAC2;
+            return 1.2 * Math.abs(pAC2);
         }
         if (pAC2 != 0) {
             return 1.2 * pAC2;
         }
-        return 1.2 * pAC1;
+        return 1.2 * Math.abs(pAC1);
     }
 
     @Override

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/DcLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/DcLineSegmentConversion.java
@@ -124,9 +124,9 @@ public class DcLineSegmentConversion extends AbstractIdentifiedObjectConversion 
             }
         } else if (mode.equals(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)) {
             if (pAC2 != 0) {
-                return Math.abs(pAC2) - poleLossP2;
+                return pAC2 - poleLossP2;
             } else if (pAC1 != 0) {
-                return pAC1 + poleLossP1;
+                return Math.abs(pAC1) + poleLossP1;
             }
         }
         return 0;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -33,6 +33,14 @@ public final class ValidationUtil {
         }
     }
 
+    public static void checkHvdcActivePowerSetpoint(Validable validable, double activePowerSetpoint) {
+        if (Double.isNaN(activePowerSetpoint)) {
+            throw createInvalidValueException(validable, activePowerSetpoint, "active power setpoint");
+        } else if (activePowerSetpoint < 0) {
+            throw createInvalidValueException(validable, activePowerSetpoint, "active power setpoint should not be negative");
+        }
+    }
+
     public static void checkActivePowerLimits(Validable validable, double minP, double maxP) {
         if (minP > maxP) {
             throw new ValidationException(validable, "invalid active limits [" + minP + ", " + maxP + "]");
@@ -365,6 +373,8 @@ public final class ValidationUtil {
     public static void checkPowerFactor(Validable validable, double powerFactor) {
         if (Double.isNaN(powerFactor)) {
             throw new ValidationException(validable, "power factor is invalid");
+        } else if (Math.abs(powerFactor) > 3) {
+            throw new ValidationException(validable, "power factor is invalid, it should be a ratio");
         }
     }
 
@@ -385,6 +395,8 @@ public final class ValidationUtil {
             throw new ValidationException(validable, "loss factor is invalid");
         } else if (lossFactor < 0) {
             throw new ValidationException(validable, "loss factor must be >= 0");
+        } else if (lossFactor > 3) {
+            throw new ValidationException(validable, "loss factor must be a ratio");
         }
     }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -111,6 +111,14 @@ public final class ValidationUtil {
         }
     }
 
+    public static void checkHvdcMaxP(Validable validable, double maxP) {
+        if (Double.isNaN(maxP)) {
+            throw createInvalidValueException(validable, maxP, "maximum P");
+        } else if (maxP < 0) {
+            throw createInvalidValueException(validable, maxP, "maximum P");
+        }
+    }
+
     public static void checkRegulatingTerminal(Validable validable, Terminal regulatingTerminal, Network network) {
         if (regulatingTerminal != null && regulatingTerminal.getVoltageLevel().getNetwork() != network) {
             throw new ValidationException(validable, "regulating terminal is not part of the network");

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -381,8 +381,8 @@ public final class ValidationUtil {
     public static void checkPowerFactor(Validable validable, double powerFactor) {
         if (Double.isNaN(powerFactor)) {
             throw new ValidationException(validable, "power factor is invalid");
-        } else if (Math.abs(powerFactor) > 3) {
-            throw new ValidationException(validable, "power factor is invalid, it should be a ratio");
+        } else if (Math.abs(powerFactor) > 1) {
+            throw new ValidationException(validable, "power factor is invalid, it should be between -1 and 1");
         }
     }
 
@@ -401,10 +401,8 @@ public final class ValidationUtil {
     public static void checkLossFactor(Validable validable, float lossFactor) {
         if (Double.isNaN(lossFactor)) {
             throw new ValidationException(validable, "loss factor is invalid");
-        } else if (lossFactor < 0) {
-            throw new ValidationException(validable, "loss factor must be >= 0");
-        } else if (lossFactor > 3) {
-            throw new ValidationException(validable, "loss factor must be a ratio");
+        } else if (lossFactor < 0 || lossFactor > 1) {
+            throw new ValidationException(validable, "loss factor must be >= 0 and <= 1");
         }
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineAdderImpl.java
@@ -100,7 +100,7 @@ public class HvdcLineAdderImpl extends AbstractIdentifiableAdder<HvdcLineAdderIm
         ValidationUtil.checkConvertersMode(this, convertersMode);
         ValidationUtil.checkNominalV(this, nominalV);
         ValidationUtil.checkHvdcActivePowerSetpoint(this, activePowerSetpoint);
-        ValidationUtil.checkMaxP(this, maxP);
+        ValidationUtil.checkHvdcMaxP(this, maxP);
         AbstractHvdcConverterStation<?> converterStation1 = getNetwork().getHvdcConverterStation(converterStationId1);
         if (converterStation1 == null) {
             throw new PowsyblException("Side 1 converter station " + converterStationId1 + " not found");

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineAdderImpl.java
@@ -99,7 +99,7 @@ public class HvdcLineAdderImpl extends AbstractIdentifiableAdder<HvdcLineAdderIm
         ValidationUtil.checkR(this, r);
         ValidationUtil.checkConvertersMode(this, convertersMode);
         ValidationUtil.checkNominalV(this, nominalV);
-        ValidationUtil.checkActivePowerSetpoint(this, activePowerSetpoint);
+        ValidationUtil.checkHvdcActivePowerSetpoint(this, activePowerSetpoint);
         ValidationUtil.checkMaxP(this, maxP);
         AbstractHvdcConverterStation<?> converterStation1 = getNetwork().getHvdcConverterStation(converterStationId1);
         if (converterStation1 == null) {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
@@ -150,7 +150,7 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
 
     @Override
     public HvdcLineImpl setActivePowerSetpoint(double activePowerSetpoint) {
-        ValidationUtil.checkActivePowerSetpoint(this, activePowerSetpoint);
+        ValidationUtil.checkHvdcActivePowerSetpoint(this, activePowerSetpoint);
         int variantIndex = getNetwork().getVariantIndex();
         double oldValue = this.activePowerSetpoint.set(variantIndex, activePowerSetpoint);
         String variantId = getNetwork().getVariantManager().getVariantId(variantIndex);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
@@ -136,7 +136,7 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
 
     @Override
     public HvdcLineImpl setMaxP(double maxP) {
-        ValidationUtil.checkMaxP(this, maxP);
+        ValidationUtil.checkHvdcMaxP(this, maxP);
         double oldValue = this.maxP;
         this.maxP = maxP;
         notifyUpdate("maxP", oldValue, maxP);

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/HvdcLineAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/HvdcLineAdapterTest.java
@@ -86,7 +86,7 @@ public class HvdcLineAdapterTest {
                                                 .setR(5.0)
                                                 .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)
                                                 .setNominalV(440.0)
-                                                .setMaxP(-50.0)
+                                                .setMaxP(50.0)
                                                 .setActivePowerSetpoint(20.0)
                                                 .setConverterStationId1("C1")
                                                 .setConverterStationId2("C2")

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractHvdcLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractHvdcLineTest.java
@@ -70,7 +70,7 @@ public abstract class AbstractHvdcLineTest {
                                         .setR(5.0)
                                         .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)
                                         .setNominalV(440.0)
-                                        .setMaxP(-50.0)
+                                        .setMaxP(50.0)
                                         .setActivePowerSetpoint(20.0)
                                         .setConverterStationId1("C1")
                                         .setConverterStationId2("C2")
@@ -82,7 +82,7 @@ public abstract class AbstractHvdcLineTest {
         assertEquals(5.0, hvdcLine.getR(), 0.0);
         assertEquals(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER, hvdcLine.getConvertersMode());
         assertEquals(440.0, hvdcLine.getNominalV(), 0.0);
-        assertEquals(-50.0, hvdcLine.getMaxP(), 0.0);
+        assertEquals(50.0, hvdcLine.getMaxP(), 0.0);
         assertEquals(20.0, hvdcLine.getActivePowerSetpoint(), 0.0);
         assertSame(network.getHvdcConverterStation("C1"), hvdcLine.getConverterStation1());
         assertSame(network.getHvdcConverterStation("C2"), hvdcLine.getConverterStation2());

--- a/math/src/main/java/com/powsybl/math/matrix/SparseLUDecomposition.java
+++ b/math/src/main/java/com/powsybl/math/matrix/SparseLUDecomposition.java
@@ -69,12 +69,6 @@ class SparseLUDecomposition implements LUDecomposition {
     @Override
     public void update() {
         checkMatrixStructure();
-/*        Integer i = 1;
-        for (double d : matrix.getValues()) {
-            System.out.println(i + " " + d);
-            i++;
-        }
-        System.out.println("end");*/
         update(id, matrix.getColumnStart(), matrix.getRowIndices(), matrix.getValues());
     }
 

--- a/math/src/main/java/com/powsybl/math/matrix/SparseLUDecomposition.java
+++ b/math/src/main/java/com/powsybl/math/matrix/SparseLUDecomposition.java
@@ -69,6 +69,12 @@ class SparseLUDecomposition implements LUDecomposition {
     @Override
     public void update() {
         checkMatrixStructure();
+/*        Integer i = 1;
+        for (double d : matrix.getValues()) {
+            System.out.println(i + " " + d);
+            i++;
+        }
+        System.out.println("end");*/
         update(id, matrix.getColumnStart(), matrix.getRowIndices(), matrix.getValues());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

The documentation in the website will follow in the Following days.

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No issue.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

It adds some validations around HVDC lines in the internal model.

**What is the current behavior?** *(You can also link to an open issue here)*

No check about the sign of active power setpoint, no hupper limits for powerFactor and lossFactor. These two factors are ratios (whitout units) but could be set in percents without new checks.

**What is the new behavior (if this is a feature change)?**

The active power setpoint cannot be negative. Ratios could not be more than 3. This number is arbitrary.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

I think that the AMPL conversion has to be fixed. I have made a fix for the CGMES conversion for active power setpoint. The factors management have to be reviewed. 
