### PR TITLE
Implement getLineStream(), getLines(), getDanglingLineStream() and getDanglingLines() in BusAdapter

### DIFF
--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
@@ -70,6 +70,32 @@ class BusAdapter extends AbstractIdentifiableAdapter<Bus> implements Bus {
     }
 
     @Override
+    public Iterable<DanglingLine> getDanglingLines() {
+        return getDanglingLineStream().collect(Collectors.toList());
+    }
+
+    @Override
+    public Stream<DanglingLine> getDanglingLineStream() {
+        return getDelegate().getDanglingLineStream()
+                .filter(dl -> !getIndex().isMerged(dl))
+                .map(dl -> getIndex().getDanglingLine(dl));
+    }
+
+    @Override
+    public Iterable<Line> getLines() {
+        return getLineStream().collect(Collectors.toList());
+    }
+
+    @Override
+    public Stream<Line> getLineStream() {
+        return Stream.concat(getDelegate().getLineStream()
+                        .map(l -> getIndex().getLine(l)),
+                getDelegate().getDanglingLineStream()
+                        .filter(dl -> getIndex().isMerged(dl))
+                        .map(dl -> getIndex().getMergedLineByCode(dl.getUcteXnodeCode())));
+    }
+
+    @Override
     public Iterable<Load> getLoads() {
         return Iterables.transform(getDelegate().getLoads(),
                                    getIndex()::getLoad);
@@ -185,32 +211,6 @@ class BusAdapter extends AbstractIdentifiableAdapter<Bus> implements Bus {
     @Override
     public int getConnectedTerminalCount() {
         throw MergingView.createNotImplementedException();
-    }
-
-    @Override
-    public Iterable<Line> getLines() {
-        return getLineStream().collect(Collectors.toList());
-    }
-
-    @Override
-    public Stream<Line> getLineStream() {
-        return Stream.concat(getDelegate().getLineStream()
-                        .map(l -> getIndex().getLine(l)),
-                getDelegate().getDanglingLineStream()
-                        .filter(dl -> getIndex().isMerged(dl))
-                        .map(dl -> getIndex().getMergedLineByCode(dl.getUcteXnodeCode())));
-    }
-
-    @Override
-    public Iterable<DanglingLine> getDanglingLines() {
-        return getDanglingLineStream().collect(Collectors.toList());
-    }
-
-    @Override
-    public Stream<DanglingLine> getDanglingLineStream() {
-        return getDelegate().getDanglingLineStream()
-                .filter(dl -> !getIndex().isMerged(dl))
-                .map(dl -> getIndex().getDanglingLine(dl));
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.mergingview;
 import com.google.common.collect.Iterables;
 import com.powsybl.iidm.network.*;
 
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -188,22 +189,25 @@ class BusAdapter extends AbstractIdentifiableAdapter<Bus> implements Bus {
 
     @Override
     public Iterable<Line> getLines() {
-        throw MergingView.createNotImplementedException();
+        return getLineStream().collect(Collectors.toList());
     }
 
     @Override
     public Stream<Line> getLineStream() {
-        throw MergingView.createNotImplementedException();
+        return Stream.concat(getDelegate().getLineStream(),
+                getDelegate().getDanglingLineStream()
+                        .filter(dl -> getIndex().isMerged(dl))
+                        .map(dl -> getIndex().getMergedLineByCode(dl.getUcteXnodeCode())));
     }
 
     @Override
     public Iterable<DanglingLine> getDanglingLines() {
-        throw MergingView.createNotImplementedException();
+        return getDanglingLineStream().collect(Collectors.toList());
     }
 
     @Override
     public Stream<DanglingLine> getDanglingLineStream() {
-        throw MergingView.createNotImplementedException();
+        return getDelegate().getDanglingLineStream().filter(dl -> !getIndex().isMerged(dl));
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
@@ -194,7 +194,8 @@ class BusAdapter extends AbstractIdentifiableAdapter<Bus> implements Bus {
 
     @Override
     public Stream<Line> getLineStream() {
-        return Stream.concat(getDelegate().getLineStream(),
+        return Stream.concat(getDelegate().getLineStream()
+                        .map(l -> getIndex().getLine(l)),
                 getDelegate().getDanglingLineStream()
                         .filter(dl -> getIndex().isMerged(dl))
                         .map(dl -> getIndex().getMergedLineByCode(dl.getUcteXnodeCode())));
@@ -207,7 +208,9 @@ class BusAdapter extends AbstractIdentifiableAdapter<Bus> implements Bus {
 
     @Override
     public Stream<DanglingLine> getDanglingLineStream() {
-        return getDelegate().getDanglingLineStream().filter(dl -> !getIndex().isMerged(dl));
+        return getDelegate().getDanglingLineStream()
+                .filter(dl -> !getIndex().isMerged(dl))
+                .map(dl -> getIndex().getDanglingLine(dl));
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
@@ -16,6 +16,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.stream.StreamSupport;
+
 import static org.junit.Assert.*;
 
 /**
@@ -114,18 +116,32 @@ public class BusAdapterTest {
         createDangingLine(vl1, baseId + "1", baseName + "1", r, x, g, b, p0, q0, ucteXnodeCode, "busA");
         createDangingLine(vl3, baseId + "2", baseName + "2", r, x, g, b, p0, q0, ucteXnodeCode, "busC");
 
-        assertFalse(network1.getBusBreakerView().getBus("busA").getDanglingLineStream().noneMatch(dl -> "DL1".equals(dl.getId())));
-        assertTrue(network1.getBusBreakerView().getBus("busA").getLineStream().noneMatch(l -> "DL1 + DL2".equals(l.getId())));
-        assertFalse(network2.getBusBreakerView().getBus("busC").getDanglingLineStream().noneMatch(dl -> "DL2".equals(dl.getId())));
-        assertTrue(network2.getBusBreakerView().getBus("busC").getLineStream().noneMatch(l -> "DL1 + DL2".equals(l.getId())));
+        Bus busA = network1.getBusBreakerView().getBus("busA");
+        assertFalse(busA.getDanglingLineStream().noneMatch(dl -> "DL1".equals(dl.getId())));
+        assertFalse(StreamSupport.stream(busA.getDanglingLines().spliterator(), false).noneMatch(dl -> "DL1".equals(dl.getId())));
+        assertTrue(busA.getLineStream().noneMatch(l -> "DL1 + DL2".equals(l.getId())));
+        assertTrue(StreamSupport.stream(busA.getLines().spliterator(), false).noneMatch(l -> "DL1 + DL2".equals(l.getId())));
+
+        Bus busC = network2.getBusBreakerView().getBus("busC");
+        assertFalse(busC.getDanglingLineStream().noneMatch(dl -> "DL2".equals(dl.getId())));
+        assertFalse(StreamSupport.stream(busC.getDanglingLines().spliterator(), false).noneMatch(dl -> "DL2".equals(dl.getId())));
+        assertTrue(busC.getLineStream().noneMatch(l -> "DL1 + DL2".equals(l.getId())));
+        assertTrue(StreamSupport.stream(busC.getLines().spliterator(), false).noneMatch(l -> "DL1 + DL2".equals(l.getId())));
 
         MergingView mergingView = MergingView.create("merge", "test");
         mergingView.merge(network1, network2);
 
-        assertTrue(mergingView.getBusBreakerView().getBus("busA").getDanglingLineStream().noneMatch(dl -> "DL1".equals(dl.getId())));
-        assertFalse(mergingView.getBusBreakerView().getBus("busA").getLineStream().noneMatch(l -> "DL1 + DL2".equals(l.getId())));
-        assertTrue(mergingView.getBusBreakerView().getBus("busC").getDanglingLineStream().noneMatch(dl -> "DL2".equals(dl.getId())));
-        assertFalse(mergingView.getBusBreakerView().getBus("busC").getLineStream().noneMatch(l -> "DL1 + DL2".equals(l.getId())));
+        Bus mergedBusA = mergingView.getBusBreakerView().getBus("busA");
+        assertTrue(mergedBusA.getDanglingLineStream().noneMatch(dl -> "DL1".equals(dl.getId())));
+        assertTrue(StreamSupport.stream(mergedBusA.getDanglingLines().spliterator(), false).noneMatch(dl -> "DL1".equals(dl.getId())));
+        assertFalse(mergedBusA.getLineStream().noneMatch(l -> "DL1 + DL2".equals(l.getId())));
+        assertFalse(StreamSupport.stream(mergedBusA.getLines().spliterator(), false).noneMatch(l -> "DL1 + DL2".equals(l.getId())));
+
+        Bus mergedBusC = mergingView.getBusBreakerView().getBus("busC");
+        assertTrue(mergedBusC.getDanglingLineStream().noneMatch(dl -> "DL2".equals(dl.getId())));
+        assertTrue(StreamSupport.stream(mergedBusC.getDanglingLines().spliterator(), false).noneMatch(dl -> "DL2".equals(dl.getId())));
+        assertFalse(mergedBusC.getLineStream().noneMatch(l -> "DL1 + DL2".equals(l.getId())));
+        assertFalse(StreamSupport.stream(mergedBusC.getLines().spliterator(), false).noneMatch(l -> "DL1 + DL2".equals(l.getId())));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?**
An exception is thrown when the user tries to retrieve lines and dangling lines connected to a bus in a merging view.

**What is the new behavior (if this is a feature change)?**
You can retrieve lines and dangling lines connected to a bus in a merging view (a merged dangling line is considered as a line).


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
