### PR TITLE
Add logback-core explicit dependency in dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,12 @@
                 <version>${logback.version}</version>
                 <scope>runtime</scope>
             </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
+                <scope>runtime</scope>
+            </dependency>
 
             <!-- Test dependencies -->
             <dependency>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
Importing powsybl-core (maven's scope=import) may lead to inconsistent logback dependencies


**What is the new behavior (if this is a feature change)?**
Importing powsybl-core (maven's scope=import) gives consistent logback dependencies


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO


**Other information**:
This prevents crashes because of mismatched versions between
logback-classic and logback-core when importing (maven's scope=import)
managed dependencies.

For exemple,
importing powsybl-core gives logback-classic 1.1.8
importing spring-dependencies gives logback-classic 1.2.3 and logback-core 1.2.3

if importing spring-dependencies first, all is well. If importing powsybl-core first,
you get the following crash:

java.lang.NoSuchMethodError: ch.qos.logback.core.util.ContextUtil.addHostNameAsProperty()V

because addHostNameAsProperty was removed in logback-core 1.2.0 and logback-classic 1.1.8 calls it
at startup in a static initializer.
