### PR TITLE
Contingency.setId removed, Contingency.addElement/removeElement added…

### DIFF
--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
@@ -30,8 +30,7 @@ public class Contingency extends AbstractExtendable<Contingency> {
     private final List<ContingencyElement> elements;
 
     public Contingency(String id, ContingencyElement... elements) {
-        this.id = Objects.requireNonNull(id);
-        this.elements = Arrays.asList(elements);
+        this(id, Arrays.asList(elements));
     }
 
     public Contingency(String id, List<ContingencyElement> elements) {

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
@@ -44,7 +44,7 @@ public class Contingency extends AbstractExtendable<Contingency> {
     }
 
     public List<ContingencyElement> getElements() {
-        return elements;
+        return Collections.unmodifiableList(elements);
     }
 
     @Override
@@ -130,15 +130,11 @@ public class Contingency extends AbstractExtendable<Contingency> {
 
     /**
      * Return a list of valid contingencies.
-     * @deprecated Use {@link ContingencyList#checkValidity(List, Network)} ()} instead.
+     * @deprecated Use {@link ContingencyList#getValidContingencies(List, Network)} ()} instead.
      */
     @Deprecated
     public static List<Contingency> checkValidity(List<Contingency> contingencies, Network network) {
-        Objects.requireNonNull(contingencies);
-        Objects.requireNonNull(network);
-        return contingencies.stream()
-                .filter(c -> c.isValid(network))
-                .collect(Collectors.toList());
+        return ContingencyList.getValidContingencies(contingencies, network);
     }
 
     private static boolean checkGeneratorContingency(Contingency contingency, GeneratorContingency element, Network network) {

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.contingency;
 
-import com.google.common.collect.ImmutableList;
 import com.powsybl.commons.extensions.AbstractExtendable;
 import com.powsybl.contingency.tasks.CompoundModificationTask;
 import com.powsybl.contingency.tasks.ModificationTask;
@@ -32,12 +31,12 @@ public class Contingency extends AbstractExtendable<Contingency> {
 
     public Contingency(String id, ContingencyElement... elements) {
         this.id = Objects.requireNonNull(id);
-        this.elements = ImmutableList.copyOf(elements);
+        this.elements = Arrays.asList(elements);
     }
 
     public Contingency(String id, List<ContingencyElement> elements) {
         this.id = Objects.requireNonNull(id);
-        this.elements = ImmutableList.copyOf(elements);
+        this.elements = new ArrayList<>(Objects.requireNonNull(elements));
     }
 
     public String getId() {
@@ -60,6 +59,16 @@ public class Contingency extends AbstractExtendable<Contingency> {
             return id.equals(other.id) && elements.equals(other.elements);
         }
         return false;
+    }
+
+    public void addElement(ContingencyElement element) {
+        Objects.requireNonNull(element);
+        elements.add(element);
+    }
+
+    public void removeElement(ContingencyElement element) {
+        Objects.requireNonNull(element);
+        elements.remove(element);
     }
 
     public ModificationTask toTask() {
@@ -117,6 +126,19 @@ public class Contingency extends AbstractExtendable<Contingency> {
             LOGGER.warn("Contingency '{}' is invalid", id);
         }
         return valid;
+    }
+
+    /**
+     * Return a list of valid contingencies.
+     * @deprecated Use {@link ContingencyList#checkValidity(List, Network)} ()} instead.
+     */
+    @Deprecated
+    public static List<Contingency> checkValidity(List<Contingency> contingencies, Network network) {
+        Objects.requireNonNull(contingencies);
+        Objects.requireNonNull(network);
+        return contingencies.stream()
+                .filter(c -> c.isValid(network))
+                .collect(Collectors.toList());
     }
 
     private static boolean checkGeneratorContingency(Contingency contingency, GeneratorContingency element, Network network) {

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyList.java
@@ -17,6 +17,8 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * @author Mathieu Bague <mathieu.bague@rte-france.com>
@@ -71,5 +73,13 @@ public interface ContingencyList {
      */
     static ContingencyList of(Contingency... contingencies) {
         return new DefaultContingencyList(contingencies);
+    }
+
+    static List<Contingency> checkValidity(List<Contingency> contingencies, Network network) {
+        Objects.requireNonNull(contingencies);
+        Objects.requireNonNull(network);
+        return contingencies.stream()
+                .filter(c -> c.isValid(network))
+                .collect(Collectors.toList());
     }
 }

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyList.java
@@ -75,7 +75,10 @@ public interface ContingencyList {
         return new DefaultContingencyList(contingencies);
     }
 
-    static List<Contingency> checkValidity(List<Contingency> contingencies, Network network) {
+    /**
+     * Return only valid contingencies based on given list of contingencies and network
+     */
+    static List<Contingency> getValidContingencies(List<Contingency> contingencies, Network network) {
         Objects.requireNonNull(contingencies);
         Objects.requireNonNull(network);
         return contingencies.stream()

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
@@ -16,6 +16,7 @@ import com.powsybl.iidm.network.test.SvcTestCaseFactory;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -45,6 +46,12 @@ public class ContingencyTest {
 
         ModificationTask task = contingency.toTask();
         assertTrue(task instanceof CompoundModificationTask);
+
+        ContingencyElement bbsElement = new BusbarSectionContingency("bbs");
+        contingency.addElement(bbsElement);
+        assertEquals(3, contingency.getElements().size());
+        contingency.removeElement(bbsElement);
+        assertEquals(2, contingency.getElements().size());
     }
 
     @Test
@@ -57,9 +64,16 @@ public class ContingencyTest {
 
         List<Contingency> validContingencies = ContingencyList.of(generatorContingency, generatorInvalidContingency, lineContingency, lineInvalidContingency)
                 .getContingencies(network);
+        List<String> expectedValidIds = Arrays.asList("GEN contingency", "NHV1_NHV2_1 contingency");
 
-        assertEquals(Arrays.asList("GEN contingency", "NHV1_NHV2_1 contingency"),
+        assertEquals(expectedValidIds,
                 validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
+
+        assertEquals(expectedValidIds,
+                ContingencyList.checkValidity(Arrays.asList(generatorContingency, generatorInvalidContingency, lineContingency, lineInvalidContingency), network)
+                        .stream()
+                        .map(Contingency::getId)
+                        .collect(Collectors.toList()));
     }
 
     @Test
@@ -71,8 +85,16 @@ public class ContingencyTest {
         List<Contingency> validContingencies = ContingencyList.of(shuntCompensatorContingency, shuntCompensatorInvalidContingency)
                 .getContingencies(network);
 
-        assertEquals(Arrays.asList("Shunt contingency"),
+        List<String> expectedValidIds = Collections.singletonList("Shunt contingency");
+
+        assertEquals(expectedValidIds,
                 validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
+
+        assertEquals(expectedValidIds,
+                ContingencyList.checkValidity(Arrays.asList(shuntCompensatorContingency, shuntCompensatorInvalidContingency), network)
+                        .stream()
+                        .map(Contingency::getId)
+                        .collect(Collectors.toList()));
     }
 
     @Test
@@ -83,8 +105,16 @@ public class ContingencyTest {
         List<Contingency> validContingencies = ContingencyList.of(staticVarCompensatorContingency, staticVarCompensatorInvalidContingency)
                 .getContingencies(network);
 
-        assertEquals(Arrays.asList("SVC contingency"),
+        List<String> expectedValidIds = Collections.singletonList("SVC contingency");
+
+        assertEquals(expectedValidIds,
                 validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
+
+        assertEquals(expectedValidIds,
+                ContingencyList.checkValidity(Arrays.asList(staticVarCompensatorContingency, staticVarCompensatorInvalidContingency), network)
+                        .stream()
+                        .map(Contingency::getId)
+                        .collect(Collectors.toList()));
     }
 
     @Test
@@ -95,7 +125,15 @@ public class ContingencyTest {
         List<Contingency> validContingencies = ContingencyList.of(danglingLineContingency, danglingLineInvalidContingency)
                 .getContingencies(network);
 
-        assertEquals(Arrays.asList("DL contingency"),
+        List<String> expectedValidIds = Collections.singletonList("DL contingency");
+
+        assertEquals(expectedValidIds,
                 validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
+
+        assertEquals(expectedValidIds,
+                ContingencyList.checkValidity(Arrays.asList(danglingLineContingency, danglingLineInvalidContingency), network)
+                        .stream()
+                        .map(Contingency::getId)
+                        .collect(Collectors.toList()));
     }
 }

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
@@ -52,6 +52,10 @@ public class ContingencyTest {
         assertEquals(3, contingency.getElements().size());
         contingency.removeElement(bbsElement);
         assertEquals(2, contingency.getElements().size());
+
+        contingency = new Contingency("test", bbsElement);
+        contingency.addElement(new LineContingency("UNKNOWN"));
+        assertEquals(2, contingency.getElements().size());
     }
 
     @Test

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
@@ -70,7 +70,7 @@ public class ContingencyTest {
                 validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
 
         assertEquals(expectedValidIds,
-                ContingencyList.checkValidity(Arrays.asList(generatorContingency, generatorInvalidContingency, lineContingency, lineInvalidContingency), network)
+                ContingencyList.getValidContingencies(Arrays.asList(generatorContingency, generatorInvalidContingency, lineContingency, lineInvalidContingency), network)
                         .stream()
                         .map(Contingency::getId)
                         .collect(Collectors.toList()));
@@ -91,7 +91,7 @@ public class ContingencyTest {
                 validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
 
         assertEquals(expectedValidIds,
-                ContingencyList.checkValidity(Arrays.asList(shuntCompensatorContingency, shuntCompensatorInvalidContingency), network)
+                ContingencyList.getValidContingencies(Arrays.asList(shuntCompensatorContingency, shuntCompensatorInvalidContingency), network)
                         .stream()
                         .map(Contingency::getId)
                         .collect(Collectors.toList()));
@@ -111,7 +111,7 @@ public class ContingencyTest {
                 validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
 
         assertEquals(expectedValidIds,
-                ContingencyList.checkValidity(Arrays.asList(staticVarCompensatorContingency, staticVarCompensatorInvalidContingency), network)
+                ContingencyList.getValidContingencies(Arrays.asList(staticVarCompensatorContingency, staticVarCompensatorInvalidContingency), network)
                         .stream()
                         .map(Contingency::getId)
                         .collect(Collectors.toList()));
@@ -131,7 +131,7 @@ public class ContingencyTest {
                 validContingencies.stream().map(Contingency::getId).collect(Collectors.toList()));
 
         assertEquals(expectedValidIds,
-                ContingencyList.checkValidity(Arrays.asList(danglingLineContingency, danglingLineInvalidContingency), network)
+                ContingencyList.getValidContingencies(Arrays.asList(danglingLineContingency, danglingLineInvalidContingency), network)
                         .stream()
                         .map(Contingency::getId)
                         .collect(Collectors.toList()));


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Following methods were removed by PR#925 : 
Contingency.setId, Contingency.getId, Contingency.addElement/removeElement, Contingency.checkValidity


**What is the new behavior (if this is a feature change)?**
Contingency.setId : still removed
Contingency.getId, Contingency.addElement/removeElement : removal is reverted
Contingency.checkValidity : removal is reverted, set to Deprecated and duplicated into ContingencyList 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
