### PR TITLE
Change the way DanglingLine::Generation is created

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineAdderImpl.java
@@ -163,19 +163,18 @@ class DanglingLineAdderImpl extends AbstractInjectionAdder<DanglingLineAdderImpl
         ValidationUtil.checkG(this, g);
         ValidationUtil.checkB(this, b);
 
-        DanglingLineImpl.GenerationImpl generation = null;
-        if (generationAdder != null) {
-            generation = new DanglingLineImpl.GenerationImpl(generationAdder.minP,
-                                                             generationAdder.maxP,
-                                                             generationAdder.targetP,
-                                                             generationAdder.targetQ,
-                                                             generationAdder.voltageRegulationOn,
-                                                             generationAdder.targetV);
-        }
-
-        DanglingLineImpl danglingLine = new DanglingLineImpl(getNetwork().getRef(), id, getName(), isFictitious(), p0, q0, r, x, g, b, ucteXnodeCode, generation);
+        DanglingLineImpl danglingLine = new DanglingLineImpl(getNetwork().getRef(), id, getName(), isFictitious(), p0, q0, r, x, g, b, ucteXnodeCode);
         danglingLine.addTerminal(terminal);
         voltageLevel.attach(terminal, false);
+        if (generationAdder != null) {
+            danglingLine.setGeneration(new DanglingLineImpl.GenerationImpl(danglingLine,
+                    generationAdder.minP,
+                    generationAdder.maxP,
+                    generationAdder.targetP,
+                    generationAdder.targetQ,
+                    generationAdder.targetV,
+                    generationAdder.voltageRegulationOn));
+        }
         getNetwork().getIndex().checkAndAdd(danglingLine);
         getNetwork().getListeners().notifyCreation(danglingLine);
         return danglingLine;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineImpl.java
@@ -21,56 +21,42 @@ class DanglingLineImpl extends AbstractConnectable<DanglingLine> implements Dang
 
     static class GenerationImpl implements Generation, ReactiveLimitsOwner, Validable {
 
-        private DanglingLineImpl danglingLine;
+        private final DanglingLineImpl danglingLine;
 
-        private ReactiveLimitsHolderImpl reactiveLimits;
+        private final ReactiveLimitsHolderImpl reactiveLimits;
 
         private double minP;
 
         private double maxP;
 
-        private final double initialTargetP;
-
-        private final double initialTargetQ;
-
-        private final boolean initialVoltageRegulationOn;
-
-        private final double initialTargetV;
-
         // attributes depending on the variant
 
-        private TDoubleArrayList targetP;
+        private final TDoubleArrayList targetP;
 
-        private TDoubleArrayList targetQ;
+        private final TDoubleArrayList targetQ;
 
-        private TBooleanArrayList voltageRegulationOn;
+        private final TDoubleArrayList targetV;
 
-        private TDoubleArrayList targetV;
+        private final TBooleanArrayList voltageRegulationOn;
 
-        GenerationImpl(double minP, double maxP, double targetP, double targetQ, boolean voltageRegulationOn, double targetV) {
+        GenerationImpl(DanglingLineImpl danglingLine, double minP, double maxP, double targetP, double targetQ, double targetV, boolean voltageRegulationOn) {
+            this.danglingLine = Objects.requireNonNull(danglingLine);
+
             this.minP = Double.isNaN(minP) ? -Double.MAX_VALUE : minP;
             this.maxP = Double.isNaN(maxP) ? Double.MAX_VALUE : maxP;
-            this.initialTargetP = targetP;
-            this.initialTargetQ = targetQ;
-            this.initialVoltageRegulationOn = voltageRegulationOn;
-            this.initialTargetV = targetV;
-        }
 
-        GenerationImpl setDanglingLine(DanglingLineImpl danglingLine) {
-            this.danglingLine = Objects.requireNonNull(danglingLine);
-            int variantArraySize = danglingLine.network.get().getVariantManager().getVariantArraySize();
+            int variantArraySize = danglingLine.getNetwork().getVariantManager().getVariantArraySize();
             this.targetP = new TDoubleArrayList(variantArraySize);
             this.targetQ = new TDoubleArrayList(variantArraySize);
-            this.voltageRegulationOn = new TBooleanArrayList(variantArraySize);
             this.targetV = new TDoubleArrayList(variantArraySize);
+            this.voltageRegulationOn = new TBooleanArrayList(variantArraySize);
             for (int i = 0; i < variantArraySize; i++) {
-                this.targetP.add(initialTargetP);
-                this.targetQ.add(initialTargetQ);
-                this.voltageRegulationOn.add(initialVoltageRegulationOn);
-                this.targetV.add(initialTargetV);
+                this.targetP.add(targetP);
+                this.targetQ.add(targetQ);
+                this.targetV.add(targetV);
+                this.voltageRegulationOn.add(voltageRegulationOn);
             }
             this.reactiveLimits = new ReactiveLimitsHolderImpl(danglingLine, new MinMaxReactiveLimitsImpl(-Double.MAX_VALUE, Double.MAX_VALUE));
-            return this;
         }
 
         @Override
@@ -237,7 +223,7 @@ class DanglingLineImpl extends AbstractConnectable<DanglingLine> implements Dang
 
     private final String ucteXnodeCode;
 
-    private final GenerationImpl generation;
+    private GenerationImpl generation;
 
     private CurrentLimitsImpl limits;
 
@@ -247,8 +233,7 @@ class DanglingLineImpl extends AbstractConnectable<DanglingLine> implements Dang
 
     private final TDoubleArrayList q0;
 
-    DanglingLineImpl(Ref<? extends VariantManagerHolder> network, String id, String name, boolean fictitious, double p0, double q0, double r, double x, double g, double b,
-                     String ucteXnodeCode, GenerationImpl generation) {
+    DanglingLineImpl(Ref<? extends VariantManagerHolder> network, String id, String name, boolean fictitious, double p0, double q0, double r, double x, double g, double b, String ucteXnodeCode) {
         super(id, name, fictitious);
         this.network = network;
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
@@ -263,7 +248,6 @@ class DanglingLineImpl extends AbstractConnectable<DanglingLine> implements Dang
         this.g = g;
         this.b = b;
         this.ucteXnodeCode = ucteXnodeCode;
-        this.generation = generation != null ? generation.setDanglingLine(this) : null;
     }
 
     @Override
@@ -375,6 +359,10 @@ class DanglingLineImpl extends AbstractConnectable<DanglingLine> implements Dang
     @Override
     public Generation getGeneration() {
         return generation;
+    }
+
+    void setGeneration(GenerationImpl generation) {
+        this.generation = generation;
     }
 
     @Override


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
The GenerationImpl class contains 4 attributes needed until the dangling is set. After that, these 4 attributes are never used.


**What is the new behavior (if this is a feature change)?**
The Generation is not passed to the command line, but after the dangling line is attached to the network and before the end of the DanglingLineAdder::add() method. The setGeneration is `private package` so it cannot be called from the public API and it should be callable because the Generation is an interface, so not easily constructible.  


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
This PR should be backported in powsybl/powsybl-iidm4cpp#206

(if any of the questions/checkboxes don't apply, please delete them entirely)
