### PR TITLE
Replace a log info to trace for node count removal

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -296,7 +296,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     }
 
     private void readNodeBreakerTopology(VoltageLevel vl, NetworkXmlReaderContext context) throws XMLStreamException {
-        IidmXmlUtil.runUntilMaximumVersion(IidmXmlVersion.V_1_1, context, () -> LOGGER.info("attribute " + NODE_BREAKER_TOPOLOGY_ELEMENT_NAME + ".nodeCount is ignored."));
+        IidmXmlUtil.runUntilMaximumVersion(IidmXmlVersion.V_1_1, context, () -> LOGGER.trace("attribute " + NODE_BREAKER_TOPOLOGY_ELEMENT_NAME + ".nodeCount is ignored."));
         XmlUtil.readUntilEndElement(NODE_BREAKER_TOPOLOGY_ELEMENT_NAME, context.getReader(), () -> {
             switch (context.getReader().getLocalName()) {
                 case BusbarSectionXml.ROOT_ELEMENT_NAME:


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Node count attribute on voltage level is not supported in IIDM 1.2. When importing a IIDM < 1.2 we have one log in info level for each voltage level of the network. 
This is not an info nor a warning, as it is normal when importing an old format. It is not really an interesting info for library user.


**What is the new behavior (if this is a feature change)?**
I downgraded the log info to a trace. I think it could have be removed maybe.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
