### PR TITLE
improve getCountry method to avoid nullPointerException when geographicalCode is not null and country is null

### DIFF
--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeFileName.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeFileName.java
@@ -77,7 +77,11 @@ public class EntsoeFileName {
     }
 
     public String getCountry() {
-        return geographicalCode != null ? geographicalCode.getCountry().toString() : null;
+        if (geographicalCode != null) {
+            return this.geographicalCode.getCountry() != null ? this.geographicalCode.getCountry().toString() : null;
+        } else {
+            return null;
+        }
     }
 
 }

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeFileName.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeFileName.java
@@ -77,11 +77,6 @@ public class EntsoeFileName {
     }
 
     public String getCountry() {
-        if (geographicalCode != null) {
-            return this.geographicalCode.getCountry() != null ? this.geographicalCode.getCountry().toString() : null;
-        } else {
-            return null;
-        }
+        return geographicalCode != null && geographicalCode.getCountry() != null ? geographicalCode.getCountry().toString() : null;
     }
-
 }

--- a/entsoe-util/src/test/java/com/powsybl/entsoe/util/EntsoeFileNameTest.java
+++ b/entsoe-util/src/test/java/com/powsybl/entsoe/util/EntsoeFileNameTest.java
@@ -47,4 +47,12 @@ public class EntsoeFileNameTest {
         EntsoeFileName ucteFileName = EntsoeFileName.parse(fileName);
         assertTrue(ucteFileName.getDate().isEqual(DateTime.parse("2020-03-14T00:30:00.000+01:00")));
     }
+
+    @Test
+    public void testGetCountry() {
+        String fileName = "20200608_0730_2D1_UX0.uct";
+        EntsoeFileName ucteFileName = EntsoeFileName.parse(fileName);
+        assertNotNull(ucteFileName.getGeographicalCode());
+        assertNull(ucteFileName.getCountry());
+    }
 }


### PR DESCRIPTION
Signed-off-by: KAHYA Amira <amira.kahya@rte-france.com>

**Please check if the PR fulfills these requirements** 
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
NO

**What kind of change does this PR introduce?** 
Bug fix


**What is the current behavior?** 
NullPointerException when the geographicalCode is not null but the Country is null. This is the case when the geographicalCode is UC or UX.

**What is the new behavior (if this is a feature change)?**
Return null when the geographicalCode is not null and the Country is Null.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


