### PR TITLE
[WIP] Fix bug topology in merging view

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Bus.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Bus.java
@@ -255,4 +255,14 @@ public interface Bus extends Identifiable<Bus> {
         return Stream.empty();
     }
 
+    /**
+     * Get the terminal reference of the bus if it has one.
+     * A terminal reference is a terminal to retrieve voltage, angle or connected and synchronous component numbers.
+     * If there is at least one connected terminal in this bus, we use the first connected terminal as reference.
+     * Otherwise this method tries to find a terminal which does not belong to this bus, but to the same "electrical" bus
+     * and therefore can be used as reference.
+     */
+    default Terminal getTerminalReference() {
+        return getConnectedTerminalStream().findFirst().orElse(null);
+    }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusExt.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusExt.java
@@ -22,6 +22,9 @@ interface BusExt extends Bus {
     @Override
     Stream<TerminalExt> getConnectedTerminalStream();
 
+    @Override
+    TerminalExt getTerminalReference();
+
     void setConnectedComponentNumber(int connectedComponentNumber);
 
     void setSynchronousComponentNumber(int componentNumber);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
@@ -109,6 +109,12 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
     }
 
     @Override
+    public TerminalExt getTerminalReference() {
+        checkValidity();
+        return terminalRef;
+    }
+
+    @Override
     public Collection<TerminalExt> getTerminals() {
         checkValidity();
         return Collections.unmodifiableCollection(terminals);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConfiguredBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConfiguredBusImpl.java
@@ -70,6 +70,11 @@ class ConfiguredBusImpl extends AbstractBus implements ConfiguredBus {
     }
 
     @Override
+    public TerminalExt getTerminalReference() {
+        return getConnectedTerminalStream().findFirst().orElseGet(() -> getTerminals().isEmpty() ? null : getTerminals().get(0));
+    }
+
+    @Override
     public int getTerminalCount() {
         return terminals.get(network.get().getVariantIndex()).size();
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MergedBus.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MergedBus.java
@@ -82,6 +82,17 @@ class MergedBus extends AbstractIdentifiable<Bus> implements CalculatedBus {
     }
 
     @Override
+    public TerminalExt getTerminalReference() {
+        checkValidity();
+        return getConnectedTerminalStream()
+                .findFirst()
+                .orElseGet(() -> buses.stream()
+                        .map(BusExt::getTerminalReference)
+                        .findFirst()
+                        .orElse(null));
+    }
+
+    @Override
     public void invalidate() {
         valid = false;
         buses.clear();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MergedBus.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/MergedBus.java
@@ -86,10 +86,7 @@ class MergedBus extends AbstractIdentifiable<Bus> implements CalculatedBus {
         checkValidity();
         return getConnectedTerminalStream()
                 .findFirst()
-                .orElseGet(() -> buses.stream()
-                        .map(BusExt::getTerminalReference)
-                        .findFirst()
-                        .orElse(null));
+                .orElse(null);
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/BusAdapter.java
@@ -227,7 +227,6 @@ class BusAdapter extends AbstractIdentifiableAdapter<Bus> implements Bus {
 
     void setConnectedComponentNumber(int connectedComponentNumber) {
         terminals.forEach(t -> t.setConnectedComponentNumber(connectedComponentNumber));
-        terminalRef.setConnectedComponentNumber(connectedComponentNumber);
     }
 
     @Override
@@ -246,7 +245,6 @@ class BusAdapter extends AbstractIdentifiableAdapter<Bus> implements Bus {
 
     void setSynchronousComponentNumber(int synchronousComponentNumber) {
         terminals.forEach(t -> t.setSynchronousComponentNumber(synchronousComponentNumber));
-        terminalRef.setSynchronousComponentNumber(synchronousComponentNumber);
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
@@ -141,7 +141,7 @@ public class BusAdapterTest {
     }
 
     @Test
-    public void testStackOverflow() {
+    public void testTerminalReference() {
         Network network = NetworkFactory.findDefault().createNetwork("testLoop", "test");
         Substation s = network.newSubstation()
             .setId("sub2")
@@ -168,12 +168,12 @@ public class BusAdapterTest {
             .newBus()
             .setId("b3")
             .add();
-        vl.getBusBreakerView()
+        Switch sw1 = vl.getBusBreakerView()
             .newSwitch()
             .setId("sw1")
             .setBus1("b1")
             .setBus2("b2")
-            .setOpen(false)
+            .setOpen(true)
             .add();
         vl.getBusBreakerView()
             .newSwitch()
@@ -182,6 +182,11 @@ public class BusAdapterTest {
             .setBus2("b3")
             .setOpen(false)
             .add();
+        assertNull(vl.getBusBreakerView().getBus("b1").getTerminalReference());
+
+        sw1.setOpen(false);
+        assertNull(vl.getBusBreakerView().getBus("b1").getTerminalReference());
+
         vl.newLoad()
             .setId("LOAD")
             .setConnectableBus("b3")

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
@@ -141,6 +141,60 @@ public class BusAdapterTest {
     }
 
     @Test
+    public void testStackOverflow() {
+        Network network = NetworkFactory.findDefault().createNetwork("testLoop", "test");
+        Substation s = network.newSubstation()
+            .setId("sub2")
+            .setCountry(Country.FR)
+            .setTso("RTE")
+            .add();
+        VoltageLevel vl = s.newVoltageLevel()
+            .setId("vl")
+            .setName("vl")
+            .setNominalV(440.0)
+            .setHighVoltageLimit(400.0)
+            .setLowVoltageLimit(200.0)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
+        vl.getBusBreakerView()
+            .newBus()
+            .setId("b1")
+            .add();
+        vl.getBusBreakerView()
+            .newBus()
+            .setId("b2")
+            .add();
+        vl.getBusBreakerView()
+            .newBus()
+            .setId("b3")
+            .add();
+        vl.getBusBreakerView()
+            .newSwitch()
+            .setId("sw1")
+            .setBus1("b1")
+            .setBus2("b2")
+            .setOpen(false)
+            .add();
+        vl.getBusBreakerView()
+            .newSwitch()
+            .setId("sw2")
+            .setBus1("b2")
+            .setBus2("b3")
+            .setOpen(false)
+            .add();
+        vl.newLoad()
+            .setId("LOAD")
+            .setConnectableBus("b3")
+            .setBus("b3")
+            .setP0(100.0)
+            .setQ0(1.0)
+            .add();
+        Terminal terminalRef1 = vl.getBusBreakerView().getBus("b1").getTerminalReference();
+        assertNotNull(terminalRef1);
+        assertEquals("LOAD", terminalRef1.getConnectable().getId());
+    }
+
+    @Test
     public void testGetMergedLine() {
         // Networks creation
         Network network1 = NoEquipmentNetworkFactory.create();

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
@@ -82,6 +82,28 @@ public class BusAdapterTest {
                 .newBus()
                 .setId("disconnected")
                 .add();
+        vl1.getBusBreakerView()
+                .newBus()
+                .setId("connected1")
+                .add();
+        vl1.getBusBreakerView()
+                .newSwitch()
+                .setId("sw1")
+                .setBus1("B1")
+                .setBus2("connected1")
+                .setOpen(false)
+                .add();
+        vl1.getBusBreakerView()
+                .newBus()
+                .setId("connected2")
+                .add();
+        vl1.getBusBreakerView()
+                .newSwitch()
+                .setId("sw2")
+                .setBus1("connected2")
+                .setBus2("connected1")
+                .setOpen(false)
+                .add();
         view.merge(network);
         HvdcLine l = view.getHvdcLine("L");
         assertNotNull(l);
@@ -106,6 +128,16 @@ public class BusAdapterTest {
         assertNull(disconnected.getSynchronousComponent());
         assertFalse(disconnected.isInMainConnectedComponent());
         assertFalse(disconnected.isInMainSynchronousComponent());
+        Bus connected1 = view.getBusBreakerView().getBus("connected1");
+        assertNotNull(connected1.getConnectedComponent());
+        assertNotNull(connected1.getSynchronousComponent());
+        assertSame(connected1.getConnectedComponent(), bus1.getConnectedComponent());
+        assertSame(connected1.getSynchronousComponent(), bus1.getSynchronousComponent());
+        Bus connected2 = view.getBusBreakerView().getBus("connected1");
+        assertNotNull(connected2.getConnectedComponent());
+        assertNotNull(connected2.getSynchronousComponent());
+        assertSame(connected2.getConnectedComponent(), bus1.getConnectedComponent());
+        assertSame(connected2.getSynchronousComponent(), bus1.getSynchronousComponent());
     }
 
     @Test

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
@@ -412,4 +412,134 @@ public class BusAdapterTest {
         busBreakerView.getSwitches().forEach(b -> assertTrue(b instanceof AbstractAdapter));
         assertEquals(1, busBreakerView.getSwitchCount());
     }
+
+    @Test
+    public void mainConnectedComponentWithSwitchTest() {
+        // TODO: delete this test when TCK tests merging view
+        Network network = Network.create("test_mcc", "test");
+
+        Substation s1 = network.newSubstation()
+                .setId("A")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("B")
+                .setNominalV(225.0)
+                .setLowVoltageLimit(0.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        vl1.getNodeBreakerView().newBusbarSection()
+                .setId("C")
+                .setNode(0)
+                .add();
+        vl1.getNodeBreakerView().newSwitch()
+                .setId("D")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(1)
+                .add();
+        vl1.getNodeBreakerView().newSwitch()
+                .setId("E")
+                .setKind(SwitchKind.BREAKER)
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(1)
+                .setNode2(2)
+                .add();
+
+        Substation s2 = network.newSubstation()
+                .setId("F")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("G")
+                .setNominalV(225.0)
+                .setLowVoltageLimit(0.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        vl2.getNodeBreakerView().newBusbarSection()
+                .setId("H")
+                .setNode(0)
+                .add();
+        vl2.getNodeBreakerView().newBusbarSection()
+                .setId("I")
+                .setNode(1)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("J")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setRetained(true)
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(2)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("K")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setRetained(true)
+                .setOpen(false)
+                .setNode1(1)
+                .setNode2(3)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("L")
+                .setKind(SwitchKind.BREAKER)
+                .setRetained(true)
+                .setOpen(false)
+                .setNode1(2)
+                .setNode2(3)
+                .add();
+        vl2.getNodeBreakerView().newSwitch()
+                .setId("M")
+                .setKind(SwitchKind.BREAKER)
+                .setRetained(false)
+                .setOpen(false)
+                .setNode1(0)
+                .setNode2(4)
+                .add();
+
+        network.newLine()
+                .setId("N")
+                .setR(0.001)
+                .setX(0.1)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .setVoltageLevel1("B")
+                .setNode1(2)
+                .setVoltageLevel2("G")
+                .setNode2(4)
+                .add();
+
+        network.getBusView().getBuses().forEach(b -> {
+            if (b.getVoltageLevel() == vl1) {
+                b.setV(230.0).setAngle(0.5);
+            } else {
+                b.setV(220.0).setAngle(0.7);
+            }
+        });
+
+        MergingView mergingView = MergingView.create("merged", "test");
+        mergingView.merge(network);
+
+        assertEquals(2, mergingView.getBusView().getBusStream().count());
+        for (Bus b : mergingView.getBusView().getBuses()) {
+            assertTrue(b.isInMainConnectedComponent());
+        }
+
+        assertEquals(5, mergingView.getBusBreakerView().getBusStream().count());
+        for (Bus b : mergingView.getBusBreakerView().getBuses()) {
+            assertTrue(b.isInMainConnectedComponent());
+            if (b.getVoltageLevel().getId().equals(vl1.getId())) {
+                assertEquals(230.0, b.getV(), 0.0);
+                assertEquals(0.5, b.getAngle(), 0.0);
+            } else {
+                assertEquals(220.0, b.getV(), 0.0);
+                assertEquals(0.7, b.getAngle(), 0.0);
+            }
+        }
+    }
 }

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/BusAdapterTest.java
@@ -76,7 +76,13 @@ public class BusAdapterTest {
     @Test
     public void testSynchronousComponentSetterGetter() {
         MergingView view = MergingView.create("testSynchronousComponentSetterGetter", "iidm");
-        view.merge(HvdcTestNetwork.createVsc());
+        Network network = HvdcTestNetwork.createVsc();
+        VoltageLevel vl1 = network.getVoltageLevel("VL1");
+        vl1.getBusBreakerView()
+                .newBus()
+                .setId("disconnected")
+                .add();
+        view.merge(network);
         HvdcLine l = view.getHvdcLine("L");
         assertNotNull(l);
         VscConverterStation cs1 = view.getVscConverterStation("C1");
@@ -95,6 +101,11 @@ public class BusAdapterTest {
         int num1 = bus1.getSynchronousComponent().getNum();
         int num2 = bus2.getSynchronousComponent().getNum();
         assertNotEquals(num1, num2);
+        Bus disconnected = view.getBusBreakerView().getBus("disconnected");
+        assertNull(disconnected.getConnectedComponent());
+        assertNull(disconnected.getSynchronousComponent());
+        assertFalse(disconnected.isInMainConnectedComponent());
+        assertFalse(disconnected.isInMainSynchronousComponent());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
It fixes a topology bug: calculated buses in bus breaker view between two retained switches didn't have a terminal reference even if they belonged to an electrical bus.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:
The test I added is already present in the TCK: it should be deleted when the TCK tests the merging view
