### PR TITLE
Always write model description dates referred to UTC

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/update/StateVariablesExport.java
@@ -15,6 +15,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.SlackTerminal;
 import org.apache.commons.math3.complex.Complex;
 import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,10 +72,10 @@ public final class StateVariablesExport {
         writer.writeStartElement(MD_NAMESPACE, "FullModel");
         writer.writeAttribute(RDF_NAMESPACE, "about", "urn:uuid:" + CgmesExportUtil.getUniqueId());
         writer.writeStartElement(MD_NAMESPACE, CgmesNames.SCENARIO_TIME);
-        writer.writeCharacters(context.getScenarioTime().toString("yyyy-MM-dd'T'HH:mm:ss"));
+        writer.writeCharacters(ISODateTimeFormat.dateTimeNoMillis().withZoneUTC().print(context.getScenarioTime()));
         writer.writeEndElement();
         writer.writeStartElement(MD_NAMESPACE, CgmesNames.CREATED);
-        writer.writeCharacters(DateTime.now().toString());
+        writer.writeCharacters(ISODateTimeFormat.dateTimeNoMillis().withZoneUTC().print(DateTime.now()));
         writer.writeEndElement();
         writer.writeStartElement(MD_NAMESPACE, CgmesNames.DESCRIPTION);
         writer.writeCharacters(context.getSvDescription());


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Model description dates (`created` and `scenarioTime`) in CGMES export are always written referred to UTC time zone, per ENTSO-E exchange requirements.

**What is the current behavior?** *(You can also link to an open issue here)*
The dates are written using the default formatting, that includes the local time zone offset in the output.

**What is the new behavior (if this is a feature change)?**
Dates `created` and `scenarioTime` in CGMES SV exported file are referred to UTC time zone.

**Other information**:
See Annex C of IEC TS 61970-600-1:2017 "Energy management system application program interface (EMS-API) –
Part 600-1: Common Grid Model Exchange Specification (CGMES) – Structure and rules".
See also rules `ModelCreated` and `ScenarioTime` of ENTSO-E  "QUALITY OF CGMES DATASETS AND CALCULATIONS FOR SYSTEM OPERATIONS" (3.1 edition).