### PR TITLE
Correct_default_implementation_of_getVoltageSetpoint_method_for_static_var_compensator

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/StaticVarCompensator.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/StaticVarCompensator.java
@@ -135,7 +135,7 @@ public interface StaticVarCompensator extends Injection<StaticVarCompensator> {
      * @return the voltage setpoint
      */
     default double getVoltageSetpoint() {
-        return getVoltageSetpoint();
+        return getVoltageSetPoint();
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug


**What is the current behavior?** *(You can also link to an open issue here)*
StackOverFlow in implementations of StaticVarCompensator that provide getVoltageSetPoint method, but not getVoltageSetpoint method


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
