### PR TITLE
Network copy with a different factory

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -618,11 +618,23 @@ public final class NetworkXml {
      * @return the copy of the network
      */
     public static Network copy(Network network) {
-        return copy(network, ForkJoinPool.commonPool());
+        return copy(network, NetworkFactory.findDefault());
     }
 
-    public static Network copy(Network network, ExecutorService executor) {
+    /**
+     * Deep copy of the network using XML converter.
+     *
+     * @param network the network to copy
+     * @param networkFactory the network factory to use for the copy
+     * @return the copy of the network
+     */
+    public static Network copy(Network network, NetworkFactory networkFactory) {
+        return copy(network, networkFactory, ForkJoinPool.commonPool());
+    }
+
+    public static Network copy(Network network, NetworkFactory networkFactory, ExecutorService executor) {
         Objects.requireNonNull(network);
+        Objects.requireNonNull(networkFactory);
         Objects.requireNonNull(executor);
         PipedOutputStream pos = new PipedOutputStream();
         try (InputStream is = new PipedInputStream(pos)) {
@@ -639,7 +651,7 @@ public final class NetworkXml {
                     }
                 }
             });
-            return read(is);
+            return read(is, new ImportOptions(), null, networkFactory);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
When we copy a network the default network factory is used.


**What is the new behavior (if this is a feature change)?**
We can copy the network using an alternative network factory


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
