### PR TITLE
Accept DL limit cases in merging view (Merged line composed of two Dangling lines with same ID + non merged DL with null UcteXnodeCode)

### DIFF
--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergedLine.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergedLine.java
@@ -44,7 +44,7 @@ class MergedLine implements TieLine {
         this.index = Objects.requireNonNull(index, "merging view index is null");
         this.half1 = new HalfLineAdapter(dl1);
         this.half2 = new HalfLineAdapter(dl2);
-        this.id = ensureIdUnicity ? Identifiables.getUniqueId(buildId(dl1, dl2), index::contains) : buildId(dl1, dl2);
+        this.id = ensureIdUnicity ? Identifiables.getUniqueId(buildIdOrName(dl1.getId(), dl2.getId()), index::contains) : buildIdOrName(dl1.getId(), dl2.getId());
         this.name = buildName(dl1, dl2);
         mergeProperties(dl1, dl2);
     }
@@ -53,32 +53,22 @@ class MergedLine implements TieLine {
         this(index, dl1, dl2, false);
     }
 
-    private static String buildId(final DanglingLine dl1, final DanglingLine dl2) {
-        String id;
-        if (dl1.getId().compareTo(dl2.getId()) < 0) {
-            id = dl1.getId() + " + " + dl2.getId();
-        } else {
-            id = dl2.getId() + " + " + dl1.getId();
-        }
-        return id;
-    }
-
     private static String buildName(final DanglingLine dl1, final DanglingLine dl2) {
         return dl1.getOptionalName()
                 .map(name1 -> dl2.getOptionalName()
-                        .map(name2 -> buildName(name1, name2))
+                        .map(name2 -> buildIdOrName(name1, name2))
                         .orElse(name1))
                 .orElseGet(() -> dl2.getOptionalName().orElse(null));
     }
 
-    private static String buildName(String name1, String name2) {
-        int compareResult = name1.compareTo(name2);
+    private static String buildIdOrName(String idOrName1, String idOrName2) {
+        int compareResult = idOrName1.compareTo(idOrName2);
         if (compareResult == 0) {
-            return name1;
+            return idOrName1;
         } else if (compareResult < 0) {
-            return name1 + " + " + name2;
+            return idOrName1 + " + " + idOrName2;
         } else {
-            return name2 + " + " + name1;
+            return idOrName2 + " + " + idOrName1;
         }
     }
 

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
@@ -84,14 +84,7 @@ class MergingViewIndex {
         for (DanglingLine dll1 : danglingLines) {
             if (dll1 != dll2) {
                 // Create MergedLine from 2 dangling lines
-                mergedLineCached.computeIfAbsent(code, key -> {
-                    MergedLine mergedLine = new MergedLine(this, dll1, dll2);
-                    if (!dll1.getId().equals(dll2.getId())) {
-                        mergedLine.addAlias(dll1.getId(), "dl1Id");
-                        mergedLine.addAlias(dll2.getId(), "dl2Id");
-                    }
-                    return mergedLine;
-                });
+                mergedLineCached.computeIfAbsent(code, key -> new MergedLine(this, dll1, dll2));
             }
         }
     }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
@@ -76,6 +76,9 @@ class MergingViewIndex {
         Objects.requireNonNull(dll2, "DanglingLine is null");
         // Manage DanglingLines
         final String code = dll2.getUcteXnodeCode();
+        if (code == null) {
+            return;
+        }
         // Find other DanglingLine if exist
         final Set<DanglingLine> danglingLines = getNetworkStream().flatMap(Network::getDanglingLineStream).filter(d -> d.getUcteXnodeCode().equals(code)).collect(Collectors.toSet());
         for (DanglingLine dll1 : danglingLines) {

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingViewIndex.java
@@ -84,7 +84,14 @@ class MergingViewIndex {
         for (DanglingLine dll1 : danglingLines) {
             if (dll1 != dll2) {
                 // Create MergedLine from 2 dangling lines
-                mergedLineCached.computeIfAbsent(code, key -> new MergedLine(this, dll1, dll2));
+                mergedLineCached.computeIfAbsent(code, key -> {
+                    MergedLine mergedLine = new MergedLine(this, dll1, dll2);
+                    if (!dll1.getId().equals(dll2.getId())) {
+                        mergedLine.addAlias(dll1.getId(), "dl1Id");
+                        mergedLine.addAlias(dll2.getId(), "dl2Id");
+                    }
+                    return mergedLine;
+                });
             }
         }
     }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ValidationUtil.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ValidationUtil.java
@@ -40,18 +40,22 @@ public final class ValidationUtil {
         index.getIdentifiableStream().forEach(identifiable -> {
             String id = identifiable.getId();
             if (otherIds.contains(id)) {
-                if (other.getIdentifiable(id) instanceof DanglingLine && identifiable instanceof DanglingLine) {
-                    String xnodeCode1 = ((DanglingLine) identifiable).getUcteXnodeCode();
-                    String xnodeCode2 = other.getDanglingLine(id).getUcteXnodeCode();
-                    if (xnodeCode1 != null && xnodeCode2 != null) {
-                        if (!xnodeCode1.equals(xnodeCode2)) {
-                            throw new PowsyblException(String.format("Dangling line couple %s have inconsistent Xnodes (%s!=%s)", id, xnodeCode1, xnodeCode2));
-                        }
-                        return;
-                    }
-                }
-                throw new PowsyblException("The object '" + identifiable + "' already exists into merging view");
+                checkValidDanglingLines(identifiable, other.getIdentifiable(id));
             }
         });
+    }
+
+    private static void checkValidDanglingLines(Identifiable origin, Identifiable other) {
+        if (other instanceof DanglingLine && origin instanceof DanglingLine) {
+            String xnodeCode1 = ((DanglingLine) origin).getUcteXnodeCode();
+            String xnodeCode2 = ((DanglingLine) other).getUcteXnodeCode();
+            if (xnodeCode1 != null && xnodeCode2 != null) {
+                if (!xnodeCode1.equals(xnodeCode2)) {
+                    throw new PowsyblException(String.format("Dangling line couple %s have inconsistent Xnodes (%s!=%s)", origin.getId(), xnodeCode1, xnodeCode2));
+                }
+                return;
+            }
+        }
+        throw new PowsyblException("The object '" + origin.getId() + "' already exists into merging view");
     }
 }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ValidationUtil.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ValidationUtil.java
@@ -45,7 +45,7 @@ public final class ValidationUtil {
         });
     }
 
-    private static void checkValidDanglingLines(Identifiable origin, Identifiable other) {
+    private static void checkValidDanglingLines(Identifiable<?> origin, Identifiable<?> other) {
         if (other instanceof DanglingLine && origin instanceof DanglingLine) {
             String xnodeCode1 = ((DanglingLine) origin).getUcteXnodeCode();
             String xnodeCode2 = ((DanglingLine) other).getUcteXnodeCode();

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ValidationUtil.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ValidationUtil.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.mergingview;
 
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 
@@ -36,9 +37,20 @@ public final class ValidationUtil {
         final Collection<String> otherIds = other.getIdentifiables().stream()
                                                                     .map(Identifiable::getId)
                                                                     .collect(Collectors.toSet());
-        index.getIdentifiableStream().map(Identifiable::getId).forEach(id -> {
+        index.getIdentifiableStream().forEach(identifiable -> {
+            String id = identifiable.getId();
             if (otherIds.contains(id)) {
-                throw new PowsyblException("The object '" + id + "' already exists into merging view");
+                if (other.getIdentifiable(id) instanceof DanglingLine && identifiable instanceof DanglingLine) {
+                    String xnodeCode1 = ((DanglingLine) identifiable).getUcteXnodeCode();
+                    String xnodeCode2 = other.getDanglingLine(id).getUcteXnodeCode();
+                    if (xnodeCode1 != null && xnodeCode2 != null) {
+                        if (!xnodeCode1.equals(xnodeCode2)) {
+                            throw new PowsyblException(String.format("Dangling line couple %s have inconsistent Xnodes (%s!=%s)", id, xnodeCode1, xnodeCode2));
+                        }
+                        return;
+                    }
+                }
+                throw new PowsyblException("The object '" + identifiable + "' already exists into merging view");
             }
         });
     }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/DanglingLineAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/DanglingLineAdapterTest.java
@@ -299,12 +299,12 @@ public class DanglingLineAdapterTest {
 
     @Test
     public void failDanglingLinesWithSameIdAndNullXnodeCode() {
+        double p0 = 1.0;
+        double q0 = 1.0;
+        Network network = EurostagTutorialExample1Factory.create();
+        createDanglingLine(network, "VLGEN", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, null, "NGEN");
+        createDanglingLine(noEquipNetwork, "vl1", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, null, "busA");
         try {
-            double p0 = 1.0;
-            double q0 = 1.0;
-            Network network = EurostagTutorialExample1Factory.create();
-            createDanglingLine(network, "VLGEN", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, null, "NGEN");
-            createDanglingLine(noEquipNetwork, "vl1", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, null, "busA");
             mergingView.merge(network, noEquipNetwork);
             fail();
         } catch (PowsyblException e) {
@@ -314,12 +314,12 @@ public class DanglingLineAdapterTest {
 
     @Test
     public void failDanglingLinesWithSameIdAndDifferentXnodeCode() {
+        double p0 = 1.0;
+        double q0 = 1.0;
+        Network network = EurostagTutorialExample1Factory.create();
+        createDanglingLine(network, "VLGEN", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, "code", "NGEN");
+        createDanglingLine(noEquipNetwork, "vl1", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, "code2", "busA");
         try {
-            double p0 = 1.0;
-            double q0 = 1.0;
-            Network network = EurostagTutorialExample1Factory.create();
-            createDanglingLine(network, "VLGEN", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, "code", "NGEN");
-            createDanglingLine(noEquipNetwork, "vl1", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, "code2", "busA");
             mergingView.merge(network, noEquipNetwork);
             fail();
         } catch (PowsyblException e) {

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/DanglingLineAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/DanglingLineAdapterTest.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.mergingview;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.NoEquipmentNetworkFactory;
 import org.junit.Before;
 import org.junit.Rule;
@@ -283,10 +284,53 @@ public class DanglingLineAdapterTest {
 
     }
 
-    private static DanglingLine createDanglingLine(Network n, String vlId, String id, String name, double r, double x, double g, double b,
-                                            double p0, double q0, String ucteCode, String busId) {
+    @Test
+    public void mergedDanglingLineWithSameId() {
+        double p0 = 1.0;
+        double q0 = 1.0;
+        Network network = EurostagTutorialExample1Factory.create();
+        createDanglingLine(network, "VLGEN", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, "code", "NGEN");
+        createDanglingLine(noEquipNetwork, "vl1", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, "code", "busA");
+        mergingView.merge(network, noEquipNetwork);
+        assertNull(mergingView.getDanglingLine("dl"));
+        Line merged = mergingView.getLine("dl");
+        assertNotNull(merged);
+    }
 
-        DanglingLine dl = n.getVoltageLevel(vlId).newDanglingLine()
+    @Test
+    public void failDanglingLinesWithSameIdAndNullXnodeCode() {
+        try {
+            double p0 = 1.0;
+            double q0 = 1.0;
+            Network network = EurostagTutorialExample1Factory.create();
+            createDanglingLine(network, "VLGEN", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, null, "NGEN");
+            createDanglingLine(noEquipNetwork, "vl1", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, null, "busA");
+            mergingView.merge(network, noEquipNetwork);
+            fail();
+        } catch (PowsyblException e) {
+            assertEquals("The object 'dl' already exists into merging view", e.getMessage());
+        }
+    }
+
+    @Test
+    public void failDanglingLinesWithSameIdAndDifferentXnodeCode() {
+        try {
+            double p0 = 1.0;
+            double q0 = 1.0;
+            Network network = EurostagTutorialExample1Factory.create();
+            createDanglingLine(network, "VLGEN", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, "code", "NGEN");
+            createDanglingLine(noEquipNetwork, "vl1", "dl", "dl1", 1.0, 1.0, 1.0, 1.0, p0, q0, "code2", "busA");
+            mergingView.merge(network, noEquipNetwork);
+            fail();
+        } catch (PowsyblException e) {
+            assertEquals("Dangling line couple dl have inconsistent Xnodes (code!=code2)", e.getMessage());
+        }
+    }
+
+    private static DanglingLine createDanglingLine(Network n, String vlId, String id, String name, double r, double x, double g, double b,
+                                                   double p0, double q0, String ucteCode, String busId) {
+
+        return n.getVoltageLevel(vlId).newDanglingLine()
                                                      .setId(id)
                                                      .setName(name)
                                                      .setR(r)
@@ -300,6 +344,5 @@ public class DanglingLineAdapterTest {
                                                      .setConnectableBus(busId)
                                                      .setEnsureIdUnicity(false)
                                                  .add();
-        return dl;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
If the merging view contains several networks, two of them containing a dangling line with the same ID, an exception is thrown


**What is the new behavior (if this is a feature change)?**
If the merging view contains several networks, two of them containing a dangling line with the same ID, if the ucteXnodeCode is identical, no exception is throw and a merged line is formed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:
- It only works when merging an existing network already containing the dangling line into the merging view, not when creating the dangling line in the merging view
- It implements the same behaviour as the destructive merging