### PR TITLE
[WIP] Add fictitious P and Q attributes to busbar sections

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/BusbarSection.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/BusbarSection.java
@@ -68,4 +68,12 @@ public interface BusbarSection extends Injection<BusbarSection> {
     double getV();
 
     double getAngle();
+
+    double getFictitiousP();
+
+    double getFictitiousQ();
+
+    BusbarSection setFictitiousP(double p);
+
+    BusbarSection setFictitiousQ(double q);
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusbarSectionImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusbarSectionImpl.java
@@ -15,8 +15,16 @@ import com.powsybl.iidm.network.ConnectableType;
  */
 class BusbarSectionImpl extends AbstractConnectable<BusbarSection> implements BusbarSection {
 
+    // After a state estimation calculation,
+    // fictitious injections may be attributed to the busbar sections
+    // in node/breaker topology.
+    double fictitiousP;
+    double fictitiousQ;
+
     BusbarSectionImpl(String id, String name, boolean fictitious) {
         super(id, name, fictitious);
+        this.fictitiousP = Double.NaN;
+        this.fictitiousQ = Double.NaN;
     }
 
     @Override
@@ -42,5 +50,27 @@ class BusbarSectionImpl extends AbstractConnectable<BusbarSection> implements Bu
     @Override
     public double getAngle() {
         return ((NodeTerminal) getTerminal()).getAngle();
+    }
+
+    @Override
+    public double getFictitiousP() {
+        return fictitiousP;
+    }
+
+    @Override
+    public double getFictitiousQ() {
+        return fictitiousQ;
+    }
+
+    @Override
+    public BusbarSection setFictitiousP(double p) {
+        fictitiousP = p;
+        return this;
+    }
+
+    @Override
+    public BusbarSection setFictitiousQ(double q) {
+        fictitiousQ = q;
+        return this;
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusbarSectionAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusbarSectionAdapter.java
@@ -29,4 +29,26 @@ public class BusbarSectionAdapter extends AbstractInjectionAdapter<BusbarSection
     public double getAngle() {
         return getDelegate().getAngle();
     }
+
+    @Override
+    public double getFictitiousP() {
+        return getDelegate().getFictitiousP();
+    }
+
+    @Override
+    public double getFictitiousQ() {
+        return getDelegate().getFictitiousQ();
+    }
+
+    @Override
+    public BusbarSection setFictitiousP(double p) {
+        this.getDelegate().setFictitiousP(p);
+        return this;
+    }
+
+    @Override
+    public BusbarSection setFictitiousQ(double q) {
+        this.getDelegate().setFictitiousQ(q);
+        return this;
+    }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusbarSectionAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusbarSectionAdapterTest.java
@@ -49,6 +49,15 @@ public class BusbarSectionAdapterTest {
         assertEquals(expectedSJB.getV(), actualSJB.getV(), 0.0d);
         assertEquals(expectedSJB.getAngle(), actualSJB.getAngle(), 0.0d);
 
+        assertEquals(expectedSJB.getFictitiousP(), actualSJB.getFictitiousP(), 0.0d);
+        assertEquals(expectedSJB.getFictitiousQ(), actualSJB.getFictitiousQ(), 0.0d);
+
+        actualSJB.setFictitiousP(0);
+        actualSJB.setFictitiousQ(0);
+
+        assertEquals(0.0d, actualSJB.getFictitiousP(), 0.0d);
+        assertEquals(0.0d, actualSJB.getFictitiousQ(), 0.0d);
+
         // Topology
         TopologyVisitor visitor = mock(TopologyVisitor.class);
         mergingView.getVoltageLevel("voltageLevel1").visitEquipments(visitor);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/BusbarSectionXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/BusbarSectionXml.java
@@ -41,6 +41,8 @@ class BusbarSectionXml extends AbstractIdentifiableXml<BusbarSection, BusbarSect
         IidmXmlUtil.runUntilMaximumVersion(IidmXmlVersion.V_1_0, context, () -> {
             XmlUtil.writeDouble("v", bs.getV(), context.getWriter());
             XmlUtil.writeDouble("angle", bs.getAngle(), context.getWriter());
+            XmlUtil.writeDouble("fictitious p", bs.getFictitiousP(), context.getWriter());
+            XmlUtil.writeDouble("fictitious q", bs.getFictitiousQ(), context.getWriter());
         });
     }
 
@@ -58,6 +60,13 @@ class BusbarSectionXml extends AbstractIdentifiableXml<BusbarSection, BusbarSect
         IidmXmlUtil.runUntilMaximumVersion(IidmXmlVersion.V_1_0, context, () -> {
             double v = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "v");
             double angle = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "angle");
+            // After a state estimation calculation,
+            // fictitious injections may be attributed to the busbar sections
+            // in node/breaker topology.
+            double p = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "fictitious p");
+            double q = XmlUtil.readOptionalDoubleAttribute(context.getReader(), "fictitious q");
+            bbs.setFictitiousP(p);
+            bbs.setFictitiousQ(q);
             context.getEndTasks().add(() -> {
                 Bus b = bbs.getTerminal().getBusView().getBus();
                 if (b != null) {


### PR DESCRIPTION
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fictitious P and Q attributes are added to the busbar sections, in order to store the fictitious injections values coming from the state estimation results.


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, these attributes do not exist.


**What is the new behavior (if this is a feature change)?**
It is now possible to set fictitious P and Q on a busbar section.


