### PR TITLE
Fix branchAdmittanceMatrix get methods

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LinkData.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LinkData.java
@@ -128,15 +128,15 @@ public final class LinkData {
         }
 
         public Complex y12() {
-            return y11;
+            return y12;
         }
 
         public Complex y21() {
-            return y11;
+            return y21;
         }
 
         public Complex y22() {
-            return y11;
+            return y22;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: José Antonio Marqués <marquesja@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*

 `y12()`, `y21()` and `y22()` methods return `y11`

**What is the new behavior (if this is a feature change)?**

`Y12()` returns `y12`, `y21() `returns `y21` and `y22()` returns `y22`. 

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)

Only one of these methods was used. It was used on the cgmes conversion update code
