### PR TITLE
add Voltage Extension class

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/extensions/AbstractPrecontingencyValueExtension.java
+++ b/commons/src/main/java/com/powsybl/commons/extensions/AbstractPrecontingencyValueExtension.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.commons.extensions;
+
+/**
+ * Abstract extension for Voltage and Current Extensions
+ *
+ * @author Etienne Lesot <etienne.lesot at rte-france.com>
+ */
+
+public abstract class AbstractPrecontingencyValueExtension<T> extends AbstractExtension<T> {
+
+    private final double preContingencyValue;
+
+    public AbstractPrecontingencyValueExtension(double value) {
+        this.preContingencyValue = checkValue(value);
+    }
+
+    public double getPreContingencyValue() {
+        return preContingencyValue;
+    }
+
+    private static double checkValue(double value) {
+        if (Double.isNaN(value)) {
+            throw new IllegalArgumentException("Value is undefined");
+        }
+        return value;
+    }
+}

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/extensions/VoltageExtension.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/extensions/VoltageExtension.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, RTE (http://www.rte-france.com)
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -10,16 +10,18 @@ import com.powsybl.commons.extensions.AbstractPrecontingencyValueExtension;
 import com.powsybl.security.LimitViolation;
 
 /**
- * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ * Extension to handle pre-contingency voltage value for a voltage limit violation
+ *
+ * @author Olivier Bretteville <olivier.bretteville at rte-france.com>
  */
-public class CurrentExtension extends AbstractPrecontingencyValueExtension<LimitViolation> {
+public class VoltageExtension extends AbstractPrecontingencyValueExtension<LimitViolation> {
 
-    public CurrentExtension(double value) {
+    public VoltageExtension(double value) {
         super(value);
     }
 
     @Override
     public String getName() {
-        return "Current";
+        return "Voltage";
     }
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/VoltageExtensionSerializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/VoltageExtensionSerializer.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.extensions.ExtensionJsonSerializer;
+import com.powsybl.security.LimitViolation;
+import com.powsybl.security.extensions.VoltageExtension;
+
+import java.io.IOException;
+
+/**
+ * @author Olivier Bretteville <olivier.bretteville at rte-france.com>
+ */
+@AutoService(ExtensionJsonSerializer.class)
+public class VoltageExtensionSerializer implements ExtensionJsonSerializer<LimitViolation, VoltageExtension> {
+
+    @Override
+    public String getExtensionName() {
+        return "Voltage";
+    }
+
+    @Override
+    public String getCategoryName() {
+        return "security-analysis";
+    }
+
+    @Override
+    public Class<? super VoltageExtension> getExtensionClass() {
+        return VoltageExtension.class;
+    }
+
+    @Override
+    public void serialize(VoltageExtension extension, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeNumberField("preContingencyValue", extension.getPreContingencyValue());
+        jsonGenerator.writeEndObject();
+    }
+
+    @Override
+    public VoltageExtension deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
+        double value = Double.NaN;
+
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            if (parser.getCurrentName().equals("preContingencyValue")) {
+                parser.nextToken();
+                value = parser.readValueAs(Float.class);
+            } else {
+                throw new PowsyblException("Unexpected field: " + parser.getCurrentName());
+            }
+        }
+
+        return new VoltageExtension(value);
+    }
+}

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
@@ -14,6 +14,7 @@ import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.security.*;
 import com.powsybl.security.extensions.ActivePowerExtension;
 import com.powsybl.security.extensions.CurrentExtension;
+import com.powsybl.security.extensions.VoltageExtension;
 import com.powsybl.security.json.SecurityAnalysisResultDeserializer;
 import org.junit.Test;
 
@@ -46,12 +47,13 @@ public class ExporterTest extends AbstractConverterTest {
 
         LimitViolation violation3 = new LimitViolation("GEN", LimitViolationType.HIGH_VOLTAGE, 100, 0.9f, 110);
         LimitViolation violation4 = new LimitViolation("GEN2", LimitViolationType.LOW_VOLTAGE, 100, 0.7f, 115);
+        violation4.addExtension(VoltageExtension.class, new VoltageExtension(400.0));
 
         List<ContingencyElement> elements = Arrays.asList(
-            new BranchContingency("NHV1_NHV2_2", "VLNHV1"),
-            new BranchContingency("NHV1_NHV2_1"),
-            new GeneratorContingency("GEN"),
-            new BusbarSectionContingency("BBS1")
+                new BranchContingency("NHV1_NHV2_2", "VLNHV1"),
+                new BranchContingency("NHV1_NHV2_1"),
+                new GeneratorContingency("GEN"),
+                new BusbarSectionContingency("BBS1")
         );
         Contingency contingency = new Contingency("contingency", elements);
 

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResult.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResult.json
@@ -72,7 +72,12 @@
         "limitType" : "LOW_VOLTAGE",
         "limit" : 100.0,
         "limitReduction" : 0.7,
-        "value" : 115.0
+        "value" : 115.0,
+        "extensions" : {
+          "Voltage" : {
+            "preContingencyValue" : 400.0
+          }
+        }
       } ],
       "actionsTaken" : [ "action1", "action2" ]
     }


### PR DESCRIPTION
Signed-off-by: Etienne Lesot <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

it adds a new extension for the limitviolations with voltage contraints. It is similar to Current Extension but for voltage.

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
