### PR TITLE
Add utility function to quickly jump to a XML path

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
@@ -36,8 +36,17 @@ public final class XmlUtil {
     }
 
     public static void readUntilStartElement(String path, XMLStreamReader reader, XmlEventHandler handler) throws XMLStreamException {
-        StringBuilder currentPath = new StringBuilder();
+        Objects.requireNonNull(path);
         String[] elements = path.split("/");
+        readUntilStartElement(elements, reader, handler);
+    }
+
+    public static void readUntilStartElement(String[] elements, XMLStreamReader reader, XmlEventHandler handler) throws XMLStreamException {
+        Objects.requireNonNull(elements);
+        if (elements.length == 0) {
+            throw new PowsyblException("Empty element list");
+        }
+        StringBuilder currentPath = new StringBuilder();
         for (int i = 1; i < elements.length; ++i) {
             currentPath.append("/").append(elements[i]);
             if (!readUntilStartElement(elements[i], elements[i - 1], reader)) {

--- a/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
@@ -130,6 +130,10 @@ public final class XmlUtil {
         return text;
     }
 
+    public static String readText(String endElementName, XMLStreamReader reader) throws XMLStreamException {
+        return readUntilEndElement(endElementName, reader, () -> { });
+    }
+
     public static void writeOptionalBoolean(String name, boolean value, boolean absentValue, XMLStreamWriter writer) throws XMLStreamException {
         if (value != absentValue) {
             writer.writeAttribute(name, Boolean.toString(value));

--- a/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
@@ -40,8 +40,8 @@ public final class XmlUtil {
         String[] elements = path.split("/");
         for (int i = 1; i < elements.length; ++i) {
             currentPath.append("/").append(elements[i]);
-            if (!readUntilStartElement(elements[i], elements[i-1], reader)) {
-                throw new PowsyblException("Unable to find " + currentPath.toString() + ": parent element " + elements[i-1] + " has been closed");
+            if (!readUntilStartElement(elements[i], elements[i - 1], reader)) {
+                throw new PowsyblException("Unable to find " + currentPath.toString() + ": parent element " + elements[i - 1] + " has been closed");
             }
         }
         if (handler != null) {

--- a/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
+++ b/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
@@ -106,4 +106,17 @@ public class XmlUtilTest {
             assertEquals("Unable to find " + path + ": parent element " + parent + " has been closed", e.getMessage());
         }
     }
+
+    @Test
+    public void readTextTest() throws XMLStreamException {
+        String xml = "<a>hello</a>";
+        try (StringReader reader = new StringReader(xml)) {
+            XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(reader);
+            try {
+                assertEquals("hello", XmlUtil.readText("a", xmlReader));
+            } finally {
+                xmlReader.close();
+            }
+        }
+    }
 }

--- a/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
+++ b/commons/src/test/java/com/powsybl/commons/xml/XmlUtilTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.commons.xml;
 
 import com.google.common.collect.ImmutableMap;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import org.junit.Test;
 
@@ -71,4 +72,38 @@ public class XmlUtilTest {
         assertEquals(ImmutableMap.of("a", 0, "b", 1, "d", 1), depths);
     }
 
+    @Test
+    public void readUntilStartElementTest() throws XMLStreamException {
+        readUntilStartElementTest("/a", "a");
+        readUntilStartElementTest("/a/b/c", "c");
+        readUntilStartElementTest("/a/d", "d");
+
+        readUntilStartElementNotFoundTest("/a/e", "a");
+        readUntilStartElementNotFoundTest("/a/b/a", "b");
+
+        try {
+            readUntilStartElementTest("/b", null);
+        } catch (PowsyblException e) {
+            assertEquals("Unable to find b: end of document has been reached", e.getMessage());
+        }
+    }
+
+    private void readUntilStartElementTest(String path, String expected) throws XMLStreamException {
+        try (StringReader reader = new StringReader(XML)) {
+            XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(reader);
+            try {
+                XmlUtil.readUntilStartElement(path, xmlReader, () -> assertEquals(expected, xmlReader.getLocalName()));
+            } finally {
+                xmlReader.close();
+            }
+        }
+    }
+
+    private void readUntilStartElementNotFoundTest(String path, String parent) throws XMLStreamException {
+        try {
+            readUntilStartElementTest(path, null);
+        } catch (PowsyblException e) {
+            assertEquals("Unable to find " + path + ": parent element " + parent + " has been closed", e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
It's not possible to quickly reach a XML element without creating a whole XML parser.


**What is the new behavior (if this is a feature change)?**
This PR introduce a new `readUntilStartElement` method in the XMLUtil class to reach an XML path (`/a/b/c`). The aim of this function is to fail as quick as possible if the specified path doesn't exist.

This function will be used to parse the CGMES FullModel. This element is at the beginning of the document. A small test on NG EQ file reach the element in few milliseconds. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
