### PR TITLE
Add a slackBus parameter to LoadFlowParameters

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -46,7 +46,9 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
 
     // VERSION = 1.0 specificCompatibility
     // VERSION = 1.1 t2wtSplitShuntAdmittance
-    public static final String VERSION = "1.2";
+    // VERSION = 1.2 twtSplitShuntAdmittance,
+    // VERSION = 1.3 simulShunt, read/write slack bus
+    public static final String VERSION = "1.3";
 
     public static final VoltageInitMode DEFAULT_VOLTAGE_INIT_MODE = VoltageInitMode.UNIFORM_VALUES;
     public static final boolean DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON = false;
@@ -54,6 +56,8 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
     public static final boolean DEFAULT_PHASE_SHIFTER_REGULATION_ON = false;
     public static final boolean DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE = false;
     public static final boolean DEFAULT_SIMUL_SHUNT = false;
+    public static final boolean DEFAULT_READ_SLACK_BUS = false;
+    public static final boolean DEFAULT_WRITE_SLACK_BUS = false;
 
     private static final Supplier<ExtensionProviders<ConfigLoader>> SUPPLIER =
             Suppliers.memoize(() -> ExtensionProviders.createProvider(ConfigLoader.class, "loadflow-parameters"));
@@ -94,7 +98,8 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
                 // keep old tag name "specificCompatibility" for compatibility
                 parameters.setTwtSplitShuntAdmittance(config.getBooleanProperty("twtSplitShuntAdmittance", config.getBooleanProperty("specificCompatibility", DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE)));
                 parameters.setSimulShunt(config.getBooleanProperty("simulShunt", DEFAULT_SIMUL_SHUNT));
-
+                parameters.setReadSlackBus(config.getBooleanProperty("readSlackBus", DEFAULT_READ_SLACK_BUS));
+                parameters.setWriteSlackBus(config.getBooleanProperty("writeSlackBus", DEFAULT_WRITE_SLACK_BUS));
             });
     }
 
@@ -110,21 +115,27 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
 
     private boolean simulShunt;
 
+    private boolean readSlackBus;
+
+    private boolean writeSlackBus;
+
     public LoadFlowParameters(VoltageInitMode voltageInitMode, boolean transformerVoltageControlOn,
                               boolean noGeneratorReactiveLimits, boolean phaseShifterRegulationOn,
-                              boolean twtSplitShuntAdmittance, boolean simulShunt) {
+                              boolean twtSplitShuntAdmittance, boolean simulShunt, boolean readSlackBus, boolean writeSlackBus) {
         this.voltageInitMode = voltageInitMode;
         this.transformerVoltageControlOn = transformerVoltageControlOn;
         this.noGeneratorReactiveLimits = noGeneratorReactiveLimits;
         this.phaseShifterRegulationOn = phaseShifterRegulationOn;
         this.twtSplitShuntAdmittance = twtSplitShuntAdmittance;
         this.simulShunt = simulShunt;
+        this.readSlackBus = readSlackBus;
+        this.writeSlackBus = writeSlackBus;
     }
 
     public LoadFlowParameters(VoltageInitMode voltageInitMode, boolean transformerVoltageControlOn,
         boolean noGeneratorReactiveLimits, boolean phaseShifterRegulationOn,
         boolean twtSplitShuntAdmittance) {
-        this(voltageInitMode, transformerVoltageControlOn, noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance, DEFAULT_SIMUL_SHUNT);
+        this(voltageInitMode, transformerVoltageControlOn, noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance, DEFAULT_SIMUL_SHUNT, DEFAULT_READ_SLACK_BUS, DEFAULT_WRITE_SLACK_BUS);
     }
 
     public LoadFlowParameters(VoltageInitMode voltageInitMode, boolean transformerVoltageControlOn) {
@@ -147,6 +158,8 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
         phaseShifterRegulationOn = other.phaseShifterRegulationOn;
         twtSplitShuntAdmittance = other.twtSplitShuntAdmittance;
         simulShunt = other.simulShunt;
+        readSlackBus = other.readSlackBus;
+        writeSlackBus = other.writeSlackBus;
     }
 
     public VoltageInitMode getVoltageInitMode() {
@@ -235,6 +248,24 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
         return this;
     }
 
+    public boolean isReadSlackBus() {
+        return readSlackBus;
+    }
+
+    public LoadFlowParameters setReadSlackBus(boolean readSlackBus) {
+        this.readSlackBus = readSlackBus;
+        return this;
+    }
+
+    public boolean isWriteSlackBus() {
+        return writeSlackBus;
+    }
+
+    public LoadFlowParameters setWriteSlackBus(boolean writeSlackBus) {
+        this.writeSlackBus = writeSlackBus;
+        return this;
+    }
+
     protected Map<String, Object> toMap() {
         ImmutableMap.Builder<String, Object> immutableMapBuilder = ImmutableMap.builder();
         immutableMapBuilder
@@ -243,7 +274,9 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
                 .put("noGeneratorReactiveLimits", noGeneratorReactiveLimits)
                 .put("phaseShifterRegulationOn", phaseShifterRegulationOn)
                 .put("twtSplitShuntAdmittance", twtSplitShuntAdmittance)
-                .put("simulShunt", simulShunt);
+                .put("simulShunt", simulShunt)
+                .put("readSlackBus", readSlackBus)
+                .put("writeSlackBus", writeSlackBus);
         return immutableMapBuilder.build();
     }
 

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersDeserializer.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersDeserializer.java
@@ -86,9 +86,21 @@ public class LoadFlowParametersDeserializer extends StdDeserializer<LoadFlowPara
                     break;
 
                 case "simulShunt":
-                    JsonUtil.assertGreaterThanReferenceVersion(CONTEXT_NAME, "Tag: simulShunt", version, "1.1");
+                    JsonUtil.assertGreaterThanReferenceVersion(CONTEXT_NAME, "Tag: simulShunt", version, "1.2");
                     parser.nextToken();
                     parameters.setSimulShunt(parser.readValueAs(Boolean.class));
+                    break;
+
+                case "readSlackBus":
+                    JsonUtil.assertGreaterThanReferenceVersion(CONTEXT_NAME, "Tag: readSlackBus", version, "1.2");
+                    parser.nextToken();
+                    parameters.setReadSlackBus(parser.readValueAs(Boolean.class));
+                    break;
+
+                case "writeSlackBus":
+                    JsonUtil.assertGreaterThanReferenceVersion(CONTEXT_NAME, "Tag: writeSlackBus", version, "1.2");
+                    parser.nextToken();
+                    parameters.setWriteSlackBus(parser.readValueAs(Boolean.class));
                     break;
 
                 case "extensions":

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersSerializer.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersSerializer.java
@@ -35,6 +35,8 @@ public class LoadFlowParametersSerializer extends StdSerializer<LoadFlowParamete
         jsonGenerator.writeBooleanField("noGeneratorReactiveLimits", parameters.isNoGeneratorReactiveLimits());
         jsonGenerator.writeBooleanField("twtSplitShuntAdmittance", parameters.isTwtSplitShuntAdmittance());
         jsonGenerator.writeBooleanField("simulShunt", parameters.isSimulShunt());
+        jsonGenerator.writeBooleanField("readSlackBus", parameters.isReadSlackBus());
+        jsonGenerator.writeBooleanField("writeSlackBus", parameters.isWriteSlackBus());
 
         JsonUtil.writeExtensions(parameters, jsonGenerator, serializerProvider, JsonLoadFlowParameters.getExtensionSerializers());
 

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
@@ -54,12 +54,16 @@ public class LoadFlowParametersTest {
 
     private void checkValues(LoadFlowParameters parameters, LoadFlowParameters.VoltageInitMode voltageInitMode,
                              boolean transformerVoltageControlOn, boolean noGeneratorReactiveLimits,
-                             boolean phaseShifterRegulationOn, boolean twtSplitShuntAdmittance) {
+                             boolean phaseShifterRegulationOn, boolean twtSplitShuntAdmittance,
+                             boolean simulShunt, boolean readSlackBus, boolean writeSlackBus) {
         assertEquals(parameters.getVoltageInitMode(), voltageInitMode);
         assertEquals(parameters.isTransformerVoltageControlOn(), transformerVoltageControlOn);
         assertEquals(parameters.isPhaseShifterRegulationOn(), phaseShifterRegulationOn);
         assertEquals(parameters.isNoGeneratorReactiveLimits(), noGeneratorReactiveLimits);
         assertEquals(parameters.isTwtSplitShuntAdmittance(), twtSplitShuntAdmittance);
+        assertEquals(parameters.isSimulShunt(), simulShunt);
+        assertEquals(parameters.isReadSlackBus(), readSlackBus);
+        assertEquals(parameters.isWriteSlackBus(), writeSlackBus);
     }
 
     @Test
@@ -70,15 +74,21 @@ public class LoadFlowParametersTest {
                 LoadFlowParameters.DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON,
                 LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
                 LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON,
-                LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE);
+                LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE,
+                LoadFlowParameters.DEFAULT_SIMUL_SHUNT,
+                LoadFlowParameters.DEFAULT_READ_SLACK_BUS,
+                LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS);
     }
 
     @Test
-    public void checkConfig() throws Exception {
+    public void checkConfig() {
         boolean transformerVoltageControlOn = true;
         boolean noGeneratorReactiveLimits = true;
         boolean phaseShifterRegulationOn = true;
         boolean twtSplitShuntAdmittance = true;
+        boolean simulShunt = true;
+        boolean readSlackBus = true;
+        boolean writeSlackBus = true;
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.UNIFORM_VALUES;
 
         MapModuleConfig moduleConfig = platformConfig.createModuleConfig("load-flow-default-parameters");
@@ -87,14 +97,17 @@ public class LoadFlowParametersTest {
         moduleConfig.setStringProperty("noGeneratorReactiveLimits", Boolean.toString(noGeneratorReactiveLimits));
         moduleConfig.setStringProperty("phaseShifterRegulationOn", Boolean.toString(phaseShifterRegulationOn));
         moduleConfig.setStringProperty("twtSplitShuntAdmittance", Boolean.toString(twtSplitShuntAdmittance));
+        moduleConfig.setStringProperty("simulShunt", Boolean.toString(simulShunt));
+        moduleConfig.setStringProperty("readSlackBus", Boolean.toString(readSlackBus));
+        moduleConfig.setStringProperty("writeSlackBus", Boolean.toString(writeSlackBus));
         LoadFlowParameters parameters = new LoadFlowParameters();
         LoadFlowParameters.load(parameters, platformConfig);
         checkValues(parameters, voltageInitMode, transformerVoltageControlOn,
-                noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance);
+                noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance, simulShunt, readSlackBus, writeSlackBus);
     }
 
     @Test
-    public void checkIncompleteConfig() throws Exception {
+    public void checkIncompleteConfig() {
         boolean transformerVoltageControlOn = true;
         MapModuleConfig moduleConfig = platformConfig.createModuleConfig("load-flow-default-parameters");
         moduleConfig.setStringProperty("transformerVoltageControlOn", Boolean.toString(transformerVoltageControlOn));
@@ -102,84 +115,106 @@ public class LoadFlowParametersTest {
         LoadFlowParameters.load(parameters, platformConfig);
         checkValues(parameters, LoadFlowParameters.DEFAULT_VOLTAGE_INIT_MODE,
                 transformerVoltageControlOn, LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
-                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE);
+                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE,
+                LoadFlowParameters.DEFAULT_SIMUL_SHUNT, LoadFlowParameters.DEFAULT_READ_SLACK_BUS, LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS);
     }
 
     @Test
-    public void checkDefaultPlatformConfig() throws Exception {
+    public void checkDefaultPlatformConfig() {
         LoadFlowParameters parameters = new LoadFlowParameters();
         LoadFlowParameters.load(parameters);
         checkValues(parameters, LoadFlowParameters.DEFAULT_VOLTAGE_INIT_MODE,
-            LoadFlowParameters.DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON, LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
-                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE);
+                LoadFlowParameters.DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON, LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
+                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE,
+                LoadFlowParameters.DEFAULT_SIMUL_SHUNT, LoadFlowParameters.DEFAULT_READ_SLACK_BUS, LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS);
     }
 
     @Test
-    public void checkConstructorByVoltageInitMode() throws Exception {
+    public void checkConstructorByVoltageInitMode() {
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.DC_VALUES;
         LoadFlowParameters parameters = new LoadFlowParameters(voltageInitMode);
         checkValues(parameters, voltageInitMode, LoadFlowParameters.DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON,
-            LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
-            LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE);
+                LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
+                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON, LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE,
+                LoadFlowParameters.DEFAULT_SIMUL_SHUNT, LoadFlowParameters.DEFAULT_READ_SLACK_BUS, LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS);
     }
 
     @Test
-    public void checkConstructorByVoltageInitModeAndTransformerVoltageControlOn() throws Exception {
+    public void checkConstructorByVoltageInitModeAndTransformerVoltageControlOn() {
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.DC_VALUES;
         boolean transformerVoltageControlOn = true;
         LoadFlowParameters parameters = new LoadFlowParameters(voltageInitMode, transformerVoltageControlOn);
         checkValues(parameters, voltageInitMode, true, LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
-            LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON,
-            LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE);
+                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON,
+                LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE,
+                LoadFlowParameters.DEFAULT_SIMUL_SHUNT,
+                LoadFlowParameters.DEFAULT_READ_SLACK_BUS,
+                LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS);
     }
 
     @Test
-    public void checkConstructorByLoadFlowParameters() throws Exception {
+    public void checkConstructorByLoadFlowParameters() {
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.DC_VALUES;
         LoadFlowParameters parameters = new LoadFlowParameters(voltageInitMode);
         checkValues(parameters, voltageInitMode, LoadFlowParameters.DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON,
-            LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
-            LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON,
-            LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE);
+                LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
+                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON,
+                LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE,
+                LoadFlowParameters.DEFAULT_SIMUL_SHUNT,
+                LoadFlowParameters.DEFAULT_READ_SLACK_BUS,
+                LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS);
         LoadFlowParameters parameters1 = new LoadFlowParameters(parameters);
         checkValues(parameters1, voltageInitMode, LoadFlowParameters.DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON,
-            LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
-            LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON,
-            LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE);
+                LoadFlowParameters.DEFAULT_NO_GENERATOR_REACTIVE_LIMITS,
+                LoadFlowParameters.DEFAULT_PHASE_SHIFTER_REGULATION_ON,
+                LoadFlowParameters.DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE,
+                LoadFlowParameters.DEFAULT_SIMUL_SHUNT,
+                LoadFlowParameters.DEFAULT_READ_SLACK_BUS,
+                LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS);
     }
 
     @Test
-    public void checkSetters() throws Exception {
+    public void checkSetters() {
         boolean transformerVoltageControlOn = true;
         boolean noGeneratorReactiveLimits = true;
         boolean phaseShifterRegulationOn = true;
         boolean twtSplitShuntAdmittance = true;
+        boolean simulShunt = true;
+        boolean readSlackBus = true;
+        boolean writeSlackBus = true;
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.DC_VALUES;
 
         LoadFlowParameters parameters = new LoadFlowParameters();
         LoadFlowParameters.load(parameters, platformConfig);
-        parameters.setNoGeneratorReactiveLimits(noGeneratorReactiveLimits);
-        parameters.setPhaseShifterRegulationOn(phaseShifterRegulationOn);
-        parameters.setTransformerVoltageControlOn(transformerVoltageControlOn);
-        parameters.setVoltageInitMode(voltageInitMode);
-        parameters.setTwtSplitShuntAdmittance(twtSplitShuntAdmittance);
+        parameters.setNoGeneratorReactiveLimits(noGeneratorReactiveLimits)
+                .setPhaseShifterRegulationOn(phaseShifterRegulationOn)
+                .setTransformerVoltageControlOn(transformerVoltageControlOn)
+                .setVoltageInitMode(voltageInitMode)
+                .setTwtSplitShuntAdmittance(twtSplitShuntAdmittance)
+                .setSimulShunt(simulShunt)
+                .setReadSlackBus(readSlackBus)
+                .setWriteSlackBus(writeSlackBus);
 
         checkValues(parameters, voltageInitMode, transformerVoltageControlOn, noGeneratorReactiveLimits,
-                phaseShifterRegulationOn, twtSplitShuntAdmittance);
+                phaseShifterRegulationOn, twtSplitShuntAdmittance, simulShunt, readSlackBus, writeSlackBus);
     }
 
     @Test
-    public void checkClone() throws Exception {
+    public void checkClone() {
         boolean transformerVoltageControlOn = true;
         boolean noGeneratorReactiveLimits = true;
         boolean phaseShifterRegulationOn = true;
         boolean twtSplitShuntAdmittance = true;
+        boolean simulShunt = true;
+        boolean readSlackBus = true;
+        boolean writeSlackBus = true;
         LoadFlowParameters.VoltageInitMode voltageInitMode = LoadFlowParameters.VoltageInitMode.UNIFORM_VALUES;
         LoadFlowParameters parameters = new LoadFlowParameters(voltageInitMode, transformerVoltageControlOn,
-                noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance);
+                noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance, simulShunt, readSlackBus, writeSlackBus);
         LoadFlowParameters parametersCloned = parameters.copy();
         checkValues(parametersCloned, parameters.getVoltageInitMode(), parameters.isTransformerVoltageControlOn(),
-                parameters.isNoGeneratorReactiveLimits(), parameters.isPhaseShifterRegulationOn(), parameters.isTwtSplitShuntAdmittance());
+                parameters.isNoGeneratorReactiveLimits(), parameters.isPhaseShifterRegulationOn(), parameters.isTwtSplitShuntAdmittance(),
+                parameters.isSimulShunt(), parameters.isReadSlackBus(), parameters.isWriteSlackBus());
     }
 
     @Test

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
@@ -66,21 +66,30 @@ public class JsonLoadFlowParametersTest extends AbstractConverterTest {
     public void readJsonVersion10() {
         LoadFlowParameters parameters = JsonLoadFlowParameters
                 .read(getClass().getResourceAsStream("/LoadFlowParametersVersion10.json"));
-        assertEquals(true, parameters.isTwtSplitShuntAdmittance());
+        assertTrue(parameters.isTwtSplitShuntAdmittance());
     }
 
     @Test
     public void readJsonVersion11() {
         LoadFlowParameters parameters = JsonLoadFlowParameters
                 .read(getClass().getResourceAsStream("/LoadFlowParametersVersion11.json"));
-        assertEquals(true, parameters.isTwtSplitShuntAdmittance());
+        assertTrue(parameters.isTwtSplitShuntAdmittance());
     }
 
     @Test
     public void readJsonVersion12() {
         LoadFlowParameters parameters = JsonLoadFlowParameters
                 .read(getClass().getResourceAsStream("/LoadFlowParametersVersion12.json"));
-        assertEquals(true, parameters.isTwtSplitShuntAdmittance());
+        assertTrue(parameters.isTwtSplitShuntAdmittance());
+    }
+
+    @Test
+    public void readJsonVersion13() {
+        LoadFlowParameters parameters = JsonLoadFlowParameters
+                .read(getClass().getResourceAsStream("/LoadFlowParametersVersion13.json"));
+        assertTrue(parameters.isSimulShunt());
+        assertTrue(parameters.isReadSlackBus());
+        assertTrue(parameters.isWriteSlackBus());
     }
 
     @Test

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowParametersError.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowParametersError.json
@@ -1,10 +1,12 @@
 {
-  "version" : "1.2",
+  "version" : "1.3",
   "voltageInitMode" : "PREVIOUS_VALUES",
   "transformerVoltageControlOn" : true,
   "phaseShifterRegulationOn" : false,
   "noGeneratorReactiveLimits" : true,
   "twtSplitShuntAdmittance" : false,
   "simulShunt" : false,
+  "readSlackBus" : false,
+  "writeSlackBus" : false,
   "unknownParameter": ""
 }

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion13.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion13.json
@@ -4,8 +4,8 @@
   "transformerVoltageControlOn" : true,
   "phaseShifterRegulationOn" : false,
   "noGeneratorReactiveLimits" : true,
-  "twtSplitShuntAdmittance" : false,
-  "simulShunt" : false,
-  "readSlackBus" : false,
-  "writeSlackBus" : false
+  "twtSplitShuntAdmittance" : true,
+  "simulShunt" : true,
+  "readSlackBus" : true,
+  "writeSlackBus" : true
 }

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowParametersWithExtension.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowParametersWithExtension.json
@@ -1,11 +1,13 @@
 {
-  "version" : "1.2",
+  "version" : "1.3",
   "voltageInitMode" : "UNIFORM_VALUES",
   "transformerVoltageControlOn" : false,
   "phaseShifterRegulationOn" : false,
   "noGeneratorReactiveLimits" : false,
   "twtSplitShuntAdmittance" : false,
   "simulShunt" : false,
+  "readSlackBus" : false,
+  "writeSlackBus" : false,
   "extensions" : {
     "dummy-extension" : { }
   }

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParameters.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParameters.json
@@ -1,12 +1,14 @@
 {
   "version" : "1.0",
   "load-flow-parameters" : {
-    "version" : "1.2",
+    "version" : "1.3",
     "voltageInitMode" : "UNIFORM_VALUES",
     "transformerVoltageControlOn" : false,
     "phaseShifterRegulationOn" : false,
     "noGeneratorReactiveLimits" : false,
     "twtSplitShuntAdmittance" : false,
-    "simulShunt" : false
+    "simulShunt" : false,
+    "readSlackBus" : false,
+    "writeSlackBus" : false
   }
 }

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParametersWithExtension.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParametersWithExtension.json
@@ -1,13 +1,15 @@
 {
   "version" : "1.0",
   "load-flow-parameters" : {
-    "version" : "1.2",
+    "version" : "1.3",
     "voltageInitMode" : "UNIFORM_VALUES",
     "transformerVoltageControlOn" : false,
     "phaseShifterRegulationOn" : false,
     "noGeneratorReactiveLimits" : false,
     "twtSplitShuntAdmittance" : false,
-    "simulShunt" : false
+    "simulShunt" : false,
+    "readSlackBus" : false,
+    "writeSlackBus" : false
   },
   "extensions" : {
     "dummy-extension" : { }

--- a/sensitivity-api/src/test/resources/SensitivityComputationParameters.json
+++ b/sensitivity-api/src/test/resources/SensitivityComputationParameters.json
@@ -1,12 +1,14 @@
 {
   "version" : "1.0",
   "load-flow-parameters" : {
-    "version" : "1.2",
+    "version" : "1.3",
     "voltageInitMode" : "UNIFORM_VALUES",
     "transformerVoltageControlOn" : false,
     "phaseShifterRegulationOn" : false,
     "noGeneratorReactiveLimits" : false,
     "twtSplitShuntAdmittance" : false,
-    "simulShunt" : false
+    "simulShunt" : false,
+    "readSlackBus" : false,
+    "writeSlackBus" : false
   }
 }

--- a/sensitivity-api/src/test/resources/SensitivityComputationParametersWithExtension.json
+++ b/sensitivity-api/src/test/resources/SensitivityComputationParametersWithExtension.json
@@ -1,13 +1,15 @@
 {
   "version" : "1.0",
   "load-flow-parameters" : {
-    "version" : "1.2",
+    "version" : "1.3",
     "voltageInitMode" : "UNIFORM_VALUES",
     "transformerVoltageControlOn" : false,
     "phaseShifterRegulationOn" : false,
     "noGeneratorReactiveLimits" : false,
     "twtSplitShuntAdmittance" : false,
-    "simulShunt" : false
+    "simulShunt" : false,
+    "readSlackBus" : false,
+    "writeSlackBus" : false
   },
   "extensions" : {
     "dummy-extension" : { }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The slack bus used by a power-flow is not available from the IIDM network.


**What is the new behavior (if this is a feature change)?**
With #1381, we create a new SlackTerminal extension to define the slack bus in the IIDM model. This PR introduce two parameters for the loadflow:
- isReadSlackBus: the extension can be used by the power flow to select the slack bus
- isWriteSlackBus: the extension has to be created by the power flow to identify the slack bus used during the simulation.

By default, both parameters are set to `false`.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
