### PR TITLE
Add hasTemporaryLimits() to CurrentLimitsAdder + correct CGMES conversion

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CurrentLimitsMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CurrentLimitsMapping.java
@@ -33,14 +33,16 @@ public class CurrentLimitsMapping {
 
     void addAll() {
         for (Map.Entry<String, CurrentLimitsAdder> entry : adders.entrySet()) {
-            CurrentLimits limits = entry.getValue().add();
-            if (Double.isNaN(limits.getPermanentLimit())) {
-                double fixedPermanentLimit = Iterables.get(limits.getTemporaryLimits(), 0).getValue();
-                context.fixed("Operational Limit Set of " + entry.getKey(),
-                        "An operational limit set without permanent limit is considered with permanent limit" +
-                                "equal to lowest TATL value",
-                        Double.NaN, fixedPermanentLimit);
-                limits.setPermanentLimit(fixedPermanentLimit);
+            if (!Double.isNaN(entry.getValue().getPermanentLimit()) || entry.getValue().hasTemporaryLimits()) {
+                CurrentLimits limits = entry.getValue().add();
+                if (Double.isNaN(limits.getPermanentLimit())) {
+                    double fixedPermanentLimit = Iterables.get(limits.getTemporaryLimits(), 0).getValue();
+                    context.fixed("Operational Limit Set of " + entry.getKey(),
+                            "An operational limit set without permanent limit is considered with permanent limit" +
+                                    "equal to lowest TATL value",
+                            Double.NaN, fixedPermanentLimit);
+                    limits.setPermanentLimit(fixedPermanentLimit);
+                }
             }
         }
         adders.clear();

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/CurrentLimitsAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/CurrentLimitsAdder.java
@@ -41,6 +41,10 @@ public interface CurrentLimitsAdder {
         return Double.NaN;
     }
 
+    default boolean hasTemporaryLimits() {
+        return false;
+    }
+
     CurrentLimits add();
 
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CurrentLimitsAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CurrentLimitsAdderImpl.java
@@ -141,6 +141,11 @@ public class CurrentLimitsAdderImpl<S, O extends CurrentLimitsOwner<S>> implemen
     }
 
     @Override
+    public boolean hasTemporaryLimits() {
+        return !temporaryLimits.isEmpty();
+    }
+
+    @Override
     public TemporaryLimitAdder beginTemporaryLimit() {
         return new TemporaryLimitAdderImpl();
     }


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Current limits are created even when the limits are apparent power or active power.


**What is the new behavior (if this is a feature change)?**
Current limits are created only when **current** TATL or PATL have been imported.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:
Bug present since PR #1360 