### PR TITLE
Fix EntsoeFileName to parse IDCF

### DIFF
--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeFileName.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeFileName.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
  */
 public class EntsoeFileName {
 
-    private static final Pattern DATE_REGEX = Pattern.compile(".*(\\d{4})[- /._]?(\\d{2})[- /._]?(\\d{2})[- /._]?(\\d{2})[- /._]?(\\d{2}).*");
+    private static final Pattern DATE_REGEX = Pattern.compile("(\\d{4})[- /._]?(\\d{2})[- /._]?(\\d{2})[- /._]?(\\d{2})[- /._]?(\\d{2}).*");
 
     private final DateTime date;
 

--- a/entsoe-util/src/test/java/com/powsybl/entsoe/util/EntsoeFileNameTest.java
+++ b/entsoe-util/src/test/java/com/powsybl/entsoe/util/EntsoeFileNameTest.java
@@ -40,4 +40,11 @@ public class EntsoeFileNameTest {
         assertEquals(0, ucteFileName.getForecastDistance());
         assertNull(ucteFileName.getCountry());
     }
+
+    @Test
+    public void testIdcf() {
+        String fileName = "20200314_0030_026_FR0.uct";
+        EntsoeFileName ucteFileName = EntsoeFileName.parse(fileName);
+        assertTrue(ucteFileName.getDate().isEqual(DateTime.parse("2020-03-14T00:30:00.000+01:00")));
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The parsing of an IDCF UCTE file fails because the regex is too permissive a handle the type of the file that is a number not correctly.


**What is the new behavior (if this is a feature change)?**
The parsing works as expected.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
