### PR TITLE
Small fix in DanglingLine's notifications

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineImpl.java
@@ -164,7 +164,7 @@ class DanglingLineImpl extends AbstractConnectable<DanglingLine> implements Dang
 
     @Override
     public void setCurrentLimits(Void side, CurrentLimitsImpl limits) {
-        CurrentLimitsImpl oldValue = limits;
+        CurrentLimitsImpl oldValue = this.limits;
         this.limits = limits;
         notifyUpdate("currentlimits", oldValue, limits);
     }


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix in DL's notifications: the `oldValue` for current limits used not to be the actual previous value.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
