### PR TITLE
Remove unexpected nodeCount log in VoltageLevelXML

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -296,7 +296,6 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     }
 
     private void readNodeBreakerTopology(VoltageLevel vl, NetworkXmlReaderContext context) throws XMLStreamException {
-        IidmXmlUtil.runUntilMaximumVersion(IidmXmlVersion.V_1_1, context, () -> LOGGER.info("attribute " + NODE_BREAKER_TOPOLOGY_ELEMENT_NAME + ".nodeCount is ignored."));
         XmlUtil.readUntilEndElement(NODE_BREAKER_TOPOLOGY_ELEMENT_NAME, context.getReader(), () -> {
             switch (context.getReader().getLocalName()) {
                 case BusbarSectionXml.ROOT_ELEMENT_NAME:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Arguable


**What is the current behavior?** *(You can also link to an open issue here)*
Each time a network in XIIDM V1.0 or V1.1 is loaded, there are lot of logs indicating that the nodeCount is deprecated.


**What is the new behavior (if this is a feature change)?**
This trace is now removed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
