### PR TITLE
Fix conductingEquipmentTerminal is overwritten

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -179,7 +179,9 @@ public abstract class AbstractCgmesModel implements CgmesModel {
 
     private Map<String, CgmesTerminal> computeTerminals() {
         Map<String, CgmesTerminal> ts = new HashMap<>();
-        conductingEquipmentTerminal = new HashMap<>();
+        if (conductingEquipmentTerminal == null) {
+            conductingEquipmentTerminal = new HashMap<>();
+        }
         terminals().forEach(t -> {
             CgmesTerminal td = new CgmesTerminal(t);
             if (ts.containsKey(td.id())) {
@@ -193,7 +195,9 @@ public abstract class AbstractCgmesModel implements CgmesModel {
 
     private Map<String, CgmesDcTerminal> computeDcTerminals() {
         Map<String, CgmesDcTerminal> ts = new HashMap<>();
-        conductingEquipmentTerminal = new HashMap<>();
+        if (conductingEquipmentTerminal == null) {
+            conductingEquipmentTerminal = new HashMap<>();
+        }
         dcTerminals().forEach(t -> {
             CgmesDcTerminal td = new CgmesDcTerminal(t);
             if (ts.containsKey(td.id())) {


### PR DESCRIPTION
Signed-off-by: Elena Kaltakova <kaltakovae@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
cgmes.model.AbstractCgmesModel.conductingEquipmentTerminal can be overwritten.


**What is the new behavior (if this is a feature change)?**
conductingEquipmentTerminal  is checked for existence  before create a new one.


**Other information**:
There are upcoming changes related to conductingEquipmentTerminal object handling. Pending for the next PR. 

@mathbagu Can this bug fix be also reported in release 3.3.0?