### PR TITLE
Fix missing call to MultiVariantObject implementations

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConfiguredBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConfiguredBusImpl.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-class ConfiguredBusImpl extends AbstractBus implements ConfiguredBus, MultiVariantObject {
+class ConfiguredBusImpl extends AbstractBus implements ConfiguredBus {
 
     private final Ref<NetworkImpl> network;
 
@@ -158,6 +158,8 @@ class ConfiguredBusImpl extends AbstractBus implements ConfiguredBus, MultiVaria
 
     @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
+        super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
+
         terminals.ensureCapacity(terminals.size() + number);
         v.ensureCapacity(v.size() + number);
         angle.ensureCapacity(angle.size() + number);
@@ -174,6 +176,8 @@ class ConfiguredBusImpl extends AbstractBus implements ConfiguredBus, MultiVaria
 
     @Override
     public void reduceVariantArraySize(int number) {
+        super.reduceVariantArraySize(number);
+
         for (int i = 0; i < number; i++) {
             terminals.remove(terminals.size() - 1);
         }
@@ -185,11 +189,15 @@ class ConfiguredBusImpl extends AbstractBus implements ConfiguredBus, MultiVaria
 
     @Override
     public void deleteVariantArrayElement(int index) {
+        super.deleteVariantArrayElement(index);
+
         terminals.set(index, null);
     }
 
     @Override
     public void allocateVariantArrayElement(int[] indexes, int sourceIndex) {
+        super.allocateVariantArrayElement(indexes, sourceIndex);
+
         for (int index : indexes) {
             terminals.set(index, new ArrayList<>(terminals.get(sourceIndex)));
             v.set(index, v.get(sourceIndex));

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/HvdcLineImpl.java
@@ -18,7 +18,7 @@ import java.util.Objects;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
  */
-class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, MultiVariantObject {
+class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine {
 
     static final String TYPE_DESCRIPTION = "hvdcLine";
 
@@ -175,6 +175,8 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
 
     @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
+        super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
+
         convertersMode.ensureCapacity(convertersMode.size() + number);
         convertersMode.fill(initVariantArraySize, initVariantArraySize + number, convertersMode.get(sourceIndex));
 
@@ -184,16 +186,21 @@ class HvdcLineImpl extends AbstractIdentifiable<HvdcLine> implements HvdcLine, M
 
     @Override
     public void reduceVariantArraySize(int number) {
+        super.reduceVariantArraySize(number);
+
         activePowerSetpoint.remove(activePowerSetpoint.size() - number, number);
     }
 
     @Override
     public void deleteVariantArrayElement(int index) {
+        super.deleteVariantArrayElement(index);
         // nothing to do
     }
 
     @Override
     public void allocateVariantArrayElement(int[] indexes, int sourceIndex) {
+        super.allocateVariantArrayElement(indexes, sourceIndex);
+
         for (int index : indexes) {
             convertersMode.set(index, convertersMode.get(sourceIndex));
             activePowerSetpoint.set(index, activePowerSetpoint.get(sourceIndex));

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -743,21 +743,29 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
 
     @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, final int sourceIndex) {
+        super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
+
         variants.push(number, () -> variants.copy(sourceIndex));
     }
 
     @Override
     public void reduceVariantArraySize(int number) {
+        super.reduceVariantArraySize(number);
+
         variants.pop(number);
     }
 
     @Override
     public void deleteVariantArrayElement(int index) {
+        super.deleteVariantArrayElement(index);
+
         variants.delete(index);
     }
 
     @Override
     public void allocateVariantArrayElement(int[] indexes, final int sourceIndex) {
+        super.allocateVariantArrayElement(indexes, sourceIndex);
+
         variants.allocate(indexes, () -> variants.copy(sourceIndex));
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
@@ -107,6 +107,8 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
 
     @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
+        super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
+
         open.ensureCapacity(open.size() + number);
         open.fill(initVariantArraySize, initVariantArraySize + number, open.get(sourceIndex));
         retained.ensureCapacity(retained.size() + number);
@@ -115,17 +117,22 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
 
     @Override
     public void reduceVariantArraySize(int number) {
+        super.reduceVariantArraySize(number);
+
         open.remove(open.size() - number, number);
         retained.remove(retained.size() - number, number);
     }
 
     @Override
     public void deleteVariantArrayElement(int index) {
+        super.deleteVariantArrayElement(index);
         // nothing to do
     }
 
     @Override
     public void allocateVariantArrayElement(int[] indexes, final int sourceIndex) {
+        super.allocateVariantArrayElement(indexes, sourceIndex);
+
         for (int index : indexes) {
             open.set(index, open.get(sourceIndex));
             retained.set(index, retained.get(sourceIndex));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In several IIDM class, that implement MultiVariantObject, the super method is not called. For most of them, their first parent implementation is AbstractIdentifiable that manage the extensions.
That means, if we have an extension that supports variant for these objects, it wouldn't work properly. A similar fix has been done in #1404 but not everywhere


**What is the new behavior (if this is a feature change)?**
Fix the implementation of all multivariantobjects


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
