### PR TITLE
Modify limit violation builder copy

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolation.java
@@ -14,7 +14,6 @@ import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
- *
  * A generic representation of a violation of a network equipment security limit.
  * For example, it may represent a current overload on a line.
  *
@@ -92,12 +91,12 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
      *
-     * @param subjectId          The identifier of the network equipment on which the violation occurred.
-     * @param subjectName        An optional name of the network equipment on which the violation occurred.
-     * @param limitType          The type of limit which has been violated.
-     * @param limit              The value of the limit which has been violated.
-     * @param limitReduction     The limit reduction factor used for violation detection.
-     * @param value              The actual value of the physical value which triggered the detection of a violation.
+     * @param subjectId      The identifier of the network equipment on which the violation occurred.
+     * @param subjectName    An optional name of the network equipment on which the violation occurred.
+     * @param limitType      The type of limit which has been violated.
+     * @param limit          The value of the limit which has been violated.
+     * @param limitReduction The limit reduction factor used for violation detection.
+     * @param value          The actual value of the physical value which triggered the detection of a violation.
      */
     public LimitViolation(String subjectId, String subjectName, LimitViolationType limitType, double limit, float limitReduction, double value) {
         this(subjectId, subjectName, limitType, null, Integer.MAX_VALUE, limit, limitReduction, value, null);
@@ -108,11 +107,11 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
      *
-     * @param subjectId          The identifier of the network equipment on which the violation occurred.
-     * @param limitType          The type of limit which has been violated.
-     * @param limit              The value of the limit which has been violated.
-     * @param limitReduction     The limit reduction factor used for violation detection.
-     * @param value              The actual value of the physical value which triggered the detection of a violation.
+     * @param subjectId      The identifier of the network equipment on which the violation occurred.
+     * @param limitType      The type of limit which has been violated.
+     * @param limit          The value of the limit which has been violated.
+     * @param limitReduction The limit reduction factor used for violation detection.
+     * @param value          The actual value of the physical value which triggered the detection of a violation.
      */
     public LimitViolation(String subjectId, LimitViolationType limitType, double limit, float limitReduction, double value) {
         this(subjectId, null, limitType, limit, limitReduction, value);
@@ -140,6 +139,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
 
     /**
      * The type of limit which has been violated.
+     *
      * @return the type of limit which has been violated.
      */
     public LimitViolationType getLimitType() {
@@ -148,6 +148,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
 
     /**
      * The value of the limit which has been violated.
+     *
      * @return the value of the limit which has been violated.
      */
     public double getLimit() {
@@ -156,6 +157,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
 
     /**
      * The name of the limit which has been violated. May be {@code null}.
+     *
      * @return the value of the limit which has been violated. May be {@code null}.
      */
     @Nullable
@@ -197,7 +199,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * other than branches.
      *
      * @return the side of the equipment where the violation occurred. Will be {@code null} for equipments
-     *         other than branches.
+     * other than branches.
      */
     @Nullable
     public Branch.Side getSide() {
@@ -209,6 +211,18 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
             return Objects.requireNonNull(side);
         } else {
             return null;
+        }
+    }
+
+    public String toString() {
+        String base = "Subject id: " + this.subjectId + ", Subject name: " + this.subjectName + ", limitType: " +
+                this.limitType.toString() + ", limit: " + this.limit + ", limitName: " + this.limitName +
+                ", acceptableDuration: " + this.acceptableDuration + ", limitReduction: " + this.limitReduction +
+                ", value: " + this.value;
+        if (side != null) {
+            return base + ", side: " + this.side.toString();
+        } else {
+            return base + ", side: null";
         }
     }
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolation.java
@@ -215,14 +215,9 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     public String toString() {
-        String base = "Subject id: " + this.subjectId + ", Subject name: " + this.subjectName + ", limitType: " +
-                this.limitType.toString() + ", limit: " + this.limit + ", limitName: " + this.limitName +
+        return "Subject id: " + this.subjectId + ", Subject name: " + this.subjectName + ", limitType: " +
+                this.limitType + ", limit: " + this.limit + ", limitName: " + this.limitName +
                 ", acceptableDuration: " + this.acceptableDuration + ", limitReduction: " + this.limitReduction +
-                ", value: " + this.value;
-        if (side != null) {
-            return base + ", side: " + this.side.toString();
-        } else {
-            return base + ", side: null";
-        }
+                ", value: " + this.value + ", side: " + this.side;
     }
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationBuilder.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationBuilder.java
@@ -104,7 +104,7 @@ public class LimitViolationBuilder {
             case HIGH_VOLTAGE:
             case LOW_SHORT_CIRCUIT_CURRENT:
             case HIGH_SHORT_CIRCUIT_CURRENT:
-                return new LimitViolation(subjectId, subjectName, type, limit, reduction, value);
+                return new LimitViolation(subjectId, subjectName, type, limitName, Integer.MAX_VALUE, limit, reduction, value, null);
             default:
                 throw new UnsupportedOperationException(String.format("Building %s limits is not supported.", type.name()));
         }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationBuilderTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationBuilderTest.java
@@ -154,4 +154,14 @@ public class LimitViolationBuilderTest {
         assertTrue(LimitViolations.comparator().compare(violation1, violation2) < 0);
     }
 
+    @Test
+    public void testLimitNameInVoltageLimitViolation() {
+        LimitViolationBuilder builder = LimitViolations.highVoltage()
+                .subject("id")
+                .type(LimitViolationType.HIGH_VOLTAGE)
+                .limit(420)
+                .value(500)
+                .limitName("high");
+        assertEquals("high", builder.build().getLimitName());
+    }
 }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.security;
 
+import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -77,5 +78,18 @@ public class LimitViolationTest {
                 .collect(Collectors.toList());
 
         assertEquals(expectedVoltageLevelIds, voltages);
+    }
+
+    @Test
+    public void testToString() {
+        LimitViolation limitViolation1 = new LimitViolation("testId", null, LimitViolationType.HIGH_VOLTAGE, "high", Integer.MAX_VALUE,
+                420, 1, 500, null);
+        LimitViolation limitViolation2 = new LimitViolation("testId", null, LimitViolationType.CURRENT, null, 6300,
+                1000, 1, 1100, Branch.Side.ONE);
+        String expected1 = "Subject id: testId, Subject name: null, limitType: HIGH_VOLTAGE, limit: 420.0, limitName: high, acceptableDuration: 2147483647, limitReduction: 1.0, value: 500.0, side: null";
+        String expected2 = "Subject id: testId, Subject name: null, limitType: CURRENT, limit: 1000.0, limitName: null, acceptableDuration: 6300, limitReduction: 1.0, value: 1100.0, side: ONE";
+
+        assertEquals(expected1, limitViolation1.toString());
+        assertEquals(expected2, limitViolation2.toString());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

update

**What is the current behavior?** *(You can also link to an open issue here)*

there is no method to read the LimitViolations
for voltage limitViolations, builder can not be used because limitName parameter is needed 

**What is the new behavior (if this is a feature change)?**

added a method toString to print the limitviolation
added limitName in build method of voltage limitViolation 

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
