### PR TITLE
Make setters in ReductionOptions public

### DIFF
--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/ReductionOptions.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/ReductionOptions.java
@@ -13,11 +13,11 @@ public class ReductionOptions {
 
     private boolean withDanglingLines = false;
 
-    boolean isWithDanglingLines() {
+    public boolean isWithDanglingLines() {
         return withDanglingLines;
     }
 
-    ReductionOptions withDanglingLlines(boolean withDanglingLines) {
+    public ReductionOptions withDanglingLlines(boolean withDanglingLines) {
         this.withDanglingLines = withDanglingLines;
         return this;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
API update


**What is the current behavior?** *(You can also link to an open issue here)*
ReductionOption getters and setters are not public, so not usable outside the package.


**What is the new behavior (if this is a feature change)?**
ReductionOption getters and setters are public


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
