### PR TITLE
[PERF] Context logs : postpone String building and check log level

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Context.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Context.java
@@ -10,6 +10,7 @@ package com.powsybl.cgmes.conversion;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,12 @@ import com.powsybl.triplestore.api.PropertyBags;
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
 public class Context {
+
+    // Log messages
+    private static final String FIXED_REASON = "Fixed {}. Reason: {}";
+    private static final String INVALID_REASON = "Invalid {}. Reason: {}";
+    private static final String IGNORED_REASON = "Ignored {}. Reason: {}";
+
     public Context(CgmesModel cgmes, Config config, Network network) {
         this.cgmes = Objects.requireNonNull(cgmes);
         this.config = Objects.requireNonNull(config);
@@ -224,19 +231,51 @@ public class Context {
     }
 
     public void invalid(String what, String reason) {
-        LOG.warn("Invalid {}. Reason: {}", what, reason);
+        LOG.warn(INVALID_REASON, what, reason);
+    }
+
+    public void invalid(String what, Supplier<String> reason) {
+        if (LOG.isWarnEnabled()) {
+            LOG.warn(INVALID_REASON, what, reason.get());
+        }
+    }
+
+    public void invalid(Supplier<String> what, Supplier<String> reason) {
+        if (LOG.isWarnEnabled()) {
+            LOG.warn(INVALID_REASON, what.get(), reason.get());
+        }
     }
 
     public void ignored(String what, String reason) {
-        LOG.warn("Ignored {}. Reason: {}", what, reason);
+        LOG.warn(IGNORED_REASON, what, reason);
     }
 
-    public void pending(String what, String reason) {
-        LOG.info("PENDING {}. Reason: {}", what, reason);
+    public void ignored(String what, Supplier<String> reason) {
+        if (LOG.isWarnEnabled()) {
+            LOG.warn(IGNORED_REASON, what, reason.get());
+        }
+    }
+
+    public void pending(String what, Supplier<String> reason) {
+        if (LOG.isInfoEnabled()) {
+            LOG.info("PENDING {}. Reason: {}", what, reason.get());
+        }
     }
 
     public void fixed(String what, String reason) {
-        LOG.warn("Fixed {}. Reason: {}", what, reason);
+        LOG.warn(FIXED_REASON, what, reason);
+    }
+
+    public void fixed(Supplier<String> what, String reason) {
+        if (LOG.isWarnEnabled()) {
+            LOG.warn(FIXED_REASON, what.get(), reason);
+        }
+    }
+
+    public void fixed(String what, Supplier<String> reason) {
+        if (LOG.isWarnEnabled()) {
+            LOG.warn(FIXED_REASON, what, reason.get());
+        }
     }
 
     public void fixed(String what, String reason, double wrong, double fixed) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.powsybl.cgmes.conversion.Conversion.Config.StateProfile.SSH;
@@ -336,8 +337,8 @@ public class Conversion {
             } else if (ends.size() == 3) {
                 c = new NewThreeWindingsTransformerConversion(ends, context);
             } else {
-                String what = String.format("PowerTransformer %s", t);
-                String reason = String.format("Has %d ends. Only 2 or 3 ends are supported", ends.size());
+                String what = "PowerTransformer " + t;
+                Supplier<String> reason = () -> String.format("Has %d ends. Only 2 or 3 ends are supported", ends.size());
                 context.invalid(what, reason);
             }
             if (c != null && c.valid()) {
@@ -365,8 +366,8 @@ public class Conversion {
                     } else if (ends.size() == 3) {
                         c = new ThreeWindingsTransformerConversion(ends, context);
                     } else {
-                        String what = String.format("PowerTransformer %s", t);
-                        String reason = String.format("Has %d ends. Only 2 or 3 ends are supported",
+                        String what = "PowerTransformer " + t;
+                        Supplier<String> reason = () -> String.format("Has %d ends. Only 2 or 3 ends are supported",
                                 ends.size());
                         context.invalid(what, reason);
                     }
@@ -393,8 +394,7 @@ public class Conversion {
     private void clearUnattachedHvdcConverterStations(Network network, Context context) {
         network.getHvdcConverterStationStream()
                 .filter(converter -> converter.getHvdcLine() == null)
-                .peek(converter -> context.ignored(String.format("HVDC Converter Station %s",
-                        converter.getId()), "No correct linked HVDC line found."))
+                .peek(converter -> context.ignored("HVDC Converter Station " + converter.getId(), "No correct linked HVDC line found."))
                 .collect(Collectors.toList())
                 .forEach(Connectable::remove);
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CurrentLimitsMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CurrentLimitsMapping.java
@@ -32,7 +32,7 @@ public class CurrentLimitsMapping {
     void addAll() {
         for (Map.Entry<String, CurrentLimitsAdder> entry : adders.entrySet()) {
             if (Double.isNaN(entry.getValue().getPermanentLimit())) {
-                context.ignored(String.format("Operational Limit Set of %s", entry.getKey()), "An operational limit set must at least contain one value for permanent limit.");
+                context.ignored("Operational Limit Set of " + entry.getKey(), "An operational limit set must at least contain one value for permanent limit.");
             } else {
                 entry.getValue().add();
             }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMapping.java
@@ -108,7 +108,7 @@ public class RegulatingControlMapping {
         cachedRegulatingControls.forEach((key, value) -> {
             if (value.correctlySet == null || !value.correctlySet) {
                 context.pending(REGULATING_TERMINAL,
-                        String.format("The setting of the regulating control %s is not entirely handled.", key));
+                    () -> String.format("The setting of the regulating control %s is not entirely handled.", key));
             }
         });
 
@@ -122,12 +122,12 @@ public class RegulatingControlMapping {
                     if (cgmesTerminal != null) {
                         // Try to obtain Terminal from TopologicalNode
                         String topologicalNode = cgmesTerminal.topologicalNode();
-                        context.invalid(REGULATING_TERMINAL, String.format("No connected IIDM terminal has been found for CGMES terminal %s. " +
+                        context.invalid(REGULATING_TERMINAL, () -> String.format("No connected IIDM terminal has been found for CGMES terminal %s. " +
                             "A connected terminal linked to the topological node %s is searched.",
                             cgmesTerminalId, topologicalNode));
                         return context.terminalMapping().findFromTopologicalNode(topologicalNode);
                     } else {
-                        context.invalid(REGULATING_TERMINAL, String.format("No CGMES terminal found with identifier %s. ", cgmesTerminalId));
+                        context.invalid(REGULATING_TERMINAL, "No CGMES terminal found with identifier " + cgmesTerminalId);
                         return null;
                     }
                 });

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForGenerators.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForGenerators.java
@@ -81,7 +81,7 @@ public class RegulatingControlMappingForGenerators {
         if (RegulatingControlMapping.isControlModeVoltage(control.mode)) {
             okSet = setRegulatingControlVoltage(controlId, control, rc.qPercent, gen);
         } else {
-            context.ignored(control.mode, String.format("Unsupported regulation mode for generator %s", gen.getId()));
+            context.ignored(control.mode, "Unsupported regulation mode for generator " + gen.getId());
         }
         control.setCorrectlySet(okSet);
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForStaticVarCompensators.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForStaticVarCompensators.java
@@ -98,7 +98,7 @@ public class RegulatingControlMappingForStaticVarCompensators {
 
         boolean okSet = false;
         if (!control.enabled && rc.controlEnabledProperty) {
-            context.fixed("SVCControlEnabledStatus", String.format("Regulating control of %s is disabled but controlEnabled property is set to true." +
+            context.fixed("SVCControlEnabledStatus", () -> String.format("Regulating control of %s is disabled but controlEnabled property is set to true." +
                     "Equipment properties are used to set local default regulation.", svc.getId()));
             setDefaultRegulatingControl(rc, svc);
             return false;
@@ -112,7 +112,7 @@ public class RegulatingControlMappingForStaticVarCompensators {
             targetReactivePower = control.targetValue;
             okSet = true;
         } else {
-            context.fixed("SVCControlMode", String.format("Invalid control mode for static var compensator %s. Regulating control is disabled", svc.getId()));
+            context.fixed("SVCControlMode", () -> String.format("Invalid control mode for static var compensator %s. Regulating control is disabled", svc.getId()));
             regulationMode = StaticVarCompensator.RegulationMode.OFF;
         }
 
@@ -139,7 +139,7 @@ public class RegulatingControlMappingForStaticVarCompensators {
             regulationMode = StaticVarCompensator.RegulationMode.REACTIVE_POWER;
             targetReactivePower = rc.defaultTargetReactivePower;
         } else {
-            context.fixed("SVCControlMode", String.format("Invalid control mode for static var compensator %s. Regulating control is disabled", svc.getId()));
+            context.fixed("SVCControlMode", () -> String.format("Invalid control mode for static var compensator %s. Regulating control is disabled", svc.getId()));
             regulationMode = StaticVarCompensator.RegulationMode.OFF;
         }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForTransformers.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForTransformers.java
@@ -219,7 +219,7 @@ public class RegulatingControlMappingForTransformers {
         }
         if (setRegulating) {
             context.fixed(transformerId,
-                    "Unsupported more than one regulating control enabled. Disable " + disabledTapChanger);
+                "Unsupported more than one regulating control enabled. Disable " + disabledTapChanger);
             return false;
         }
         return true;
@@ -236,7 +236,7 @@ public class RegulatingControlMappingForTransformers {
             okSet = setRtcRegulatingControlVoltage(rc.id, regulating, control, rtc, context);
         } else if (!isControlModeFixed(control.mode)) {
             context.fixed(control.mode,
-                    "Unsupported regulation mode for Ratio tap changer. Considered as a fixed ratio tap changer.");
+                "Unsupported regulation mode for Ratio tap changer. Considered as a fixed ratio tap changer.");
         }
         control.setCorrectlySet(okSet);
     }
@@ -252,7 +252,7 @@ public class RegulatingControlMappingForTransformers {
         // Even if regulating is false, we reset the target voltage if it is not valid
         if (control.targetValue <= 0) {
             context.ignored(rtcId,
-                    String.format("Regulating control has a bad target voltage %f", control.targetValue));
+                "Regulating control has a bad target voltage " + control.targetValue);
             return false;
         }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractObjectConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractObjectConversion.java
@@ -13,6 +13,7 @@ import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
 
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -62,7 +63,7 @@ public abstract class AbstractObjectConversion {
 
     public boolean presentMandatoryProperty(String pname) {
         if (!p.containsKey(pname)) {
-            invalid(String.format("Missing property %s", pname));
+            invalid("Missing property " + pname);
             return false;
         }
         return true;
@@ -70,34 +71,42 @@ public abstract class AbstractObjectConversion {
 
     public boolean inRange(String p, int x, int xmin, int xmax) {
         if (x < xmin || x > xmax) {
-            invalid(String.format("%s value %d not in range [%d, %d]", p, x, xmin, xmax));
+            invalid(() -> String.format("%s value %d not in range [%d, %d]", p, x, xmin, xmax));
             return false;
         }
         return true;
+    }
+
+    public void invalid(Supplier<String> reason) {
+        context.invalid(what(), reason);
     }
 
     public void invalid(String reason) {
         context.invalid(what(), reason);
     }
 
+    public void invalid(String what, String reason, double defaultValue) {
+        Supplier<String> reason1 = () -> String.format("%s. Used default value %f", reason, defaultValue);
+        context.invalid(complete(what), reason1);
+    }
+
     public void ignored(String reason) {
         context.ignored(what(), reason);
     }
 
-    public void ignored(String what, String reason) {
+    public void ignored(Supplier<String> reason) {
+        context.ignored(what(), reason);
+    }
+
+    public void ignored(String what, Supplier<String> reason) {
         context.ignored(complete(what), reason);
     }
 
-    public void invalid(String what, String reason, double defaultValue) {
-        String reason1 = String.format("%s. Used default value %f", reason, defaultValue);
-        context.invalid(complete(what), reason1);
-    }
-
-    public void pending(String what, String reason) {
-        context.pending(complete(what), reason);
-    }
-
     public void fixed(String what, String reason) {
+        context.fixed(complete(what), reason);
+    }
+
+    public void fixed(String what, Supplier<String> reason) {
         context.fixed(complete(what), reason);
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractReactiveLimitsOwnerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractReactiveLimitsOwnerConversion.java
@@ -16,6 +16,7 @@ import com.powsybl.triplestore.api.PropertyBags;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -54,10 +55,10 @@ public abstract class AbstractReactiveLimitsOwnerConversion extends AbstractCond
                 Range<Double> prev = qRanges.get(p);
                 if (prev != null) {
                     if (prev.isConnected(qRange)) {
-                        fixed("reactive capability curve", String.format("point merged with another one with same p (%f)", p));
+                        fixed("reactive capability curve", () -> String.format("point merged with another one with same p (%f)", p));
                         qRanges.put(p, prev.span(qRange));
                     } else {
-                        ignored("reactive capability curve point", String.format("another point with same p (%f) and a disconnected reactive range", p));
+                        ignored("reactive capability curve point", () -> String.format("another point with same p (%f) and a disconnected reactive range", p));
                     }
                 } else {
                     qRanges.put(p, qRange);
@@ -110,7 +111,7 @@ public abstract class AbstractReactiveLimitsOwnerConversion extends AbstractCond
 
     private boolean checkPointValidity(double p, double minQ, double maxQ) {
         if (Double.isNaN(p) || Double.isNaN(minQ) || Double.isNaN(maxQ)) {
-            String reason = String.format("Incomplete point p, minQ, maxQ = %f, %f, %f", p, minQ, maxQ);
+            Supplier<String> reason = () -> String.format("Incomplete point p, minQ, maxQ = %f, %f, %f", p, minQ, maxQ);
             ignored("ReactiveCapabilityCurvePoint", reason);
             return false;
         }
@@ -119,7 +120,7 @@ public abstract class AbstractReactiveLimitsOwnerConversion extends AbstractCond
 
     private Range<Double> fixedMinMaxQ(String context, double minQ, double maxQ) {
         if (minQ > maxQ) {
-            String reason = String.format("minQ > maxQ (%.4f > %.4f)", minQ, maxQ);
+            Supplier<String> reason = () -> String.format("minQ > maxQ (%.4f > %.4f)", minQ, maxQ);
             fixed(context, reason);
             return Range.closed(maxQ, minQ);
         }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
@@ -8,6 +8,7 @@
 package com.powsybl.cgmes.conversion.elements;
 
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +87,7 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
         return CountryConversion.fromIsoCode(p.getLocal("fromEndIsoCode"))
             .orElseGet(() -> CountryConversion.fromIsoCode(p.getLocal("toEndIsoCode"))
                 .orElseGet(() -> {
-                    String countryCodes = String.format("Country. ISO codes %s %s",
+                    Supplier<String> countryCodes = () -> String.format("Country. ISO codes %s %s",
                         p.getLocal("fromEndIsoCode"),
                         p.getLocal("toEndIsoCode"));
                     ignored(countryCodes);
@@ -184,8 +185,8 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
                 return;
             }
             LOG.warn(
-                "Can't find a bus from the Bus View to set Voltage and Angle, we use the bus {} from the Bus/Breaker view. Connectivity node {}",
-                bus, id);
+                    "Can't find a bus from the Bus View to set Voltage and Angle, we use the bus {} from the Bus/Breaker view. Connectivity node {}",
+                    bus, id);
         }
         setVoltageAngle(bus);
     }
@@ -235,18 +236,18 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
         double angle = p.asDouble(CgmesNames.ANGLE);
         boolean valid = valid(v, angle);
         if (!valid) {
-            String reason = String.format(
+            Supplier<String> reason = () -> String.format(
                 "v = %f, angle = %f. Node %s",
                 v,
                 angle,
                 id);
-            String location = bus == null
+            Supplier<String> location = () -> bus == null
                 ? "No bus"
                 : String.format("Bus %s, Substation %s, Voltage level %s",
                     bus.getId(),
                     bus.getVoltageLevel().getSubstation().getNameOrId(),
                     bus.getVoltageLevel().getNameOrId());
-            String message = String.format("%s. %s", reason, location);
+            Supplier<String> message = () -> reason.get() + ". " + location.get();
             context.invalid("SvVoltage", message);
         }
         return valid;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
@@ -17,6 +17,8 @@ import com.powsybl.iidm.network.Terminal;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.triplestore.api.PropertyBag;
 
+import java.util.function.Supplier;
+
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
@@ -130,10 +132,10 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
         } else {
             if (terminalId != null) {
                 context.fixed(PERMANENT_CURRENT_LIMIT,
-                        String.format("Several permanent limits defined for Terminal %s. Only the lowest is kept.", terminalId));
+                    () -> String.format("Several permanent limits defined for Terminal %s. Only the lowest is kept.", terminalId));
             } else {
                 context.fixed(PERMANENT_CURRENT_LIMIT,
-                        String.format("Several permanent limits defined for Equipment %s. Only the lowest is kept.", equipmentId));
+                    () -> String.format("Several permanent limits defined for Equipment %s. Only the lowest is kept.", equipmentId));
             }
             if (adder.getPermanentLimit() > value) {
                 adder.setPermanentLimit(value);
@@ -171,10 +173,10 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
         } else {
             if (terminalId != null) {
                 context.fixed(TEMPORARY_CURRENT_LIMIT,
-                        String.format("Several temporary limits defined for same acceptable duration (%d s) for Terminal %s. Only the lowest is kept.", acceptableDuration, terminalId));
+                    () -> String.format("Several temporary limits defined for same acceptable duration (%d s) for Terminal %s. Only the lowest is kept.", acceptableDuration, terminalId));
             } else {
                 context.fixed(TEMPORARY_CURRENT_LIMIT,
-                        String.format("Several temporary limits defined for same acceptable duration (%d s) for Equipment %s. Only the lowest is kept.", acceptableDuration, equipmentId));
+                    () -> String.format("Several temporary limits defined for same acceptable duration (%d s) for Equipment %s. Only the lowest is kept.", acceptableDuration, equipmentId));
             }
             if (adder.getTemporaryLimitValue(acceptableDuration) > value) {
                 adder.beginTemporaryLimit()
@@ -206,9 +208,9 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
                 }
             }
         } else if (direction.endsWith("low")) {
-            context.invalid(TEMPORARY_CURRENT_LIMIT, String.format("TATL %s is a low limit", id));
+            context.invalid(TEMPORARY_CURRENT_LIMIT, () -> String.format("TATL %s is a low limit", id));
         } else {
-            context.invalid(TEMPORARY_CURRENT_LIMIT, String.format("TATL %s does not have a valid direction", id));
+            context.invalid(TEMPORARY_CURRENT_LIMIT, () -> String.format("TATL %s does not have a valid direction", id));
         }
     }
 
@@ -220,7 +222,7 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
         String type = p.getLocal(LIMIT_TYPE);
         String typeName = p.getLocal(OPERATIONAL_LIMIT_TYPE_NAME);
         String subclass = p.getLocal(OPERATIONAL_LIMIT_SUBCLASS);
-        String reason = String.format(
+        Supplier<String> reason = () -> String.format(
                 "Not assigned for %s %s. Limit id, type, typeName, subClass, terminal : %s, %s, %s, %s, %s",
                 eq != null ? className(eq) : "",
                 eq != null ? eq.getId() : "",
@@ -229,7 +231,6 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
                 typeName,
                 subclass,
                 terminalId);
-        context.pending(OPERATIONAL_LIMIT, reason);
         context.pending(OPERATIONAL_LIMIT, reason);
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/PhaseTapChangerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/PhaseTapChangerConversion.java
@@ -10,6 +10,7 @@ package com.powsybl.cgmes.conversion.elements;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Supplier;
 
 import com.powsybl.cgmes.conversion.elements.transformers.NewThreeWindingsTransformerConversion;
 import com.powsybl.cgmes.model.CgmesModelException;
@@ -74,11 +75,10 @@ public class PhaseTapChangerConversion extends AbstractIdentifiedObjectConversio
                 int position = fromContinuous(p.asDouble("SVtapStep", neutralStep));
                 boolean regulating = p.asBoolean(REGULATING_CONTROL_ENABLED, false);
                 if (position == neutralStep && !regulating) {
-                    String reason = String.format(
-                            "%s, but is at neutralStep and regulating control disabled", reason0);
+                    Supplier<String> reason = () -> reason0 + ", but is at neutralStep and regulating control disabled";
                     ignored(reason);
                 } else {
-                    String reason = String.format(
+                    Supplier<String> reason = () -> String.format(
                             "%s, tap step: %d, neutral [low, high]: %d [%d, %d], regulating control enabled: %b",
                             reason0,
                             position,
@@ -98,7 +98,7 @@ public class PhaseTapChangerConversion extends AbstractIdentifiedObjectConversio
             return false;
         }
         if (!validType()) {
-            invalid(String.format("Unexpected phaseTapChangerType %s", ptcType));
+            invalid("Unexpected phaseTapChangerType " + ptcType);
             return false;
         }
         return true;
@@ -192,8 +192,8 @@ public class PhaseTapChangerConversion extends AbstractIdentifiedObjectConversio
         double value = point.asDouble(attr, defaultValue);
         if (Double.isNaN(value)) {
             fixed(
-                    "PhaseTapChangerTablePoint " + attr + " for step " + step + " in table " + tableId,
-                    "invalid value " + point.get(attr));
+                "PhaseTapChangerTablePoint " + attr + " for step " + step + " in table " + tableId,
+                "invalid value " + point.get(attr));
             return defaultValue;
         }
         return value;
@@ -425,9 +425,11 @@ public class PhaseTapChangerConversion extends AbstractIdentifiedObjectConversio
         boolean xStepRangeIsConsistent = true;
         if (xStepMin < 0 || xStepMax <= 0 || xStepMin > xStepMax) {
             xStepRangeIsConsistent = false;
-            String reason = String.format("Inconsistent xStepMin, xStepMax [%f, %f]",
-                    xStepMin,
-                    xStepMax);
+            final double xStepMinParam = xStepMin;
+            final double xStepMaxParam = xStepMax;
+            Supplier<String> reason = () -> String.format("Inconsistent xStepMin, xStepMax [%f, %f]",
+                    xStepMinParam,
+                    xStepMaxParam);
             ignored("xStep range", reason);
         }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/RatioTapChangerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/RatioTapChangerConversion.java
@@ -8,6 +8,7 @@
 package com.powsybl.cgmes.conversion.elements;
 
 import java.util.Comparator;
+import java.util.function.Supplier;
 
 import com.powsybl.cgmes.conversion.elements.transformers.NewThreeWindingsTransformerConversion;
 import com.powsybl.cgmes.model.CgmesModelException;
@@ -61,7 +62,7 @@ public class RatioTapChangerConversion extends AbstractIdentifiedObjectConversio
                 if (position == neutralStep && !regulating) {
                     ignored(reason0 + ", but is at neutralStep and regulating control disabled");
                 } else {
-                    String reason = String.format(
+                    Supplier<String> reason = () -> String.format(
                             "%s, tap step: %d, regulating control enabled: %b",
                             reason0,
                             position,
@@ -170,8 +171,8 @@ public class RatioTapChangerConversion extends AbstractIdentifiedObjectConversio
         double value = point.asDouble(attr, defaultValue);
         if (Double.isNaN(value)) {
             fixed(
-                    "RatioTapChangerTablePoint " + attr + " for step " + step + " in table " + tableId,
-                    "invalid value " + point.get(attr));
+                "RatioTapChangerTablePoint " + attr + " for step " + step + " in table " + tableId,
+                "invalid value " + point.get(attr));
             return defaultValue;
         }
         return value;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
@@ -25,7 +25,7 @@ public class StaticVarCompensatorConversion extends AbstractConductingEquipmentC
     @Override
     public void convert() {
         double slope = p.asDouble("slope", 0.0);
-        ignored(String.format("Slope %f", slope));
+        ignored("Slope " + slope);
 
         double capacitiveRating = p.asDouble("capacitiveRating", 0.0);
         double inductiveRating = p.asDouble("inductiveRating", 0.0);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SvInjectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SvInjectionConversion.java
@@ -73,7 +73,7 @@ public class SvInjectionConversion extends AbstractIdentifiedObjectConversion {
         if (associatedTerminal == null) {
             cgmesTerminal = context.cgmes().terminal(context.terminalMapping().findCgmesTerminalFromTopologicalNode(topologicalNode));
             if (cgmesTerminal == null || context.cgmes().voltageLevel(cgmesTerminal, context.nodeBreaker()) == null) {
-                context.invalid(id,
+                context.invalid(id, () ->
                         String.format("The CGMES terminal and/or the voltage level associated to the topological node %slinked to the SV injection %s is missing",
                                 topologicalNode, id));
                 return false;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
@@ -18,6 +18,8 @@ import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.triplestore.api.PropertyBag;
 
+import java.util.function.Supplier;
+
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
@@ -33,7 +35,7 @@ public class SwitchConversion extends AbstractConductingEquipmentConversion {
             return false;
         }
         if (busId(1).equals(busId(2))) {
-            ignored(String.format("end buses are the same bus %s", busId(1)));
+            ignored("end buses are the same bus " + busId(1));
             return false;
         }
         if ((isBoundary(1) || isBoundary(2)) && LOG.isWarnEnabled()) {
@@ -107,7 +109,7 @@ public class SwitchConversion extends AbstractConductingEquipmentConversion {
     }
 
     private void warnLowImpedanceLineCreated() {
-        String reason = String.format(
+        Supplier<String> reason = () -> String.format(
                 "Connected to a terminal not in the same voltage level %s (side 1: %s, side 2: %s)",
                 switchVoltageLevelId(),
                 cgmesVoltageLevelId(1),

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ThreeWindingsTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ThreeWindingsTransformerConversion.java
@@ -49,7 +49,7 @@ public class ThreeWindingsTransformerConversion extends AbstractConductingEquipm
             String name1 = voltageLevel(1).getSubstation().getNameOrId();
             String name2 = voltageLevel(2).getSubstation().getNameOrId();
             String name3 = voltageLevel(3).getSubstation().getNameOrId();
-            invalid(String.format("different substations at ends %s %s %s", name1, name2, name3));
+            invalid(() -> String.format("different substations at ends %s %s %s", name1, name2, name3));
             return false;
         }
         return true;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TwoWindingsTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TwoWindingsTransformerConversion.java
@@ -15,6 +15,8 @@ import com.powsybl.iidm.network.TwoWindingsTransformerAdder;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
 
+import java.util.function.Supplier;
+
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  *
@@ -154,10 +156,12 @@ public class TwoWindingsTransformerConversion extends AbstractConductingEquipmen
             context.tapChangerTransformers().add(ptc, tx, "ptc", ptcSide);
         }
         if (rtcSide > 0 && ptcSide > 0 && rtcSide != ptcSide) {
-            String reason = String.format(
+            final String rtcParam = rtc;
+            final String ptcParam = ptc;
+            Supplier<String> reason = () -> String.format(
                     "Unsupported modelling: transformer with ratio and tap changer not on the same winding, rtc: %s, ptc: %s",
-                    rtc,
-                    ptc);
+                    rtcParam,
+                    ptcParam);
             invalid(reason);
         }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/AcDcConverterConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/AcDcConverterConversion.java
@@ -45,7 +45,7 @@ public class AcDcConverterConversion extends AbstractConductingEquipmentConversi
             return false;
         }
         if (converterType == null) {
-            invalid(String.format("Type %s", p.getLocal("type")));
+            invalid("Type " + p.getLocal("type"));
             return false;
         }
         return true;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/DcMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/DcMapping.java
@@ -51,7 +51,7 @@ public class DcMapping {
         this.cgmesConverters.entrySet().stream()
             .filter(c -> !c.getValue().used)
             .forEach(c -> {
-                String what = String.format("AcDcConverter Id: %s", c.getKey());
+                String what = "AcDcConverter Id: " + c.getKey();
                 context.ignored(what, "Dc configuration not supported");
             });
     }
@@ -75,7 +75,7 @@ public class DcMapping {
         this.cgmesDcLineSegments.entrySet().stream()
             .filter(c -> !c.getValue().used)
             .forEach(c -> {
-                String what = String.format("DcLineSegment Id: %s", c.getKey());
+                String what = "DcLineSegment Id: " + c.getKey();
                 context.ignored(what, "Ground DcLineSegment or Dc configuration not supported");
             });
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractCgmesTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractCgmesTapChangerBuilder.java
@@ -79,8 +79,8 @@ abstract class AbstractCgmesTapChangerBuilder {
         double value = point.asDouble(attr, defaultValue);
         if (Double.isNaN(value)) {
             context.fixed(
-                    "RatioTapChangerTablePoint " + attr + " for step " + step + " in table " + tableId,
-                    "invalid value " + point.get(attr));
+                "RatioTapChangerTablePoint " + attr + " for step " + step + " in table " + tableId,
+                "invalid value " + point.get(attr));
             return defaultValue;
         }
         return value;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
@@ -8,6 +8,7 @@
 package com.powsybl.cgmes.conversion.elements.transformers;
 
 import java.util.Comparator;
+import java.util.function.Supplier;
 
 import com.powsybl.cgmes.conversion.Context;
 import com.powsybl.cgmes.conversion.RegulatingControlMappingForTransformers;
@@ -32,8 +33,8 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
     @Override
     public TapChanger build() {
         if (!validType()) {
-            String type = p.getLocal(CgmesNames.PHASE_TAP_CHANGER_TYPE).toLowerCase();
-            context.invalid(CgmesNames.PHASE_TAP_CHANGER_TYPE, String.format("Unexpected type %s", type));
+            Supplier<String> type = () -> "Unexpected type " + p.getLocal(CgmesNames.PHASE_TAP_CHANGER_TYPE).toLowerCase();
+            context.invalid(CgmesNames.PHASE_TAP_CHANGER_TYPE, type);
             return null;
         }
         return super.build();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChangerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChangerConversion.java
@@ -135,7 +135,7 @@ public class TapChangerConversion {
     */
     private TapChanger tapChangerFixPosition(TapChanger tc) {
         if (tc.getLowTapPosition() != tc.getHighTapPosition()) {
-            context.fixed(String.format("TapChanger Id %s fixed tap at position %d ", tc.getId(), tc.getTapPosition()), "");
+            context.fixed(() -> String.format("TapChanger Id %s fixed tap at position %d ", tc.getId(), tc.getTapPosition()), "");
         }
         TapChanger tapChanger = baseCloneTapChanger(tc);
         tapChanger.setLowTapPosition(tapChanger.getTapPosition());

--- a/cgmes/cgmes-conversion/src/test/resources/logback-test.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/logback-test.xml
@@ -14,25 +14,22 @@
             <pattern>%-5p %-20C{1} | %m%n</pattern>
         </encoder>
     </appender>
-    <root level="info">
-        <appender-ref ref="STDOUT" />
+    <root level="error">
+        <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="com.bigdata" level="warn" additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
+    <logger name="com.bigdata" level="error"/>
     <!-- To see the query text in the log, set level to debug -->
-    <logger name="com.powsybl.triplestore.TripleStore" level="info" />
+    <logger name="com.powsybl.triplestore.TripleStore" level="error"/>
     <!-- To see how much time each query costs, set level to debug -->
-    <logger name="com.powsybl.cgmes.triplestore.CgmesModelTripleStore"
-        level="info" />
+    <logger name="com.powsybl.cgmes.triplestore.CgmesModelTripleStore" level="error"/>
     <!-- To watch the properties of every object converted, level to debug -->
-    <logger name="com.powsybl.cgmes.conversion.Conversion" level="info" />
-        <!-- To watch always the test Hvdc configurations after the topological analysis -->
-    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.CgmesDcConversion" level="debug" />
-    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.Adjacency" level="debug" />
-    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.TPnodeEquipments" level="debug" />
-    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.Islands" level="debug" />
-    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.IslandsEnds" level="debug" />
-    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.IslandEndHvdc" level="debug" />
-    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.Hvdc" level="debug" />
+    <logger name="com.powsybl.cgmes.conversion.Conversion" level="error"/>
+    <!-- To watch always the test Hvdc configurations after the topological analysis -->
+    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.CgmesDcConversion" level="error"/>
+    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.Adjacency" level="error"/>
+    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.TPnodeEquipments" level="error"/>
+    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.Islands" level="error"/>
+    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.IslandsEnds" level="error"/>
+    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.IslandEndHvdc" level="error"/>
+    <logger name="com.powsybl.cgmes.conversion.elements.hvdc.Hvdc" level="error"/>
 </configuration>


### PR DESCRIPTION
Signed-off-by: Laurent Cosson <lcosson@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

#1032 

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

This PR modifies the way the Context class logs messages. Appropriate log levels are checked (enabled/disabled) and formatted messages are built when logging, not before calling the logging methods. 

**What is the current behavior?** *(You can also link to an open issue here)*

Formatted strings are built first, then passed to logging methods as String parameters. Also, LOG.isXxxEnabled() is not always checked.

**What is the new behavior (if this is a feature change)?**

Supplier<String> lambdas replace String arguments.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

No.

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
