### PR TITLE
Throw a comprehensive exception when a terminal ref of a busbar section is written in bus-breaker or bus-branch

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TerminalRefXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TerminalRefXml.java
@@ -40,6 +40,12 @@ public final class TerminalRefXml {
         if (!context.getFilter().test(c)) {
             throw new PowsyblException("Oups, terminal ref point to a filtered equipment " + c.getId());
         }
+        if (t.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER
+                && context.getOptions().getTopologyLevel() != TopologyLevel.NODE_BREAKER
+                && t.getConnectable() instanceof BusbarSection) {
+            throw new PowsyblException(String.format("Terminal ref should not point to a busbar section (here %s). Try to export in node-breaker or delete this terminal ref.",
+                    t.getConnectable().getId()));
+        }
         writer.writeAttribute("id", context.getAnonymizer().anonymizeString(c.getId()));
         if (c.getTerminals().size() > 1) {
             if (c instanceof Injection) {


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When a terminal ref points to a bus bar section in a node breaker network, it is written when exported in a bus breaker or bus branch network


**What is the new behavior (if this is a feature change)?**
It throws an exception in this case


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


