### PR TITLE
Fix typo in dynamic simulation tool option

### DIFF
--- a/dynamic-simulation/dynamic-simulation-tool/src/main/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationTool.java
+++ b/dynamic-simulation/dynamic-simulation-tool/src/main/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationTool.java
@@ -48,7 +48,7 @@ import java.util.Properties;
 public class DynamicSimulationTool implements Tool {
 
     private static final String CASE_FILE = "case-file";
-    private static final String DYNAMIC_MODEL_FILE = "dynamic-model-file";
+    private static final String DYNAMIC_MODEL_FILE = "dynamic-models-file";
     private static final String CURVES_FILE = "curves-file";
     private static final String PARAMETERS_FILE = "parameters-file";
     private static final String OUTPUT_FILE = "output-file";

--- a/dynamic-simulation/dynamic-simulation-tool/src/test/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationToolTest.java
+++ b/dynamic-simulation/dynamic-simulation-tool/src/test/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationToolTest.java
@@ -69,7 +69,7 @@ public class DynamicSimulationToolTest extends AbstractToolTest {
         assertEquals("Run dynamic simulation", command.getDescription());
         assertNull(command.getUsageFooter());
         assertOption(command.getOptions(), "case-file", true, true);
-        assertOption(command.getOptions(), "dynamic-model-file", true, true);
+        assertOption(command.getOptions(), "dynamic-models-file", true, true);
         assertOption(command.getOptions(), "curves-file", false, true);
         assertOption(command.getOptions(), "output-file", false, true);
     }
@@ -95,19 +95,19 @@ public class DynamicSimulationToolTest extends AbstractToolTest {
                 "+--------+",
                 "| true   |",
                 "+--------+");
-        assertCommand(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-model-file", "/dynamicModels.groovy"}, 0, expectedOut, "");
+        assertCommand(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-models-file", "/dynamicModels.groovy"}, 0, expectedOut, "");
 
         // Run with curves
-        assertCommand(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-model-file", "/dynamicModels.groovy", "--curves-file", "/curves.groovy"}, 0, expectedOut, "");
+        assertCommand(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-models-file", "/dynamicModels.groovy", "--curves-file", "/curves.groovy"}, 0, expectedOut, "");
     }
 
     @Test
     public void testDynamicSimulationWithCurves() throws IOException {
         // Run with curves in groovy
-        assertCommand(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-model-file", "/dynamicModels.groovy", "--curves-file", "/curves.groovy"}, 0, null, "");
+        assertCommand(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-models-file", "/dynamicModels.groovy", "--curves-file", "/curves.groovy"}, 0, null, "");
 
         // Run with curves in JSON (not supported)
-        assertCommand(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-model-file", "/dynamicModels.groovy", "--curves-file", "/curves.json"}, 3, null, "Unsupported curves format: json");
+        assertCommand(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-models-file", "/dynamicModels.groovy", "--curves-file", "/curves.json"}, 3, null, "Unsupported curves format: json");
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Agnès Leroy <agnes.leroy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix an option name in the dynamic-simulation tool: the dynamic-model-file option is renamed to dynamic-models-file.

