### PR TITLE
Fix bug in LineAdderAdapter (node1 used to be set twice)

### DIFF
--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/LineAdderAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/LineAdderAdapter.java
@@ -155,7 +155,7 @@ class LineAdderAdapter implements LineAdder {
             adder.setNode1(node1);
         }
         if (node2 != null) {
-            adder.setNode1(node2);
+            adder.setNode2(node2);
         }
         return adder.add();
     }


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix: nodes of a line are now correct when a new line is created in a merging view



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

**Other information**:
I did not add tests but it will be tested once the PR changing the TCK will be merged (cf. #1510)