### PR TITLE
Introduce DanglingLine extension containing CGMES boundarySide

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConnectorConversion.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import com.powsybl.cgmes.conversion.Context;
 import com.powsybl.cgmes.model.CgmesNames;
+import com.powsybl.cgmes.conversion.extensions.CgmesBoundarySideAdder;
 import com.powsybl.cgmes.model.PowerFlow;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.DanglingLine;
@@ -102,6 +103,7 @@ public abstract class AbstractConnectorConversion extends AbstractConductingEqui
         addAliases(dl);
         dl.addAlias(boundaryNode, "CGMES." + CgmesNames.TOPOLOGICAL_NODE);
         context.convertedTerminal(terminalId(modelSide), dl.getTerminal(), 1, powerFlow(modelSide));
+        dl.newExtension(CgmesBoundarySideAdder.class).setBoundarySide(boundarySide).add();
 
         // If we do not have power flow at model side and we can compute it,
         // do it and assign the result at the terminal of the dangling line

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySide.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySide.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.extensions.Extension;
+import com.powsybl.iidm.network.DanglingLine;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public interface CgmesBoundarySide extends Extension<DanglingLine> {
+
+    int getBoundarySide();
+
+    @Override
+    default String getName() {
+        return "cgmesBoundarySide";
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideAdder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideAdder.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.extensions.ExtensionAdder;
+import com.powsybl.iidm.network.DanglingLine;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public interface CgmesBoundarySideAdder extends ExtensionAdder<DanglingLine, CgmesBoundarySide> {
+
+    CgmesBoundarySideAdder setBoundarySide(int boundarySide);
+
+    @Override
+    default Class<CgmesBoundarySide> getExtensionClass() {
+        return CgmesBoundarySide.class;
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideAdderImpl.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideAdderImpl.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.extensions.AbstractExtensionAdder;
+import com.powsybl.iidm.network.DanglingLine;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class CgmesBoundarySideAdderImpl extends AbstractExtensionAdder<DanglingLine, CgmesBoundarySide> implements CgmesBoundarySideAdder {
+
+    private int boundarySide = -1;
+
+    CgmesBoundarySideAdderImpl(DanglingLine extendable) {
+        super(extendable);
+    }
+
+    @Override
+    public CgmesBoundarySideAdder setBoundarySide(int boundarySide) {
+        this.boundarySide = boundarySide;
+        return this;
+    }
+
+    @Override
+    protected CgmesBoundarySide createExtension(DanglingLine extendable) {
+        if (boundarySide != 1 && boundarySide != 2) {
+            throw new PowsyblException("Incorrect boundary side (" + boundarySide + ") for dangling line " + extendable.getId());
+        }
+        return new CgmesBoundarySideImpl(boundarySide);
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideAdderImplProvider.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideAdderImplProvider.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionAdderProvider;
+import com.powsybl.iidm.network.DanglingLine;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionAdderProvider.class)
+public class CgmesBoundarySideAdderImplProvider implements ExtensionAdderProvider<DanglingLine, CgmesBoundarySide, CgmesBoundarySideAdderImpl> {
+
+    @Override
+    public String getImplementationName() {
+        return "Default";
+    }
+
+    @Override
+    public Class<? super CgmesBoundarySideAdderImpl> getAdderClass() {
+        return CgmesBoundarySideAdderImpl.class;
+    }
+
+    @Override
+    public CgmesBoundarySideAdderImpl newAdder(DanglingLine extendable) {
+        return new CgmesBoundarySideAdderImpl(extendable);
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideImpl.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideImpl.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.DanglingLine;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class CgmesBoundarySideImpl extends AbstractExtension<DanglingLine> implements CgmesBoundarySide {
+
+    private final int boundarySide;
+
+    CgmesBoundarySideImpl(int boundarySide) {
+        if (boundarySide != 1 && boundarySide != 2) {
+            throw new PowsyblException("Incorrect boundary side (" + boundarySide + ")");
+        }
+        this.boundarySide = boundarySide;
+    }
+
+    @Override
+    public int getBoundarySide() {
+        return boundarySide;
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideXmlSerializer.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideXmlSerializer.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.AbstractExtensionXmlSerializer;
+import com.powsybl.commons.extensions.ExtensionXmlSerializer;
+import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlUtil;
+import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.DanglingLine;
+import com.powsybl.iidm.xml.NetworkXmlReaderContext;
+import com.powsybl.iidm.xml.NetworkXmlWriterContext;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionXmlSerializer.class)
+public class CgmesBoundarySideXmlSerializer extends AbstractExtensionXmlSerializer<DanglingLine, CgmesBoundarySide> {
+
+    public CgmesBoundarySideXmlSerializer() {
+        super("cgmesBoundarySide", "network", CgmesBoundarySide.class, false, "cgmesBoundarySide.xsd",
+                "http://www.powsybl.org/schema/iidm/ext/cgmes_boundary_side/1_0", "cbs");
+    }
+
+    @Override
+    public void write(CgmesBoundarySide extension, XmlWriterContext context) throws XMLStreamException {
+        NetworkXmlWriterContext networkContext = (NetworkXmlWriterContext) context;
+        XMLStreamWriter writer = networkContext.getWriter();
+        XmlUtil.writeInt("boundarySide", extension.getBoundarySide(), writer);
+    }
+
+    @Override
+    public CgmesBoundarySide read(DanglingLine extendable, XmlReaderContext context) {
+        NetworkXmlReaderContext networkContext = (NetworkXmlReaderContext) context;
+        XMLStreamReader reader = networkContext.getReader();
+        extendable.newExtension(CgmesBoundarySideAdder.class)
+                .setBoundarySide(XmlUtil.readIntAttribute(reader, "boundarySide"))
+                .add();
+        return extendable.getExtension(CgmesBoundarySide.class);
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/resources/xsd/cgmesBoundarySide.xsd
+++ b/cgmes/cgmes-conversion/src/main/resources/xsd/cgmesBoundarySide.xsd
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema version="1.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:cbs="http://www.powsybl.org/schema/iidm/ext/cgmes_boundary_side/1_0"
            targetNamespace="http://www.powsybl.org/schema/iidm/ext/cgmes_boundary_side/1_0"
            elementFormDefault="qualified">
-    <xs:element name="cgmesSvMetadata">
+    <xs:element name="cgmesBoundarySide">
         <xs:complexType>
             <xs:attribute name="boundarySide" use="required" type="xs:int"/>
         </xs:complexType>

--- a/cgmes/cgmes-conversion/src/main/resources/xsd/cgmesBoundarySide.xsd
+++ b/cgmes/cgmes-conversion/src/main/resources/xsd/cgmesBoundarySide.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:cbs="http://www.powsybl.org/schema/iidm/ext/cgmes_boundary_side/1_0"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/cgmes_boundary_side/1_0"
+           elementFormDefault="qualified">
+    <xs:element name="cgmesSvMetadata">
+        <xs:complexType>
+            <xs:attribute name="boundarySide" use="required" type="xs:int"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.DanglingLine;
+import com.powsybl.iidm.network.test.DanglingLineNetworkFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class CgmesBoundarySideTest {
+
+    private DanglingLine dl;
+
+    @Rule
+    public final ExpectedException expected = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        dl = DanglingLineNetworkFactory.create().getDanglingLine("DL");
+    }
+
+    @Test
+    public void test() {
+        dl.newExtension(CgmesBoundarySideAdder.class)
+                .setBoundarySide(1)
+                .add();
+        CgmesBoundarySide extension = dl.getExtension(CgmesBoundarySide.class);
+        assertNotNull(extension);
+        assertEquals(1, extension.getBoundarySide());
+    }
+
+    @Test
+    public void noBoundarySideSet() {
+        expected.expect(PowsyblException.class);
+        expected.expectMessage("Incorrect boundary side (-1) for dangling line DL");
+        dl.newExtension(CgmesBoundarySideAdder.class).add();
+    }
+
+    @Test
+    public void failBoundarySideSet() {
+        expected.expect(PowsyblException.class);
+        expected.expectMessage("Incorrect boundary side (3) for dangling line DL");
+        dl.newExtension(CgmesBoundarySideAdder.class)
+                .setBoundarySide(3)
+                .add();
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideXmlSerializerTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesBoundarySideXmlSerializerTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.extensions;
+
+import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.DanglingLineNetworkFactory;
+import com.powsybl.iidm.xml.NetworkXml;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+public class CgmesBoundarySideXmlSerializerTest extends AbstractConverterTest {
+
+    @Test
+    public void test() throws IOException {
+        Network network = DanglingLineNetworkFactory.create();
+        network.setCaseDate(DateTime.parse("2020-09-22T09:41:46.853+02:00"));
+        network.getDanglingLine("DL")
+                .newExtension(CgmesBoundarySideAdder.class)
+                .setBoundarySide(2)
+                .add();
+        roundTripXmlTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead, "/extensions/dl_cgmes_boundary_side.xml");
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/extensions/CgmesSvMetadataTest.java
@@ -9,7 +9,9 @@ package com.powsybl.cgmes.conversion.extensions;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -19,6 +21,9 @@ import static org.junit.Assert.assertTrue;
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
  */
 public class CgmesSvMetadataTest {
+
+    @Rule
+    public final ExpectedException expected = ExpectedException.none();
 
     @Test
     public void test() {
@@ -42,8 +47,10 @@ public class CgmesSvMetadataTest {
         assertTrue(extension.getDependencies().contains("http://dependency2"));
     }
 
-    @Test(expected = PowsyblException.class)
+    @Test
     public void invalid() {
+        expected.expect(PowsyblException.class);
+        expected.expectMessage("cgmesSvMetadata.scenarioTime is undefined");
         Network network = EurostagTutorialExample1Factory.create();
         network.newExtension(CgmesSvMetadataAdder.class)
                 .add();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -12,6 +12,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.powsybl.cgmes.conversion.extensions.CgmesBoundarySide;
 import com.powsybl.cgmes.conversion.extensions.CimCharacteristics;
 import com.powsybl.cgmes.conversion.extensions.CgmesSvMetadata;
 import com.powsybl.iidm.network.*;
@@ -530,6 +531,15 @@ public class Comparison {
         compareCurrentLimits(expected, actual,
                 expected.getCurrentLimits(),
                 actual.getCurrentLimits());
+        CgmesBoundarySide expectedBoundarySide = expected.getExtension(CgmesBoundarySide.class);
+        CgmesBoundarySide actualBoundarySide = actual.getExtension(CgmesBoundarySide.class);
+        if (expectedBoundarySide == null && actualBoundarySide != null) {
+            diff.unexpected("boundarySide");
+        } else if (expectedBoundarySide != null && actualBoundarySide == null) {
+            diff.missing("boundarySide");
+        } else if (expectedBoundarySide != null) {
+            compare("boundarySide", expectedBoundarySide.getBoundarySide(), actualBoundarySide.getBoundarySide());
+        }
     }
 
     private void compareCurrentLimits(

--- a/cgmes/cgmes-conversion/src/test/resources/extensions/dl_cgmes_boundary_side.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/extensions/dl_cgmes_boundary_side.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_4" xmlns:cbs="http://www.powsybl.org/schema/iidm/ext/cgmes_boundary_side/1_0" id="dangling-line" caseDate="2020-09-22T09:41:46.853+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="S" country="FR">
+        <iidm:voltageLevel id="VL" nominalV="100.0" lowVoltageLimit="80.0" highVoltageLimit="120.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+            </iidm:generator>
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" bus="BUS" connectableBus="BUS">
+                <iidm:currentLimits permanentLimit="100.0">
+                    <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="120.0"/>
+                    <iidm:temporaryLimit name="10'" acceptableDuration="600" value="140.0"/>
+                </iidm:currentLimits>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:extension id="DL">
+        <cbs:cgmesBoundarySide boundarySide="2"/>
+    </iidm:extension>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
CGMES boundary side is not stored during CGMES import for AC Line Segment on boundaries


**What is the new behavior (if this is a feature change)?**
CGMES boundary side is now stored for DanglingLines on boundaries


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
