### PR TITLE
Names for generators from CGMES synchronous machines

### DIFF
--- a/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
+++ b/cgmes/cgmes-conformity/src/test/java/com/powsybl/cgmes/conformity/test/CgmesConformity1NetworkCatalog.java
@@ -87,6 +87,7 @@ public final class CgmesConformity1NetworkCatalog {
                 .add();
         Bus busAnvers220 = vlAnvers220.getBusBreakerView().newBus()
                 .setId("_f70f6bad-eb8d-4b8f-8431-4ab93581514e")
+                .setName("BE-Busbar_2")
                 .add();
         busAnvers220.setV(224.871595);
         busAnvers220.setAngle(-7.624900);
@@ -142,6 +143,7 @@ public final class CgmesConformity1NetworkCatalog {
 
         Bus busBrussels225 = vlBrussels225.getBusBreakerView().newBus()
                 .setId("_99b219f3-4593-428b-a4da-124a54630178")
+                .setName("BE_TR_BUS4")
                 .add();
         busBrussels225.setV(224.315268);
         busBrussels225.setAngle(-8.770120);
@@ -157,6 +159,7 @@ public final class CgmesConformity1NetworkCatalog {
         loadBrussels225.getTerminal().setQ(50.0);
         Bus busBrussels110 = vlBrussels110.getBusBreakerView().newBus()
                 .setId("_5c74cb26-ce2f-40c6-951d-89091eb781b6")
+                .setName("BE-Busbar_6")
                 .add();
         busBrussels110.setV(115.5);
         busBrussels110.setAngle(-9.391330);
@@ -172,6 +175,7 @@ public final class CgmesConformity1NetworkCatalog {
         loadBrussels110.getTerminal().setQ(90.0);
         Bus busBrussels380 = vlBrussels380.getBusBreakerView().newBus()
                 .setId("_e44141af-f1dc-44d3-bfa4-b674e5c953d7")
+                .setName("BE_TR_BUS2")
                 .add();
         busBrussels380.setV(412.989001);
         busBrussels380.setAngle(-6.780710);
@@ -281,6 +285,7 @@ public final class CgmesConformity1NetworkCatalog {
         shBrussels110.getTerminal().setQ(-330.75);
         Bus busBrussels21 = vlBrussels21.getBusBreakerView().newBus()
                 .setId("_f96d552a-618d-4d0c-a39a-2dea3c411dee")
+                .setName("BE-Busbar_5")
                 .add();
         busBrussels21.setV(21.987000);
         busBrussels21.setAngle(-6.650800);
@@ -289,7 +294,7 @@ public final class CgmesConformity1NetworkCatalog {
             double q = -18.720301;
             Generator genBrussels21 = vlBrussels21.newGenerator()
                     .setId("_550ebe0d-f2b2-48c1-991f-cebea43a21aa")
-                    .setName("Gen-1229753024")
+                    .setName("BE-G2")
                     .setConnectableBus(busBrussels21.getId())
                     .setBus(busBrussels21.getId())
                     .setMinP(50)
@@ -309,6 +314,7 @@ public final class CgmesConformity1NetworkCatalog {
         }
         Bus busBrussels10 = vlBrussels10.getBusBreakerView().newBus()
                 .setId("_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e")
+                .setName("BE-Busbar_4")
                 .add();
         busBrussels10.setV(10.820805);
         busBrussels10.setAngle(-7.057180);
@@ -635,7 +641,7 @@ public final class CgmesConformity1NetworkCatalog {
             double q = -100.256;
             Generator genBrussels10 = vlBrussels10.newGenerator()
                     .setId("_3a3b27be-b18b-4385-b557-6735d733baf0")
-                    .setName("Gen-1229753060")
+                    .setName("BE-G1")
                     .setConnectableBus(busBrussels10.getId())
                     .setBus(busBrussels10.getId())
                     .setMinP(50)
@@ -815,7 +821,7 @@ public final class CgmesConformity1NetworkCatalog {
         VoltageLevel vlAnvers225 = network.getSubstation("_87f7002b-056f-4a6a-a872-1744eea757e3")
                 .newVoltageLevel()
                 .setId("_69ef0dbd-da79-4eef-a02f-690cb8a28361")
-                .setName("225 kV")
+                .setName("225.0")
                 .setNominalV(225.0)
                 .setLowVoltageLimit(202.5)
                 .setHighVoltageLimit(247.5)
@@ -823,6 +829,7 @@ public final class CgmesConformity1NetworkCatalog {
                 .add();
         Bus busAnvers225 = vlAnvers225.getBusBreakerView().newBus()
                 .setId("_23b65c6b-2351-4673-89e9-1895c7291543")
+                .setName("Series Compensator")
                 .add()
                 .setV(223.435281)
                 .setAngle(-17.412200);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/cim14/Cim14SmallCasesNetworkCatalog.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/cim14/Cim14SmallCasesNetworkCatalog.java
@@ -59,11 +59,13 @@ public final class Cim14SmallCasesNetworkCatalog {
             .add();
         Bus busGrid = vlGrid.getBusBreakerView().newBus()
             .setId("_GRID_____TN")
+            .setName("GRID")
             .add();
         busGrid.setV(419);
         busGrid.setAngle(0);
         Bus busGen = vlGen.getBusBreakerView().newBus()
             .setId("_GEN______TN")
+            .setName("GEN")
             .add();
         busGen.setV(21);
         busGen.setAngle(0);
@@ -88,6 +90,7 @@ public final class Cim14SmallCasesNetworkCatalog {
         gen.setRegulatingTerminal(gen.getTerminal());
         Bus busInf = vlInf.getBusBreakerView().newBus()
             .setId("_INF______TN")
+            .setName("INF")
             .add();
         busInf.setV(419);
         busInf.setAngle(0);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -682,7 +682,7 @@ public class Comparison {
         // The names could be different only in trailing whitespace
         // Blazegraph does not preserve whitespace in input XML text
         String expected1 = expected.trim();
-        String actual1 = expected.trim();
+        String actual1 = actual.trim();
         if (config.compareNamesAllowSuffixes) {
             int endIndex = Math.min(expected.length(), actual.length());
             compare(context,

--- a/cgmes/cgmes-conversion/src/test/resources/cim14/7buses.xiidm
+++ b/cgmes/cgmes-conversion/src/test/resources/cim14/7buses.xiidm
@@ -3,16 +3,16 @@
     <iidm:substation id="_FP.AND11_SS" name="FP.AND11_SS" geographicalTags="_SGR_07">
         <iidm:voltageLevel id="_FTDPRA11_VL" name="FTDPRA11_VL" nominalV="380.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_FTDPRA12_TN" v="406.4447937011719" angle="-0.017328999936580658"/>
-                <iidm:bus id="_FTDPRA11_TN" v="406.4447937011719" angle="-0.017328999936580658"/>
+                <iidm:bus id="_FTDPRA12_TN" name="FTDPRA12" v="406.4447937011719" angle="-0.017328999936580658"/>
+                <iidm:bus id="_FTDPRA11_TN" name="FTDPRA11" v="406.4447937011719" angle="-0.017328999936580658"/>
                 <iidm:switch id="_FTDPRA11-FTDPRA12-A_SW" name="FTDPRA11-FTDPRA12-A" kind="BREAKER" retained="true" open="false" bus1="_FTDPRA11_TN" bus2="_FTDPRA12_TN"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_FTDPRC11_EC" name="FTDPRC11" loadType="UNDEFINED" p0="480.0" q0="4.800000190734863" bus="_FTDPRA11_TN" connectableBus="_FTDPRA11_TN" p="480.0" q="4.800000190734863"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_FP.AND11_VL" name="FP.AND11_VL" nominalV="380.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_FP.AND12_TN" v="406.4466552734375" angle="0.01733900047838688"/>
-                <iidm:bus id="_FP.AND11_TN" v="406.4466552734375" angle="0.01733900047838688"/>
+                <iidm:bus id="_FP.AND12_TN" name="FP.AND12" v="406.4466552734375" angle="0.01733900047838688"/>
+                <iidm:bus id="_FP.AND11_TN" name="FP.AND11" v="406.4466552734375" angle="0.01733900047838688"/>
                 <iidm:switch id="_FP.AND11-FP.AND12-A_SW" name="FP.AND11-FP.AND12-A" kind="BREAKER" retained="true" open="false" bus1="_FP.AND11_TN" bus2="_FP.AND12_TN"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_FP.ANC12_EC" name="FP.ANC12" loadType="UNDEFINED" p0="240.0" q0="2.4000000953674316" bus="_FP.AND11_TN" connectableBus="_FP.AND11_TN" p="240.0" q="2.4000000953674316"/>
@@ -60,8 +60,8 @@
     <iidm:substation id="_FS.BIS11_SS" name="FS.BIS11_SS" geographicalTags="_SGR_07">
         <iidm:voltageLevel id="_FS.BIS11_VL" name="FS.BIS11_VL" nominalV="380.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_FS.BIS12_TN" v="406.44244384765625" angle="-0.0034580000210553408"/>
-                <iidm:bus id="_FS.BIS11_TN" v="406.44244384765625" angle="-0.0034580000210553408"/>
+                <iidm:bus id="_FS.BIS12_TN" name="FS.BIS12" v="406.44244384765625" angle="-0.0034580000210553408"/>
+                <iidm:bus id="_FS.BIS11_TN" name="FS.BIS11" v="406.44244384765625" angle="-0.0034580000210553408"/>
                 <iidm:switch id="_FS.BIS11-FS.BIS12-A_SW" name="FS.BIS11-FS.BIS12-A" kind="BREAKER" retained="true" open="false" bus1="_FS.BIS11_TN" bus2="_FS.BIS12_TN"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_FS.BIC11_EC" name="FS.BIC11" loadType="UNDEFINED" p0="240.0" q0="2.4000000953674316" bus="_FS.BIS11_TN" connectableBus="_FS.BIS11_TN" p="240.0" q="2.4000000953674316"/>
@@ -70,8 +70,8 @@
     <iidm:substation id="_FSSV.O11_SS" name="FSSV.O11_SS" geographicalTags="_SGR_07">
         <iidm:voltageLevel id="_FSSV.O11_VL" name="FSSV.O11_VL" nominalV="380.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_FSSV.O12_TN" v="406.45001220703125" angle="0.09358499944210052"/>
-                <iidm:bus id="_FSSV.O11_TN" v="406.45001220703125" angle="0.09358499944210052"/>
+                <iidm:bus id="_FSSV.O12_TN" name="FSSV.O12" v="406.45001220703125" angle="0.09358499944210052"/>
+                <iidm:bus id="_FSSV.O11_TN" name="FSSV.O11" v="406.45001220703125" angle="0.09358499944210052"/>
                 <iidm:switch id="_FSSV.O11-FSSV.O12-A_SW" name="FSSV.O11-FSSV.O12-A" kind="BREAKER" retained="true" open="false" bus1="_FSSV.O11_TN" bus2="_FSSV.O12_TN"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_FSSV.T11_SM" name="FSSV.T11" energySource="OTHER" minP="400.0" maxP="1200.0" voltageRegulatorOn="true" targetP="960.0130004882812" targetV="406.45001220703125" targetQ="2.865334987640381" bus="_FSSV.O11_TN" connectableBus="_FSSV.O11_TN" p="-960.0130004882812" q="-2.865334987640381">
@@ -82,8 +82,8 @@
     <iidm:substation id="_FTILL511_SS" name="FTILL511_SS" geographicalTags="_SGR_07">
         <iidm:voltageLevel id="_FTILL511_VL" name="FTILL511_VL" nominalV="380.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_FTILL512_TN" v="406.4404602050781" angle="0.0034779999405145645"/>
-                <iidm:bus id="_FTILL511_TN" v="406.4404602050781" angle="0.0034779999405145645"/>
+                <iidm:bus id="_FTILL512_TN" name="FTILL512" v="406.4404602050781" angle="0.0034779999405145645"/>
+                <iidm:bus id="_FTILL511_TN" name="FTILL511" v="406.4404602050781" angle="0.0034779999405145645"/>
                 <iidm:switch id="_FTILL511-FTILL512-A_SW" name="FTILL511-FTILL512-A" kind="BREAKER" retained="true" open="false" bus1="_FTILL511_TN" bus2="_FTILL512_TN"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_FTILLC51_EC" name="FTILLC51" loadType="UNDEFINED" p0="480.0" q0="4.800000190734863" bus="_FTILL511_TN" connectableBus="_FTILL511_TN" p="480.0" q="4.800000190734863"/>
@@ -92,8 +92,8 @@
     <iidm:substation id="_FVALDI11_SS" name="FVALDI11_SS" geographicalTags="_SGR_07">
         <iidm:voltageLevel id="_FVALDI11_VL" name="FVALDI11_VL" nominalV="380.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_FVALDI12_TN" v="406.45001220703125" angle="0.03119100071489811"/>
-                <iidm:bus id="_FVALDI11_TN" v="406.45001220703125" angle="0.03119100071489811"/>
+                <iidm:bus id="_FVALDI12_TN" name="FVALDI12" v="406.45001220703125" angle="0.03119100071489811"/>
+                <iidm:bus id="_FVALDI11_TN" name="FVALDI11" v="406.45001220703125" angle="0.03119100071489811"/>
                 <iidm:switch id="_FVALDI11-FVALDI12-A_SW" name="FVALDI11-FVALDI12-A" kind="BREAKER" retained="true" open="false" bus1="_FVALDI11_TN" bus2="_FVALDI12_TN"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_FVALDT11_SM" name="FVALDT11" energySource="OTHER" minP="400.0" maxP="1200.0" voltageRegulatorOn="true" targetP="480.0060119628906" targetV="406.45001220703125" targetQ="6.419357776641846" bus="_FVALDI11_TN" connectableBus="_FVALDI11_TN" p="-480.0060119628906" q="-6.419357776641846">
@@ -104,8 +104,8 @@
     <iidm:substation id="_FVERGE11_SS" name="FVERGE11_SS" geographicalTags="_SGR_07">
         <iidm:voltageLevel id="_FVERGE11_VL" name="FVERGE11_VL" nominalV="380.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_FVERGE12_TN" v="406.45001220703125" angle="0.0"/>
-                <iidm:bus id="_FVERGE11_TN" v="406.45001220703125" angle="0.0"/>
+                <iidm:bus id="_FVERGE12_TN" name="FVERGE12" v="406.45001220703125" angle="0.0"/>
+                <iidm:bus id="_FVERGE11_TN" name="FVERGE11" v="406.45001220703125" angle="0.0"/>
                 <iidm:switch id="_FVERGE11-FVERGE12-A_SW" name="FVERGE11-FVERGE12-A" kind="BREAKER" retained="true" open="false" bus1="_FVERGE11_TN" bus2="_FVERGE12_TN"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_FVERGT11_SM" name="FVERGT11" energySource="OTHER" minP="-9999.0" maxP="9999.0" voltageRegulatorOn="true" targetP="-0.002566999988630414" targetV="406.45001220703125" targetQ="7.002781867980957" bus="_FVERGE11_TN" connectableBus="_FVERGE11_TN" p="0.002566999988630414" q="-7.002781867980957">

--- a/cgmes/cgmes-conversion/src/test/resources/cim14/ieee14.xiidm
+++ b/cgmes/cgmes-conversion/src/test/resources/cim14/ieee14.xiidm
@@ -3,7 +3,7 @@
     <iidm:substation id="_BUS___10_SS" name="BUS   10_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS___10_VL" name="BUS   10_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS___10_TN" v="14.524100303649902" angle="-15.113293647766113"/>
+                <iidm:bus id="_BUS___10_TN" name="BUS   10" v="14.524100303649902" angle="-15.113293647766113"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD__10_EC" name="LOAD  10" loadType="UNDEFINED" p0="9.0" q0="5.800000190734863" bus="_BUS___10_TN" connectableBus="_BUS___10_TN" p="9.0" q="5.800000190734863"/>
         </iidm:voltageLevel>
@@ -11,7 +11,7 @@
     <iidm:substation id="_BUS___11_SS" name="BUS   11_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS___11_VL" name="BUS   11_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS___11_TN" v="14.59589958190918" angle="-14.809061050415039"/>
+                <iidm:bus id="_BUS___11_TN" name="BUS   11" v="14.59589958190918" angle="-14.809061050415039"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD__11_EC" name="LOAD  11" loadType="UNDEFINED" p0="3.5" q0="1.7999999523162842" bus="_BUS___11_TN" connectableBus="_BUS___11_TN" p="3.5" q="1.7999999523162842"/>
         </iidm:voltageLevel>
@@ -19,7 +19,7 @@
     <iidm:substation id="_BUS___12_SS" name="BUS   12_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS___12_VL" name="BUS   12_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS___12_TN" v="14.563400268554688" angle="-15.092975616455078"/>
+                <iidm:bus id="_BUS___12_TN" name="BUS   12" v="14.563400268554688" angle="-15.092975616455078"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD__12_EC" name="LOAD  12" loadType="UNDEFINED" p0="6.099999904632568" q0="1.600000023841858" bus="_BUS___12_TN" connectableBus="_BUS___12_TN" p="6.099999904632568" q="1.600000023841858"/>
         </iidm:voltageLevel>
@@ -27,7 +27,7 @@
     <iidm:substation id="_BUS___13_SS" name="BUS   13_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS___13_VL" name="BUS   13_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS___13_TN" v="14.49899959564209" angle="-15.174944877624512"/>
+                <iidm:bus id="_BUS___13_TN" name="BUS   13" v="14.49899959564209" angle="-15.174944877624512"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD__13_EC" name="LOAD  13" loadType="UNDEFINED" p0="13.5" q0="5.800000190734863" bus="_BUS___13_TN" connectableBus="_BUS___13_TN" p="13.5" q="5.800000190734863"/>
         </iidm:voltageLevel>
@@ -35,7 +35,7 @@
     <iidm:substation id="_BUS___14_SS" name="BUS   14_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS___14_VL" name="BUS   14_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS___14_TN" v="14.30620002746582" angle="-16.048330307006836"/>
+                <iidm:bus id="_BUS___14_TN" name="BUS   14" v="14.30620002746582" angle="-16.048330307006836"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD__14_EC" name="LOAD  14" loadType="UNDEFINED" p0="14.899999618530273" q0="5.0" bus="_BUS___14_TN" connectableBus="_BUS___14_TN" p="14.899999618530273" q="5.0"/>
         </iidm:voltageLevel>
@@ -43,7 +43,7 @@
     <iidm:substation id="_BUS____1_SS" name="BUS    1_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS____1_VL" name="BUS    1_VL" nominalV="69.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS____1_TN" v="73.13999938964844" angle="0.0"/>
+                <iidm:bus id="_BUS____1_TN" name="BUS    1" v="73.13999938964844" angle="0.0"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_GEN____1_SM" name="GEN    1" energySource="OTHER" minP="-9999.0" maxP="9999.0" voltageRegulatorOn="true" targetP="232.3699951171875" targetV="73.13999938964844" targetQ="-17.26449966430664" bus="_BUS____1_TN" connectableBus="_BUS____1_TN" p="-232.3699951171875" q="17.26449966430664">
                 <iidm:minMaxReactiveLimits minQ="-999.0" maxQ="999.0"/>
@@ -53,7 +53,7 @@
     <iidm:substation id="_BUS____2_SS" name="BUS    2_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS____2_VL" name="BUS    2_VL" nominalV="69.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS____2_TN" v="72.1050033569336" angle="-4.979506969451904"/>
+                <iidm:bus id="_BUS____2_TN" name="BUS    2" v="72.1050033569336" angle="-4.979506969451904"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_GEN____2_SM" name="GEN    2" energySource="OTHER" minP="-9999.0" maxP="9999.0" voltageRegulatorOn="true" targetP="40.0" targetV="72.1050033569336" targetQ="42.1343994140625" bus="_BUS____2_TN" connectableBus="_BUS____2_TN" p="-40.0" q="-42.1343994140625">
                 <iidm:minMaxReactiveLimits minQ="-40.0" maxQ="50.0"/>
@@ -64,7 +64,7 @@
     <iidm:substation id="_BUS____3_SS" name="BUS    3_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS____3_VL" name="BUS    3_VL" nominalV="69.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS____3_TN" v="69.69000244140625" angle="-12.716755867004395"/>
+                <iidm:bus id="_BUS____3_TN" name="BUS    3" v="69.69000244140625" angle="-12.716755867004395"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_GEN____3_SM" name="GEN    3" energySource="OTHER" minP="-9999.0" maxP="9999.0" voltageRegulatorOn="true" targetP="-0.0" targetV="69.69000244140625" targetQ="24.587400436401367" bus="_BUS____3_TN" connectableBus="_BUS____3_TN" p="0.0" q="-24.587400436401367">
                 <iidm:minMaxReactiveLimits minQ="0.0" maxQ="40.0"/>
@@ -75,7 +75,7 @@
     <iidm:substation id="_BUS____4_SS" name="BUS    4_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS____9_VL" name="BUS    9_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS____9_TN" v="14.596500396728516" angle="-14.953522682189941"/>
+                <iidm:bus id="_BUS____9_TN" name="BUS    9" v="14.596500396728516" angle="-14.953522682189941"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD___9_EC" name="LOAD   9" loadType="UNDEFINED" p0="29.5" q0="16.600000381469727" bus="_BUS____9_TN" connectableBus="_BUS____9_TN" p="29.5" q="16.600000381469727"/>
             <iidm:shunt id="_BANK___9_SC" name="BANK   9" sectionCount="1" voltageRegulatorOn="false" bus="_BUS____9_TN" connectableBus="_BUS____9_TN">
@@ -84,12 +84,12 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_BUS____7_VL" name="BUS    7_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS____7_TN" v="14.656100273132324" angle="-13.3749361038208"/>
+                <iidm:bus id="_BUS____7_TN" name="BUS    7" v="14.656100273132324" angle="-13.3749361038208"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_BUS____4_VL" name="BUS    4_VL" nominalV="69.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS____4_TN" v="70.27559661865234" angle="-10.319840431213379"/>
+                <iidm:bus id="_BUS____4_TN" name="BUS    4" v="70.27559661865234" angle="-10.319840431213379"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD___4_EC" name="LOAD   4" loadType="UNDEFINED" p0="47.79999923706055" q0="-3.9000000953674316" bus="_BUS____4_TN" connectableBus="_BUS____4_TN" p="47.79999923706055" q="-3.9000000953674316"/>
         </iidm:voltageLevel>
@@ -131,7 +131,7 @@
     <iidm:substation id="_BUS____5_SS" name="BUS    5_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS____6_VL" name="BUS    6_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS____6_TN" v="14.765999794006348" angle="-14.239948272705078"/>
+                <iidm:bus id="_BUS____6_TN" name="BUS    6" v="14.765999794006348" angle="-14.239948272705078"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_GEN____6_SM" name="GEN    6" energySource="OTHER" minP="-9999.0" maxP="9999.0" voltageRegulatorOn="true" targetP="-0.0" targetV="14.765999794006348" targetQ="15.40820026397705" bus="_BUS____6_TN" connectableBus="_BUS____6_TN" p="0.0" q="-15.40820026397705">
                 <iidm:minMaxReactiveLimits minQ="-6.0" maxQ="24.0"/>
@@ -140,7 +140,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_BUS____5_VL" name="BUS    5_VL" nominalV="69.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS____5_TN" v="70.4552001953125" angle="-8.789777755737305"/>
+                <iidm:bus id="_BUS____5_TN" name="BUS    5" v="70.4552001953125" angle="-8.789777755737305"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD___5_EC" name="LOAD   5" loadType="UNDEFINED" p0="7.599999904632568" q0="1.600000023841858" bus="_BUS____5_TN" connectableBus="_BUS____5_TN" p="7.599999904632568" q="1.600000023841858"/>
         </iidm:voltageLevel>
@@ -165,7 +165,7 @@
     <iidm:substation id="_BUS____8_SS" name="BUS    8_SS" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_BUS____8_VL" name="BUS    8_VL" nominalV="13.800000190734863" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_BUS____8_TN" v="15.041999816894531" angle="-13.3749361038208"/>
+                <iidm:bus id="_BUS____8_TN" name="BUS    8" v="15.041999816894531" angle="-13.3749361038208"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_GEN____8_SM" name="GEN    8" energySource="OTHER" minP="-9999.0" maxP="9999.0" voltageRegulatorOn="true" targetP="-0.0" targetV="15.041999816894531" targetQ="17.30500030517578" bus="_BUS____8_TN" connectableBus="_BUS____8_TN" p="0.0" q="-17.30500030517578">
                 <iidm:minMaxReactiveLimits minQ="-6.0" maxQ="24.0"/>

--- a/cgmes/cgmes-conversion/src/test/resources/cim14/nordic32.xiidm
+++ b/cgmes/cgmes-conversion/src/test/resources/cim14/nordic32.xiidm
@@ -3,7 +3,7 @@
     <iidm:substation id="_N1011____SS" name="N1011   _SS" country="NO" geographicalTags="_SGR_13">
         <iidm:voltageLevel id="_NG9______VL" name="NG9     _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG9______TN" v="15.0" angle="0.0"/>
+                <iidm:bus id="_NG9______TN" name="NG9" v="15.0" angle="0.0"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G9_______SM" name="G9      " energySource="OTHER" minP="-20000.0" maxP="20000.0" voltageRegulatorOn="true" targetP="565.8359985351562" targetV="15.0" targetQ="13.823800086975098" bus="_NG9______TN" connectableBus="_NG9______TN" p="-565.8359985351562" q="-13.823800086975098">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -11,12 +11,12 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4011____VL" name="N4011   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4011____TN" v="381.7569885253906" angle="-5.357859134674072"/>
+                <iidm:bus id="_N4011____TN" name="N4011" v="381.7569885253906" angle="-5.357859134674072"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1011____VL" name="N1011   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1011____TN" v="118.47100067138672" angle="-4.263614177703857"/>
+                <iidm:bus id="_N1011____TN" name="N1011" v="118.47100067138672" angle="-4.263614177703857"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1011____EC" name="N1011   " loadType="UNDEFINED" p0="200.0" q0="80.0" bus="_N1011____TN" connectableBus="_N1011____TN" p="200.0" q="80.0"/>
         </iidm:voltageLevel>
@@ -32,7 +32,7 @@
     <iidm:substation id="_N1012____SS" name="N1012   _SS" country="NO" geographicalTags="_SGR_13">
         <iidm:voltageLevel id="_NG1______VL" name="NG1     _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG1______TN" v="16.025999069213867" angle="6.043698787689209"/>
+                <iidm:bus id="_NG1______TN" name="NG1" v="16.025999069213867" angle="6.043698787689209"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G1_______SM" name="G1      " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="600.0" targetV="16.025999069213867" targetQ="654.0869750976562" bus="_NG1______TN" connectableBus="_NG1______TN" p="-600.0" q="-654.0869750976562">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -40,7 +40,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_NG10_____VL" name="NG10    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG10_____TN" v="15.23550033569336" angle="3.7609670162200928"/>
+                <iidm:bus id="_NG10_____TN" name="NG10" v="15.23550033569336" angle="3.7609670162200928"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G10______SM" name="G10     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="600.0" targetV="15.23550033569336" targetQ="8.778579711914062" bus="_NG10_____TN" connectableBus="_NG10_____TN" p="-600.0" q="-8.778579711914062">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -48,7 +48,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4012____VL" name="N4012   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4012____TN" v="389.052001953125" angle="-3.1062989234924316"/>
+                <iidm:bus id="_N4012____TN" name="N4012" v="389.052001953125" angle="-3.1062989234924316"/>
             </iidm:busBreakerTopology>
             <iidm:shunt id="_N4012____SC" name="N4012   " sectionCount="1" voltageRegulatorOn="false" bus="_N4012____TN" connectableBus="_N4012____TN">
                 <iidm:shuntLinearModel bPerSection="-6.249999860301614E-4" gPerSection="0.0" maximumSectionCount="1"/>
@@ -56,7 +56,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1012____VL" name="N1012   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1012____TN" v="124.7229995727539" angle="-0.2573759853839874"/>
+                <iidm:bus id="_N1012____TN" name="N1012" v="124.7229995727539" angle="-0.2573759853839874"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1012____EC" name="N1012   " loadType="UNDEFINED" p0="300.0" q0="100.0" bus="_N1012____TN" connectableBus="_N1012____TN" p="300.0" q="100.0"/>
         </iidm:voltageLevel>
@@ -76,7 +76,7 @@
     <iidm:substation id="_N1022____SS" name="N1022   _SS" country="NO" geographicalTags="_SGR_13">
         <iidm:voltageLevel id="_NG5______VL" name="NG5     _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG5______TN" v="15.440999984741211" angle="-9.349656105041504"/>
+                <iidm:bus id="_NG5______TN" name="NG5" v="15.440999984741211" angle="-9.349656105041504"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G5_______SM" name="G5      " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="200.0" targetV="15.440999984741211" targetQ="226.20899963378906" bus="_NG5______TN" connectableBus="_NG5______TN" p="-200.0" q="-226.20899963378906">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -84,12 +84,12 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4022____VL" name="N4022   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4022____TN" v="361.79400634765625" angle="-20.041955947875977"/>
+                <iidm:bus id="_N4022____TN" name="N4022" v="361.79400634765625" angle="-20.041955947875977"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1022____VL" name="N1022   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1022____TN" v="110.60600280761719" angle="-17.621028900146484"/>
+                <iidm:bus id="_N1022____TN" name="N1022" v="110.60600280761719" angle="-17.621028900146484"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1022____EC" name="N1022   " loadType="UNDEFINED" p0="280.0" q0="95.0" bus="_N1022____TN" connectableBus="_N1022____TN" p="280.0" q="95.0"/>
             <iidm:shunt id="_N1022____SC" name="N1022   " sectionCount="1" voltageRegulatorOn="false" bus="_N1022____TN" connectableBus="_N1022____TN">
@@ -108,7 +108,7 @@
     <iidm:substation id="_N1041____SS" name="N1041   _SS" country="NO" geographicalTags="_SGR_13">
         <iidm:voltageLevel id="_N1041____VL" name="N1041   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1041____TN" v="110.677001953125" angle="-94.36389923095703"/>
+                <iidm:bus id="_N1041____TN" name="N1041" v="110.677001953125" angle="-94.36389923095703"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1041____EC" name="N1041   " loadType="UNDEFINED" p0="400.0" q0="180.0" bus="_N1041____TN" connectableBus="_N1041____TN" p="400.0" q="180.0"/>
             <iidm:shunt id="_N1041____SC" name="N1041   " sectionCount="1" voltageRegulatorOn="false" bus="_N1041____TN" connectableBus="_N1041____TN">
@@ -119,12 +119,12 @@
     <iidm:substation id="_N1044____SS" name="N1044   _SS" country="NO" geographicalTags="_SGR_13">
         <iidm:voltageLevel id="_N4044____VL" name="N4044   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4044____TN" v="339.8810119628906" angle="-75.97722625732422"/>
+                <iidm:bus id="_N4044____TN" name="N4044" v="339.8810119628906" angle="-75.97722625732422"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1044____VL" name="N1044   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1044____TN" v="112.66100311279297" angle="-80.51592254638672"/>
+                <iidm:bus id="_N1044____TN" name="N1044" v="112.66100311279297" angle="-80.51592254638672"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1044____EC" name="N1044   " loadType="UNDEFINED" p0="840.0" q0="300.0" bus="_N1044____TN" connectableBus="_N1044____TN" p="840.0" q="300.0"/>
             <iidm:shunt id="_N1044____SC" name="N1044   " sectionCount="1" voltageRegulatorOn="false" bus="_N1044____TN" connectableBus="_N1044____TN">
@@ -143,12 +143,12 @@
     <iidm:substation id="_N1045____SS" name="N1045   _SS" country="NO" geographicalTags="_SGR_13">
         <iidm:voltageLevel id="_N4045____VL" name="N4045   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4045____TN" v="345.0270080566406" angle="-82.18965148925781"/>
+                <iidm:bus id="_N4045____TN" name="N4045" v="345.0270080566406" angle="-82.18965148925781"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1045____VL" name="N1045   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1045____TN" v="115.51200103759766" angle="-85.65843200683594"/>
+                <iidm:bus id="_N1045____TN" name="N1045" v="115.51200103759766" angle="-85.65843200683594"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1045____EC" name="N1045   " loadType="UNDEFINED" p0="720.0" q0="230.0" bus="_N1045____TN" connectableBus="_N1045____TN" p="720.0" q="230.0"/>
             <iidm:shunt id="_N1045____SC" name="N1045   " sectionCount="1" voltageRegulatorOn="false" bus="_N1045____TN" connectableBus="_N1045____TN">
@@ -167,7 +167,7 @@
     <iidm:substation id="_N2031____SS" name="N2031   _SS" country="BE" geographicalTags="_SGR_22">
         <iidm:voltageLevel id="_NG12_____VL" name="NG12    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG12_____TN" v="15.694499969482422" angle="-34.04362106323242"/>
+                <iidm:bus id="_NG12_____TN" name="NG12" v="15.694499969482422" angle="-34.04362106323242"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G12______SM" name="G12     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="310.0" targetV="15.694499969482422" targetQ="279.2359924316406" bus="_NG12_____TN" connectableBus="_NG12_____TN" p="-310.0" q="-279.2359924316406">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -175,12 +175,12 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4031____VL" name="N4031   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4031____TN" v="354.5920104980469" angle="-42.69413757324219"/>
+                <iidm:bus id="_N4031____TN" name="N4031" v="354.5920104980469" angle="-42.69413757324219"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N2031____VL" name="N2031   _VL" nominalV="220.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N2031____TN" v="193.55999755859375" angle="-38.91523361206055"/>
+                <iidm:bus id="_N2031____TN" name="N2031" v="193.55999755859375" angle="-38.91523361206055"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N2031____EC" name="N2031   " loadType="UNDEFINED" p0="100.0" q0="30.0" bus="_N2031____TN" connectableBus="_N2031____TN" p="100.0" q="30.0"/>
         </iidm:voltageLevel>
@@ -196,14 +196,14 @@
     <iidm:substation id="_N4032____SS" name="N4032   _SS" country="DK" geographicalTags="_SGR_40">
         <iidm:voltageLevel id="_N4032____VL" name="N4032   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4032____TN" v="352.6319885253906" angle="-49.30524444580078"/>
+                <iidm:bus id="_N4032____TN" name="N4032" v="352.6319885253906" angle="-49.30524444580078"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="_N4043____SS" name="N4043   _SS" country="DK" geographicalTags="_SGR_40">
         <iidm:voltageLevel id="_N4043____VL" name="N4043   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4043____TN" v="343.68499755859375" angle="-75.2749252319336"/>
+                <iidm:bus id="_N4043____TN" name="N4043" v="343.68499755859375" angle="-75.2749252319336"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4043____EC" name="N4043   " loadType="UNDEFINED" p0="900.0" q0="303.20001220703125" bus="_N4043____TN" connectableBus="_N4043____TN" p="900.0" q="303.20001220703125"/>
             <iidm:shunt id="_N4043____SC" name="N4043   " sectionCount="1" voltageRegulatorOn="false" bus="_N4043____TN" connectableBus="_N4043____TN">
@@ -214,7 +214,7 @@
     <iidm:substation id="_N4046____SS" name="N4046   _SS" country="DK" geographicalTags="_SGR_40">
         <iidm:voltageLevel id="_N4046____VL" name="N4046   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4046____TN" v="346.0889892578125" angle="-76.19192504882812"/>
+                <iidm:bus id="_N4046____TN" name="N4046" v="346.0889892578125" angle="-76.19192504882812"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4046____EC" name="N4046   " loadType="UNDEFINED" p0="700.0" q0="250.0" bus="_N4046____TN" connectableBus="_N4046____TN" p="700.0" q="250.0"/>
             <iidm:shunt id="_N4046____SC" name="N4046   " sectionCount="1" voltageRegulatorOn="false" bus="_N4046____TN" connectableBus="_N4046____TN">
@@ -225,7 +225,7 @@
     <iidm:substation id="_N4061____SS" name="N4061   _SS" country="DK" geographicalTags="_SGR_40">
         <iidm:voltageLevel id="_N4061____VL" name="N4061   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4061____TN" v="354.6520080566406" angle="-67.66624450683594"/>
+                <iidm:bus id="_N4061____TN" name="N4061" v="354.6520080566406" angle="-67.66624450683594"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4061____EC" name="N4061   " loadType="UNDEFINED" p0="500.0" q0="149.0" bus="_N4061____TN" connectableBus="_N4061____TN" p="500.0" q="149.0"/>
         </iidm:voltageLevel>
@@ -233,7 +233,7 @@
     <iidm:substation id="_NG11_____SS" name="NG11    _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG11_____VL" name="NG11    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG11_____TN" v="15.316499710083008" angle="-30.300371170043945"/>
+                <iidm:bus id="_NG11_____TN" name="NG11" v="15.316499710083008" angle="-30.300371170043945"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G11______SM" name="G11     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="250.0" targetV="15.316499710083008" targetQ="159.67799377441406" bus="_NG11_____TN" connectableBus="_NG11_____TN" p="-250.0" q="-159.67799377441406">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -241,7 +241,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4021____VL" name="N4021   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4021____TN" v="359.85101318359375" angle="-38.514652252197266"/>
+                <iidm:bus id="_N4021____TN" name="N4021" v="359.85101318359375" angle="-38.514652252197266"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_NG11____-N4021___-1_PT" name="NG11    -N4021   -1" r="0.0" x="79.99981689453125" g="0.0" b="0.0" ratedU1="15.0" ratedU2="380.9599914550781" bus1="_NG11_____TN" connectableBus1="_NG11_____TN" voltageLevelId1="_NG11_____VL" bus2="_N4021____TN" connectableBus2="_N4021____TN" voltageLevelId2="_N4021____VL">
@@ -252,7 +252,7 @@
     <iidm:substation id="_NG13_____SS" name="NG13    _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG13_____VL" name="NG13    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG13_____TN" v="15.255000114440918" angle="-62.66741180419922"/>
+                <iidm:bus id="_NG13_____TN" name="NG13" v="15.255000114440918" angle="-62.66741180419922"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G13______SM" name="G13     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="-0.0" targetV="15.255000114440918" targetQ="249.27999877929688" bus="_NG13_____TN" connectableBus="_NG13_____TN" p="0.0" q="-249.27999877929688">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -260,7 +260,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4041____VL" name="N4041   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4041____TN" v="353.125" angle="-62.66741180419922"/>
+                <iidm:bus id="_N4041____TN" name="N4041" v="353.125" angle="-62.66741180419922"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4041____EC" name="N4041   " loadType="UNDEFINED" p0="540.0" q0="160.0" bus="_N4041____TN" connectableBus="_N4041____TN" p="540.0" q="160.0"/>
             <iidm:shunt id="_N4041____SC" name="N4041   " sectionCount="1" voltageRegulatorOn="false" bus="_N4041____TN" connectableBus="_N4041____TN">
@@ -275,7 +275,7 @@
     <iidm:substation id="_NG14_____SS" name="NG14    _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG14_____VL" name="NG14    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG14_____TN" v="15.680999755859375" angle="-57.85282897949219"/>
+                <iidm:bus id="_NG14_____TN" name="NG14" v="15.680999755859375" angle="-57.85282897949219"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G14______SM" name="G14     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="630.0" targetV="15.680999755859375" targetQ="621.416015625" bus="_NG14_____TN" connectableBus="_NG14_____TN" p="-630.0" q="-621.416015625">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -283,7 +283,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4042____VL" name="N4042   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4042____TN" v="348.9949951171875" angle="-66.79387664794922"/>
+                <iidm:bus id="_N4042____TN" name="N4042" v="348.9949951171875" angle="-66.79387664794922"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4042____EC" name="N4042   " loadType="UNDEFINED" p0="400.0" q0="149.39999389648438" bus="_N4042____TN" connectableBus="_N4042____TN" p="400.0" q="149.39999389648438"/>
         </iidm:voltageLevel>
@@ -295,7 +295,7 @@
     <iidm:substation id="_NG15_____SS" name="NG15    _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG15_____VL" name="NG15    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG15_____TN" v="15.682499885559082" angle="-61.41239929199219"/>
+                <iidm:bus id="_NG15_____TN" name="NG15" v="15.682499885559082" angle="-61.41239929199219"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G15______SM" name="G15     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="1080.0" targetV="15.682499885559082" targetQ="733.7080078125" bus="_NG15_____TN" connectableBus="_NG15_____TN" p="-1080.0" q="-733.7080078125">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -303,7 +303,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4047____VL" name="N4047   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4047____TN" v="365.49700927734375" angle="-69.94529724121094"/>
+                <iidm:bus id="_N4047____TN" name="N4047" v="365.49700927734375" angle="-69.94529724121094"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4047____EC" name="N4047   " loadType="UNDEFINED" p0="100.0" q0="50.0" bus="_N4047____TN" connectableBus="_N4047____TN" p="100.0" q="50.0"/>
         </iidm:voltageLevel>
@@ -315,7 +315,7 @@
     <iidm:substation id="_NG16_____SS" name="NG16    _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG16_____VL" name="NG16    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG16_____TN" v="15.796500205993652" angle="-77.35078430175781"/>
+                <iidm:bus id="_NG16_____TN" name="NG16" v="15.796500205993652" angle="-77.35078430175781"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G16______SM" name="G16     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="600.0" targetV="15.796500205993652" targetQ="483.47100830078125" bus="_NG16_____TN" connectableBus="_NG16_____TN" p="-600.0" q="-483.47100830078125">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -323,7 +323,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4051____VL" name="N4051   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4051____TN" v="363.5039978027344" angle="-85.46057891845703"/>
+                <iidm:bus id="_N4051____TN" name="N4051" v="363.5039978027344" angle="-85.46057891845703"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4051____EC" name="N4051   " loadType="UNDEFINED" p0="800.0" q0="302.3999938964844" bus="_N4051____TN" connectableBus="_N4051____TN" p="800.0" q="302.3999938964844"/>
             <iidm:shunt id="_N4051____SC" name="N4051   " sectionCount="1" voltageRegulatorOn="false" bus="_N4051____TN" connectableBus="_N4051____TN">
@@ -338,7 +338,7 @@
     <iidm:substation id="_NG17_____SS" name="NG17    _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG17_____VL" name="NG17    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG17_____TN" v="15.137999534606934" angle="-54.26876449584961"/>
+                <iidm:bus id="_NG17_____TN" name="NG17" v="15.137999534606934" angle="-54.26876449584961"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G17______SM" name="G17     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="530.0" targetV="15.137999534606934" targetQ="189.6269989013672" bus="_NG17_____TN" connectableBus="_NG17_____TN" p="-530.0" q="-189.6269989013672">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -346,7 +346,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4062____VL" name="N4062   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4062____TN" v="368.8800048828125" angle="-62.865760803222656"/>
+                <iidm:bus id="_N4062____TN" name="N4062" v="368.8800048828125" angle="-62.865760803222656"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4062____EC" name="N4062   " loadType="UNDEFINED" p0="300.0" q0="100.0" bus="_N4062____TN" connectableBus="_N4062____TN" p="300.0" q="100.0"/>
         </iidm:voltageLevel>
@@ -358,7 +358,7 @@
     <iidm:substation id="_NG18_____SS" name="NG18    _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG18_____VL" name="NG18    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG18_____TN" v="15.46049976348877" angle="-49.925662994384766"/>
+                <iidm:bus id="_NG18_____TN" name="NG18" v="15.46049976348877" angle="-49.925662994384766"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G18______SM" name="G18     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="1060.0" targetV="15.46049976348877" targetQ="443.7669982910156" bus="_NG18_____TN" connectableBus="_NG18_____TN" p="-1060.0" q="-443.7669982910156">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -366,7 +366,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4063____VL" name="N4063   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4063____TN" v="373.9700012207031" angle="-58.22666931152344"/>
+                <iidm:bus id="_N4063____TN" name="N4063" v="373.9700012207031" angle="-58.22666931152344"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4063____EC" name="N4063   " loadType="UNDEFINED" p0="590.0" q0="300.0" bus="_N4063____TN" connectableBus="_N4063____TN" p="590.0" q="300.0"/>
         </iidm:voltageLevel>
@@ -378,7 +378,7 @@
     <iidm:substation id="_NG19_____SS" name="NG19    _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG19_____VL" name="NG19    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG19_____TN" v="15.449999809265137" angle="3.17626690864563"/>
+                <iidm:bus id="_NG19_____TN" name="NG19" v="15.449999809265137" angle="3.17626690864563"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G19______SM" name="G19     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="300.0" targetV="15.449999809265137" targetQ="82.3125991821289" bus="_NG19_____TN" connectableBus="_NG19_____TN" p="-300.0" q="-82.3125991821289">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -386,7 +386,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4071____VL" name="N4071   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4071____TN" v="384.0769958496094" angle="-2.306674003601074"/>
+                <iidm:bus id="_N4071____TN" name="N4071" v="384.0769958496094" angle="-2.306674003601074"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4071____EC" name="N4071   " loadType="UNDEFINED" p0="300.0" q0="100.0" bus="_N4071____TN" connectableBus="_N4071____TN" p="300.0" q="100.0"/>
             <iidm:shunt id="_N4071____SC" name="N4071   " sectionCount="1" voltageRegulatorOn="false" bus="_N4071____TN" connectableBus="_N4071____TN">
@@ -401,7 +401,7 @@
     <iidm:substation id="_NG20_____SS" name="NG20    _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG20_____VL" name="NG20    _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG20_____TN" v="15.27750015258789" angle="3.315453052520752"/>
+                <iidm:bus id="_NG20_____TN" name="NG20" v="15.27750015258789" angle="3.315453052520752"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G20______SM" name="G20     " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="2132.5" targetV="15.27750015258789" targetQ="375.85101318359375" bus="_NG20_____TN" connectableBus="_NG20_____TN" p="-2132.5" q="-375.85101318359375">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -409,7 +409,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N4072____VL" name="N4072   _VL" nominalV="400.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N4072____TN" v="383.9649963378906" angle="-1.0584160089492798"/>
+                <iidm:bus id="_N4072____TN" name="N4072" v="383.9649963378906" angle="-1.0584160089492798"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N4072____EC" name="N4072   " loadType="UNDEFINED" p0="2000.0" q0="500.0" bus="_N4072____TN" connectableBus="_N4072____TN" p="2000.0" q="500.0"/>
         </iidm:voltageLevel>
@@ -421,7 +421,7 @@
     <iidm:substation id="_NG2______SS" name="NG2     _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG2______VL" name="NG2     _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG2______TN" v="15.84749984741211" angle="8.6207275390625"/>
+                <iidm:bus id="_NG2______TN" name="NG2" v="15.84749984741211" angle="8.6207275390625"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G2_______SM" name="G2      " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="300.0" targetV="15.84749984741211" targetQ="251.48300170898438" bus="_NG2______TN" connectableBus="_NG2______TN" p="-300.0" q="-251.48300170898438">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -429,7 +429,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1013____VL" name="N1013   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1013____TN" v="129.93699645996094" angle="4.547952175140381"/>
+                <iidm:bus id="_N1013____TN" name="N1013" v="129.93699645996094" angle="4.547952175140381"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1013____EC" name="N1013   " loadType="UNDEFINED" p0="100.0" q0="40.0" bus="_N1013____TN" connectableBus="_N1013____TN" p="100.0" q="40.0"/>
         </iidm:voltageLevel>
@@ -441,7 +441,7 @@
     <iidm:substation id="_NG3______SS" name="NG3     _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG3______VL" name="NG3     _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG3______TN" v="15.892499923706055" angle="13.968607902526855"/>
+                <iidm:bus id="_NG3______TN" name="NG3" v="15.892499923706055" angle="13.968607902526855"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G3_______SM" name="G3      " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="550.0" targetV="15.892499923706055" targetQ="227.73500061035156" bus="_NG3______TN" connectableBus="_NG3______TN" p="-550.0" q="-227.73500061035156">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -449,7 +449,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1014____VL" name="N1014   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1014____TN" v="132.53799438476562" angle="7.704280853271484"/>
+                <iidm:bus id="_N1014____TN" name="N1014" v="132.53799438476562" angle="7.704280853271484"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_NG3_____-N1014___-1_PT" name="NG3     -N1014   -1" r="0.0" x="3.6216702461242676" g="0.0" b="0.0" ratedU1="15.0" ratedU2="130.0" bus1="_NG3______TN" connectableBus1="_NG3______TN" voltageLevelId1="_NG3______VL" bus2="_N1014____TN" connectableBus2="_N1014____TN" voltageLevelId2="_N1014____VL">
@@ -460,7 +460,7 @@
     <iidm:substation id="_NG4______SS" name="NG4     _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG4______VL" name="NG4     _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG4______TN" v="15.508500099182129" angle="14.51465892791748"/>
+                <iidm:bus id="_NG4______TN" name="NG4" v="15.508500099182129" angle="14.51465892791748"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G4_______SM" name="G4      " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="400.0" targetV="15.508500099182129" targetQ="208.8249969482422" bus="_NG4______TN" connectableBus="_NG4______TN" p="-400.0" q="-208.8249969482422">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -468,7 +468,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1021____VL" name="N1021   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1021____TN" v="128.4600067138672" angle="8.89749813079834"/>
+                <iidm:bus id="_N1021____TN" name="N1021" v="128.4600067138672" angle="8.89749813079834"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="_NG4_____-N1021___-1_PT" name="NG4     -N1021   -1" r="0.0" x="4.224999904632568" g="0.0" b="0.0" ratedU1="15.0" ratedU2="130.0" bus1="_NG4______TN" connectableBus1="_NG4______TN" voltageLevelId1="_NG4______VL" bus2="_N1021____TN" connectableBus2="_N1021____TN" voltageLevelId2="_N1021____VL">
@@ -479,7 +479,7 @@
     <iidm:substation id="_NG6______SS" name="NG6     _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG6______VL" name="NG6     _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG6______TN" v="15.12600040435791" angle="-71.39446258544922"/>
+                <iidm:bus id="_NG6______TN" name="NG6" v="15.12600040435791" angle="-71.39446258544922"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G6_______SM" name="G6      " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="360.0" targetV="15.12600040435791" targetQ="172.55499267578125" bus="_NG6______TN" connectableBus="_NG6______TN" p="-360.0" q="-172.55499267578125">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -487,7 +487,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1042____VL" name="N1042   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1042____TN" v="117.52200317382812" angle="-80.3396987915039"/>
+                <iidm:bus id="_N1042____TN" name="N1042" v="117.52200317382812" angle="-80.3396987915039"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1042____EC" name="N1042   " loadType="UNDEFINED" p0="330.0" q0="90.0" bus="_N1042____TN" connectableBus="_N1042____TN" p="330.0" q="90.0"/>
         </iidm:voltageLevel>
@@ -499,7 +499,7 @@
     <iidm:substation id="_NG7______SS" name="NG7     _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG7______VL" name="NG7     _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG7______TN" v="15.21150016784668" angle="-80.41766357421875"/>
+                <iidm:bus id="_NG7______TN" name="NG7" v="15.21150016784668" angle="-80.41766357421875"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G7_______SM" name="G7      " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="180.0" targetV="15.21150016784668" targetQ="134.14300537109375" bus="_NG7______TN" connectableBus="_NG7______TN" p="-180.0" q="-134.14300537109375">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -507,7 +507,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N1043____VL" name="N1043   _VL" nominalV="130.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N1043____TN" v="113.4800033569336" angle="-89.6317367553711"/>
+                <iidm:bus id="_N1043____TN" name="N1043" v="113.4800033569336" angle="-89.6317367553711"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N1043____EC" name="N1043   " loadType="UNDEFINED" p0="260.0" q0="100.0" bus="_N1043____TN" connectableBus="_N1043____TN" p="260.0" q="100.0"/>
             <iidm:shunt id="_N1043____SC" name="N1043   " sectionCount="1" voltageRegulatorOn="false" bus="_N1043____TN" connectableBus="_N1043____TN">
@@ -522,7 +522,7 @@
     <iidm:substation id="_NG8______SS" name="NG8     _SS" country="FR" geographicalTags="_SGR_01">
         <iidm:voltageLevel id="_NG8______VL" name="NG8     _VL" nominalV="15.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_NG8______TN" v="15.746999740600586" angle="-14.407537460327148"/>
+                <iidm:bus id="_NG8______TN" name="NG8" v="15.746999740600586" angle="-14.407537460327148"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_G8_______SM" name="G8      " energySource="OTHER" minP="-9999.990234375" maxP="9999.990234375" voltageRegulatorOn="true" targetP="750.0" targetV="15.746999740600586" targetQ="322.73699951171875" bus="_NG8______TN" connectableBus="_NG8______TN" p="-750.0" q="-322.73699951171875">
                 <iidm:minMaxReactiveLimits minQ="-9999.990234375" maxQ="9999.990234375"/>
@@ -530,7 +530,7 @@
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_N2032____VL" name="N2032   _VL" nominalV="220.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_N2032____TN" v="209.46400451660156" angle="-22.400848388671875"/>
+                <iidm:bus id="_N2032____TN" name="N2032" v="209.46400451660156" angle="-22.400848388671875"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_N2032____EC" name="N2032   " loadType="UNDEFINED" p0="200.0" q0="50.0" bus="_N2032____TN" connectableBus="_N2032____TN" p="200.0" q="50.0"/>
         </iidm:voltageLevel>

--- a/cgmes/cgmes-conversion/src/test/resources/cim14/tx-from-microBE-adapted.xiidm
+++ b/cgmes/cgmes-conversion/src/test/resources/cim14/tx-from-microBE-adapted.xiidm
@@ -3,13 +3,13 @@
     <iidm:substation id="_37e14a0f-5e34-4647-a062-8bfd9305fa9d" name="PP_Brussels" geographicalTags="_c1d5bfc88f8011e08e4d00247eb1f55e">
         <iidm:voltageLevel id="_GRID_VL" name="GRID_VL" nominalV="110.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_GRID_TN" v="115.5" angle="-9.391329765319824"/>
+                <iidm:bus id="_GRID_TN" name="GRID" v="115.5" angle="-9.391329765319824"/>
             </iidm:busBreakerTopology>
             <iidm:load id="_LOAD" name="LOAD" loadType="UNDEFINED" p0="89.68599700927734" q0="-57.13199996948242" bus="_GRID_TN" connectableBus="_GRID_TN" p="89.68599700927734" q="-57.13199996948242"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_GEN_VL" name="GEN_VL" nominalV="10.5" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
-                <iidm:bus id="_GEN_TN" v="10.820804595947266" angle="-7.057179927825928"/>
+                <iidm:bus id="_GEN_TN" name="GEN" v="10.820804595947266" angle="-7.057179927825928"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="_BE-G1_SM" name="BE-G1" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="false" targetP="90.0" targetQ="-51.11600112915039" bus="_GEN_TN" connectableBus="_GEN_TN" p="-90.0" q="51.11600112915039">
                 <iidm:minMaxReactiveLimits minQ="-999.0" maxQ="999.0"/>

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -729,6 +729,7 @@ WHERE {
 { GRAPH ?graph {
     ?SynchronousMachine
         a cim:SynchronousMachine ;
+        cim:IdentifiedObject.name ?name ;
         cim:RotatingMachine.GeneratingUnit ?GeneratingUnit .
     OPTIONAL {
         ?SynchronousMachine cim:RotatingMachine.ratedS ?ratedS
@@ -738,7 +739,7 @@ WHERE {
         cim:GeneratingUnit.minOperatingP ?minP ;
         cim:GeneratingUnit.maxOperatingP ?maxP ;
         cim:GeneratingUnit.initialP ?initialP ;
-        cim:IdentifiedObject.name ?name .
+        cim:IdentifiedObject.name ?nameGeneratingUnit .
     ?Terminal cim:Terminal.ConductingEquipment ?SynchronousMachine .
     OPTIONAL { ?SynchronousMachine cim:SynchronousMachine.minQ ?minQ }
     OPTIONAL { ?SynchronousMachine cim:SynchronousMachine.maxQ ?maxQ }


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
CGMES import was modified to set `Network.Generator.name` from CGMES `SynchronousMachine` instead of `GeneratingUnit`.

The change in the name was introduced for enhancing consistency (name of `Generator` now comes from the CGMES `IdentifiedObject` that is converted to the IIDM generator, not from a grouping element that contains it) and to have more readable names in the reference conformity test cases.

An error in CGMES conversion tests was detected, while comparing names of elements imported from CGMES test cases against expected Network elements. The error was fixed and the unit tests were updated.
