### PR TITLE
Fix : all VLs with the same nominal voltage in a substation are now created

### DIFF
--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Iterator;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.*;
 
@@ -190,5 +191,15 @@ public class UcteImporterTest {
         assertFalse(iter.hasNext());
     }
 
+    @Test
+    public void substationNameInvariance() {
+        ResourceDataSource dataSource = new ResourceDataSource("VLsCreationIssue", new ResourceSet("/", "VLsCreationIssue.uct"));
+
+        IntStream.iterate(0, i -> i + 1).limit(10).forEach(i -> {
+            Network network = new UcteImporter().importData(dataSource, null);
+            assertNotNull(network.getSubstation("FTESTU"));
+            assertNull(network.getSubstation("F1TEST"));
+        });
+    }
 }
 

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
@@ -17,6 +17,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Iterator;
+
 import static org.junit.Assert.*;
 
 /**
@@ -176,5 +178,17 @@ public class UcteImporterTest {
         assertEquals(1.0, dl.getGeneration().getReactiveLimits().getMaxQ(dl.getGeneration().getTargetP()), 0.01);
         assertEquals(-1.0, dl.getGeneration().getReactiveLimits().getMinQ(dl.getGeneration().getTargetP()), 0.01);
     }
+
+    @Test
+    public void voltageLevelsCreationIssueTest() {
+        ResourceDataSource dataSource = new ResourceDataSource("VLsCreationIssue", new ResourceSet("/", "VLsCreationIssue.uct"));
+
+        Network network = new UcteImporter().importData(dataSource, null);
+        assertEquals(2, network.getVoltageLevelCount());
+        Iterator<VoltageLevel> iter = network.getVoltageLevels().iterator();
+        assertEquals(iter.next().getNominalV(), iter.next().getNominalV(), 0.01);
+        assertFalse(iter.hasNext());
+    }
+
 }
 

--- a/ucte/ucte-converter/src/test/resources/VLsCreationIssue.uct
+++ b/ucte/ucte-converter/src/test/resources/VLsCreationIssue.uct
@@ -1,0 +1,12 @@
+##C 2007.05.01
+Test case for UCTE import issue in PowSyBl core package
+When multiples VLs with the same nominal voltage are present in a substation, only one is created
+contact : slimane.amar@rte-france.com
+
+##N
+##ZFR
+F1TEST11 1TEST77 1    0 0        0.15546 72.7296 0.00000 0.00000
+FTESTU11 TESTUP7 1-2  0 0        0.00000 0.00000 0.00000 0.00000
+
+##T
+F1TEST11 FTESTU11 1 0 380.0 380.0 1186. 0.1280 44.280 0.000000 0.0000   1803 TESTUY771

--- a/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/ext/UcteNetworkExt.java
+++ b/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/ext/UcteNetworkExt.java
@@ -212,7 +212,8 @@ public class UcteNetworkExt implements UcteNetwork {
                             nodeCode2.getUcteCountryCode() == UcteCountryCode.XX) {
                         return -1;
                     } else {
-                        return compareVoltageLevelThenBusbar(nodeCode1, nodeCode2);
+                        int c = compareVoltageLevelThenBusbar(nodeCode1, nodeCode2);
+                        return (c != 0) ? c : nodeCode2.compareTo(nodeCode1); // Alphabetical order to always have the same main node (invariant)
                     }
                 })
                 .findFirst()


### PR DESCRIPTION
Signed-off-by: Slimane AMAR <slimane.amar@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug


**What is the current behavior?** *(You can also link to an open issue here)*
When multiples VLs with the same nominal voltage are present in a substation, only one is created
which contains all the buses

**What is the new behavior (if this is a feature change)?**
All VLs with the same nominal voltage in a substation are now created


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
