### PR TITLE
Don't use fail() inside a try-catch catching an AssertionError

### DIFF
--- a/commons/src/test/java/com/powsybl/commons/AbstractConverterTest.java
+++ b/commons/src/test/java/com/powsybl/commons/AbstractConverterTest.java
@@ -11,6 +11,8 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.Diff;
@@ -32,6 +34,9 @@ import static org.junit.Assert.*;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public abstract class AbstractConverterTest {
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
 
     protected FileSystem fileSystem;
     protected Path tmpDir;

--- a/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
+++ b/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
@@ -299,7 +299,7 @@ public class LocalComputationManagerTest {
     }
 
     @Test
-    public void cancelDuringExecutionShouldThrowAndEventuallyStopExecution() throws InterruptedException {
+    public void cancelDuringExecutionShouldThrowAndEventuallyStopExecution() throws InterruptedException, ExecutionException, IOException {
 
         CountDownLatch waitForExecution = new CountDownLatch(1);
         CountDownLatch execution = new CountDownLatch(1); // Will be interrupted, not decremented
@@ -349,11 +349,9 @@ public class LocalComputationManagerTest {
             waitForExecution.await();
             result.cancel(true);
             result.get();
-            fail();
+            fail("Should not happen: result has been cancelled");
         } catch (CancellationException exc) {
             //OK
-        } catch (Throwable t) {
-            fail();
         }
 
         waitForInterruption.await(10, TimeUnit.SECONDS);

--- a/computation/src/test/java/com/powsybl/computation/CompletableFutureTaskTest.java
+++ b/computation/src/test/java/com/powsybl/computation/CompletableFutureTaskTest.java
@@ -114,11 +114,9 @@ public class CompletableFutureTaskTest {
 
         try {
             task.get();
-            fail();
+            fail("Should not happen: task has been cancelled");
         } catch (CancellationException exc) {
             //ignored
-        } catch (Throwable exc) {
-            fail();
         }
 
         waitForInterruption.await();

--- a/dynamic-simulation/dynamic-simulation-api/src/test/java/com/powsybl/dynamicsimulation/json/DynamicSimulationResultJsonTest.java
+++ b/dynamic-simulation/dynamic-simulation-api/src/test/java/com/powsybl/dynamicsimulation/json/DynamicSimulationResultJsonTest.java
@@ -6,13 +6,11 @@
  */
 package com.powsybl.dynamicsimulation.json;
 
-import java.io.IOException;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.dynamicsimulation.DynamicSimulationResult;
+import org.junit.Test;
+
+import java.io.IOException;
 
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>
@@ -40,11 +38,9 @@ public class DynamicSimulationResultJsonTest extends AbstractConverterTest {
 
     @Test
     public void handleErrorTest() throws IOException {
-        try {
-            DynamicSimulationResultDeserializer.read(getClass().getResourceAsStream("/DynamicSimulationResultError.json"));
-            Assert.fail();
-        } catch (AssertionError ignored) {
-        }
+        expected.expect(AssertionError.class);
+        expected.expectMessage("Unexpected field: metrics");
+        DynamicSimulationResultDeserializer.read(getClass().getResourceAsStream("/DynamicSimulationResultError.json"));
     }
 
 }

--- a/dynamic-simulation/dynamic-simulation-api/src/test/java/com/powsybl/dynamicsimulation/json/JsonDynamicSimulationParametersTest.java
+++ b/dynamic-simulation/dynamic-simulation-api/src/test/java/com/powsybl/dynamicsimulation/json/JsonDynamicSimulationParametersTest.java
@@ -6,14 +6,6 @@
  */
 package com.powsybl.dynamicsimulation.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.IOException;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -22,6 +14,12 @@ import com.google.auto.service.AutoService;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.dynamicsimulation.DynamicSimulationParameters;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>
@@ -44,7 +42,7 @@ public class JsonDynamicSimulationParametersTest extends AbstractConverterTest {
     }
 
     @Test
-    public void readExtension() throws IOException {
+    public void readExtension() {
         DynamicSimulationParameters parameters = JsonDynamicSimulationParameters.read(getClass().getResourceAsStream("/DynamicSimulationParametersWithExtension.json"));
         assertEquals(1, parameters.getExtensions().size());
         assertNotNull(parameters.getExtension(DummyExtension.class));
@@ -52,12 +50,10 @@ public class JsonDynamicSimulationParametersTest extends AbstractConverterTest {
     }
 
     @Test
-    public void readError() throws IOException {
-        try {
-            JsonDynamicSimulationParameters.read(getClass().getResourceAsStream("/DynamicSimulationParametersError.json"));
-            Assert.fail();
-        } catch (AssertionError ignored) {
-        }
+    public void readError() {
+        expected.expect(AssertionError.class);
+        expected.expectMessage("Unexpected field: unknownParameter");
+        JsonDynamicSimulationParameters.read(getClass().getResourceAsStream("/DynamicSimulationParametersError.json"));
     }
 
     static class DummyExtension extends AbstractExtension<DynamicSimulationParameters> {

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
@@ -13,7 +13,6 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.loadflow.LoadFlowParameters;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -49,7 +48,7 @@ public class JsonLoadFlowParametersTest extends AbstractConverterTest {
     }
 
     @Test
-    public void readExtension() throws IOException {
+    public void readExtension() {
         LoadFlowParameters parameters = JsonLoadFlowParameters.read(getClass().getResourceAsStream("/LoadFlowParametersWithExtension.json"));
         assertEquals(1, parameters.getExtensions().size());
         assertNotNull(parameters.getExtension(DummyExtension.class));
@@ -57,51 +56,49 @@ public class JsonLoadFlowParametersTest extends AbstractConverterTest {
     }
 
     @Test
-    public void readError() throws IOException {
-        try {
-            JsonLoadFlowParameters.read(getClass().getResourceAsStream("/LoadFlowParametersError.json"));
-            Assert.fail();
-        } catch (AssertionError ignored) {
-        }
+    public void readError() {
+        expected.expect(AssertionError.class);
+        expected.expectMessage("Unexpected field: unknownParameter");
+        JsonLoadFlowParameters.read(getClass().getResourceAsStream("/LoadFlowParametersError.json"));
     }
 
     @Test
-    public void readJsonVersion10() throws IOException {
+    public void readJsonVersion10() {
         LoadFlowParameters parameters = JsonLoadFlowParameters
                 .read(getClass().getResourceAsStream("/LoadFlowParametersVersion10.json"));
         assertEquals(true, parameters.isTwtSplitShuntAdmittance());
     }
 
     @Test
-    public void readJsonVersion11() throws IOException {
+    public void readJsonVersion11() {
         LoadFlowParameters parameters = JsonLoadFlowParameters
                 .read(getClass().getResourceAsStream("/LoadFlowParametersVersion11.json"));
         assertEquals(true, parameters.isTwtSplitShuntAdmittance());
     }
 
     @Test
-    public void readJsonVersion12() throws IOException {
+    public void readJsonVersion12() {
         LoadFlowParameters parameters = JsonLoadFlowParameters
                 .read(getClass().getResourceAsStream("/LoadFlowParametersVersion12.json"));
         assertEquals(true, parameters.isTwtSplitShuntAdmittance());
     }
 
     @Test
-    public void readJsonVersion10Exception() throws IOException {
+    public void readJsonVersion10Exception() {
         exception.expect(PowsyblException.class);
         exception.expectMessage("LoadFlowParameters. Tag: t2wtSplitShuntAdmittance is not valid for version 1.0. Version should be > 1.0");
         JsonLoadFlowParameters.read(getClass().getResourceAsStream("/LoadFlowParametersVersion10Exception.json"));
     }
 
     @Test
-    public void readJsonVersion11Exception() throws IOException {
+    public void readJsonVersion11Exception() {
         exception.expect(PowsyblException.class);
         exception.expectMessage("LoadFlowParameters. Tag: specificCompatibility is not valid for version 1.1. Version should be <= 1.0");
         JsonLoadFlowParameters.read(getClass().getResourceAsStream("/LoadFlowParametersVersion11Exception.json"));
     }
 
     @Test
-    public void readJsonVersion12Exception() throws IOException {
+    public void readJsonVersion12Exception() {
         exception.expect(PowsyblException.class);
         exception.expectMessage("LoadFlowParameters. Tag: t2wtSplitShuntAdmittance is not valid for version 1.2. Version should be <= 1.1");
         JsonLoadFlowParameters.read(getClass().getResourceAsStream("/LoadFlowParametersVersion12Exception.json"));

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/LoadFlowResultJsonTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/LoadFlowResultJsonTest.java
@@ -8,7 +8,6 @@ package com.powsybl.loadflow.json;
 
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.loadflow.LoadFlowResult;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -53,11 +52,9 @@ public class LoadFlowResultJsonTest extends AbstractConverterTest {
 
     @Test
     public void handleErrorTest() throws IOException {
-        try {
-            LoadFlowResultDeserializer.read(getClass().getResourceAsStream("/LoadFlowResultError.json"));
-            Assert.fail();
-        } catch (AssertionError ignored) {
-        }
+        expected.expect(AssertionError.class);
+        expected.expectMessage("Unexpected field: alienAttribute");
+        LoadFlowResultDeserializer.read(getClass().getResourceAsStream("/LoadFlowResultError.json"));
     }
 
 }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/JsonSecurityAnalysisParametersTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/JsonSecurityAnalysisParametersTest.java
@@ -12,7 +12,6 @@ import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.security.SecurityAnalysisParameters;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -54,12 +53,10 @@ public class JsonSecurityAnalysisParametersTest extends AbstractConverterTest {
     }
 
     @Test
-    public void readError() throws IOException {
-        try {
-            JsonSecurityAnalysisParameters.read(getClass().getResourceAsStream("/SecurityAnalysisParametersWithExtension.json"));
-            Assert.fail();
-        } catch (AssertionError ignored) {
-        }
+    public void readError() {
+        expected.expect(AssertionError.class);
+        expected.expectMessage("Unexpected field: unexpected");
+        JsonSecurityAnalysisParameters.read(getClass().getResourceAsStream("/SecurityAnalysisParametersInvalid.json"));
     }
 
     @Test

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParametersInvalid.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParametersInvalid.json
@@ -1,0 +1,12 @@
+{
+  "version" : "1.0",
+  "load-flow-parameters" : {
+    "version" : "1.2",
+    "voltageInitMode" : "UNIFORM_VALUES",
+    "transformerVoltageControlOn" : false,
+    "phaseShifterRegulationOn" : false,
+    "noGeneratorReactiveLimits" : false,
+    "twtSplitShuntAdmittance" : false
+  },
+  "unexpected" : true
+}

--- a/sensitivity-api/src/test/java/com/powsybl/sensitivity/json/JsonSensitivityComputationParametersTest.java
+++ b/sensitivity-api/src/test/java/com/powsybl/sensitivity/json/JsonSensitivityComputationParametersTest.java
@@ -18,7 +18,6 @@ import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.sensitivity.SensitivityComputationParameters;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -78,11 +77,9 @@ public class JsonSensitivityComputationParametersTest extends AbstractConverterT
 
     @Test
     public void readError() {
-        try {
-            JsonSensitivityComputationParameters.read(getClass().getResourceAsStream("/SensitivityComputationParametersWithExtension.json"));
-            Assert.fail();
-        } catch (AssertionError ignored) {
-        }
+        expected.expect(AssertionError.class);
+        expected.expectMessage("Unexpected field: unexpected");
+        JsonSensitivityComputationParameters.read(getClass().getResourceAsStream("/SensitivityComputationParametersInvalid.json"));
     }
 
     static class DummyExtension extends AbstractExtension<SensitivityComputationParameters> {

--- a/sensitivity-api/src/test/resources/SensitivityComputationParametersInvalid.json
+++ b/sensitivity-api/src/test/resources/SensitivityComputationParametersInvalid.json
@@ -1,0 +1,12 @@
+{
+  "version" : "1.0",
+  "load-flow-parameters" : {
+    "version" : "1.2",
+    "voltageInitMode" : "UNIFORM_VALUES",
+    "transformerVoltageControlOn" : false,
+    "phaseShifterRegulationOn" : false,
+    "noGeneratorReactiveLimits" : false,
+    "twtSplitShuntAdmittance" : false
+  },
+  "unexpected" : true
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Some of our unit tests are not well implemented and pass whatever are the inputs because the assertions are not precise enough. This was the case with `JsonSensitivityComputationParametersTest.java` where a valid file is used, but the test pass whereas it's expected to not throw an exception.

Sonar has reported these as bugs, so the quality gate fails.
```
try {
    throwAssertionError();
    Assert.fail();
} catch (AssertionError e) {
}
```
In this kind of configuration, both `thorwAssertionError` and `Assert.fail()` throw an `AssertionError`. It's impossible to distinguish which statement raise the exception. The best practice is:
- to refactor the code `Assert.assertThrows(() -> throwAssertionError());`
- to pass a message to `Assert.fail` and assert the error message of the exception is the expected one. 


**What is the new behavior (if this is a feature change)?**
Sonar bugs have been fixed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
