### PR TITLE
Fix a memory leak in Matpower reader

### DIFF
--- a/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerReader.java
+++ b/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerReader.java
@@ -32,7 +32,9 @@ public final class MatpowerReader {
     }
 
     public static MatpowerModel read(Path file, String caseName) throws IOException {
-        return read(Files.newInputStream(file), caseName);
+        try (InputStream stream = Files.newInputStream(file)) {
+            return read(stream, caseName);
+        }
     }
 
     public static MatpowerModel read(InputStream iStream, String caseName) throws IOException {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When importing a Matpower network from a path, an input stream is created but never closed


**What is the new behavior (if this is a feature change)?**
Use try-with-resources to close the inputstream.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
