### PR TITLE
CGMES updates: reduce size of changelog not recording state variables

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/IidmChangeUpdate.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/IidmChangeUpdate.java
@@ -35,6 +35,11 @@ public class IidmChangeUpdate extends IidmChange {
         return newValue;
     }
 
+    @Override
+    public String toString() {
+        return getIdentifiable().getNameOrId() + "." + getAttribute() + " = " + getNewValue();
+    }
+
     private final String attribute;
     private final Object oldValue;
     private final Object newValue;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/GeneratorToSynchronousMachine.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/GeneratorToSynchronousMachine.java
@@ -17,8 +17,6 @@ import com.powsybl.iidm.network.Identifiable;
 public class GeneratorToSynchronousMachine extends IidmToCgmes {
 
     public GeneratorToSynchronousMachine() {
-        ignore("p");
-        ignore("q");
         // Changes in energy source are ignored
         // In CGMES generating units with diferent energy source are separate types
         // This would be a major update

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/GeneratorToSynchronousMachine.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/GeneratorToSynchronousMachine.java
@@ -18,7 +18,7 @@ public class GeneratorToSynchronousMachine extends IidmToCgmes {
 
     public GeneratorToSynchronousMachine() {
         // Changes in energy source are ignored
-        // In CGMES generating units with diferent energy source are separate types
+        // In CGMES generating units with different energy source are separate types
         // This would be a major update
         // It would require changing the class of the generating unit linked to the
         // synchronous machine related to this IIDM generator

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/LineToACLineSegment.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/LineToACLineSegment.java
@@ -17,10 +17,6 @@ import com.powsybl.iidm.network.Line;
 public class LineToACLineSegment extends IidmToCgmes {
 
     LineToACLineSegment() {
-        ignore("p1");
-        ignore("q1");
-        ignore("p2");
-        ignore("q2");
 
         simpleUpdate("r", "cim:ACLineSegment.r", CgmesSubset.EQUIPMENT);
         simpleUpdate("x", "cim:ACLineSegment.x", CgmesSubset.EQUIPMENT);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/LoadToEnergyConsumer.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/LoadToEnergyConsumer.java
@@ -17,8 +17,6 @@ public class LoadToEnergyConsumer extends IidmToCgmes {
     LoadToEnergyConsumer() {
         // Ignore changes on (p, q) from Load Terminal
         // They will be added directly as new objects in SV subset
-        ignore("p");
-        ignore("q");
 
         simpleUpdate("p0", "cim:EnergyConsumer.p", CgmesSubset.STEADY_STATE_HYPOTHESIS);
         simpleUpdate("q0", "cim:EnergyConsumer.q", CgmesSubset.STEADY_STATE_HYPOTHESIS);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/ShuntCompensatorToShuntCompensator.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/ShuntCompensatorToShuntCompensator.java
@@ -15,7 +15,6 @@ import com.powsybl.cgmes.model.CgmesSubset;
 public class ShuntCompensatorToShuntCompensator extends IidmToCgmes {
 
     ShuntCompensatorToShuntCompensator() {
-        ignore("q");
 
         simpleUpdate("bPerSection", "cim:LinearShuntCompensator.bPerSection", CgmesSubset.EQUIPMENT);
         simpleUpdate("maximumSectionCount", "cim:ShuntCompensator.maximumSections", CgmesSubset.EQUIPMENT);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/TwoWindingsTransformerToPowerTransformer.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/elements16/TwoWindingsTransformerToPowerTransformer.java
@@ -15,10 +15,6 @@ import com.powsybl.cgmes.model.CgmesSubset;
 public class TwoWindingsTransformerToPowerTransformer extends IidmToCgmes {
 
     public TwoWindingsTransformerToPowerTransformer() {
-        ignore("p1");
-        ignore("q1");
-        ignore("p2");
-        ignore("q2");
 
         // These are examples of not-so-simple updates where
         // we have to find a CGMES sub-object related to IIDM main object

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -12,7 +12,6 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.ReactiveCapabilityCurve.Point;
 import com.powsybl.iidm.network.extensions.CoordinatedReactiveControl;
@@ -188,8 +187,8 @@ public class Comparison {
 
     private void compareBuses(Bus expected, Bus actual) {
         equivalent("VoltageLevel", expected.getVoltageLevel(), actual.getVoltageLevel());
-        compare(CgmesNames.VOLTAGE, expected.getV(), actual.getV());
-        compare(CgmesNames.ANGLE, expected.getAngle(), actual.getAngle());
+        compare("v", expected.getV(), actual.getV());
+        compare("angle", expected.getAngle(), actual.getAngle());
     }
 
     private void compareLoads(Load expected, Load actual) {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/update/CgmesUpdateTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/update/CgmesUpdateTest.java
@@ -12,15 +12,18 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,21 +33,17 @@ import com.powsybl.cgmes.conformity.test.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conversion.CgmesExport;
 import com.powsybl.cgmes.conversion.CgmesImport;
 import com.powsybl.cgmes.conversion.CgmesModelExtension;
+import com.powsybl.cgmes.conversion.test.ConversionTester;
 import com.powsybl.cgmes.conversion.test.network.compare.Comparison;
 import com.powsybl.cgmes.conversion.test.network.compare.ComparisonConfig;
 import com.powsybl.cgmes.conversion.update.IidmChange;
+import com.powsybl.cgmes.conversion.update.IidmChangeUpdate;
 import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.commons.datasource.DataSource;
 import com.powsybl.commons.datasource.FileDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
-import com.powsybl.computation.ComputationManager;
-import com.powsybl.iidm.network.Branch.Side;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.NetworkFactory;
-import com.powsybl.iidm.network.Terminal;
-import com.powsybl.loadflow.LoadFlowParameters;
-import com.powsybl.loadflow.resultscompletion.LoadFlowResultsCompletion;
-import com.powsybl.loadflow.resultscompletion.LoadFlowResultsCompletionParameters;
 import com.powsybl.triplestore.api.TripleStoreFactory;
 
 /**
@@ -75,44 +74,39 @@ public class CgmesUpdateTest {
         testSimpleUpdate(CgmesConformity1Catalog.miniBusBranch().dataSource());
     }
 
-    @Ignore("Calculated bus lists can not be compared with current implementation (lists not searchable by calculated bus id)")
+    @Ignore("Requires node-breaker management of updates")
     @Test
     public void testSimpleUpdateMiniNodeBreaker() throws IOException {
         testSimpleUpdate(CgmesConformity1Catalog.miniNodeBreaker().dataSource());
     }
 
     void testSimpleUpdate(ReadOnlyDataSource ds) throws IOException {
-        boolean invalidateFlows = true;
-        testSimpleUpdate(ds, invalidateFlows);
+        testSimpleUpdate(ds, TripleStoreFactory.defaultImplementation());
     }
 
-    void testSimpleUpdate(ReadOnlyDataSource ds, boolean invalidateFlows) throws IOException {
-        testSimpleUpdate(ds, TripleStoreFactory.defaultImplementation(), invalidateFlows);
-    }
-
-    private void testSimpleUpdate(ReadOnlyDataSource ds, String impl, boolean invalidateFlows) throws IOException {
+    private void testSimpleUpdate(ReadOnlyDataSource ds, String impl) throws IOException {
         Network network0 = cgmesImport.importData(ds, NetworkFactory.findDefault(), importParameters(impl));
         if (isEmpty(network0)) {
             fail("Network is empty");
             return;
         }
-        // For very big networks we will limit the number of changes made in the test
-        boolean isBigNetwork = network0.getBusView().getBusStream().count() > 5000;
 
         network0.getVariantManager().cloneVariant(network0.getVariantManager().getWorkingVariantId(), "1");
         network0.getVariantManager().setWorkingVariant("1");
 
         NetworkChanges.modifyEquipmentCharacteristics(network0);
-        int numChangesInLoadsAndGenerators = isBigNetwork ? 1000 : Integer.MAX_VALUE;
-        NetworkChanges.scaleLoadGenerator(network0, numChangesInLoadsAndGenerators);
+        int maxChanges = 1000;
+        NetworkChanges.scaleLoadGenerator(network0, maxChanges);
         NetworkChanges.modifySteadyStateHypothesis(network0);
 
-        if (!isBigNetwork) {
-            // Compute all flows only for small networks
-            // as this will introduce a lot of changes
-            runLoadFlowResultsCompletion(network0, invalidateFlows);
-        }
-        List<IidmChange> changes = network0.getExtension(CgmesModelExtension.class).getCgmesUpdate().changelog().getChangesForVariant(network0.getVariantManager().getWorkingVariantId());
+        // Modify state variables altering all the voltages
+        // and recalculating all the flows
+        NetworkChanges.modifyStateVariables(network0);
+        ConversionTester.invalidateFlows(network0);
+        ConversionTester.computeMissingFlows(network0);
+
+        // Flows and voltages should have not been recorded as changes
+        checkStateVariablesNotRecordedInChangelog(network0);
 
         DataSource tmp = tmpDataSource(impl);
         CgmesExport e = new CgmesExport();
@@ -120,49 +114,28 @@ public class CgmesUpdateTest {
 
         // import saved data and compare with original Network
         Network network1 = cgmesImport.importData(tmp, NetworkFactory.findDefault(), importParameters(impl));
-        runLoadFlowResultsCompletion(network1, false);
+        // TODO Think if we should complete flows in the re-imported Network
+        // ConversionTester.computeMissingFlows(network1);
         compare(network0, network1);
+    }
+
+    private static void checkStateVariablesNotRecordedInChangelog(Network network) {
+        Set<String> stateVariables = Stream.of("v", "angle", "p", "q", "p1", "p2", "p3", "q1", "q2", "q3")
+                .collect(Collectors.toCollection(HashSet::new));
+        List<IidmChange> changes = network.getExtension(CgmesModelExtension.class).getCgmesUpdate().changelog()
+                .getChangesForVariant(network.getVariantManager().getWorkingVariantId());
+        changes.stream().filter(c -> c instanceof IidmChangeUpdate).map(c -> (IidmChangeUpdate) c)
+                .filter(c -> stateVariables.contains(c.getAttribute())).findFirst().map(c -> {
+                    LOG.error("State variable found in changelog {}.{}", c.getIdentifiable().getClass().getSimpleName(),
+                            c.getAttribute());
+                    return c;
+                }).ifPresent(c -> fail());
     }
 
     private void compare(Network network0, Network network1) {
         ComparisonConfig config = new ComparisonConfig().checkNetworkId(false).tolerance(2.4e-4);
         Comparison comparison = new Comparison(network0, network1, config);
         comparison.compare();
-    }
-
-    private void runLoadFlowResultsCompletion(Network network, boolean invalidateFlows) {
-        if (invalidateFlows) {
-            invalidateFlows(network);
-        }
-        LoadFlowParameters lfParameters = new LoadFlowParameters();
-        LoadFlowResultsCompletionParameters parameters = new LoadFlowResultsCompletionParameters();
-        LoadFlowResultsCompletion lfResultsCompletion = new LoadFlowResultsCompletion(parameters, lfParameters);
-        lfResultsCompletion.run(network, Mockito.mock(ComputationManager.class));
-    }
-
-    private void invalidateFlows(Network n) {
-        n.getLineStream().forEach(line -> {
-            invalidateFlow(line.getTerminal(Side.ONE));
-            invalidateFlow(line.getTerminal(Side.TWO));
-        });
-        n.getTwoWindingsTransformerStream().forEach(twt -> {
-            invalidateFlow(twt.getTerminal(Side.ONE));
-            invalidateFlow(twt.getTerminal(Side.TWO));
-        });
-        n.getShuntCompensatorStream().forEach(sh -> {
-            Terminal terminal = sh.getTerminal();
-            terminal.setQ(Double.NaN);
-        });
-        n.getThreeWindingsTransformerStream().forEach(twt -> {
-            invalidateFlow(twt.getLeg1().getTerminal());
-            invalidateFlow(twt.getLeg2().getTerminal());
-            invalidateFlow(twt.getLeg3().getTerminal());
-        });
-    }
-
-    private void invalidateFlow(Terminal t) {
-        t.setP(Double.NaN);
-        t.setQ(Double.NaN);
     }
 
     private boolean isEmpty(Network network) {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/update/NetworkChanges.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/update/NetworkChanges.java
@@ -106,7 +106,7 @@ public final class NetworkChanges {
             }
         }
         if (!found) {
-            LOG.error("Did not find a ShuntCompensator to test");
+            LOG.warn("Did not find a ShuntCompensator to test");
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
The changelog that records changes in IIDM attributes is used to perform updates in the CGMES triplestore when the user requests a CGMES export.
State variables (voltages, angles, flows at terminals) are not recorded explicitly in the changelog, as its values will be systematically obtained during the export to build the CGMES SV profile from scratch. No selective update of these attributes is required.

**What is the current behavior?** *(You can also link to an open issue here)*
These attributes were previously stored in the changelog, and later ignored during the update.

**What is the new behavior (if this is a feature change)?**
Changelog size is reduced, and less operations are perform during update.

**Other information**:
The tests for CGMES update have been modified to remove size limitations on the number of changes performed. 