### PR TITLE
Fix file leak in CGMES import

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -12,6 +12,7 @@ import static com.powsybl.cgmes.model.CgmesNamespace.CIM_16_NAMESPACE;
 import static com.powsybl.cgmes.model.CgmesNamespace.RDF_NAMESPACE;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -74,8 +75,8 @@ public class CgmesOnDataSource {
     }
 
     private boolean containsValidNamespace(String name) {
-        try {
-            Set<String> ns = NamespaceReader.namespaces1(dataSource.newInputStream(name));
+        try (InputStream is = dataSource.newInputStream(name)) {
+            Set<String> ns = NamespaceReader.namespaces1(is);
             return ns.contains(RDF_NAMESPACE) && (ns.contains(CIM_16_NAMESPACE) || ns.contains(CIM_14_NAMESPACE));
         } catch (XMLStreamException e) {
             return false;
@@ -87,8 +88,8 @@ public class CgmesOnDataSource {
     public Set<String> namespaces() {
         Set<String> ns = new HashSet<>();
         names().forEach(n -> {
-            try {
-                ns.addAll(NamespaceReader.namespaces(dataSource.newInputStream(n)));
+            try (InputStream is = dataSource.newInputStream(n)) {
+                ns.addAll(NamespaceReader.namespaces(is));
             } catch (IOException x) {
                 throw new UncheckedIOException(x);
             }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
After a number of CGMES import we end up with:
```java
for (int i = 0; i < 1000; i++) {
    Network network = Importers.loadNetwork("test.zip");
}
```

```bash
12:32:17.494 [main] DEBUG  o.e.rdf4j.sail.memory.MemoryStore - MemoryStore initialized
Exception in thread "main" com.powsybl.cgmes.model.CgmesModelException: namespaces
	at com.powsybl.cgmes.model.NamespaceReader.namespaces(NamespaceReader.java:33)
	at com.powsybl.cgmes.model.CgmesOnDataSource.lambda$namespaces$1(CgmesOnDataSource.java:91)
	at java.lang.Iterable.forEach(Iterable.java:75)
	at com.powsybl.cgmes.model.CgmesOnDataSource.namespaces(CgmesOnDataSource.java:89)
	at com.powsybl.cgmes.model.CgmesOnDataSource.cimNamespace(CgmesOnDataSource.java:102)
	at com.powsybl.cgmes.model.CgmesModelFactory.createImplementation(CgmesModelFactory.java:55)
	at com.powsybl.cgmes.model.CgmesModelFactory.create(CgmesModelFactory.java:47)
	at com.powsybl.cgmes.conversion.CgmesImport.importData(CgmesImport.java:104)
	at com.powsybl.iidm.import_.Importer.importData(Importer.java:65)
	at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:390)
	at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:396)
	at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:400)
	at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:404)
	at FileLeak.main(FileLeak.java:8)
Caused by: javax.xml.stream.XMLStreamException: java.net.MalformedURLException
	at com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl.setInputSource(XMLStreamReaderImpl.java:212)
	at com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl.<init>(XMLStreamReaderImpl.java:184)
	at com.sun.xml.internal.stream.XMLInputFactoryImpl.getXMLStreamReaderImpl(XMLInputFactoryImpl.java:277)
	at com.sun.xml.internal.stream.XMLInputFactoryImpl.createXMLStreamReader(XMLInputFactoryImpl.java:129)
	at com.powsybl.cgmes.model.NamespaceReader.namespaces1(NamespaceReader.java:39)
	at com.powsybl.cgmes.model.NamespaceReader.namespaces(NamespaceReader.java:31)
	... 13 more
Caused by: java.net.MalformedURLException
	at java.net.URL.<init>(URL.java:644)
	at java.net.URL.<init>(URL.java:507)
	at java.net.URL.<init>(URL.java:456)
	at com.sun.org.apache.xerces.internal.impl.XMLEntityManager.setupCurrentEntity(XMLEntityManager.java:620)
	at com.sun.org.apache.xerces.internal.impl.XMLEntityManager.startEntity(XMLEntityManager.java:1304)
	at com.sun.org.apache.xerces.internal.impl.XMLEntityManager.startDocumentEntity(XMLEntityManager.java:1255)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.setInputSource(XMLDocumentScannerImpl.java:253)
	at com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl.setInputSource(XMLStreamReaderImpl.java:199)
	... 18 more
Caused by: java.lang.NullPointerException
	at java.net.URL.<init>(URL.java:549)
	... 25 more
Exception in thread "Thread-1" java.io.UncheckedIOException: java.nio.file.FileSystemException: /tmp/itools_common_2933058837017747025: Trop de fichiers ouverts
	at com.powsybl.computation.local.LocalComputationManager.close(LocalComputationManager.java:367)
	at com.powsybl.computation.local.LocalComputationManager.lambda$getDefault$0(LocalComputationManager.java:67)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.nio.file.FileSystemException: /tmp/itools_common_2933058837017747025: Trop de fichiers ouverts
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:91)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:427)
	at java.nio.file.Files.newDirectoryStream(Files.java:457)
	at java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:300)
	at java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:322)
	at java.nio.file.Files.walkFileTree(Files.java:2662)
	at java.nio.file.Files.walkFileTree(Files.java:2742)
	at com.powsybl.commons.io.FileUtil.removeDir(FileUtil.java:28)
	at com.powsybl.commons.io.WorkingDirectory.close(WorkingDirectory.java:38)
	at com.powsybl.computation.local.LocalComputationManager.close(LocalComputationManager.java:365)
	... 2 more
```

**What is the new behavior (if this is a feature change)?**
The file leak has been fixed.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
