### PR TITLE
Add logs to loadflow result and manage version compatibility

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowResultDeserializer.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowResultDeserializer.java
@@ -97,7 +97,7 @@ public class LoadFlowResultDeserializer extends StdDeserializer<LoadFlowResult> 
         String version = null;
         Boolean ok = null;
         Map<String, String> metrics = null;
-        String log = null;
+        String logs = null;
         List<LoadFlowResult.ComponentResult> componentResults = new ArrayList<>();
 
         while (parser.nextToken() != JsonToken.END_OBJECT) {
@@ -117,6 +117,12 @@ public class LoadFlowResultDeserializer extends StdDeserializer<LoadFlowResult> 
                     metrics = parser.readValueAs(HashMap.class);
                     break;
 
+                case "logs":
+                    JsonUtil.assertGreaterThanReferenceVersion(CONTEXT_NAME, "Tag: logs", version, "1.1");
+                    parser.nextToken();
+                    logs = parser.getValueAsString();
+                    break;
+
                 case "componentResults":
                     JsonUtil.assertGreaterThanReferenceVersion(CONTEXT_NAME, "Tag: componentResults", version, "1.0");
                     parser.nextToken();
@@ -132,7 +138,7 @@ public class LoadFlowResultDeserializer extends StdDeserializer<LoadFlowResult> 
             throw new IllegalStateException("Ok field not found");
         }
 
-        return new LoadFlowResultImpl(ok, metrics, log, componentResults);
+        return new LoadFlowResultImpl(ok, metrics, logs, componentResults);
     }
 
     public static LoadFlowResult read(InputStream is) throws IOException {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowResultSerializer.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowResultSerializer.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  */
 public class LoadFlowResultSerializer extends StdSerializer<LoadFlowResult> {
 
-    private static final String VERSION = "1.1";
+    private static final String VERSION = "1.2";
 
     LoadFlowResultSerializer() {
         super(LoadFlowResult.class);
@@ -40,6 +40,7 @@ public class LoadFlowResultSerializer extends StdSerializer<LoadFlowResult> {
         jsonGenerator.writeStringField("version", VERSION);
         jsonGenerator.writeBooleanField("isOK", result.isOk());
         jsonGenerator.writeObjectField("metrics", result.getMetrics());
+        jsonGenerator.writeObjectField("logs", result.getLogs());
         List<LoadFlowResult.ComponentResult> componentResults = result.getComponentResults();
         if (!componentResults.isEmpty()) {
             jsonGenerator.writeFieldName("componentResults");

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/LoadFlowResultJsonTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/LoadFlowResultJsonTest.java
@@ -8,6 +8,7 @@ package com.powsybl.loadflow.json;
 
 import com.google.common.collect.ImmutableMap;
 import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.loadflow.LoadFlowResultImpl;
 import org.junit.Test;
@@ -41,9 +42,13 @@ public class LoadFlowResultJsonTest extends AbstractConverterTest {
         return new LoadFlowResultImpl(true, createMetrics(), "", Collections.singletonList(new LoadFlowResultImpl.ComponentResultImpl(0, LoadFlowResult.ComponentResult.Status.CONVERGED, 7, "bus1", 235.3)));
     }
 
+    private static LoadFlowResult createVersion12() {
+        return new LoadFlowResultImpl(true, createMetrics(), "logs", Collections.singletonList(new LoadFlowResultImpl.ComponentResultImpl(0, LoadFlowResult.ComponentResult.Status.CONVERGED, 7, "bus1", 235.3)));
+    }
+
     @Test
-    public void roundTripVersion11Test() throws IOException {
-        roundTripTest(createVersion11(), LoadFlowResultSerializer::write, LoadFlowResultDeserializer::read, "/LoadFlowResultVersion11.json");
+    public void roundTripVersion12Test() throws IOException {
+        roundTripTest(createVersion12(), LoadFlowResultSerializer::write, LoadFlowResultDeserializer::read, "/LoadFlowResultVersion12.json");
     }
 
     @Test
@@ -56,10 +61,26 @@ public class LoadFlowResultJsonTest extends AbstractConverterTest {
     }
 
     @Test
+    public void readJsonVersion11() throws IOException {
+        LoadFlowResult result = LoadFlowResultDeserializer.read(getClass().getResourceAsStream("/LoadFlowResultVersion11.json"));
+        assertTrue(result.isOk());
+        assertEquals(createMetrics(), result.getMetrics());
+        assertNull(result.getLogs());
+        assertFalse(result.getComponentResults().isEmpty());
+    }
+
+    @Test
     public void handleErrorTest() throws IOException {
         expected.expect(AssertionError.class);
         expected.expectMessage("Unexpected field: alienAttribute");
         LoadFlowResultDeserializer.read(getClass().getResourceAsStream("/LoadFlowResultVersion10Error.json"));
+    }
+
+    @Test
+    public void handleErrorTest12() throws IOException {
+        expected.expect(PowsyblException.class);
+        expected.expectMessage("LoadFlowResult. Tag: logs is not valid for version 1.1. Version should be > 1.1");
+        LoadFlowResultDeserializer.read(getClass().getResourceAsStream("/LoadFlowResultVersion12Error.json"));
     }
 
 }

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowResultVersion12.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowResultVersion12.json
@@ -1,0 +1,20 @@
+{
+  "version" : "1.2",
+  "isOK" : true,
+  "metrics" : {
+    "nbiter" : "4",
+    "dureeCalcul" : "0.02",
+    "cause" : "0",
+    "contraintes" : "0",
+    "statut" : "OK",
+    "csprMarcheForcee" : "0"
+  },
+  "logs" : "logs",
+  "componentResults" : [ {
+    "componentNum" : 0,
+    "status" : "CONVERGED",
+    "iterationCount" : 7,
+    "slackBusId" : "bus1",
+    "slackBusActivePowerMismatch" : 235.3
+  } ]
+}

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowResultVersion12Error.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowResultVersion12Error.json
@@ -1,0 +1,20 @@
+{
+  "version" : "1.1",
+  "isOK" : true,
+  "metrics" : {
+    "nbiter" : "4",
+    "dureeCalcul" : "0.02",
+    "cause" : "0",
+    "contraintes" : "0",
+    "statut" : "OK",
+    "csprMarcheForcee" : "0"
+  },
+  "logs" : "logs",
+  "componentResults" : [ {
+    "componentNum" : 0,
+    "status" : "CONVERGED",
+    "iterationCount" : 7,
+    "slackBusId" : "bus1",
+    "slackBusActivePowerMismatch" : 235.3
+  } ]
+}


### PR DESCRIPTION
Signed-off-by: HOMER Etienne <etiennehomer@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Enrich serialization and deserialization of LoadFlowResult object with loadflow logs.


**What is the current behavior?** *(You can also link to an open issue here)*
The serializer and deserializer don't use the logs attribute.


**What is the new behavior (if this is a feature change)?**
Logs attribute is well serialized and deserialized.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No.
