### PR TITLE
Remove Groovy script from loadflow validation tool

### DIFF
--- a/loadflow/loadflow-validation/pom.xml
+++ b/loadflow/loadflow-validation/pom.xml
@@ -41,10 +41,6 @@
     <dependencies>
         <!-- Compilation dependencies -->
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature removal


**What is the current behavior?** *(You can also link to an open issue here)*
We can specify a Groovy script to apply to the IIDM network in the loadflow validation tool.
It seems this feature is not used and it add a fat dependency for nothing.

**What is the new behavior (if this is a feature change)?**
We cannot anymore apply a Groovy script in this tool.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
