### PR TITLE
Change Map implementation used in UCTE import

### DIFF
--- a/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/ext/UcteNetworkExt.java
+++ b/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/ext/UcteNetworkExt.java
@@ -187,7 +187,7 @@ public class UcteNetworkExt implements UcteNetwork {
         if (substations == null) {
             LOGGER.trace("Update substations...");
             substations = new ArrayList<>();
-            node2voltageLevel = new HashMap<>();
+            node2voltageLevel = new TreeMap<>();
             UndirectedGraph<UcteNodeCode, Object> graph = createSubstationGraph(network);
             for (Set<UcteNodeCode> substationNodes : new ConnectivityInspector<>(graph).connectedSets()) {
                 // the main node of the substation is not an xnode and the one with the highest voltage


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Current implementation of UCTE importer may merge UCTE substations in one unique substation if they are only connected by transformers.
However the ID chosen for this substation may change from a run to another due to the use of an HashMap in the importer.


**What is the new behavior (if this is a feature change)?**
The substation name generated is no longer changed from a run to another
