### PR TITLE
Fix property name of shunt compensator sections in SV export

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/StateVariablesAdder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/StateVariablesAdder.java
@@ -180,7 +180,7 @@ public class StateVariablesAdder {
         PropertyBags shuntCompensatorSections = new PropertyBags();
         for (ShuntCompensator s : network.getShuntCompensators()) {
             PropertyBag p = new PropertyBag(SV_SHUNTCOMPENSATORSECTIONS_PROPERTIES);
-            p.put("continuousSections", is(s.getSectionCount()));
+            p.put("sections", is(s.getSectionCount()));
             p.put("ShuntCompensator", s.getId());
             shuntCompensatorSections.add(p);
         }
@@ -414,7 +414,7 @@ public class StateVariablesAdder {
         CgmesNames.TOPOLOGICAL_NODE);
     private static final List<String> SV_POWERFLOW_PROPERTIES = Arrays.asList("p", "q", CgmesNames.TERMINAL);
     private static final List<String> SV_SHUNTCOMPENSATORSECTIONS_PROPERTIES = Arrays.asList("ShuntCompensator",
-        "continuousSections");
+        "sections");
     private static final List<String> SV_SVSTATUS_PROPERTIES = Arrays.asList(IN_SERVICE,
         CgmesNames.CONDUCTING_EQUIPMENT);
     private static final List<String> SV_FULLMODEL_PROPERTIES = Arrays.asList(CgmesNames.SCENARIO_TIME,


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
In CGMES SV export, the name for the number of sections in service is `sections`


**What is the current behavior?** *(You can also link to an open issue here)*
Previously, the name written in the export was `continuousSections` (it was the name of the property in CIM14).

