### PR TITLE
Add aliases during CGMES import for missing IDs

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/NodeMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/NodeMapping.java
@@ -68,7 +68,7 @@ public class NodeMapping {
             vl.getNodeBreakerView().newSwitch()
                     .setFictitious(true)
                     // Use the id and name of terminal
-                    .setId(t.id())
+                    .setId(t.id() + "_SW_fict")
                     .setName(t.name())
                     .setNode1(iidmNodeForConductingEquipment)
                     .setNode2(iidmNodeForConnectivityNode)

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
@@ -141,6 +141,7 @@ public class ACLineSegmentConversion extends AbstractBranchConversion {
         } else {
             mline = createQuadripole(boundaryLine1, boundaryLine2);
         }
+        addAliases(mline);
         context.convertedTerminal(terminalId(thisEnd), mline.getTerminal1(), 1, powerFlow(thisEnd));
         context.convertedTerminal(otherc.terminalId(otherEnd), mline.getTerminal2(), 2, otherc.powerFlow(otherEnd));
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
@@ -82,6 +82,7 @@ public class ACLineSegmentConversion extends AbstractBranchConversion {
         identify(adder);
         connect(adder);
         final Line l = adder.add();
+        addAliases(l);
         convertedTerminals(l.getTerminal1(), l.getTerminal2());
     }
 
@@ -110,6 +111,7 @@ public class ACLineSegmentConversion extends AbstractBranchConversion {
         } else {
             mline = createQuadripole(boundaryLine1, boundaryLine2);
         }
+        addAliases(mline);
         context.convertedTerminal(terminalId(thisEnd), mline.getTerminal1(), 1, powerFlow(thisEnd));
         context.convertedTerminal(otherc.terminalId(otherEnd), mline.getTerminal2(), 2, otherc.powerFlow(otherEnd));
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
@@ -113,7 +113,6 @@ public class ACLineSegmentConversion extends AbstractBranchConversion {
         }
         addAliases(mline);
         context.convertedTerminal(terminalId(thisEnd), mline.getTerminal1(), 1, powerFlow(thisEnd));
-        context.convertedTerminal(terminalId(thisEnd), mline.getTerminal1(), 1, powerFlow(thisEnd));
         context.convertedTerminal(otherc.terminalId(otherEnd), mline.getTerminal2(), 2, otherc.powerFlow(otherEnd));
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
@@ -113,6 +113,7 @@ public class ACLineSegmentConversion extends AbstractBranchConversion {
         }
         addAliases(mline);
         context.convertedTerminal(terminalId(thisEnd), mline.getTerminal1(), 1, powerFlow(thisEnd));
+        context.convertedTerminal(terminalId(thisEnd), mline.getTerminal1(), 1, powerFlow(thisEnd));
         context.convertedTerminal(otherc.terminalId(otherEnd), mline.getTerminal2(), 2, otherc.powerFlow(otherEnd));
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
@@ -438,7 +438,7 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
             if (td == null) {
                 return;
             }
-            identifiable.addAlias(td.t.id(), CgmesNames.TERMINAL + i);
+            identifiable.addAlias(td.t.id(), "CGMES." + CgmesNames.TERMINAL + i);
             i++;
         }
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
@@ -12,12 +12,8 @@ import com.powsybl.cgmes.conversion.ConversionException;
 import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.cgmes.model.CgmesTerminal;
 import com.powsybl.cgmes.model.PowerFlow;
-import com.powsybl.iidm.network.BranchAdder;
-import com.powsybl.iidm.network.InjectionAdder;
-import com.powsybl.iidm.network.Substation;
-import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.ThreeWindingsTransformerAdder.LegAdder;
-import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
 
@@ -433,6 +429,17 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
                 .setVoltageLevel(iidmVoltageLevelId(terminal))
                 .setBus(terminalConnected(terminal) ? busId(terminal) : null)
                 .setConnectableBus(busId(terminal));
+        }
+    }
+
+    protected void addAliases(Identifiable<?> identifiable) {
+        int i = 1;
+        for (TerminalData td : terminals) {
+            if (td == null) {
+                return;
+            }
+            identifiable.addAlias(td.t.id(), CgmesNames.TERMINAL + i);
+            i++;
         }
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
@@ -100,7 +100,7 @@ public abstract class AbstractConnectorConversion extends AbstractConductingEqui
                 .add();
             addAliases(dl);
         }
-        dl.addAlias(boundaryNode, CgmesNames.TOPOLOGICAL_NODE);
+        dl.addAlias(boundaryNode, "CGMES." + CgmesNames.TOPOLOGICAL_NODE);
         context.convertedTerminal(terminalId(modelSide), dl.getTerminal(), 1, powerFlow(modelSide));
 
         // If we do not have power flow at model side and we can compute it,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
@@ -10,6 +10,7 @@ package com.powsybl.cgmes.conversion.elements;
 import java.util.List;
 
 import com.powsybl.cgmes.conversion.Context;
+import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.cgmes.model.PowerFlow;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.DanglingLine;
@@ -97,8 +98,9 @@ public abstract class AbstractConnectorConversion extends AbstractConductingEqui
                 .setVoltageRegulationOn(false)
                 .add()
                 .add();
+            addAliases(dl);
         }
-        addAliases(dl);
+        dl.addAlias(boundaryNode, CgmesNames.TOPOLOGICAL_NODE);
         context.convertedTerminal(terminalId(modelSide), dl.getTerminal(), 1, powerFlow(modelSide));
 
         // If we do not have power flow at model side and we can compute it,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
@@ -98,8 +98,8 @@ public abstract class AbstractConnectorConversion extends AbstractConductingEqui
                 .setVoltageRegulationOn(false)
                 .add()
                 .add();
-            addAliases(dl);
         }
+        addAliases(dl);
         dl.addAlias(boundaryNode, "CGMES." + CgmesNames.TOPOLOGICAL_NODE);
         context.convertedTerminal(terminalId(modelSide), dl.getTerminal(), 1, powerFlow(modelSide));
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
@@ -98,6 +98,7 @@ public abstract class AbstractConnectorConversion extends AbstractConductingEqui
                 .add()
                 .add();
         }
+        addAliases(dl);
         context.convertedTerminal(terminalId(modelSide), dl.getTerminal(), 1, powerFlow(modelSide));
 
         // If we do not have power flow at model side and we can compute it,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AsynchronousMachineConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AsynchronousMachineConversion.java
@@ -36,6 +36,7 @@ public class AsynchronousMachineConversion extends AbstractConductingEquipmentCo
         identify(adder);
         connect(adder);
         Load load = adder.add();
+        addAliases(load);
         convertedTerminals(load.getTerminal());
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
@@ -35,6 +35,7 @@ public class BusbarSectionConversion extends AbstractConductingEquipmentConversi
                 .setEnsureIdUnicity(false);
         bbsAdder.setNode(iidmNode());
         BusbarSection bbs = bbsAdder.add();
+        addAliases(bbs);
         convertedTerminals(bbs.getTerminal());
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergyConsumerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergyConsumerConversion.java
@@ -34,6 +34,7 @@ public class EnergyConsumerConversion extends AbstractConductingEquipmentConvers
         identify(adder);
         connect(adder);
         Load load = adder.add();
+        addAliases(load);
         convertedTerminals(load.getTerminal());
         setLoadDetail(loadKind, load);
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergySourceConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EnergySourceConversion.java
@@ -35,6 +35,7 @@ public class EnergySourceConversion extends AbstractConductingEquipmentConversio
         identify(adder);
         connect(adder);
         Load load = adder.add();
+        addAliases(load);
         convertedTerminals(load.getTerminal());
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentBranchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentBranchConversion.java
@@ -53,6 +53,7 @@ public class EquivalentBranchConversion extends AbstractBranchConversion {
         identify(adder);
         connect(adder);
         Line l = adder.add();
+        addAliases(l);
         convertedTerminals(l.getTerminal1(), l.getTerminal2());
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentInjectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentInjectionConversion.java
@@ -8,6 +8,7 @@
 package com.powsybl.cgmes.conversion.elements;
 
 import com.powsybl.cgmes.conversion.Context;
+import com.powsybl.cgmes.model.CgmesTerminal;
 import com.powsybl.cgmes.model.PowerFlow;
 import com.powsybl.iidm.network.*;
 import com.powsybl.triplestore.api.PropertyBag;
@@ -67,7 +68,6 @@ public class EquivalentInjectionConversion extends AbstractReactiveLimitsOwnerCo
                         .setTargetV(regulation.targetV)
                     .add()
                     .add();
-            addAliases(dl);
         } else {
             // Map all the observed flows to the 'virtual load'
             // of the dangling line
@@ -82,7 +82,18 @@ public class EquivalentInjectionConversion extends AbstractReactiveLimitsOwnerCo
                         .setTargetQ(0.0)
                     .add()
                     .add();
-            addAliases(dl);
+        }
+        // We do not call addAliases(dl) !
+        // Because we do not want to add this equivalent injection
+        // terminal id as a generic "Terminal" alias of the dangling line,
+        // Terminal1 and Terminal2 aliases should be used for
+        // the original ACLineSegment or Switch terminals
+        // We want to keep track add this equivalent injection terminal
+        // under a separate, specific, alias type
+        dl.addAlias(this.id, "CGMES.EquivalentInjection");
+        CgmesTerminal cgmesTerminal = context.cgmes().terminal(terminalId());
+        if (cgmesTerminal != null) {
+            dl.addAlias(cgmesTerminal.id(), "CGMES.EquivalentInjectionTerminal");
         }
         return dl;
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentInjectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentInjectionConversion.java
@@ -67,6 +67,7 @@ public class EquivalentInjectionConversion extends AbstractReactiveLimitsOwnerCo
                         .setTargetV(regulation.targetV)
                     .add()
                     .add();
+            addAliases(dl);
         } else {
             // Map all the observed flows to the 'virtual load'
             // of the dangling line
@@ -81,6 +82,7 @@ public class EquivalentInjectionConversion extends AbstractReactiveLimitsOwnerCo
                         .setTargetQ(0.0)
                     .add()
                     .add();
+            addAliases(dl);
         }
         return dl;
     }
@@ -102,6 +104,7 @@ public class EquivalentInjectionConversion extends AbstractReactiveLimitsOwnerCo
         identify(adder);
         connect(adder);
         Generator g = adder.add();
+        addAliases(g);
         convertedTerminals(g.getTerminal());
         convertReactiveLimits(g);
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/EquivalentShuntConversion.java
@@ -29,6 +29,6 @@ public class EquivalentShuntConversion extends AbstractConductingEquipmentConver
                     .add();
         identify(adder);
         connect(adder);
-        adder.add();
+        addAliases(adder.add());
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ExternalNetworkInjectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ExternalNetworkInjectionConversion.java
@@ -47,6 +47,7 @@ public class ExternalNetworkInjectionConversion extends AbstractReactiveLimitsOw
         identify(adder);
         connect(adder);
         Generator g = adder.add();
+        addAliases(g);
         convertedTerminals(g.getTerminal());
         convertReactiveLimits(g);
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
@@ -36,6 +36,7 @@ public class SeriesCompensatorConversion extends AbstractBranchConversion {
         identify(adder);
         connect(adder);
         final Line l = adder.add();
+        addAliases(l);
         convertedTerminals(l.getTerminal1(), l.getTerminal2());
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
@@ -83,6 +83,7 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
         identify(adder);
         connect(adder);
         ShuntCompensator shunt = adder.add();
+        addAliases(shunt);
 
         // At a shunt terminal, only Q can be set
         PowerFlow f = powerFlow();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
@@ -37,6 +37,7 @@ public class StaticVarCompensatorConversion extends AbstractConductingEquipmentC
         RegulatingControlMappingForStaticVarCompensators.initialize(adder);
 
         StaticVarCompensator svc = adder.add();
+        addAliases(svc);
         convertedTerminals(svc.getTerminal());
         if (slope >= 0) {
             svc.newExtension(VoltagePerReactivePowerControlAdder.class).withSlope(slope).add();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
@@ -7,15 +7,12 @@
 
 package com.powsybl.cgmes.conversion.elements;
 
+import com.powsybl.iidm.network.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.powsybl.cgmes.conversion.Context;
 import com.powsybl.cgmes.model.CgmesContainer;
-import com.powsybl.iidm.network.Line;
-import com.powsybl.iidm.network.LineAdder;
-import com.powsybl.iidm.network.SwitchKind;
-import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.triplestore.api.PropertyBag;
 
 import java.util.function.Supplier;
@@ -82,21 +79,24 @@ public class SwitchConversion extends AbstractConnectorConversion {
             boolean branchIsClosed = !open;
             connect(adder, terminalConnected(1), terminalConnected(2), branchIsClosed);
             Line line = adder.add();
+            addAliases(line);
             convertedTerminals(line.getTerminal1(), line.getTerminal2());
         } else {
+            Switch s;
             if (context.nodeBreaker()) {
                 VoltageLevel.NodeBreakerView.SwitchAdder adder;
                 adder = voltageLevel().getNodeBreakerView().newSwitch().setKind(kind());
                 identify(adder);
                 connect(adder, open);
-                adder.add();
+                s = adder.add();
             } else {
                 VoltageLevel.BusBreakerView.SwitchAdder adder;
                 adder = voltageLevel().getBusBreakerView().newSwitch();
                 identify(adder);
                 connect(adder, open);
-                adder.add();
+                s = adder.add();
             }
+            addAliases(s);
         }
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SynchronousMachineConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SynchronousMachineConversion.java
@@ -54,6 +54,7 @@ public class SynchronousMachineConversion extends AbstractReactiveLimitsOwnerCon
         identify(adder);
         connect(adder);
         Generator g = adder.add();
+        addAliases(g);
         convertedTerminals(g.getTerminal());
         convertReactiveLimits(g);
         if (p.asInt("referencePriority", 0) > 0) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/AcDcConverterConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/AcDcConverterConversion.java
@@ -73,6 +73,7 @@ public class AcDcConverterConversion extends AbstractConductingEquipmentConversi
             identify(adder);
             connect(adder);
             VscConverterStation c = adder.add();
+            addAliases(c);
 
             convertedTerminals(c.getTerminal());
         } else if (converterType.equals(HvdcType.LCC)) {
@@ -87,6 +88,7 @@ public class AcDcConverterConversion extends AbstractConductingEquipmentConversi
             identify(adder);
             connect(adder);
             LccConverterStation c = adder.add();
+            addAliases(c);
 
             this.lccConverter = c;
             convertedTerminals(c.getTerminal());

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
@@ -17,6 +17,9 @@ import com.powsybl.iidm.network.PhaseTapChangerAdder;
 import com.powsybl.iidm.network.RatioTapChangerAdder;
 import com.powsybl.triplestore.api.PropertyBags;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  * @author José Antonio Marqués <marquesja at aia.es>
@@ -101,13 +104,19 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
     @Override
     protected void addAliases(Identifiable<?> identifiable) {
         super.addAliases(identifiable);
-        String ptc = context.cgmes().phaseTapChangerForPowerTransformer(identifiable.getId());
-        if (ptc != null) {
-            identifiable.addAlias(ptc, CgmesNames.PHASE_TAP_CHANGER);
+        List<String> ptcs = context.cgmes().phaseTapChangerListForPowerTransformer(identifiable.getId());
+        if (ptcs != null) {
+            for (int  i = 0; i < ptcs.size(); i++) {
+                int index = i + 1;
+                Optional.ofNullable(ptcs.get(i)).ifPresent(ptc -> identifiable.addAlias(ptc, CgmesNames.PHASE_TAP_CHANGER + index));
+            }
         }
-        String rtc = context.cgmes().ratioTapChangerForPowerTransformer(identifiable.getId());
-        if (rtc != null) {
-            identifiable.addAlias(rtc, CgmesNames.RATIO_TAP_CHANGER);
+        List<String> rtcs = context.cgmes().ratioTapChangerListForPowerTransformer(identifiable.getId());
+        if (rtcs != null) {
+            for (int i = 0; i < rtcs.size(); i++) {
+                int index = i + 1;
+                Optional.ofNullable(rtcs.get(i)).ifPresent(rtc -> identifiable.addAlias(rtc, CgmesNames.RATIO_TAP_CHANGER + index));
+            }
         }
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
@@ -11,6 +11,8 @@ import com.powsybl.cgmes.conversion.Context;
 import com.powsybl.cgmes.conversion.RegulatingControlMappingForTransformers.CgmesRegulatingControlPhase;
 import com.powsybl.cgmes.conversion.RegulatingControlMappingForTransformers.CgmesRegulatingControlRatio;
 import com.powsybl.cgmes.conversion.elements.AbstractConductingEquipmentConversion;
+import com.powsybl.cgmes.model.CgmesNames;
+import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.PhaseTapChangerAdder;
 import com.powsybl.iidm.network.RatioTapChangerAdder;
 import com.powsybl.triplestore.api.PropertyBags;
@@ -94,5 +96,18 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
                 tc.getRegulatingControlId(), tc.isTapChangerControlEnabled(), tc.isLtcFlag());
         }
         return rcPtc;
+    }
+
+    @Override
+    protected void addAliases(Identifiable<?> identifiable) {
+        super.addAliases(identifiable);
+        String ptc = context.cgmes().phaseTapChangerForPowerTransformer(identifiable.getId());
+        if (ptc != null) {
+            identifiable.addAlias(ptc, CgmesNames.PHASE_TAP_CHANGER);
+        }
+        String rtc = context.cgmes().ratioTapChangerForPowerTransformer(identifiable.getId());
+        if (rtc != null) {
+            identifiable.addAlias(rtc, CgmesNames.RATIO_TAP_CHANGER);
+        }
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
@@ -108,14 +108,14 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
         if (ptcs != null) {
             for (int  i = 0; i < ptcs.size(); i++) {
                 int index = i + 1;
-                Optional.ofNullable(ptcs.get(i)).ifPresent(ptc -> identifiable.addAlias(ptc, CgmesNames.PHASE_TAP_CHANGER + index));
+                Optional.ofNullable(ptcs.get(i)).ifPresent(ptc -> identifiable.addAlias(ptc, "CGMES." + CgmesNames.PHASE_TAP_CHANGER + index));
             }
         }
         List<String> rtcs = context.cgmes().ratioTapChangerListForPowerTransformer(identifiable.getId());
         if (rtcs != null) {
             for (int i = 0; i < rtcs.size(); i++) {
                 int index = i + 1;
-                Optional.ofNullable(rtcs.get(i)).ifPresent(rtc -> identifiable.addAlias(rtc, CgmesNames.RATIO_TAP_CHANGER + index));
+                Optional.ofNullable(rtcs.get(i)).ifPresent(rtc -> identifiable.addAlias(rtc, "CGMES." + CgmesNames.RATIO_TAP_CHANGER + index));
             }
         }
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/ThreeWindingsTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/ThreeWindingsTransformerConversion.java
@@ -90,7 +90,7 @@ public class ThreeWindingsTransformerConversion extends AbstractTransformerConve
         l3adder.add();
 
         ThreeWindingsTransformer tx = txadder.add();
-
+        addAliases(tx);
         convertedTerminals(
             tx.getLeg1().getTerminal(),
             tx.getLeg2().getTerminal(),

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TwoWindingsTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TwoWindingsTransformerConversion.java
@@ -92,6 +92,7 @@ public class TwoWindingsTransformerConversion extends AbstractTransformerConvers
         identify(adder);
         connect(adder);
         TwoWindingsTransformer tx = adder.add();
+        addAliases(tx);
         convertedTerminals(tx.getTerminal1(), tx.getTerminal2());
 
         setToIidmRatioTapChanger(convertedT2xModel, tx);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -249,6 +249,7 @@ public class Comparison {
 
     private void compareBuses(Bus expected, Bus actual) {
         equivalent("VoltageLevel", expected.getVoltageLevel(), actual.getVoltageLevel());
+        compareAliases(expected, actual);
         compare("v", expected.getV(), actual.getV());
         compare("angle", expected.getAngle(), actual.getAngle());
     }
@@ -257,6 +258,7 @@ public class Comparison {
         equivalent("VoltageLevel",
                 expected.getTerminal().getVoltageLevel(),
                 actual.getTerminal().getVoltageLevel());
+        compareAliases(expected, actual);
         compare("p0", expected.getP0(), actual.getP0());
         compare("q0", expected.getQ0(), actual.getQ0());
         // TODO Should we check terminals ? (we are not setting terminal id)
@@ -287,6 +289,7 @@ public class Comparison {
         equivalent("VoltageLevel",
                 expected.getTerminal().getVoltageLevel(),
                 actual.getTerminal().getVoltageLevel());
+        compareAliases(expected, actual);
         compare("sectionCount",
                 expected.getSectionCount(),
                 actual.getSectionCount());
@@ -351,6 +354,7 @@ public class Comparison {
         equivalent("VoltageLevel",
                 expected.getTerminal().getVoltageLevel(),
                 actual.getTerminal().getVoltageLevel());
+        compareAliases(expected, actual);
         compare("Bmin",
                 expected.getBmin(),
                 actual.getBmin());
@@ -375,6 +379,7 @@ public class Comparison {
         equivalent("VoltageLevel",
                 expected.getTerminal().getVoltageLevel(),
                 actual.getTerminal().getVoltageLevel());
+        compareAliases(expected, actual);
         sameIdentifier("ConnectableBus",
                 expected.getTerminal().getBusBreakerView().getConnectableBus(),
                 actual.getTerminal().getBusBreakerView().getConnectableBus());
@@ -481,6 +486,7 @@ public class Comparison {
 
     private void compareSwitches(Switch expected, Switch actual) {
         equivalent("VoltageLevel", expected.getVoltageLevel(), actual.getVoltageLevel());
+        compareAliases(expected, actual);
         // No additional properties to check
     }
 
@@ -491,6 +497,7 @@ public class Comparison {
         equivalent("VoltageLevel2",
                 expected.getTerminal2().getVoltageLevel(),
                 actual.getTerminal2().getVoltageLevel());
+        compareAliases(expected, actual);
         compare("r", expected.getR(), actual.getR());
         compare("x", expected.getX(), actual.getX());
         compare("g1", expected.getG1(), actual.getG1());
@@ -509,6 +516,7 @@ public class Comparison {
         equivalent("VoltageLevel",
                 expected.getTerminal().getVoltageLevel(),
                 actual.getTerminal().getVoltageLevel());
+        compareAliases(expected, actual);
         compare("r", expected.getR(), actual.getR());
         compare("x", expected.getX(), actual.getX());
         compare("g", expected.getG(), actual.getG());
@@ -552,6 +560,7 @@ public class Comparison {
         equivalent("VoltageLevel2",
                 expected.getTerminal2().getVoltageLevel(),
                 actual.getTerminal2().getVoltageLevel());
+        compareAliases(expected, actual);
         compare("r", expected.getR(), actual.getR());
         compare("x", expected.getX(), actual.getX());
         compare("g", expected.getG(), actual.getG());
@@ -586,6 +595,7 @@ public class Comparison {
 
     private void compareThreeWindingsTransformers(ThreeWindingsTransformer expected,
                                                   ThreeWindingsTransformer actual) {
+        compareAliases(expected, actual);
         compareLeg(expected.getLeg1(), actual.getLeg1(), expected, actual);
         compareLeg(expected.getLeg2(), actual.getLeg2(), expected, actual);
         compareLeg(expected.getLeg3(), actual.getLeg3(), expected, actual);
@@ -776,6 +786,29 @@ public class Comparison {
 
     private void compare(String context, Object expected, Object actual) {
         diff.compare(context, expected, actual);
+    }
+
+    private <I extends Identifiable<I>> void compareAliases(I expected, I actual) {
+        for (String alias : expected.getAliases()) {
+            if (!actual.getAliases().contains(alias)) {
+                diff.missing(alias);
+                break;
+            }
+            Optional<String> type = expected.getAliasType(alias);
+            if (!type.isPresent()) {
+                actual.getAliasType(alias).ifPresent(diff::unexpected);
+            } else {
+                if (!actual.getAliasType(alias).isPresent()) {
+                    diff.missing(type.get());
+                }
+                compare("alias", type.get(), actual.getAliasType(alias).get());
+            }
+        }
+        for (String alias : actual.getAliases()) {
+            if (!expected.getAliases().contains(alias)) {
+                diff.unexpected(alias);
+            }
+        }
     }
 
     private void equivalent(

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -131,6 +131,7 @@ public abstract class AbstractCgmesModel implements CgmesModel {
         // Alternative implementation:
         // instead of sorting after building each list,
         // use a sorted collection when inserting
+        String endNumber = "endNumber";
         Map<String, PropertyBags> gends = new HashMap<>();
         powerTransformerRatioTapChanger = new HashMap<>();
         powerTransformerPhaseTapChanger = new HashMap<>();
@@ -141,10 +142,10 @@ public abstract class AbstractCgmesModel implements CgmesModel {
                 ends.add(end);
                 if (end.getId("PhaseTapChanger") != null) {
                     powerTransformerPhaseTapChanger.computeIfAbsent(id, s -> new String[3]);
-                    powerTransformerPhaseTapChanger.get(id)[end.asInt("endNumber", 1) - 1] = end.getId("PhaseTapChanger");
+                    powerTransformerPhaseTapChanger.get(id)[end.asInt(endNumber, 1) - 1] = end.getId("PhaseTapChanger");
                 } else if (end.getId("RatioTapChanger") != null) {
                     powerTransformerRatioTapChanger.computeIfAbsent(id, s -> new String[3]);
-                    powerTransformerRatioTapChanger.get(id)[end.asInt("endNumber", 1) - 1] = end.getId("RatioTapChanger");
+                    powerTransformerRatioTapChanger.get(id)[end.asInt(endNumber, 1) - 1] = end.getId("RatioTapChanger");
                 }
             });
         gends.entrySet()
@@ -153,7 +154,7 @@ public abstract class AbstractCgmesModel implements CgmesModel {
                     tends.getValue().stream()
                         .sorted(Comparator
                             .comparing(WindingType::fromTransformerEnd)
-                            .thenComparing(end -> end.asInt("endNumber", -1)))
+                            .thenComparing(end -> end.asInt(endNumber, -1)))
                         .collect(Collectors.toList()));
                 tends.setValue(tends1);
             });

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -19,8 +19,6 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
@@ -61,11 +59,6 @@ public abstract class AbstractCgmesModel implements CgmesModel {
             cachedDcTerminals = computeDcTerminals();
         }
         return cachedDcTerminals.get(dcTerminalId);
-    }
-
-    @Override
-    public String terminalForEquipment(String conductingEquipmentId, int sequenceNumber) {
-        return conductingEquipmentTerminals.get(conductingEquipmentId, sequenceNumber);
     }
 
     @Override
@@ -178,32 +171,24 @@ public abstract class AbstractCgmesModel implements CgmesModel {
 
     private Map<String, CgmesTerminal> computeTerminals() {
         Map<String, CgmesTerminal> ts = new HashMap<>();
-        if (conductingEquipmentTerminals == null) {
-            conductingEquipmentTerminals = HashBasedTable.create();
-        }
         terminals().forEach(t -> {
             CgmesTerminal td = new CgmesTerminal(t);
             if (ts.containsKey(td.id())) {
                 return;
             }
             ts.put(td.id(), td);
-            conductingEquipmentTerminals.put(t.getId("ConductingEquipment"), t.asInt(CgmesNames.SEQUENCE_NUMBER, 1), t.getId(CgmesNames.TERMINAL));
         });
         return ts;
     }
 
     private Map<String, CgmesDcTerminal> computeDcTerminals() {
         Map<String, CgmesDcTerminal> ts = new HashMap<>();
-        if (conductingEquipmentTerminals == null) {
-            conductingEquipmentTerminals = HashBasedTable.create();
-        }
         dcTerminals().forEach(t -> {
             CgmesDcTerminal td = new CgmesDcTerminal(t);
             if (ts.containsKey(td.id())) {
                 return;
             }
             ts.put(td.id(), td);
-            conductingEquipmentTerminals.put(t.getId("DCConductingEquipment"), t.asInt(CgmesNames.SEQUENCE_NUMBER, 1), t.getId(CgmesNames.DC_TERMINAL));
         });
         return ts;
     }
@@ -267,7 +252,6 @@ public abstract class AbstractCgmesModel implements CgmesModel {
     private Map<String, Double> cachedBaseVoltages;
     private Map<String, PropertyBag> cachedNodes;
     // equipmentId, sequenceNumber, terminalId
-    private Table<String, Integer, String> conductingEquipmentTerminals;
     private Map<String, String> powerTransformerRatioTapChanger;
     private Map<String, String> powerTransformerPhaseTapChanger;
     private Map<String, CgmesDcTerminal> cachedDcTerminals;

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -9,11 +9,7 @@ package com.powsybl.cgmes.model;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -62,13 +58,13 @@ public abstract class AbstractCgmesModel implements CgmesModel {
     }
 
     @Override
-    public String ratioTapChangerForPowerTransformer(String powerTransformerId) {
-        return powerTransformerRatioTapChanger.get(powerTransformerId);
+    public List<String> ratioTapChangerListForPowerTransformer(String powerTransformerId) {
+        return powerTransformerRatioTapChanger.get(powerTransformerId) == null ? null : Arrays.asList(powerTransformerRatioTapChanger.get(powerTransformerId));
     }
 
     @Override
-    public String phaseTapChangerForPowerTransformer(String powerTransformerId) {
-        return powerTransformerPhaseTapChanger.get(powerTransformerId);
+    public List<String> phaseTapChangerListForPowerTransformer(String powerTransformerId) {
+        return powerTransformerPhaseTapChanger.get(powerTransformerId) == null ? null : Arrays.asList(powerTransformerPhaseTapChanger.get(powerTransformerId));
     }
 
     @Override
@@ -144,9 +140,11 @@ public abstract class AbstractCgmesModel implements CgmesModel {
                 PropertyBags ends = gends.computeIfAbsent(id, x -> new PropertyBags());
                 ends.add(end);
                 if (end.getId("PhaseTapChanger") != null) {
-                    powerTransformerPhaseTapChanger.put(id, end.getId("PhaseTapChanger"));
+                    powerTransformerPhaseTapChanger.computeIfAbsent(id, s -> new String[3]);
+                    powerTransformerPhaseTapChanger.get(id)[end.asInt("endNumber", 1) - 1] = end.getId("PhaseTapChanger");
                 } else if (end.getId("RatioTapChanger") != null) {
-                    powerTransformerRatioTapChanger.put(id, end.getId("RatioTapChanger"));
+                    powerTransformerRatioTapChanger.computeIfAbsent(id, s -> new String[3]);
+                    powerTransformerRatioTapChanger.get(id)[end.asInt("endNumber", 1) - 1] = end.getId("RatioTapChanger");
                 }
             });
         gends.entrySet()
@@ -252,8 +250,8 @@ public abstract class AbstractCgmesModel implements CgmesModel {
     private Map<String, Double> cachedBaseVoltages;
     private Map<String, PropertyBag> cachedNodes;
     // equipmentId, sequenceNumber, terminalId
-    private Map<String, String> powerTransformerRatioTapChanger;
-    private Map<String, String> powerTransformerPhaseTapChanger;
+    private Map<String, String[]> powerTransformerRatioTapChanger;
+    private Map<String, String[]> powerTransformerPhaseTapChanger;
     private Map<String, CgmesDcTerminal> cachedDcTerminals;
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractCgmesModel.class);

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -177,16 +177,21 @@ public interface CgmesModel {
 
     // Helper mappings
 
-    @Deprecated
     default String terminalForEquipment(String conductingEquipmentId, int sequenceNumber) {
         return null;
     }
 
+    /**
+     * @deprecated Use {@link #ratioTapChangerListForPowerTransformer(String)} instead.
+     */
     @Deprecated
     default String ratioTapChangerForPowerTransformer(String powerTransformerId) {
         return ratioTapChangerListForPowerTransformer(powerTransformerId).stream().filter(Objects::nonNull).findFirst().orElse(null);
     }
 
+    /**
+     * @deprecated Use {@link #phaseTapChangerListForPowerTransformer(String)} instead.
+     */
     @Deprecated
     default String phaseTapChangerForPowerTransformer(String powerTransformerId) {
         return phaseTapChangerListForPowerTransformer(powerTransformerId).stream().filter(Objects::nonNull).findFirst().orElse(null);

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -180,8 +180,10 @@ public interface CgmesModel {
 
     // TODO If we could store identifiers for tap changers and terminals in IIDM
     // then we would not need to query back the CGMES model for these mappings
-
-    String terminalForEquipment(String conductingEquipmentId, int sequenceNumber);
+    @Deprecated
+    default String terminalForEquipment(String conductingEquipmentId, int sequenceNumber) {
+        return null;
+    }
 
     String ratioTapChangerForPowerTransformer(String powerTransformerId);
 

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -177,6 +177,11 @@ public interface CgmesModel {
 
     // Helper mappings
 
+    /**
+     * @deprecated Not used anymore. To get the CGMES Terminal ID of an equipment, use alias i.e.
+     * {@code equipement.getAlias("CGMES.Terminal1")}
+     */
+    @Deprecated
     default String terminalForEquipment(String conductingEquipmentId, int sequenceNumber) {
         return null;
     }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -15,10 +15,7 @@ import org.joda.time.DateTime;
 
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.function.Consumer;
 
 /**
@@ -187,12 +184,12 @@ public interface CgmesModel {
 
     @Deprecated
     default String ratioTapChangerForPowerTransformer(String powerTransformerId) {
-        return ratioTapChangerListForPowerTransformer(powerTransformerId).get(0);
+        return ratioTapChangerListForPowerTransformer(powerTransformerId).stream().filter(Objects::nonNull).findFirst().orElse(null);
     }
 
     @Deprecated
     default String phaseTapChangerForPowerTransformer(String powerTransformerId) {
-        return phaseTapChangerListForPowerTransformer(powerTransformerId).get(0);
+        return phaseTapChangerListForPowerTransformer(powerTransformerId).stream().filter(Objects::nonNull).findFirst().orElse(null);
     }
 
     default List<String> ratioTapChangerListForPowerTransformer(String powerTransformerId) {

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesModel.java
@@ -15,6 +15,8 @@ import org.joda.time.DateTime;
 
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -178,16 +180,28 @@ public interface CgmesModel {
 
     // Helper mappings
 
-    // TODO If we could store identifiers for tap changers and terminals in IIDM
-    // then we would not need to query back the CGMES model for these mappings
     @Deprecated
     default String terminalForEquipment(String conductingEquipmentId, int sequenceNumber) {
         return null;
     }
 
-    String ratioTapChangerForPowerTransformer(String powerTransformerId);
+    @Deprecated
+    default String ratioTapChangerForPowerTransformer(String powerTransformerId) {
+        return ratioTapChangerListForPowerTransformer(powerTransformerId).get(0);
+    }
 
-    String phaseTapChangerForPowerTransformer(String powerTransformerId);
+    @Deprecated
+    default String phaseTapChangerForPowerTransformer(String powerTransformerId) {
+        return phaseTapChangerListForPowerTransformer(powerTransformerId).get(0);
+    }
+
+    default List<String> ratioTapChangerListForPowerTransformer(String powerTransformerId) {
+        return Collections.singletonList(ratioTapChangerForPowerTransformer(powerTransformerId));
+    }
+
+    default List<String> phaseTapChangerListForPowerTransformer(String powerTransformerId) {
+        return Collections.singletonList(phaseTapChangerForPowerTransformer(powerTransformerId));
+    }
 
     // TODO(Luma) refactoring node-breaker conversion temporal
 

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/test/FakeCgmesModel.java
@@ -564,11 +564,6 @@ public final class FakeCgmesModel implements CgmesModel {
     }
 
     @Override
-    public String terminalForEquipment(String conductingEquipmentId, int sequenceNumber) {
-        return null;
-    }
-
-    @Override
     public String ratioTapChangerForPowerTransformer(String powerTransformerId) {
         return null;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Terminals' and tap changer's IDs are lost during CGMES import


**What is the new behavior (if this is a feature change)?**
These IDs are kept as aliases


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
