### PR TITLE
Allow creation of timeseries from BigDecimal

### DIFF
--- a/time-series/time-series-api/src/main/groovy/com/powsybl/timeseries/CalculatedTimeSeriesDslLoader.groovy
+++ b/time-series/time-series-api/src/main/groovy/com/powsybl/timeseries/CalculatedTimeSeriesDslLoader.groovy
@@ -89,6 +89,12 @@ class CalculatedTimeSeriesDslLoader {
             nodes.put(name, new DoubleNodeCalc(aDouble))
         }
 
+        void putAt(String name, BigDecimal aBigDecimal) {
+            assert name != null
+            assert aBigDecimal != null
+            nodes.put(name, new DoubleNodeCalc(aBigDecimal.doubleValue()))
+        }
+
         String[] getNames() {
             store.getTimeSeriesNames(new TimeSeriesFilter())
         }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/CalculatedTimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/CalculatedTimeSeriesTest.java
@@ -202,6 +202,9 @@ public class CalculatedTimeSeriesTest {
         evaluate("timeSeries['foo'].time() == time('2015-01-01T00:00:00Z')", 1);
         evaluate("timeSeries['foo'].time() <= time('2015-01-01T00:15:00Z')", 1);
         evaluate("timeSeries['foo'].time() < time('2014-01-01T00:00:00Z')", 0);
+        evaluate("timeSeries['foo'] = 1", 1);
+        evaluate("timeSeries['foo'] = 1.5d", 1.5d);
+        evaluate("timeSeries['foo'] = 1.5", 1.5d);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#1421 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
It's not possible to create a timeseries from groovy from a BigDecimal. User has to add the `d` suffix to its constant, that is not possible when the value is computed.


**What is the new behavior (if this is a feature change)?**
This PR introduce a new `putAt` overload to create a timeseries from a BigDecimal


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
