### PR TITLE
Fixed NPE observed after Network merge 

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -926,6 +926,8 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
         graph.setVertexObject(node, null);
 
+        invalidateCache();
+
         // remove the link terminal -> voltage level
         terminal.setVoltageLevel(null);
         clean();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -1146,6 +1146,9 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         for (int n = 0; n < graph.getVertexCount(); n++) {
+            if (!graph.vertexExists(n)) {
+                continue;
+            }
             Bus bus = getCalculatedBusBreakerTopology().getBus(n);
             String label = "" + n;
             TerminalExt terminal = graph.getVertexObject(n);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MergeTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MergeTest.java
@@ -1,0 +1,100 @@
+package com.powsybl.iidm.network.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.powsybl.iidm.network.DanglingLine;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.test.NetworkTest1Factory;
+
+public class MergeTest {
+
+    @Test
+    public void mergeNodeBreakerTestNPE() throws IOException {
+        Network n1 = createNetworkWithDanglingLine("1");
+        Network n2 = createNetworkWithDanglingLine("2");
+
+        logVoltageLevel("Network 1 first voltage level", n1.getVoltageLevels().iterator().next());
+        n1.merge(n2);
+        // If we try to get connected components directly on the merged network,
+        // A Null Pointer Exception happens in AbstractConnectable.notifyUpdate:
+        // There is a CalculatedBus that has a terminal that refers to the removed DanglingLine
+        // DanglingLine object has VoltageLevel == null,
+        // NPE comes from trying to getNetwork() using VoltageLevel to notify a change in connected components
+        checkConnectedComponents(n1);
+    }
+
+    @Test
+    public void mergeNodeBreakerTestPass1() throws IOException {
+        Network n1 = createNetworkWithDanglingLine("1");
+        Network n2 = createNetworkWithDanglingLine("2");
+
+        // The test passes if we do not log voltage level (exportTopology)
+        n1.merge(n2);
+        checkConnectedComponents(n1);
+    }
+
+    @Test
+    public void mergeNodeBreakerTestPass2() throws IOException {
+        Network n1 = createNetworkWithDanglingLine("1");
+        Network n2 = createNetworkWithDanglingLine("2");
+
+        logVoltageLevel("Network 1 first voltage level", n1.getVoltageLevels().iterator().next());
+        // The test also passes if we "force" the connected component calculation before merge
+        checkConnectedComponents(n1);
+        n1.merge(n2);
+        checkConnectedComponents(n1);
+    }
+
+    private static void logVoltageLevel(String title, VoltageLevel vl) throws IOException {
+        LOG.info(title);
+        try (StringWriter w = new StringWriter()) {
+            vl.exportTopology(w);
+            LOG.info(w.toString());
+        }
+    }
+
+    private static void checkConnectedComponents(Network n) {
+        n.getBusView().getBuses().forEach(b -> {
+            assertEquals(0, b.getConnectedComponent().getNum());
+        });
+    }
+
+    private static Network createNetworkWithDanglingLine(String nid) {
+        Network n = NetworkTest1Factory.create(nid);
+        VoltageLevel vl = n.getVoltageLevel(id("voltageLevel1", nid));
+        DanglingLine dl = vl.newDanglingLine()
+                .setId(id("danglingLineb", nid))
+                .setNode(6)
+                .setR(1.0)
+                .setX(0.1)
+                .setG(0.0)
+                .setB(0.001)
+                .setP0(10)
+                .setQ0(1)
+                // Same UCTE XnodeCode for dangling lines
+                .setUcteXnodeCode("X")
+                .add();
+        vl.getNodeBreakerView().newBreaker()
+                .setId(id("voltageLevel1BreakerDLb", nid))
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(n.getBusbarSection(id("voltageLevel1BusbarSection1", nid)).getTerminal().getNodeBreakerView().getNode())
+                .setNode2(dl.getTerminal().getNodeBreakerView().getNode())
+                .add();
+        return n;
+    }
+
+    private static String id(String localId, String networkId) {
+        return NetworkTest1Factory.id(localId, networkId);
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(MergeTest.class);
+}

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MergeTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MergeTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.iidm.network.impl;
 
 import static org.junit.Assert.assertEquals;
@@ -14,6 +20,9 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.test.NetworkTest1Factory;
 
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
 public class MergeTest {
 
     @Test
@@ -32,7 +41,7 @@ public class MergeTest {
     }
 
     @Test
-    public void mergeNodeBreakerTestPass1() throws IOException {
+    public void mergeNodeBreakerTestPass1() {
         Network n1 = createNetworkWithDanglingLine("1");
         Network n2 = createNetworkWithDanglingLine("2");
 
@@ -62,9 +71,7 @@ public class MergeTest {
     }
 
     private static void checkConnectedComponents(Network n) {
-        n.getBusView().getBuses().forEach(b -> {
-            assertEquals(0, b.getConnectedComponent().getNum());
-        });
+        n.getBusView().getBuses().forEach(b -> assertEquals(0, b.getConnectedComponent().getNum()));
     }
 
     private static Network createNetworkWithDanglingLine(String nid) {

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NetworkTest1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NetworkTest1Factory.java
@@ -106,6 +106,6 @@ public final class NetworkTest1Factory {
     }
 
     public static String id(String localId, String networkId) {
-        return networkId != null ? "n" + networkId + localId : localId;
+        return networkId != null ? "n" + networkId + "_" + localId : localId;
     }
 }

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NetworkTest1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/NetworkTest1Factory.java
@@ -20,60 +20,64 @@ public final class NetworkTest1Factory {
     }
 
     public static Network create() {
-        return create(NetworkFactory.findDefault());
+        return create(NetworkFactory.findDefault(), null);
     }
 
-    public static Network create(NetworkFactory networkFactory) {
+    public static Network create(String networkId) {
+        return create(NetworkFactory.findDefault(), networkId);
+    }
+
+    public static Network create(NetworkFactory networkFactory, String nid) {
         Objects.requireNonNull(networkFactory);
 
-        Network network = networkFactory.createNetwork("network1", "test");
+        Network network = networkFactory.createNetwork(id("network", nid), "test");
         Substation substation1 = network.newSubstation()
-                .setId("substation1")
+                .setId(id("substation1", nid))
                 .setCountry(Country.FR)
-                .setTso("TSO1")
-                .setGeographicalTags("region1")
+                .setTso(id("TSO1", nid))
+                .setGeographicalTags(id("region1", nid))
                 .add();
         VoltageLevel voltageLevel1 = substation1.newVoltageLevel()
-                .setId("voltageLevel1")
+                .setId(id("voltageLevel1", nid))
                 .setNominalV(400)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
         VoltageLevel.NodeBreakerView topology1 = voltageLevel1.getNodeBreakerView();
         BusbarSection voltageLevel1BusbarSection1 = topology1.newBusbarSection()
-                .setId("voltageLevel1BusbarSection1")
+                .setId(id("voltageLevel1BusbarSection1", nid))
                 .setNode(0)
                 .add();
         BusbarSection voltageLevel1BusbarSection2 = topology1.newBusbarSection()
-                .setId("voltageLevel1BusbarSection2")
+                .setId(id("voltageLevel1BusbarSection2", nid))
                 .setNode(1)
                 .add();
         topology1.newBreaker()
-                .setId("voltageLevel1Breaker1")
+                .setId(id("voltageLevel1Breaker1", nid))
                 .setRetained(true)
                 .setOpen(false)
                 .setNode1(voltageLevel1BusbarSection1.getTerminal().getNodeBreakerView().getNode())
                 .setNode2(voltageLevel1BusbarSection2.getTerminal().getNodeBreakerView().getNode())
                 .add();
         Load load1 = voltageLevel1.newLoad()
-                .setId("load1")
+                .setId(id("load1", nid))
                 .setNode(2)
                 .setP0(10)
                 .setQ0(3)
                 .add();
         topology1.newDisconnector()
-                .setId("load1Disconnector1")
+                .setId(id("load1Disconnector1", nid))
                 .setOpen(false)
                 .setNode1(load1.getTerminal().getNodeBreakerView().getNode())
                 .setNode2(3)
                 .add();
         topology1.newDisconnector()
-                .setId("load1Breaker1")
+                .setId(id("load1Breaker1", nid))
                 .setOpen(false)
                 .setNode1(3)
                 .setNode2(voltageLevel1BusbarSection1.getTerminal().getNodeBreakerView().getNode())
                 .add();
         Generator generator1 = voltageLevel1.newGenerator()
-                .setId("generator1")
+                .setId(id("generator1", nid))
                 .setEnergySource(EnergySource.NUCLEAR)
                 .setMinP(200.0)
                 .setMaxP(900.0)
@@ -87,13 +91,13 @@ public final class NetworkTest1Factory {
                 .beginPoint().setP(900.0).setMinQ(300.0).setMaxQ(500.0).endPoint()
                 .add();
         topology1.newDisconnector()
-                .setId("generator1Disconnector1")
+                .setId(id("generator1Disconnector1", nid))
                 .setOpen(false)
                 .setNode1(generator1.getTerminal().getNodeBreakerView().getNode())
                 .setNode2(6)
                 .add();
         topology1.newDisconnector()
-                .setId("generator1Breaker1")
+                .setId(id("generator1Breaker1", nid))
                 .setOpen(false)
                 .setNode1(6)
                 .setNode2(voltageLevel1BusbarSection2.getTerminal().getNodeBreakerView().getNode())
@@ -101,4 +105,7 @@ public final class NetworkTest1Factory {
         return network;
     }
 
+    public static String id(String localId, String networkId) {
+        return networkId != null ? "n" + networkId + localId : localId;
+    }
 }


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

This PR adds a unit test that demonstrates the Null Pointer Exception produced in the following situation: after a Network merge, removed DanglingLines are still reachable when computing connected components.

It has been observed with real-world test cases and reproduced here with a minimal network.

It can only be reproduced under specific circumstances (memory related issue?) that are described in the related unit tests.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix
Fix made my @mathbagu, cache must be invalidated in node-breaker voltage level after an element is removed. 

**Other information**:
NetworkTest1Factory has a "hole" in the used node numbers (node 4 is not used). Export topology of voltage level has been fixed to take into account this.

