### PR TITLE
Prevent x of step to be undefined (NaN) during CGMES import for non tabular ptc

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
@@ -142,8 +142,12 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
             return;
         }
         double alphaMax = tapChanger.getSteps().stream().map(TapChanger.Step::getAngle)
-                .mapToDouble(Double::doubleValue).max().orElse(Double.NaN);
+                .mapToDouble(Double::doubleValue).max().orElse(0);
         tapChanger.getSteps().forEach(step -> {
+            if (alphaMax == 0 || xtx == 0) {
+                step.setX(0);
+                return;
+            }
             double alpha = step.getAngle();
             double x = getStepXforAsymmetrical(xMin, xMax, alpha, alphaMax, windingConnectionAngle);
             step.setX((x - xtx) / xtx * 100);
@@ -190,8 +194,12 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
             return;
         }
         double alphaMax = tapChanger.getSteps().stream().map(TapChanger.Step::getAngle)
-            .mapToDouble(Double::doubleValue).max().orElse(Double.NaN);
+            .mapToDouble(Double::doubleValue).max().orElse(0);
         tapChanger.getSteps().forEach(step -> {
+            if (alphaMax == 0.0 || xtx == 0.0) {
+                step.setX(0);
+                return;
+            }
             double alpha = step.getAngle();
             double x = getStepXforLinearAndSymmetrical(xMin, xMax, alpha, alphaMax);
             step.setX(100 * (x - xtx) / xtx);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
@@ -144,7 +144,7 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
         double alphaMax = tapChanger.getSteps().stream().map(TapChanger.Step::getAngle)
                 .mapToDouble(Double::doubleValue).max().orElse(0);
         tapChanger.getSteps().forEach(step -> {
-            if (alphaMax == 0 || xtx == 0) {
+            if (alphaMax == 0) { // all angles are equal to 0: x is considered equal to 0
                 step.setX(0);
                 return;
             }
@@ -196,7 +196,7 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
         double alphaMax = tapChanger.getSteps().stream().map(TapChanger.Step::getAngle)
             .mapToDouble(Double::doubleValue).max().orElse(0);
         tapChanger.getSteps().forEach(step -> {
-            if (alphaMax == 0.0 || xtx == 0.0) {
+            if (alphaMax == 0.0) { // all angles are equal to 0: x is considered equal to 0
                 step.setX(0);
                 return;
             }


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When all alpha are equal to 0 in a PTC, the calculated x for non tabular PTC is undefined. 


**What is the new behavior (if this is a feature change)?**
In this case, x is equal to 0.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
