### PR TITLE
Performances - tabulate logs using a StringBuilder instead of concat()

### DIFF
--- a/triple-store/triple-store-api/src/main/java/com/powsybl/triplestore/api/PropertyBag.java
+++ b/triple-store/triple-store-api/src/main/java/com/powsybl/triplestore/api/PropertyBag.java
@@ -139,10 +139,12 @@ public class PropertyBag extends HashMap<String, String> {
                 .max(Integer::compare);
         if (maxLenName.isPresent()) {
             int lenPad = maxLenName.get();
-            return title.concat(lineSeparator).concat(propertyNames.stream()
-                    .map(n -> INDENTATION.concat(padr(n, lenPad)).concat(" : ")
-                            + getValue.apply(this, n))
-                    .collect(Collectors.joining(lineSeparator)));
+            String format = String.format("%%-%ds", lenPad);
+
+            // Performance : avoid using concat() -> use a StringBuilder instead.
+            return new StringBuilder(title).append(lineSeparator).append(propertyNames.stream()
+                    .map(n -> new StringBuilder(INDENTATION).append(String.format(format, n)).append(" : ").append(getValue.apply(this, n)).toString())
+                    .collect(Collectors.joining(lineSeparator))).toString();
         }
         return "";
     }


### PR DESCRIPTION
* Related to Issue #1032

Signed-off-by: Laurent Cosson <lcosson@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

#1032

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Performance : reduce execution time with debug log level.

**What is the current behavior?** *(You can also link to an open issue here)*

Import and conversion time are too long, this is but one of the possible improvements.

**What is the new behavior (if this is a feature change)?**

Aiming for a 15% gain on conversion time in debug mode.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

No.

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
