### PR TITLE
Warning instead of error log when extensions have not been found

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -428,7 +428,7 @@ public final class NetworkXml {
                 throw new PowsyblException("Extensions " + extensionNamesNotFound + " " +
                         "not found !");
             } else {
-                LOGGER.error("Extensions {} not found", extensionNamesNotFound);
+                LOGGER.warn("Extensions {} not found", extensionNamesNotFound);
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
When a XIIDM is imported, and some extensions are in the file but the plugin extensions are not found, a log error is printed.


**What is the new behavior (if this is a feature change)?**
A warn log is printed instead of error, because it is not necessarily an error to not import some extensions, it just depends on what you want to do with the data. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
