### PR TITLE
Refactoring getLines(), getLineStream(), getDanglingLines(), getDanglingLineStream() in Merging View

### DIFF
--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
@@ -9,7 +9,6 @@ package com.powsybl.iidm.mergingview;
 import com.google.common.collect.Iterables;
 import com.powsybl.iidm.network.*;
 
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -71,28 +70,22 @@ class BusAdapter extends AbstractIdentifiableAdapter<Bus> implements Bus {
 
     @Override
     public Iterable<DanglingLine> getDanglingLines() {
-        return getDanglingLineStream().collect(Collectors.toList());
+        return MergingViewUtil.getDanglingLines(getDelegate().getDanglingLines(), getIndex());
     }
 
     @Override
     public Stream<DanglingLine> getDanglingLineStream() {
-        return getDelegate().getDanglingLineStream()
-                .filter(dl -> !getIndex().isMerged(dl))
-                .map(dl -> getIndex().getDanglingLine(dl));
+        return MergingViewUtil.getDanglingLineStream(getDelegate().getDanglingLineStream(), getIndex());
     }
 
     @Override
     public Iterable<Line> getLines() {
-        return getLineStream().collect(Collectors.toList());
+        return MergingViewUtil.getLines(getDelegate().getLines(), getDelegate().getDanglingLines(), getIndex());
     }
 
     @Override
     public Stream<Line> getLineStream() {
-        return Stream.concat(getDelegate().getLineStream()
-                        .map(l -> getIndex().getLine(l)),
-                getDelegate().getDanglingLineStream()
-                        .filter(dl -> getIndex().isMerged(dl))
-                        .map(dl -> getIndex().getMergedLineByCode(dl.getUcteXnodeCode())));
+        return MergingViewUtil.getLineStream(getDelegate().getLineStream(), getDelegate().getDanglingLineStream(), getIndex());
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
@@ -703,7 +703,7 @@ public final class MergingView implements Network {
 
     @Override
     public int getLineCount() {
-        return (int) index.getLineStream().count();
+        return index.getLineCount();
     }
 
     @Override
@@ -724,7 +724,7 @@ public final class MergingView implements Network {
 
     @Override
     public int getDanglingLineCount() {
-        return (int) index.getDanglingLineStream().count();
+        return index.getDanglingLineCount();
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
@@ -693,17 +693,17 @@ public final class MergingView implements Network {
 
     @Override
     public Iterable<Line> getLines() {
-        return Collections.unmodifiableCollection(index.getLines());
+        return index.getLines();
     }
 
     @Override
     public Stream<Line> getLineStream() {
-        return index.getLines().stream();
+        return index.getLineStream();
     }
 
     @Override
     public int getLineCount() {
-        return index.getLines().size();
+        return (int) index.getLineStream().count();
     }
 
     @Override
@@ -714,17 +714,17 @@ public final class MergingView implements Network {
     // DanglingLines
     @Override
     public Iterable<DanglingLine> getDanglingLines() {
-        return Collections.unmodifiableCollection(index.getDanglingLines());
+        return index.getDanglingLines();
     }
 
     @Override
     public Stream<DanglingLine> getDanglingLineStream() {
-        return index.getDanglingLines().stream();
+        return index.getDanglingLineStream();
     }
 
     @Override
     public int getDanglingLineCount() {
-        return index.getDanglingLines().size();
+        return (int) index.getDanglingLineStream().count();
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
@@ -303,6 +303,10 @@ class MergingViewIndex {
         return Iterables.concat(Iterables.concat(Iterables.concat(Iterables.transform(networks, Network::getLines)), mergedLineCached.values()));
     }
 
+    int getLineCount() {
+        return getNetworkStream().mapToInt(Network::getLineCount).sum() + mergedLineCached.size();
+    }
+
     boolean isMerged(final DanglingLine dl) {
         return mergedLineCached.containsKey(dl.getUcteXnodeCode());
     }
@@ -314,6 +318,10 @@ class MergingViewIndex {
     Iterable<DanglingLine> getDanglingLines() {
         // Search DanglingLine into merging & working networks
         return MergingViewUtil.getDanglingLines(Iterables.concat(Iterables.transform(networks, Network::getDanglingLines)), this);
+    }
+
+    int getDanglingLineCount() {
+        return getNetworkStream().mapToInt(Network::getDanglingLineCount).sum() - 2 * mergedLineCached.size();
     }
 
     Collection<HvdcLine> getHvdcLines() {

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.mergingview;
 
+import com.google.common.collect.Iterables;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 
@@ -136,9 +137,9 @@ class MergingViewIndex {
     <C extends Connectable> Collection<C> getConnectables(Class<C> clazz) {
         // Search Connectables of a given type into merging & working networks
         if (clazz == Line.class) {
-            return getLines().stream().filter(clazz::isInstance).map(clazz::cast).collect(Collectors.toList());
+            return getLineStream().filter(clazz::isInstance).map(clazz::cast).collect(Collectors.toList());
         } else if (clazz == DanglingLine.class) {
-            return getDanglingLines().stream().filter(clazz::isInstance).map(clazz::cast).collect(Collectors.toList());
+            return getDanglingLineStream().filter(clazz::isInstance).map(clazz::cast).collect(Collectors.toList());
         } else {
             return getNetworkStream()
                     .flatMap(n -> n.getConnectableStream(clazz))
@@ -291,25 +292,28 @@ class MergingViewIndex {
                 .collect(Collectors.toList());
     }
 
-    Collection<Line> getLines() {
+    Stream<Line> getLineStream() {
         // Search Line into merging & working networks, and MergedLines
         return Stream.concat(getNetworkStream().flatMap(Network::getLineStream)
                         .map(this::getLine),
-                mergedLineCached.values().stream())
-                .collect(Collectors.toList());
+                mergedLineCached.values().stream());
+    }
+
+    Iterable<Line> getLines() {
+        return Iterables.concat(Iterables.concat(Iterables.concat(Iterables.transform(networks, Network::getLines)), mergedLineCached.values()));
     }
 
     boolean isMerged(final DanglingLine dl) {
         return mergedLineCached.containsKey(dl.getUcteXnodeCode());
     }
 
-    Collection<DanglingLine> getDanglingLines() {
+    Stream<DanglingLine> getDanglingLineStream() {
+        return MergingViewUtil.getDanglingLineStream(getNetworkStream().flatMap(Network::getDanglingLineStream), this);
+    }
+
+    Iterable<DanglingLine> getDanglingLines() {
         // Search DanglingLine into merging & working networks
-        return getNetworkStream()
-                .flatMap(Network::getDanglingLineStream)
-                .filter(dl -> !isMerged(dl))
-                .map(this::getDanglingLine)
-                .collect(Collectors.toList());
+        return MergingViewUtil.getDanglingLines(Iterables.concat(Iterables.transform(networks, Network::getDanglingLines)), this);
     }
 
     Collection<HvdcLine> getHvdcLines() {

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewUtil.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewUtil.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.mergingview;
+
+import com.google.common.collect.Iterables;
+import com.powsybl.iidm.network.DanglingLine;
+import com.powsybl.iidm.network.Line;
+
+import java.util.stream.Stream;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+final class MergingViewUtil {
+
+    static Iterable<DanglingLine> getDanglingLines(Iterable<DanglingLine> delegateDanglingLines, MergingViewIndex index) {
+        return Iterables.transform(Iterables.filter(delegateDanglingLines, dl -> !index.isMerged(dl)), index::getDanglingLine);
+    }
+
+    static Iterable<Line> getLines(Iterable<Line> delegateLines, Iterable<DanglingLine> delegateDl, MergingViewIndex index) {
+        return Iterables.concat(Iterables.transform(delegateLines, index::getLine),
+                Iterables.transform(Iterables.filter(delegateDl, index::isMerged), dl -> index.getMergedLineByCode(dl.getUcteXnodeCode())));
+    }
+
+    static Stream<DanglingLine> getDanglingLineStream(Stream<DanglingLine> delegateDanglingLines, MergingViewIndex index) {
+        return delegateDanglingLines
+                .filter(dl -> !index.isMerged(dl))
+                .map(index::getDanglingLine);
+    }
+
+    static Stream<Line> getLineStream(Stream<Line> delegateLines, Stream<DanglingLine> delegateDl, MergingViewIndex index) {
+        return Stream.concat(
+                delegateLines
+                        .map(index::getLine),
+                delegateDl
+                        .filter(index::isMerged)
+                        .map(dl -> index.getMergedLineByCode(dl.getUcteXnodeCode())));
+    }
+
+    private MergingViewUtil() {
+    }
+}


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
The lists returned by  `getLines()` and `getDanglingLines()` are read twice (once during the building, once during the using of the list). It is not efficient.


**What is the new behavior (if this is a feature change)?**
The list is only read when used.


**Does this PR introduce a breaking change or deprecate an API?** 
No

