### PR TITLE
Fix: when CGMES regulating control is disabled, SVC local regulation is disabled if voltage

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForStaticVarCompensators.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForStaticVarCompensators.java
@@ -73,14 +73,14 @@ public class RegulatingControlMappingForStaticVarCompensators {
         String controlId = rc.regulatingControlId;
         if (controlId == null) {
             context.missing("Regulating control Id not defined");
-            setDefaultRegulatingControl(rc, svc);
+            setDefaultRegulatingControl(rc, svc, false);
             return;
         }
 
         RegulatingControl control = parent.cachedRegulatingControls().get(controlId);
         if (control == null) {
             context.missing(String.format("Regulating control %s", controlId));
-            setDefaultRegulatingControl(rc, svc);
+            setDefaultRegulatingControl(rc, svc, false);
             return;
         }
 
@@ -99,8 +99,8 @@ public class RegulatingControlMappingForStaticVarCompensators {
         boolean okSet = false;
         if (!control.enabled && rc.controlEnabledProperty) {
             context.fixed("SVCControlEnabledStatus", () -> String.format("Regulating control of %s is disabled but controlEnabled property is set to true." +
-                    "Equipment properties are used to set local default regulation.", svc.getId()));
-            setDefaultRegulatingControl(rc, svc);
+                    "Equipment properties are used to set local default regulation if local default regulation is reactive power. Else, regulation is disabled.", svc.getId()));
+            setDefaultRegulatingControl(rc, svc, true);
             return false;
         }
         if (RegulatingControlMapping.isControlModeVoltage(control.mode.toLowerCase())) {
@@ -126,14 +126,14 @@ public class RegulatingControlMappingForStaticVarCompensators {
         return okSet;
     }
 
-    private void setDefaultRegulatingControl(CgmesRegulatingControlForStaticVarCompensator rc, StaticVarCompensator svc) {
+    private void setDefaultRegulatingControl(CgmesRegulatingControlForStaticVarCompensator rc, StaticVarCompensator svc, boolean onlyReactivePowerReg) {
 
         double targetVoltage = Double.NaN;
         double targetReactivePower = Double.NaN;
         StaticVarCompensator.RegulationMode regulationMode;
 
         if (RegulatingControlMapping.isControlModeVoltage(rc.defaultRegulationMode.toLowerCase())) {
-            regulationMode = StaticVarCompensator.RegulationMode.VOLTAGE;
+            regulationMode = onlyReactivePowerReg ? StaticVarCompensator.RegulationMode.OFF : StaticVarCompensator.RegulationMode.VOLTAGE;
             targetVoltage = rc.defaultTargetVoltage;
         } else if (isControlModeReactivePower(rc.defaultRegulationMode.toLowerCase())) {
             regulationMode = StaticVarCompensator.RegulationMode.REACTIVE_POWER;


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines



**What kind of change does this PR introduce?**
Bug fix: when CGMES regulating control is disabled, associated SVC has no voltage regulation (only reactive power regulation if it is specified).
