### PR TITLE
Small fixes after #1319: Add assert when reading and writing aliases in XIIDM (incorrect sub-elements names should be detected) + Network's aliases are read and written

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
@@ -57,7 +57,7 @@ abstract class AbstractIdentifiableXml<T extends Identifiable, A extends Identif
 
         IidmXmlUtil.runFromMinimumVersion(IidmXmlVersion.V_1_3, context, () -> {
             try {
-                AliasesXml.write(identifiable, context);
+                AliasesXml.write(identifiable, getRootElementName(), context);
             } catch (XMLStreamException e) {
                 throw new UncheckedXmlStreamException(e);
             }
@@ -85,6 +85,7 @@ abstract class AbstractIdentifiableXml<T extends Identifiable, A extends Identif
         if (context.getReader().getLocalName().equals(PropertiesXml.PROPERTY)) {
             PropertiesXml.read(identifiable, context);
         } else if (context.getReader().getLocalName().equals(AliasesXml.ALIAS)) {
+            IidmXmlUtil.assertMinimumVersion(getRootElementName(), AliasesXml.ALIAS, IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_3, context);
             AliasesXml.read(identifiable, context);
         } else {
             throw new PowsyblException("Unknown element name <" + context.getReader().getLocalName() + "> in <" + identifiable.getId() + ">");

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AliasesXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AliasesXml.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.xml.util.IidmXmlUtil;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -17,7 +18,8 @@ public final class AliasesXml {
 
     static final String ALIAS = "alias";
 
-    public static void write(Identifiable<?> identifiable, NetworkXmlWriterContext context) throws XMLStreamException {
+    public static void write(Identifiable<?> identifiable, String rootElementName, NetworkXmlWriterContext context) throws XMLStreamException {
+        IidmXmlUtil.assertMinimumVersionIfNotDefault(!identifiable.getAliases().isEmpty(), rootElementName, ALIAS, IidmXmlUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion.V_1_3, context);
         for (String alias : identifiable.getAliases()) {
             context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), ALIAS);
             context.getWriter().writeCharacters(context.getAnonymizer().anonymizeString(alias));

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -24,6 +24,7 @@ import com.powsybl.iidm.export.ExportOptions;
 import com.powsybl.iidm.import_.ImportOptions;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.xml.extensions.AbstractVersionableNetworkExtensionXmlSerializer;
+import com.powsybl.iidm.xml.util.IidmXmlUtil;
 import javanet.staxutils.IndentingXMLStreamWriter;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -267,6 +268,7 @@ public final class NetworkXml {
         // Consider the network has been exported so its extensions will be written also
         context.addExportedEquipment(n);
 
+        AliasesXml.write(n, NETWORK_ROOT_ELEMENT_NAME, context);
         PropertiesXml.write(n, context);
 
         for (Substation s : n.getSubstations()) {
@@ -381,6 +383,11 @@ public final class NetworkXml {
 
             XmlUtil.readUntilEndElement(NETWORK_ROOT_ELEMENT_NAME, reader, () -> {
                 switch (reader.getLocalName()) {
+                    case AliasesXml.ALIAS:
+                        IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, AliasesXml.ALIAS, IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_3, context);
+                        AliasesXml.read(network, context);
+                        break;
+
                     case PropertiesXml.PROPERTY:
                         PropertiesXml.read(network, context);
                         break;

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ShuntXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ShuntXml.java
@@ -148,6 +148,7 @@ class ShuntXml extends AbstractConnectableXml<ShuntCompensator, ShuntCompensator
                     properties.put(name, value);
                     break;
                 case AliasesXml.ALIAS:
+                    IidmXmlUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, AliasesXml.ALIAS, IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_3, context);
                     String alias = context.getAnonymizer().deanonymizeString(context.getReader().getElementText());
                     aliases.add(alias);
                     break;


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix after PR #1319 : some corrections in XIIDM version assertions and de/serialization of network's aliases


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
