### PR TITLE
Remove the hupper bound for Hvdc converter station lossFactor

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -401,8 +401,8 @@ public final class ValidationUtil {
     public static void checkLossFactor(Validable validable, float lossFactor) {
         if (Double.isNaN(lossFactor)) {
             throw new ValidationException(validable, "loss factor is invalid");
-        } else if (lossFactor < 0 || lossFactor > 1) {
-            throw new ValidationException(validable, "loss factor must be >= 0 and <= 1");
+        } else if (lossFactor < 0) {
+            throw new ValidationException(validable, "loss factor must be >= 0");
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <atilloy@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*


**What is the current behavior?** *(You can also link to an open issue here)*

The files that have a lossFactor greater than 1 are not imported.

**What is the new behavior (if this is a feature change)?**

The files that have a lossFactor greater than 1 are imported.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

It is just a fix. I think that I need to clarify what we want as lossFactor unit and formula, and check that all the gateways have to be checked.
