### PR TITLE
Implement TopologyTraverserAdapter to traverse mergingview from TerminalAdapter

### DIFF
--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TerminalAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TerminalAdapter.java
@@ -209,9 +209,6 @@ public class TerminalAdapter extends AbstractAdapter<Terminal> implements Termin
         this.synchronousComponentNumber.put(variantId, synchronousComponentNumber);
     }
 
-    // -------------------------------
-    // Not implemented methods -------
-    // -------------------------------
     @Override
     public void traverse(final TopologyTraverser traverser) {
         getDelegate().traverse(new TopologyTraverserAdapter(traverser, getIndex()));

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TerminalAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TerminalAdapter.java
@@ -214,6 +214,6 @@ public class TerminalAdapter extends AbstractAdapter<Terminal> implements Termin
     // -------------------------------
     @Override
     public void traverse(final TopologyTraverser traverser) {
-        throw MergingView.createNotImplementedException();
+        getDelegate().traverse(new TopologyTraverserAdapter(traverser, getIndex()));
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TopologyTraverserAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TopologyTraverserAdapter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.mergingview;
+
+import com.powsybl.iidm.network.Switch;
+import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.VoltageLevel;
+
+import java.util.Objects;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class TopologyTraverserAdapter implements VoltageLevel.TopologyTraverser {
+
+    private final VoltageLevel.TopologyTraverser delegate;
+    private final MergingViewIndex index;
+
+    TopologyTraverserAdapter(VoltageLevel.TopologyTraverser traverser, MergingViewIndex index) {
+        this.delegate = Objects.requireNonNull(traverser);
+        this.index = Objects.requireNonNull(index);
+    }
+
+    @Override
+    public boolean traverse(Terminal terminal, boolean connected) {
+        return delegate.traverse(index.getTerminal(terminal), connected);
+    }
+
+    @Override
+    public boolean traverse(Switch aSwitch) {
+        return delegate.traverse(index.getSwitch(aSwitch));
+    }
+}

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TopologyTraverserAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TopologyTraverserAdapterTest.java
@@ -32,9 +32,9 @@ public class TopologyTraverserAdapterTest {
         List<String> traversed1bis = recordTraversed(start1, aSwitch -> !aSwitch.isOpen() && aSwitch.getKind() != SwitchKind.BREAKER);
         assertEquals(Collections.singletonList("LOAD1"), traversed1bis);
 
-        Terminal start2 = cgm.getLoad("LOAD1").getTerminal();
+        Terminal start2 = cgm.getLoad("LOAD2").getTerminal();
         List<String> traversed2 = recordTraversed(start2, s -> true);
-        assertEquals(Arrays.asList("LOAD1", "BBS1", "DL1 + DL2"), traversed2);
+        assertEquals(Arrays.asList("LOAD2", "DL1 + DL2"), traversed2);
     }
 
     private List<String> recordTraversed(Terminal start, Predicate<Switch> switchPredicate) {

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TopologyTraverserAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TopologyTraverserAdapterTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.mergingview;
+
+import com.powsybl.iidm.network.*;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class TopologyTraverserAdapterTest {
+
+    @Test
+    public void test() {
+        MergingView cgm = MergingViewFactory.createCGM(null);
+        Terminal start1 = cgm.getLoad("LOAD1").getTerminal();
+        List<String> traversed1 = recordTraversed(start1, s -> true);
+        assertEquals(Arrays.asList("LOAD1", "BBS1", "DL1 + DL2"), traversed1);
+
+        List<String> traversed1bis = recordTraversed(start1, aSwitch -> !aSwitch.isOpen() && aSwitch.getKind() != SwitchKind.BREAKER);
+        assertEquals(Collections.singletonList("LOAD1"), traversed1bis);
+
+        Terminal start2 = cgm.getLoad("LOAD1").getTerminal();
+        List<String> traversed2 = recordTraversed(start2, s -> true);
+        assertEquals(Arrays.asList("LOAD1", "BBS1", "DL1 + DL2"), traversed2);
+    }
+
+    private List<String> recordTraversed(Terminal start, Predicate<Switch> switchPredicate) {
+        List<String> traversed = new ArrayList<>();
+        start.traverse(new VoltageLevel.TopologyTraverser() {
+            @Override
+            public boolean traverse(Terminal terminal, boolean connected) {
+                traversed.add(terminal.getConnectable().getId());
+                return true;
+            }
+
+            @Override
+            public boolean traverse(Switch aSwitch) {
+                return switchPredicate.test(aSwitch);
+            }
+        });
+        return traversed;
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

Linked to #1436 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
`TerminalAdapter.traverse(TopologyTraverser)` is not implemented.


**What is the new behavior (if this is a feature change)?**
This method is now implemented and uses a specific `TopologyTraverserAdapter`.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

