### PR TITLE
Add an extension containing SV metadata information for CGMES SV export

### DIFF
--- a/cgmes/cgmes-conversion/pom.xml
+++ b/cgmes/cgmes-conversion/pom.xml
@@ -64,6 +64,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-xml-converter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-iidm-extensions</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -126,12 +131,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>powsybl-iidm-xml-converter</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <!-- Test with all known triple store engines -->
         <dependency>
@@ -155,6 +154,19 @@
         
         <!-- To validate bus balances on converted Network -->
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-commons</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-loadflow-api</artifactId>
             <version>${project.version}</version>
@@ -176,6 +188,18 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-config-test</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>${xmlunit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -11,9 +11,11 @@ import com.powsybl.cgmes.conversion.elements.*;
 import com.powsybl.cgmes.conversion.elements.hvdc.CgmesDcConversion;
 import com.powsybl.cgmes.conversion.elements.transformers.ThreeWindingsTransformerConversion;
 import com.powsybl.cgmes.conversion.elements.transformers.TwoWindingsTransformerConversion;
+import com.powsybl.cgmes.conversion.extensions.CgmesSvMetadataAdder;
 import com.powsybl.cgmes.conversion.update.CgmesUpdate;
 import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.cgmes.model.CgmesModelException;
+import com.powsybl.cgmes.model.CgmesSubset;
 import com.powsybl.iidm.network.Connectable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.NetworkFactory;
@@ -140,6 +142,7 @@ public class Conversion {
         Network network = createNetwork();
         Context context = createContext(network);
         assignNetworkProperties(context);
+        addCgmesSvMetadata(network);
 
         Function<PropertyBag, AbstractObjectConversion> convf;
 
@@ -276,6 +279,19 @@ public class Conversion {
         LOG.info("cgmes modelCreated       : {}", modelCreated);
         LOG.info("network caseDate         : {}", context.network().getCaseDate());
         LOG.info("network forecastDistance : {}", context.network().getForecastDistance());
+    }
+
+    private void addCgmesSvMetadata(Network network) {
+        PropertyBags svDescription = cgmes.fullModel(CgmesSubset.STATE_VARIABLES.getProfile());
+        if (svDescription != null && !svDescription.isEmpty()) {
+            CgmesSvMetadataAdder adder = network.newExtension(CgmesSvMetadataAdder.class)
+                    .setScenarioTime(svDescription.get(0).getId("scenarioTime"))
+                    .setDescription(svDescription.get(0).getId("description"))
+                    .setSvVersion(svDescription.get(0).asInt("version"))
+                    .setModelingAuthoritySet(svDescription.get(0).getId("modelingAuthoritySet"));
+            svDescription.pluckLocals("DependentOn").forEach(adder::addDependency);
+            adder.add();
+        }
     }
 
     private void convertACLineSegmentsToLines(Context context) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadata.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadata.java
@@ -8,7 +8,6 @@ package com.powsybl.cgmes.conversion.extensions;
 
 import com.powsybl.commons.extensions.Extension;
 import com.powsybl.iidm.network.Network;
-import org.joda.time.DateTime;
 
 import java.util.List;
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadata.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadata.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 public interface CgmesSvMetadata extends Extension<Network> {
 
-    DateTime getScenarioTime();
+    String getScenarioTime();
 
     String getDescription();
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadata.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadata.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.extensions.Extension;
+import com.powsybl.iidm.network.Network;
+import org.joda.time.DateTime;
+
+import java.util.List;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public interface CgmesSvMetadata extends Extension<Network> {
+
+    DateTime getScenarioTime();
+
+    String getDescription();
+
+    int getSvVersion();
+
+    List<String> getDependencies();
+
+    String getModelingAuthoritySet();
+
+    @Override
+    default String getName() {
+        return "CgmesSvMetadata";
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadata.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadata.java
@@ -28,6 +28,6 @@ public interface CgmesSvMetadata extends Extension<Network> {
 
     @Override
     default String getName() {
-        return "CgmesSvMetadata";
+        return "cgmesSvMetadata";
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdder.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.extensions.ExtensionAdder;
+import com.powsybl.iidm.network.Network;
+import org.joda.time.DateTime;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public interface CgmesSvMetadataAdder extends ExtensionAdder<Network, CgmesSvMetadata> {
+
+    CgmesSvMetadataAdder setScenarioTime(DateTime scenarioTime);
+
+    CgmesSvMetadataAdder setDescription(String description);
+
+    CgmesSvMetadataAdder setSvVersion(int svVersion);
+
+    CgmesSvMetadataAdder addDependency(String dependency);
+
+    CgmesSvMetadataAdder setModelingAuthoritySet(String modelingAuthoritySet);
+
+    @Override
+    default Class<CgmesSvMetadata> getExtensionClass() {
+        return CgmesSvMetadata.class;
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdder.java
@@ -15,7 +15,7 @@ import org.joda.time.DateTime;
  */
 public interface CgmesSvMetadataAdder extends ExtensionAdder<Network, CgmesSvMetadata> {
 
-    CgmesSvMetadataAdder setScenarioTime(DateTime scenarioTime);
+    CgmesSvMetadataAdder setScenarioTime(String scenarioTime);
 
     CgmesSvMetadataAdder setDescription(String description);
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdder.java
@@ -8,7 +8,6 @@ package com.powsybl.cgmes.conversion.extensions;
 
 import com.powsybl.commons.extensions.ExtensionAdder;
 import com.powsybl.iidm.network.Network;
-import org.joda.time.DateTime;
 
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImpl.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImpl.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.cgmes.conversion.extensions;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.extensions.AbstractExtensionAdder;
 import com.powsybl.iidm.network.Network;
 
@@ -20,7 +21,7 @@ class CgmesSvMetadataAdderImpl extends AbstractExtensionAdder<Network, CgmesSvMe
 
     private String scenarioTime;
     private String description;
-    private int svVersion;
+    private int svVersion = 0;
     private final List<String> dependencies = new ArrayList<>();
     private String modelingAuthoritySet;
 
@@ -60,6 +61,18 @@ class CgmesSvMetadataAdderImpl extends AbstractExtensionAdder<Network, CgmesSvMe
 
     @Override
     protected CgmesSvMetadata createExtension(Network extendable) {
+        if (scenarioTime == null) {
+            throw new PowsyblException("cgmesSvMetadata.scenarioTime is undefined");
+        }
+        if (description == null) {
+            throw new PowsyblException("cgmesSvMetadata.description is undefined");
+        }
+        if (dependencies.isEmpty()) {
+            throw new PowsyblException("cgmesSvMetadata.dependencies must have at least one dependency");
+        }
+        if (modelingAuthoritySet == null) {
+            throw new PowsyblException("cgmesSvMetadata.modelingAuthoritySet is undefined");
+        }
         return new CgmesSvMetadataImpl(scenarioTime, description, svVersion, dependencies, modelingAuthoritySet);
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImpl.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImpl.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtensionAdder;
+import com.powsybl.iidm.network.Network;
+import org.joda.time.DateTime;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class CgmesSvMetadataAdderImpl extends AbstractExtensionAdder<Network, CgmesSvMetadata> implements CgmesSvMetadataAdder {
+
+    private DateTime scenarioTime;
+    private String description;
+    private int svVersion;
+    private final List<String> dependencies = new ArrayList<>();
+    private String modelingAuthoritySet;
+
+    public CgmesSvMetadataAdderImpl(Network extendable) {
+        super(extendable);
+    }
+
+    @Override
+    public CgmesSvMetadataAdder setScenarioTime(DateTime scenarioTime) {
+        this.scenarioTime = scenarioTime;
+        return this;
+    }
+
+    @Override
+    public CgmesSvMetadataAdder setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    @Override
+    public CgmesSvMetadataAdder setSvVersion(int svVersion) {
+        this.svVersion = svVersion;
+        return this;
+    }
+
+    @Override
+    public CgmesSvMetadataAdder addDependency(String dependency) {
+        this.dependencies.add(Objects.requireNonNull(dependency));
+        return this;
+    }
+
+    @Override
+    public CgmesSvMetadataAdder setModelingAuthoritySet(String modelingAuthoritySet) {
+        this.modelingAuthoritySet = modelingAuthoritySet;
+        return this;
+    }
+
+    @Override
+    protected CgmesSvMetadata createExtension(Network extendable) {
+        return new CgmesSvMetadataImpl(scenarioTime, description, svVersion, dependencies, modelingAuthoritySet);
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImpl.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImpl.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  */
 class CgmesSvMetadataAdderImpl extends AbstractExtensionAdder<Network, CgmesSvMetadata> implements CgmesSvMetadataAdder {
 
-    private DateTime scenarioTime;
+    private String scenarioTime;
     private String description;
     private int svVersion;
     private final List<String> dependencies = new ArrayList<>();
@@ -30,7 +30,7 @@ class CgmesSvMetadataAdderImpl extends AbstractExtensionAdder<Network, CgmesSvMe
     }
 
     @Override
-    public CgmesSvMetadataAdder setScenarioTime(DateTime scenarioTime) {
+    public CgmesSvMetadataAdder setScenarioTime(String scenarioTime) {
         this.scenarioTime = scenarioTime;
         return this;
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImpl.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImpl.java
@@ -8,7 +8,6 @@ package com.powsybl.cgmes.conversion.extensions;
 
 import com.powsybl.commons.extensions.AbstractExtensionAdder;
 import com.powsybl.iidm.network.Network;
-import org.joda.time.DateTime;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImplProvider.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImplProvider.java
@@ -24,7 +24,7 @@ public class CgmesSvMetadataAdderImplProvider implements
 
     @Override
     public Class<? super CgmesSvMetadataAdderImpl> getAdderClass() {
-        return CgmesSvMetadataAdder.class;
+        return CgmesSvMetadataAdderImpl.class;
     }
 
     @Override

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImplProvider.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImplProvider.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionAdderProvider;
+import com.powsybl.iidm.network.Network;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionAdderProvider.class)
+public class CgmesSvMetadataAdderImplProvider implements
+        ExtensionAdderProvider<Network, CgmesSvMetadata, CgmesSvMetadataAdderImpl> {
+
+    @Override
+    public String getImplementationName() {
+        return "Default";
+    }
+
+    @Override
+    public Class<? super CgmesSvMetadataAdderImpl> getAdderClass() {
+        return CgmesSvMetadataAdderImpl.class;
+    }
+
+    @Override
+    public CgmesSvMetadataAdderImpl newAdder(Network extendable) {
+        return new CgmesSvMetadataAdderImpl(extendable);
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImplProvider.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataAdderImplProvider.java
@@ -24,7 +24,7 @@ public class CgmesSvMetadataAdderImplProvider implements
 
     @Override
     public Class<? super CgmesSvMetadataAdderImpl> getAdderClass() {
-        return CgmesSvMetadataAdderImpl.class;
+        return CgmesSvMetadataAdder.class;
     }
 
     @Override

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataImpl.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataImpl.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.Network;
+import org.joda.time.DateTime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class CgmesSvMetadataImpl extends AbstractExtension<Network> implements CgmesSvMetadata {
+
+    private final DateTime scenarioTime;
+    private final String description;
+    private final int svVersion;
+    private final List<String> dependencies = new ArrayList<>();
+    private final String modelingAuthoritySet;
+
+    public CgmesSvMetadataImpl(DateTime scenarioTime, String description, int svVersion, List<String> dependencies, String modelingAuthoritySet) {
+        this.scenarioTime = Objects.requireNonNull(scenarioTime);
+        this.description = Objects.requireNonNull(description);
+        this.svVersion = svVersion;
+        this.dependencies.addAll(Objects.requireNonNull(dependencies));
+        this.modelingAuthoritySet = Objects.requireNonNull(modelingAuthoritySet);
+    }
+
+    @Override
+    public DateTime getScenarioTime() {
+        return scenarioTime;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public int getSvVersion() {
+        return svVersion;
+    }
+
+    @Override
+    public List<String> getDependencies() {
+        return Collections.unmodifiableList(dependencies);
+    }
+
+    @Override
+    public String getModelingAuthoritySet() {
+        return modelingAuthoritySet;
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataImpl.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataImpl.java
@@ -8,7 +8,6 @@ package com.powsybl.cgmes.conversion.extensions;
 
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.iidm.network.Network;
-import org.joda.time.DateTime;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataImpl.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataImpl.java
@@ -20,13 +20,13 @@ import java.util.Objects;
  */
 class CgmesSvMetadataImpl extends AbstractExtension<Network> implements CgmesSvMetadata {
 
-    private final DateTime scenarioTime;
+    private final String scenarioTime;
     private final String description;
     private final int svVersion;
     private final List<String> dependencies = new ArrayList<>();
     private final String modelingAuthoritySet;
 
-    public CgmesSvMetadataImpl(DateTime scenarioTime, String description, int svVersion, List<String> dependencies, String modelingAuthoritySet) {
+    public CgmesSvMetadataImpl(String scenarioTime, String description, int svVersion, List<String> dependencies, String modelingAuthoritySet) {
         this.scenarioTime = Objects.requireNonNull(scenarioTime);
         this.description = Objects.requireNonNull(description);
         this.svVersion = svVersion;
@@ -35,7 +35,7 @@ class CgmesSvMetadataImpl extends AbstractExtension<Network> implements CgmesSvM
     }
 
     @Override
-    public DateTime getScenarioTime() {
+    public String getScenarioTime() {
         return scenarioTime;
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataXmlSerializer.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataXmlSerializer.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.extensions.AbstractExtensionXmlSerializer;
+import com.powsybl.commons.extensions.ExtensionXmlSerializer;
+import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlUtil;
+import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.xml.NetworkXmlReaderContext;
+import com.powsybl.iidm.xml.NetworkXmlWriterContext;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionXmlSerializer.class)
+public class CgmesSvMetadataXmlSerializer extends AbstractExtensionXmlSerializer<Network, CgmesSvMetadata> {
+
+    public CgmesSvMetadataXmlSerializer() {
+        super("cgmesSvMetadata", "network", CgmesSvMetadata.class, true, "cgmesSvMetadata.xsd",
+                "http://www.powsybl.org/schema/iidm/ext/cgmes_sv_metadata/1_0", "csm");
+    }
+
+    @Override
+    public void write(CgmesSvMetadata extension, XmlWriterContext context) throws XMLStreamException {
+        NetworkXmlWriterContext networkContext = (NetworkXmlWriterContext) context;
+        XMLStreamWriter writer = networkContext.getWriter();
+        writer.writeAttribute("scenarioTime", extension.getScenarioTime());
+        writer.writeAttribute("description", extension.getDescription());
+        XmlUtil.writeInt("svVersion", extension.getSvVersion(), writer);
+        writer.writeAttribute("modelingAuthoritySet", extension.getModelingAuthoritySet());
+        for (String dep : extension.getDependencies()) {
+            writer.writeStartElement(getNamespaceUri(), "dependentOn");
+            writer.writeCharacters(dep);
+            writer.writeEndElement();
+        }
+    }
+
+    @Override
+    public CgmesSvMetadata read(Network extendable, XmlReaderContext context) throws XMLStreamException {
+        NetworkXmlReaderContext networkContext = (NetworkXmlReaderContext) context;
+        XMLStreamReader reader = networkContext.getReader();
+        CgmesSvMetadataAdder adder = extendable.newExtension(CgmesSvMetadataAdder.class);
+        adder.setScenarioTime(reader.getAttributeValue(null, "scenarioTime"))
+                .setDescription(reader.getAttributeValue(null, "description"))
+                .setSvVersion(XmlUtil.readIntAttribute(reader, "svVersion"))
+                .setModelingAuthoritySet(reader.getAttributeValue(null, "modelingAuthoritySet"));
+        XmlUtil.readUntilEndElement("cgmesSvMetadata", reader, () -> {
+            if (reader.getLocalName().equals("dependentOn")) {
+                adder.addDependency(reader.getElementText());
+            } else {
+                throw new PowsyblException("Unknown element name <" + reader.getLocalName() + "> in <cgmesSvMetadata>");
+            }
+        });
+        adder.add();
+        return extendable.getExtension(CgmesSvMetadata.class);
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/resources/xsd/cgmesSvMetadata.xsd
+++ b/cgmes/cgmes-conversion/src/main/resources/xsd/cgmesSvMetadata.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:csm="http://www.powsybl.org/schema/iidm/ext/cgmes_sv_metadata/1_0"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/cgmes_sv_metadata/1_0"
+           elementFormDefault="qualified">
+    <xs:simpleType name='nonEmptyString'>
+        <xs:restriction base='xs:string'>
+            <xs:minLength value='1'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="cgmesSvMetadata">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="dependentOn" type="csm:nonEmptyString" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="scenarioTime" use="required" type="csm:nonEmptyString"/>
+            <xs:attribute name="description" use="required" type="xs:string"/>
+            <xs:attribute name="svVersion" use="required" type="csm:nonEmptyString"/>
+            <xs:attribute name="modelingAuthoritySet" use="required" type="csm:nonEmptyString"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class CgmesSvMetadataTest {
+
+    @Test
+    public void test() {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.newExtension(CgmesSvMetadataAdder.class)
+                .setScenarioTime("2020-09-07T15:44:10.425+02:00")
+                .setDescription("test description")
+                .setModelingAuthoritySet("http://powsybl.org")
+                .setSvVersion(1)
+                .addDependency("http://dependency1")
+                .addDependency("http://dependency2")
+                .add();
+        CgmesSvMetadata extension = network.getExtension(CgmesSvMetadata.class);
+        assertNotNull(extension);
+        assertEquals("2020-09-07T15:44:10.425+02:00", extension.getScenarioTime());
+        assertEquals("test description", extension.getDescription());
+        assertEquals("http://powsybl.org", extension.getModelingAuthoritySet());
+        assertEquals(1, extension.getSvVersion());
+        assertEquals(2, extension.getDependencies().size());
+        assertTrue(extension.getDependencies().contains("http://dependency1"));
+        assertTrue(extension.getDependencies().contains("http://dependency2"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void invalid() {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.newExtension(CgmesSvMetadataAdder.class)
+                .add();
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.cgmes.conversion.extensions;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class CgmesSvMetadataTest {
         assertTrue(extension.getDependencies().contains("http://dependency2"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = PowsyblException.class)
     public void invalid() {
         Network network = EurostagTutorialExample1Factory.create();
         network.newExtension(CgmesSvMetadataAdder.class)

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataXmlSerializerTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataXmlSerializerTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.xml.NetworkXml;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class CgmesSvMetadataXmlSerializerTest extends AbstractConverterTest {
+
+    @Test
+    public void test() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.setCaseDate(DateTime.parse("2020-09-07T15:44:10.209+02:00"));
+        network.newExtension(CgmesSvMetadataAdder.class)
+                .setScenarioTime("2020-09-07T15:44:10.425+02:00")
+                .setDescription("test description")
+                .setModelingAuthoritySet("http://powsybl.org")
+                .setSvVersion(1)
+                .addDependency("http://dependency1")
+                .addDependency("http://dependency2")
+                .add();
+        roundTripXmlTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead, "/extensions/eurostag_cgmes_sv_metadata.xml");
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -12,6 +12,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.powsybl.cgmes.conversion.extensions.CgmesSvMetadata;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.ReactiveCapabilityCurve.Point;
 import com.powsybl.iidm.network.extensions.CoordinatedReactiveControl;
@@ -40,6 +41,10 @@ public class Comparison {
         if (config.checkNetworkId) {
             compare("networkId", expected.getId(), actual.getId());
         }
+
+        // Compare SV metadata
+        compareCgmesSvMetadata(expected.getExtension(CgmesSvMetadata.class), actual.getExtension(CgmesSvMetadata.class));
+
         // TODO Consider other attributes of network (name, caseData, forecastDistance, ...)
         compare(
                 expected.getSubstationStream(),
@@ -124,6 +129,33 @@ public class Comparison {
             T tactual = (T) actual;
             testAttributes.accept((T) expected, tactual);
         });
+    }
+
+    private void compareCgmesSvMetadata(CgmesSvMetadata expected, CgmesSvMetadata actual) {
+        if (expected == null && actual != null) {
+            diff.unexpected(actual.getExtendable().getId() + "_cgmesSvMetadata_extension");
+            return;
+        }
+        if (expected != null) {
+            if (actual == null) {
+                diff.missing(expected.getExtendable().getId() + "_cgmesSvMetadata_extension");
+                return;
+            }
+            compare("scenarioTime", expected.getScenarioTime(), actual.getScenarioTime());
+            compare("description", expected.getDescription(), actual.getDescription());
+            compare("svVersion", expected.getSvVersion(), actual.getSvVersion());
+            compare("modelingAuthoritySet", expected.getModelingAuthoritySet(), actual.getModelingAuthoritySet());
+            for (String dep : expected.getDependencies()) {
+                if (!actual.getDependencies().contains(dep)) {
+                    diff.missing("dependentOn: " + dep);
+                }
+            }
+            for (String dep : actual.getDependencies()) {
+                if (!expected.getDependencies().contains(dep)) {
+                    diff.unexpected("dependentOn: " + dep);
+                }
+            }
+        }
     }
 
     // Buses in bus breaker view are not inserted in the index for Network Identifiables

--- a/cgmes/cgmes-conversion/src/test/resources/extensions/eurostag_cgmes_sv_metadata.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/extensions/eurostag_cgmes_sv_metadata.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_3" xmlns:csm="http://www.powsybl.org/schema/iidm/ext/cgmes_sv_metadata/1_0" id="sim1" caseDate="2020-09-07T15:44:10.209+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:extension id="sim1">
+        <csm:cgmesSvMetadata scenarioTime="2020-09-07T15:44:10.425+02:00" description="test description" svVersion="1" modelingAuthoritySet="http://powsybl.org">
+            <csm:dependentOn>http://dependency1</csm:dependentOn>
+            <csm:dependentOn>http://dependency2</csm:dependentOn>
+        </csm:cgmesSvMetadata>
+    </iidm:extension>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
CGMES SV metadata are only accessible from the CgmesModel


**What is the new behavior (if this is a feature change)?**
CGMES SV metadata can now be stored in the `CgmesSvMetadata` extension


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
More or less: the `CgmesSvMetadata` must be implemented in IIDM implementation to make the CGMES import working if you have a custom implementation.

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
