### PR TITLE
Extendable: move newExtension from AbstractExtendable to default Exte…

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/extensions/AbstractExtendable.java
+++ b/commons/src/main/java/com/powsybl/commons/extensions/AbstractExtendable.java
@@ -61,13 +61,9 @@ public abstract class AbstractExtendable<T> implements Extendable<T> {
         return extensionsByName.values();
     }
 
-    // Don't bother all the way with generics because the this is a runtime system
-    // that doesn't know generics. We do check that the builder is from the the same
-    // extendable class T as "this".
     @Override
-    public <E extends Extension<T>, B extends ExtensionAdder<T, E>> B newExtension(Class<B> type) {
-        ExtensionAdderProvider provider = ExtensionAdderProviders.findCachedProvider(getImplementationName(), type);
-        return (B) provider.newAdder(this);
+    public String getImplementationName() {
+        return "Default";
     }
 
 }

--- a/commons/src/main/java/com/powsybl/commons/extensions/Extendable.java
+++ b/commons/src/main/java/com/powsybl/commons/extensions/Extendable.java
@@ -78,5 +78,12 @@ public interface Extendable<O> {
      * @param type The interface of the ExtensionAdder
      * @return the adder
      */
-    <E extends Extension<O>, B extends ExtensionAdder<O, E>> B newExtension(Class<B> type);
+    // Don't bother all the way with generics because the this is a runtime system
+    // that doesn't know generics. We do check that the builder is from the the same
+    // extendable class T as "this".
+    default <E extends Extension<O>, B extends ExtensionAdder<O, E>> B newExtension(Class<B> type) {
+        ExtensionAdderProvider provider = ExtensionAdderProviders.findCachedProvider(getImplementationName(), type);
+        return (B) provider.newAdder(this);
+    }
+
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractIdentifiableAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractIdentifiableAdapter.java
@@ -112,6 +112,11 @@ abstract class AbstractIdentifiableAdapter<I extends Identifiable<I>> extends Ab
     }
 
     @Override
+    public String getImplementationName() {
+        return "MergingView";
+    }
+
+    @Override
     public <E extends Extension<I>, B extends ExtensionAdder<I, E>> B newExtension(Class<B> type) {
         return getDelegate().newExtension(type);
     }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergedLine.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergedLine.java
@@ -512,6 +512,11 @@ class MergedLine implements Line {
     }
 
     @Override
+    public String getImplementationName() {
+        return "MergingView";
+    }
+
+    @Override
     public <E extends Extension<Line>, B extends ExtensionAdder<Line, E>> B newExtension(Class<B> type) {
         throw MergingView.createNotImplementedException();
     }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
@@ -795,6 +795,11 @@ public final class MergingView implements Network {
     }
 
     @Override
+    public String getImplementationName() {
+        return "MergingView";
+    }
+
+    @Override
     public <E extends Extension<Network>, B extends ExtensionAdder<Network, E>> B newExtension(Class<B> type) {
         return workingNetwork.newExtension(type);
     }


### PR DESCRIPTION
…ndable for broader compatibility. Override getImplementationName where needed

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature/Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
powsybl 3.2 and 3.3 are not compatible with 3.1 because of the newExtension method. We could have made them compatible by providing the implementation of newExtension not in abstractExtendable, but as a default method in the Extendable interface.


**What is the new behavior (if this is a feature change)?**
3.4 will be compatible with 3.1. 3.4 will also be compatible with 3.2 and 3.3 because moving the method from AbstractExtendable to Extendable is binary compatible


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
Also made the getImplementationName return "MergingView" for the merging view impl.
Also overrode getImplementationName in AbstractExtendable for maintainability