### PR TITLE
Add a requireNonNull to ensure the extension XML serializer is not null when writeExtension() is called

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -150,7 +150,7 @@ public final class NetworkXml {
 
     private static void writeExtension(Extension<? extends Identifiable<?>> extension, NetworkXmlWriterContext context) throws XMLStreamException {
         XMLStreamWriter writer = context.getExtensionsWriter();
-        ExtensionXmlSerializer extensionXmlSerializer = getExtensionXmlSerializer(context.getOptions(), extension);
+        ExtensionXmlSerializer extensionXmlSerializer = Objects.requireNonNull(getExtensionXmlSerializer(context.getOptions(), extension));
 
         String namespaceUri = getNamespaceUri(extensionXmlSerializer, context.getOptions(), context.getVersion());
 
@@ -216,6 +216,7 @@ public final class NetworkXml {
 
             Collection<? extends Extension<? extends Identifiable<?>>> extensions = identifiable.getExtensions().stream()
                     .filter(e -> getExtensionXmlSerializer(options, e) != null)
+                    .filter(e -> context.getOptions().withExtension(e.getName()))
                     .collect(Collectors.toList());
             if (!extensions.isEmpty()) {
                 context.getExtensionsWriter().writeStartElement(context.getVersion().getNamespaceURI(), EXTENSION_ELEMENT_NAME);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -150,7 +150,10 @@ public final class NetworkXml {
 
     private static void writeExtension(Extension<? extends Identifiable<?>> extension, NetworkXmlWriterContext context) throws XMLStreamException {
         XMLStreamWriter writer = context.getExtensionsWriter();
-        ExtensionXmlSerializer extensionXmlSerializer = Objects.requireNonNull(getExtensionXmlSerializer(context.getOptions(), extension));
+        ExtensionXmlSerializer extensionXmlSerializer = getExtensionXmlSerializer(context.getOptions(), extension);
+        if (extensionXmlSerializer == null) {
+            throw new AssertionError("Extension XML Serializer of " + extension.getName() + " should not be null");
+        }
 
         String namespaceUri = getNamespaceUri(extensionXmlSerializer, context.getOptions(), context.getVersion());
 

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -216,7 +216,6 @@ public final class NetworkXml {
 
             Collection<? extends Extension<? extends Identifiable<?>>> extensions = identifiable.getExtensions().stream()
                     .filter(e -> getExtensionXmlSerializer(options, e) != null)
-                    .filter(e -> context.getOptions().withExtension(e.getName()))
                     .collect(Collectors.toList());
             if (!extensions.isEmpty()) {
                 context.getExtensionsWriter().writeStartElement(context.getVersion().getNamespaceURI(), EXTENSION_ELEMENT_NAME);


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix: ensure that extension XML serializer is not null when `writeExtension` is called
Bug fix: filter extensions which are not in options during XML export



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

**Other information**:
If you agree with these fixes, they should be also merged for release 3.7.0
