### PR TITLE
Correct bugs in MergingView: getDanglingLine(String id) if there is no dangling line with the given id in the sub-networks + getVariantManager() returns a VariantManager instead of the (private-package) MergingVariantManager

### DIFF
--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
@@ -744,7 +744,7 @@ public final class MergingView implements Network, MultiVariantObject {
     @Override
     public DanglingLine getDanglingLine(final String id) {
         final DanglingLine dl = index.get(n -> n.getDanglingLine(id), index::getDanglingLine);
-        return index.isMerged(dl) ? null : dl;
+        return dl == null || index.isMerged(dl) ? null : dl;
     }
 
     // HvdcLines
@@ -819,7 +819,7 @@ public final class MergingView implements Network, MultiVariantObject {
     }
 
     @Override
-    public MergingVariantManager getVariantManager() {
+    public VariantManager getVariantManager() {
         return variantManager;
     }
 


### PR DESCRIPTION


Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
- if the given id in `getDanglingLine(String id)` does not exist in any of the `MergingView`'s subnetworks, there is a `NullPointerException`
- `getVariantManager()` returns a `MergingVariantManager` which is package-private


**What is the new behavior (if this is a feature change)?**
- if the given id in `getDanglingLine(String id)` does not exist in any of the `MergingView`'s subnetworks, `null` is returned
- `getVariantManager()` returns a `VariantManager`


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
