### PR TITLE
Make some methods public to be able to use them for the estim integration tests

### DIFF
--- a/commons/src/test/java/com/powsybl/commons/AbstractConverterTest.java
+++ b/commons/src/test/java/com/powsybl/commons/AbstractConverterTest.java
@@ -63,12 +63,12 @@ public abstract class AbstractConverterTest {
         assertFalse(hasDiff);
     }
 
-    private static String normalizeLineSeparator(String str) {
+    public static String normalizeLineSeparator(String str) {
         return str.replace("\r\n", "\n")
                 .replace("\r", "\n");
     }
 
-    protected static void compareTxt(InputStream expected, InputStream actual) {
+    public static void compareTxt(InputStream expected, InputStream actual) {
         try {
             compareTxt(expected, new String(ByteStreams.toByteArray(actual), StandardCharsets.UTF_8));
         } catch (IOException e) {
@@ -111,7 +111,7 @@ public abstract class AbstractConverterTest {
         return writeTest(data, out, AbstractConverterTest::compareXml, ref);
     }
 
-    protected <T> Path writeTest(T data, BiConsumer<T, Path> out, BiConsumer<InputStream, InputStream> compare, String ref) throws IOException {
+    public <T> Path writeTest(T data, BiConsumer<T, Path> out, BiConsumer<InputStream, InputStream> compare, String ref) throws IOException {
         Path xmlFile = tmpDir.resolve("data");
         out.accept(data, xmlFile);
         try (InputStream is = Files.newInputStream(xmlFile)) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** *(You can also link to an open issue here)*
At the moment writeTest, compareTxt and normalizeLineSeparator are private in AbstractConverterTest.


**What is the new behavior (if this is a feature change)?**
This PR makes these methods public, so as to be able to use them in powsybl-rte-core
