### PR TITLE
Bug fix in serialization XIIDM: not writing non supported subequipment of t3w in version < 1.1 in LOG_ERROR version compatibility + never lose information on regulating status of rtc

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
@@ -78,9 +78,7 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
         if (rtc.hasLoadTapChangingCapabilities() || rtc.isRegulating()) {
             context.getWriter().writeAttribute(ATTR_REGULATING, Boolean.toString(rtc.isRegulating()));
         }
-        if (rtc.hasLoadTapChangingCapabilities() || !Double.isNaN(rtc.getTargetV())) {
-            XmlUtil.writeDouble("targetV", rtc.getTargetV(), context.getWriter());
-        }
+        XmlUtil.writeDouble("targetV", rtc.getTargetV(), context.getWriter());
         if (rtc.getRegulationTerminal() != null) {
             TerminalRefXml.writeTerminalRef(rtc.getRegulationTerminal(), context, ELEM_TERMINAL_REF);
         }
@@ -103,10 +101,8 @@ abstract class AbstractTransformerXml<T extends Connectable, A extends Identifia
                 .setTapPosition(tapPosition)
                 .setTargetDeadband(targetDeadband)
                 .setLoadTapChangingCapabilities(loadTapChangingCapabilities)
-                .setTargetV(targetV);
-        if (loadTapChangingCapabilities) {
-            adder.setRegulating(regulating);
-        }
+                .setTargetV(targetV)
+                .setRegulating(regulating);
         boolean[] hasTerminalRef = new boolean[1];
         XmlUtil.readUntilEndElement(elementName, context.getReader(), () -> {
             switch (context.getReader().getLocalName()) {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
@@ -41,12 +41,12 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
 
     @Override
     protected boolean hasSubElements(ThreeWindingsTransformer twt, NetworkXmlWriterContext context) {
-        return twt.getLeg1().hasRatioTapChanger()
+        return (twt.getLeg1().hasRatioTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0)
                 || twt.getLeg2().hasRatioTapChanger()
                 || twt.getLeg3().hasRatioTapChanger()
-                || twt.getLeg1().hasPhaseTapChanger()
-                || twt.getLeg2().hasPhaseTapChanger()
-                || twt.getLeg3().hasPhaseTapChanger()
+                || (twt.getLeg1().hasPhaseTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0)
+                || (twt.getLeg2().hasPhaseTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0)
+                || (twt.getLeg3().hasPhaseTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0)
                 || hasValidOperationalLimits(twt.getLeg1(), context)
                 || hasValidOperationalLimits(twt.getLeg2(), context)
                 || hasValidOperationalLimits(twt.getLeg3(), context);
@@ -90,20 +90,16 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
 
     @Override
     protected void writeSubElements(ThreeWindingsTransformer twt, Substation s, NetworkXmlWriterContext context) throws XMLStreamException {
-        IidmXmlUtil.assertMinimumVersionIfNotDefault(twt.getLeg1().hasRatioTapChanger(), ROOT_ELEMENT_NAME, RATIO_TAP_CHANGER_1,
-                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
-        writeRatioTapChanger(twt.getLeg1().getRatioTapChanger(), 1, context);
-        IidmXmlUtil.assertMinimumVersionIfNotDefault(twt.getLeg1().hasPhaseTapChanger(), ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_1,
-                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
-        writePhaseTapChanger(twt.getLeg1().getPhaseTapChanger(), 1, context);
+        IidmXmlUtil.assertMinimumVersionAndRunIfNotDefault(twt.getLeg1().hasRatioTapChanger(), ROOT_ELEMENT_NAME, RATIO_TAP_CHANGER_1,
+                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context, () -> writeRatioTapChanger(twt.getLeg1().getRatioTapChanger(), 1, context));
+        IidmXmlUtil.assertMinimumVersionAndRunIfNotDefault(twt.getLeg1().hasPhaseTapChanger(), ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_1,
+                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context, () -> writePhaseTapChanger(twt.getLeg1().getPhaseTapChanger(), 1, context));
         writeRatioTapChanger(twt.getLeg2().getRatioTapChanger(), 2, context);
-        IidmXmlUtil.assertMinimumVersionIfNotDefault(twt.getLeg2().hasPhaseTapChanger(), ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_2,
-                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
-        writePhaseTapChanger(twt.getLeg2().getPhaseTapChanger(), 2, context);
+        IidmXmlUtil.assertMinimumVersionAndRunIfNotDefault(twt.getLeg2().hasPhaseTapChanger(), ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_2,
+                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context, () -> writePhaseTapChanger(twt.getLeg2().getPhaseTapChanger(), 2, context));
         writeRatioTapChanger(twt.getLeg3().getRatioTapChanger(), 3, context);
-        IidmXmlUtil.assertMinimumVersionIfNotDefault(twt.getLeg3().hasPhaseTapChanger(), ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_3,
-                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context);
-        writePhaseTapChanger(twt.getLeg3().getPhaseTapChanger(), 3, context);
+        IidmXmlUtil.assertMinimumVersionAndRunIfNotDefault(twt.getLeg3().hasPhaseTapChanger(), ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_3,
+                IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context, () -> writePhaseTapChanger(twt.getLeg3().getPhaseTapChanger(), 3, context));
         int[] i = new int[1];
         i[0] = 1;
         for (ThreeWindingsTransformer.Leg leg : twt.getLegs()) {


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In 1.0 and with LOG_ERROR behavior, the t3w had 1.1 serialization


**What is the new behavior (if this is a feature change)?**
In 1.0 and with LOG_ERROR behavior, the t3w has a 1.0 serialization


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:
Do not squash the commits
