### PR TITLE
Deprecate useless extension writer in XmlWriterContext

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/xml/XmlWriterContext.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlWriterContext.java
@@ -15,5 +15,11 @@ public interface XmlWriterContext {
 
     XMLStreamWriter getWriter();
 
-    XMLStreamWriter getExtensionsWriter();
+    /**
+     * @deprecated Use {@link #getWriter()} instead.
+     */
+    @Deprecated
+    default XMLStreamWriter getExtensionsWriter() {
+        return getWriter();
+    }
 }

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeAreaXmlSerializer.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/EntsoeAreaXmlSerializer.java
@@ -29,7 +29,7 @@ public class EntsoeAreaXmlSerializer extends AbstractExtensionXmlSerializer<Subs
 
     @Override
     public void write(EntsoeArea country, XmlWriterContext context) throws XMLStreamException {
-        context.getExtensionsWriter().writeCharacters(country.getCode().name());
+        context.getWriter().writeCharacters(country.getCode().name());
     }
 
     @Override

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/MergedXnodeXmlSerializer.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/MergedXnodeXmlSerializer.java
@@ -29,13 +29,13 @@ public class MergedXnodeXmlSerializer extends AbstractExtensionXmlSerializer<Lin
 
     @Override
     public void write(MergedXnode xnode, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeFloat("rdp", xnode.getRdp(), context.getExtensionsWriter());
-        XmlUtil.writeFloat("xdp", xnode.getXdp(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("xnodeP1", xnode.getXnodeP1(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("xnodeQ1", xnode.getXnodeQ1(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("xnodeP2", xnode.getXnodeP2(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("xnodeQ2", xnode.getXnodeQ2(), context.getExtensionsWriter());
-        context.getExtensionsWriter().writeAttribute("code", xnode.getCode());
+        XmlUtil.writeFloat("rdp", xnode.getRdp(), context.getWriter());
+        XmlUtil.writeFloat("xdp", xnode.getXdp(), context.getWriter());
+        XmlUtil.writeDouble("xnodeP1", xnode.getXnodeP1(), context.getWriter());
+        XmlUtil.writeDouble("xnodeQ1", xnode.getXnodeQ1(), context.getWriter());
+        XmlUtil.writeDouble("xnodeP2", xnode.getXnodeP2(), context.getWriter());
+        XmlUtil.writeDouble("xnodeQ2", xnode.getXnodeQ2(), context.getWriter());
+        context.getWriter().writeAttribute("code", xnode.getCode());
     }
 
     @Override

--- a/entsoe-util/src/main/java/com/powsybl/entsoe/util/XnodeXmlSerializer.java
+++ b/entsoe-util/src/main/java/com/powsybl/entsoe/util/XnodeXmlSerializer.java
@@ -28,7 +28,7 @@ public class XnodeXmlSerializer extends AbstractExtensionXmlSerializer<DanglingL
 
     @Override
     public void write(Xnode xnode, XmlWriterContext context) throws XMLStreamException {
-        context.getExtensionsWriter().writeAttribute("code", xnode.getCode());
+        context.getWriter().writeAttribute("code", xnode.getCode());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -149,7 +149,7 @@ public final class NetworkXml {
     }
 
     private static void writeExtension(Extension<? extends Identifiable<?>> extension, NetworkXmlWriterContext context) throws XMLStreamException {
-        XMLStreamWriter writer = context.getExtensionsWriter();
+        XMLStreamWriter writer = context.getWriter();
         ExtensionXmlSerializer extensionXmlSerializer = getExtensionXmlSerializer(context.getOptions(), extension);
         if (extensionXmlSerializer == null) {
             throw new AssertionError("Extension XML Serializer of " + extension.getName() + " should not be null");
@@ -221,12 +221,12 @@ public final class NetworkXml {
                     .filter(e -> getExtensionXmlSerializer(options, e) != null)
                     .collect(Collectors.toList());
             if (!extensions.isEmpty()) {
-                context.getExtensionsWriter().writeStartElement(context.getVersion().getNamespaceURI(), EXTENSION_ELEMENT_NAME);
-                context.getExtensionsWriter().writeAttribute(ID, context.getAnonymizer().anonymizeString(identifiable.getId()));
+                context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(), EXTENSION_ELEMENT_NAME);
+                context.getWriter().writeAttribute(ID, context.getAnonymizer().anonymizeString(identifiable.getId()));
                 for (Extension<? extends Identifiable<?>> extension : IidmXmlUtil.sortedExtensions(extensions, options)) {
                     writeExtension(extension, context);
                 }
-                context.getExtensionsWriter().writeEndElement();
+                context.getWriter().writeEndElement();
             }
         }
     }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlWriterContext.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlWriterContext.java
@@ -24,7 +24,6 @@ import java.util.Set;
 public class NetworkXmlWriterContext extends AbstractNetworkXmlContext<ExportOptions> implements XmlWriterContext {
 
     private final XMLStreamWriter writer;
-    private XMLStreamWriter extensionsWriter;
     private final ExportOptions options;
     private final BusFilter filter;
     private final Set<Identifiable> exportedEquipments;
@@ -34,7 +33,6 @@ public class NetworkXmlWriterContext extends AbstractNetworkXmlContext<ExportOpt
         this.writer = writer;
         this.options = options;
         this.filter = filter;
-        this.extensionsWriter = writer;
         this.exportedEquipments = new HashSet<>();
     }
 
@@ -52,16 +50,17 @@ public class NetworkXmlWriterContext extends AbstractNetworkXmlContext<ExportOpt
         return options;
     }
 
-    public XMLStreamWriter getExtensionsWriter() {
-        return extensionsWriter;
-    }
-
     public BusFilter getFilter() {
         return filter;
     }
 
+    /**
+     * @deprecated Should not be used anymore.
+     */
+    @Deprecated
     public void setExtensionsWriter(XMLStreamWriter extensionsWriter) {
-        this.extensionsWriter = extensionsWriter;
+        // does nothing
+        // only kept to prevent breaking change
     }
 
     public Set<Identifiable> getExportedEquipments() {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/ActivePowerControlXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/ActivePowerControlXmlSerializer.java
@@ -31,8 +31,8 @@ public class ActivePowerControlXmlSerializer<T extends Injection<T>> extends Abs
 
     @Override
     public void write(ActivePowerControl activePowerControl, XmlWriterContext context) throws XMLStreamException {
-        context.getExtensionsWriter().writeAttribute("participate", Boolean.toString(activePowerControl.isParticipate()));
-        XmlUtil.writeFloat("droop", activePowerControl.getDroop(), context.getExtensionsWriter());
+        context.getWriter().writeAttribute("participate", Boolean.toString(activePowerControl.isParticipate()));
+        XmlUtil.writeFloat("droop", activePowerControl.getDroop(), context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/CoordinatedReactiveControlXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/CoordinatedReactiveControlXmlSerializer.java
@@ -31,7 +31,7 @@ public class CoordinatedReactiveControlXmlSerializer extends AbstractExtensionXm
 
     @Override
     public void write(CoordinatedReactiveControl coordinatedReactiveControl, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeDouble("qPercent", coordinatedReactiveControl.getQPercent(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("qPercent", coordinatedReactiveControl.getQPercent(), context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/LoadDetailXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/LoadDetailXmlSerializer.java
@@ -33,10 +33,10 @@ public class LoadDetailXmlSerializer extends AbstractExtensionXmlSerializer<Load
 
     @Override
     public void write(LoadDetail detail, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeFloat("fixedActivePower", detail.getFixedActivePower(), context.getExtensionsWriter());
-        XmlUtil.writeFloat("fixedReactivePower", detail.getFixedReactivePower(), context.getExtensionsWriter());
-        XmlUtil.writeFloat("variableActivePower", detail.getVariableActivePower(), context.getExtensionsWriter());
-        XmlUtil.writeFloat("variableReactivePower", detail.getVariableReactivePower(), context.getExtensionsWriter());
+        XmlUtil.writeFloat("fixedActivePower", detail.getFixedActivePower(), context.getWriter());
+        XmlUtil.writeFloat("fixedReactivePower", detail.getFixedReactivePower(), context.getWriter());
+        XmlUtil.writeFloat("variableActivePower", detail.getVariableActivePower(), context.getWriter());
+        XmlUtil.writeFloat("variableReactivePower", detail.getVariableReactivePower(), context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.java
@@ -34,8 +34,8 @@ public class ThreeWindingsTransformerPhaseAngleClockXmlSerializer
 
     @Override
     public void write(ThreeWindingsTransformerPhaseAngleClock extension, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeOptionalInt("phaseAngleClockLeg2", extension.getPhaseAngleClockLeg2(), 0, context.getExtensionsWriter());
-        XmlUtil.writeOptionalInt("phaseAngleClockLeg3", extension.getPhaseAngleClockLeg3(), 0, context.getExtensionsWriter());
+        XmlUtil.writeOptionalInt("phaseAngleClockLeg2", extension.getPhaseAngleClockLeg2(), 0, context.getWriter());
+        XmlUtil.writeOptionalInt("phaseAngleClockLeg3", extension.getPhaseAngleClockLeg3(), 0, context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/TwoWindingsTransformerPhaseAngleClockXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/TwoWindingsTransformerPhaseAngleClockXmlSerializer.java
@@ -33,7 +33,7 @@ public class TwoWindingsTransformerPhaseAngleClockXmlSerializer
 
     @Override
     public void write(TwoWindingsTransformerPhaseAngleClock extension, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeOptionalInt("phaseAngleClock", extension.getPhaseAngleClock(), 0, context.getExtensionsWriter());
+        XmlUtil.writeOptionalInt("phaseAngleClock", extension.getPhaseAngleClock(), 0, context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/VoltagePerReactivePowerControlXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/VoltagePerReactivePowerControlXmlSerializer.java
@@ -31,7 +31,7 @@ public class VoltagePerReactivePowerControlXmlSerializer extends AbstractExtensi
 
     @Override
     public void write(VoltagePerReactivePowerControl control, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeDouble("slope", control.getSlope(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("slope", control.getSlope(), context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadZipModelXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadZipModelXmlSerializer.java
@@ -30,13 +30,13 @@ public class LoadZipModelXmlSerializer extends AbstractExtensionXmlSerializer<Lo
 
     @Override
     public void write(LoadZipModel zipModel, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeDouble("a1", zipModel.getA1(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("a2", zipModel.getA2(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("a3", zipModel.getA3(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("a4", zipModel.getA4(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("a5", zipModel.getA5(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("a6", zipModel.getA6(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("v0", zipModel.getV0(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("a1", zipModel.getA1(), context.getWriter());
+        XmlUtil.writeDouble("a2", zipModel.getA2(), context.getWriter());
+        XmlUtil.writeDouble("a3", zipModel.getA3(), context.getWriter());
+        XmlUtil.writeDouble("a4", zipModel.getA4(), context.getWriter());
+        XmlUtil.writeDouble("a5", zipModel.getA5(), context.getWriter());
+        XmlUtil.writeDouble("a6", zipModel.getA6(), context.getWriter());
+        XmlUtil.writeDouble("v0", zipModel.getV0(), context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalMockXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalMockXmlSerializer.java
@@ -70,7 +70,7 @@ public class TerminalMockXmlSerializer extends AbstractVersionableNetworkExtensi
         NetworkXmlWriterContext networkContext = (NetworkXmlWriterContext) context;
         String extensionVersion = networkContext.getOptions().getExtensionVersion(getExtensionName())
                 .orElseGet(() -> getVersion(networkContext.getVersion()));
-        TerminalRefXml.writeTerminalRef(extension.getTerminal(), networkContext, getNamespaceUri(extensionVersion), "terminal", context.getExtensionsWriter());
+        TerminalRefXml.writeTerminalRef(extension.getTerminal(), networkContext, getNamespaceUri(extensionVersion), "terminal", context.getWriter());
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Deprecate useless/error-prone method


**What is the current behavior?** *(You can also link to an open issue here)*
Extensionwriter is a different objet than writer


**What is the new behavior (if this is a feature change)?**
Extensionwriter does not exist anymore, only writer is used


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
