### PR TITLE
Add dangling line contingency

### DIFF
--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
@@ -81,6 +81,14 @@ public class Contingency extends AbstractExtendable<Contingency> {
         return true;
     }
 
+    private static boolean checkDanglingLineContingency(Contingency contingency, DanglingLineContingency element, Network network) {
+        if (network.getDanglingLine(element.getId()) == null) {
+            LOGGER.warn("Dangling line '{}' of contingency '{}' not found", element.getId(), contingency.getId());
+            return false;
+        }
+        return true;
+    }
+
     private static boolean isValid(Contingency contingency, Network network) {
         Objects.requireNonNull(contingency);
         Objects.requireNonNull(network);
@@ -104,6 +112,10 @@ public class Contingency extends AbstractExtendable<Contingency> {
 
                 case BUSBAR_SECTION:
                     valid = checkBusbarSectionContingency(contingency, (BusbarSectionContingency) element, network);
+                    break;
+
+                case DANGLING_LINE:
+                    valid = checkDanglingLineContingency(contingency, (DanglingLineContingency) element, network);
                     break;
 
                 default:

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyElementType.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyElementType.java
@@ -17,5 +17,6 @@ public enum ContingencyElementType {
     SHUNT_COMPENSATOR,
     BRANCH,
     HVDC_LINE,
-    BUSBAR_SECTION
+    BUSBAR_SECTION,
+    DANGLING_LINE
 }

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/DanglingLineContingency.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/DanglingLineContingency.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.contingency;
+
+import com.powsybl.contingency.tasks.AbstractTrippingTask;
+import com.powsybl.contingency.tasks.DanglingLineTripping;
+
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
+public class DanglingLineContingency extends AbstractInjectionContingency {
+
+    public DanglingLineContingency(String id) {
+        super(id);
+    }
+
+    @Override
+    public ContingencyElementType getType() {
+        return ContingencyElementType.DANGLING_LINE;
+    }
+
+    @Override
+    public AbstractTrippingTask toTask() {
+        return new DanglingLineTripping(id);
+    }
+}

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencyElementDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencyElementDeserializer.java
@@ -69,6 +69,9 @@ public class ContingencyElementDeserializer extends StdDeserializer<ContingencyE
                 case BUSBAR_SECTION:
                     return new BusbarSectionContingency(id);
 
+                case DANGLING_LINE:
+                    return new DanglingLineContingency(id);
+
                 default:
                     throw new AssertionError("Unexpected ContingencyElementType value: " + type);
             }

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/tasks/DanglingLineTripping.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/tasks/DanglingLineTripping.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.contingency.tasks;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.Injection;
+import com.powsybl.iidm.network.Network;
+
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
+public class DanglingLineTripping extends AbstractInjectionTripping {
+
+    public DanglingLineTripping(String id) {
+        super(id);
+    }
+
+    @Override
+    protected Injection getInjection(Network network) {
+        Injection injection = network.getDanglingLine(id);
+        if (injection == null) {
+            throw new PowsyblException("Dangling line '" + id + "' not found");
+        }
+
+        return injection;
+    }
+}

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
@@ -9,6 +9,7 @@ package com.powsybl.contingency;
 import com.powsybl.contingency.tasks.CompoundModificationTask;
 import com.powsybl.contingency.tasks.ModificationTask;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.DanglingLineNetworkFactory;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.HvdcTestNetwork;
 import com.powsybl.iidm.network.test.SvcTestCaseFactory;
@@ -74,6 +75,16 @@ public class ContingencyTest {
         Contingency staticVarCompensatorInvalidContingency = new Contingency("SVC invalid contingency", new StaticVarCompensatorContingency("SVC"));
         List<Contingency> validContingencies = Contingency.checkValidity(Arrays.asList(staticVarCompensatorContingency, staticVarCompensatorInvalidContingency), network);
         assertEquals(Arrays.asList("SVC contingency"),
+                validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void validationTestForDL() {
+        Network network = DanglingLineNetworkFactory.create();
+        Contingency danglingLineContingency = new Contingency("DL contingency", new DanglingLineContingency("DL"));
+        Contingency danglingLineInvalidContingency = new Contingency("DL invalid contingency", new DanglingLineContingency("DL_THAT_DO_NOT_EXIST"));
+        List<Contingency> validContingencies = Contingency.checkValidity(Arrays.asList(danglingLineContingency, danglingLineInvalidContingency), network);
+        assertEquals(Arrays.asList("DL contingency"),
                 validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
     }
 }

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/DanglingLineContingencyTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/DanglingLineContingencyTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.contingency;
+
+import com.google.common.testing.EqualsTester;
+import com.powsybl.contingency.tasks.DanglingLineTripping;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
+public class DanglingLineContingencyTest {
+    @Test
+    public void test() {
+        DanglingLineContingency contingency = new DanglingLineContingency("id");
+        assertEquals("id", contingency.getId());
+        assertEquals(ContingencyElementType.DANGLING_LINE, contingency.getType());
+
+        assertNotNull(contingency.toTask());
+        assertTrue(contingency.toTask() instanceof DanglingLineTripping);
+
+        new EqualsTester()
+                .addEqualityGroup(new DanglingLineContingency("dl1"), new DanglingLineContingency("dl1"))
+                .addEqualityGroup(new DanglingLineContingency("dl2"), new DanglingLineContingency("dl2"))
+                .testEquals();
+    }
+}

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/ContingencyJsonTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/ContingencyJsonTest.java
@@ -47,6 +47,7 @@ public class ContingencyJsonTest extends AbstractConverterTest {
         elements.add(new ShuntCompensatorContingency("SC"));
         elements.add(new StaticVarCompensatorContingency("SVC"));
         elements.add(new BusbarSectionContingency("BBS1"));
+        elements.add(new DanglingLineContingency("DL1"));
 
         Contingency contingency = new Contingency("contingency", elements);
 

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/tasks/DanglingLineTrippingTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/tasks/DanglingLineTrippingTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.contingency.tasks;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.contingency.Contingency;
+import com.powsybl.contingency.DanglingLineContingency;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.DanglingLineNetworkFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
+public class DanglingLineTrippingTest extends AbstractTrippingTest {
+
+    private Network network;
+
+    @Before
+    public void setUp() {
+        network = DanglingLineNetworkFactory.create();
+    }
+
+    @Test
+    public void generatorTrippingTest() {
+        assertTrue(network.getDanglingLine("DL").getTerminal().isConnected());
+
+        DanglingLineContingency tripping = new DanglingLineContingency("DL");
+        Contingency contingency = new Contingency("contingency", tripping);
+
+        ModificationTask task = contingency.toTask();
+        task.modify(network, null);
+
+        assertFalse(network.getDanglingLine("DL").getTerminal().isConnected());
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void unknownShuntCompensatorTest() {
+        DanglingLineTripping tripping = new DanglingLineTripping("DL_THAT_DO_NOT_EXIST");
+        tripping.modify(network, null);
+    }
+}

--- a/contingency/contingency-api/src/test/resources/contingency.json
+++ b/contingency/contingency-api/src/test/resources/contingency.json
@@ -26,6 +26,9 @@
   }, {
     "id" : "BBS1",
     "type" : "BUSBAR_SECTION"
+  }, {
+    "id" : "DL1",
+    "type" : "DANGLING_LINE"
   } ],
   "extensions" : {
     "dummy-extension" : { }

--- a/contingency/contingency-dsl/src/main/groovy/com/powsybl/contingency/dsl/ContingencyDslLoader.groovy
+++ b/contingency/contingency-dsl/src/main/groovy/com/powsybl/contingency/dsl/ContingencyDslLoader.groovy
@@ -84,6 +84,8 @@ class ContingencyDslLoader extends DslLoader {
                     elements.add(new ShuntCompensatorContingency(equipment))
                 } else if (identifiable instanceof StaticVarCompensator) {
                     elements.add(new StaticVarCompensatorContingency(equipment))
+                } else if (identifiable instanceof DanglingLine) {
+                    elements.add(new DanglingLineContingency(equipment))
                 } else {
                     LOGGER.warn("Equipment type {} not supported in contingencies", identifiable.getClass().name)
                     valid = false


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
New feature


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, it is not possible to create a contingency that consists of a dangling line tripping. It can be found on some process (to simulate JVDC trip on UCTE files for example).


**What is the new behavior (if this is a feature change)?**
It is now possible to create a dangling line contingency using the contingency API of PowSyBl.

