### PR TITLE
Check on qPercent is deleted to prevent regression in CGMES import

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForGenerators.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForGenerators.java
@@ -112,13 +112,9 @@ public class RegulatingControlMappingForGenerators {
 
         // add qPercent as an extension
         if (!Double.isNaN(qPercent)) {
-            if (qPercent < 0.0 || qPercent > 100) {
-                context.ignored(QPERCENT, () -> String.format("Unexpected value for qPercent of generator %s: %s", gen.getId(), qPercent));
-            } else {
-                gen.newExtension(CoordinatedReactiveControlAdder.class)
-                        .withQPercent(qPercent)
-                        .add();
-            }
+            gen.newExtension(CoordinatedReactiveControlAdder.class)
+                    .withQPercent(qPercent)
+                    .add();
         }
 
         return true;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForGenerators.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForGenerators.java
@@ -112,9 +112,13 @@ public class RegulatingControlMappingForGenerators {
 
         // add qPercent as an extension
         if (!Double.isNaN(qPercent)) {
-            gen.newExtension(CoordinatedReactiveControlAdder.class)
-                    .withQPercent(qPercent)
-                    .add();
+            if (qPercent < 0.0 || qPercent > 100) {
+                context.ignored(QPERCENT, () -> String.format("Unexpected value for qPercent of generator %s: %s", gen.getId(), String.valueOf(qPercent)));
+            } else {
+                gen.newExtension(CoordinatedReactiveControlAdder.class)
+                        .withQPercent(qPercent)
+                        .add();
+            }
         }
 
         return true;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForGenerators.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForGenerators.java
@@ -113,7 +113,7 @@ public class RegulatingControlMappingForGenerators {
         // add qPercent as an extension
         if (!Double.isNaN(qPercent)) {
             if (qPercent < 0.0 || qPercent > 100) {
-                context.ignored(QPERCENT, () -> String.format("Unexpected value for qPercent of generator %s: %s", gen.getId(), String.valueOf(qPercent)));
+                context.ignored(QPERCENT, () -> String.format("Unexpected value for qPercent of generator %s: %s", gen.getId(), qPercent));
             } else {
                 gen.newExtension(CoordinatedReactiveControlAdder.class)
                         .withQPercent(qPercent)

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlImpl.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlImpl.java
@@ -36,9 +36,6 @@ public class CoordinatedReactiveControlImpl extends AbstractExtension<Generator>
         if (Double.isNaN(qPercent)) {
             throw new PowsyblException("Undefined value for qPercent");
         }
-        if (qPercent < 0.0 || qPercent > 100.0) {
-            throw new PowsyblException("Unexpected value for qPercent: " + qPercent);
-        }
         return qPercent;
     }
 }

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlImpl.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlImpl.java
@@ -9,17 +9,20 @@ package com.powsybl.iidm.network.extensions;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.iidm.network.Generator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
  */
 public class CoordinatedReactiveControlImpl extends AbstractExtension<Generator> implements CoordinatedReactiveControl {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoordinatedReactiveControlImpl.class);
     private double qPercent;
 
     public CoordinatedReactiveControlImpl(Generator generator, double qPercent) {
         super(generator);
-        this.qPercent = checkQPercent(qPercent);
+        this.qPercent = checkQPercent(generator, qPercent);
     }
 
     @Override
@@ -29,12 +32,15 @@ public class CoordinatedReactiveControlImpl extends AbstractExtension<Generator>
 
     @Override
     public void setQPercent(double qPercent) {
-        this.qPercent = checkQPercent(qPercent);
+        this.qPercent = checkQPercent(getExtendable(), qPercent);
     }
 
-    private static double checkQPercent(double qPercent) {
+    private static double checkQPercent(Generator generator, double qPercent) {
         if (Double.isNaN(qPercent)) {
             throw new PowsyblException("Undefined value for qPercent");
+        }
+        if (qPercent < 0 || qPercent > 100) {
+            LOGGER.debug("qPercent value of generator {} does not seem to be a valid percent: {}", generator.getId(), qPercent);
         }
         return qPercent;
     }

--- a/iidm/iidm-extensions/src/test/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlTest.java
+++ b/iidm/iidm-extensions/src/test/java/com/powsybl/iidm/network/extensions/CoordinatedReactiveControlTest.java
@@ -48,18 +48,4 @@ public class CoordinatedReactiveControlTest {
         exception.expectMessage("Undefined value for qPercent");
         new CoordinatedReactiveControlImpl(generator, Double.NaN);
     }
-
-    @Test
-    public void testUpperBoundError() {
-        exception.expect(PowsyblException.class);
-        exception.expectMessage("Unexpected value for qPercent: 101.0");
-        new CoordinatedReactiveControlImpl(generator, 101.0);
-    }
-
-    @Test
-    public void testLowerBoundError() {
-        exception.expect(PowsyblException.class);
-        exception.expectMessage("Unexpected value for qPercent: -1.0");
-        new CoordinatedReactiveControlImpl(generator, -1.0);
-    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Prevent regression


**What is the current behavior?** *(You can also link to an open issue here)*
If qPercent has an invalid value during CGMES import, an exception is thrown.


**What is the new behavior (if this is a feature change)?**
If qPercent has an invalid value during CGMES import, the value is ignored.


**Does this PR introduce a breaking change or deprecate an API?** 
No


**Other information**:
This bug was not seen before as some regulating controls went undetected in node/breaker (cf PR #1251 )

@mathbagu This should be in release 3.3.0 as it prevents a regression in CGMES import
