### PR TITLE
Bug fix in SecurityAnalysisImpl: no error anymore when contingency list empty

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisImpl.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisImpl.java
@@ -151,7 +151,7 @@ public class SecurityAnalysisImpl extends AbstractSecurityAnalysis {
                                                        SecurityAnalysisResultBuilder resultBuilder) {
 
         List<Contingency> contingencies = contingenciesProvider.getContingencies(network);
-        int workerCount = Math.min(MAX_VARIANTS_PER_ANALYSIS, Math.min(computationManager.getResourcesStatus().getAvailableCores(), contingencies.size()));
+        int workerCount = Math.min(MAX_VARIANTS_PER_ANALYSIS, Math.min(computationManager.getResourcesStatus().getAvailableCores(), contingencies.isEmpty() ? 1 : contingencies.size()));
         List<String> variantIds = makeWorkingVariantsNames(workerCount);
         BlockingQueue<String> queue = new ArrayBlockingQueue<>(workerCount, false, variantIds);
 


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?**
With `SecurityAnalysisImpl`, security analysis with an empty contingency list produces an error.



**What is the new behavior (if this is a feature change)?**
With `SecurityAnalysisImpl`, security analysis with an empty contingency list no longer produces an error: the worker count is at least at 1.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
