### PR TITLE
Fix empty alias type management

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Identifiable.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Identifiable.java
@@ -47,6 +47,8 @@ public interface Identifiable<I extends Identifiable<I>> extends Extendable<I> {
 
     /**
      * Get the alias of the object with a given alias type if it exists. Else return an empty optional.
+     *
+     * @throws {@link com.powsybl.commons.PowsyblException} if the aliasType is null or empty
      */
     default Optional<String> getAliasFromType(String aliasType) {
         return Optional.empty();
@@ -76,7 +78,7 @@ public interface Identifiable<I extends Identifiable<I>> extends Extendable<I> {
     /**
      * Add an alias to the object. Aliases must be unique in associated Network, and different
      * from any identifiable ID. This alias is associated to a given alias type.
-     * If the given alias type is null, no alias type is considered associated to the alias.
+     * If the given alias type is null or empty, no alias type is considered associated to the alias.
      * Only one alias can be associated to a non null given alias type for one object.
      *
      * If the alias already exists (i.e. is not unique) or equals an identifiable ID, throw a {@link com.powsybl.commons.PowsyblException}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
@@ -77,7 +77,7 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
     @Override
     public Optional<String> getAliasFromType(String aliasType) {
         if (Strings.isNullOrEmpty(aliasType)) {
-            throw new PowsyblException("Invalid alias type: " + aliasType);
+            throw new PowsyblException("Alias type must not be null or empty");
         }
         return Optional.ofNullable(aliasesByType.get(aliasType));
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractIdentifiable.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.network.impl;
 
+import com.google.common.base.Strings;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.extensions.AbstractExtendable;
 import com.powsybl.iidm.network.Identifiable;
@@ -75,7 +76,9 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
 
     @Override
     public Optional<String> getAliasFromType(String aliasType) {
-        Objects.requireNonNull(aliasType);
+        if (Strings.isNullOrEmpty(aliasType)) {
+            throw new PowsyblException("Invalid alias type: " + aliasType);
+        }
         return Optional.ofNullable(aliasesByType.get(aliasType));
     }
 
@@ -101,14 +104,14 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
         if (ensureAliasUnicity) {
             uniqueAlias = Identifiables.getUniqueId(alias, getNetwork().getIndex()::contains);
         }
-        if (aliasType != null && aliasesByType.containsKey(aliasType)) {
+        if (!Strings.isNullOrEmpty(aliasType) && aliasesByType.containsKey(aliasType)) {
             throw new PowsyblException(id + " already has an alias of type " + aliasType);
         }
         if (getNetwork().getIndex().addAlias(this, uniqueAlias)) {
-            if (aliasType != null) {
-                aliasesByType.put(aliasType, uniqueAlias);
-            } else {
+            if (Strings.isNullOrEmpty(aliasType)) {
                 aliasesWithoutType.add(uniqueAlias);
+            } else {
+                aliasesByType.put(aliasType, uniqueAlias);
             }
         }
     }
@@ -118,10 +121,10 @@ abstract class AbstractIdentifiable<I extends Identifiable<I>> extends AbstractE
         Objects.requireNonNull(alias);
         getNetwork().getIndex().removeAlias(this, alias);
         String type = aliasesByType.entrySet().stream().filter(entry -> entry.getValue().equals(alias)).map(Map.Entry::getKey).filter(Objects::nonNull).findFirst().orElse(null);
-        if (type != null) {
-            aliasesByType.remove(type);
-        } else {
+        if (Strings.isNullOrEmpty(type)) {
             aliasesWithoutType.remove(alias);
+        } else {
+            aliasesByType.remove(type);
         }
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAliasesTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAliasesTest.java
@@ -34,6 +34,16 @@ public abstract class AbstractAliasesTest {
         assertNotNull(network.getLoad("Load alias"));
         assertEquals(network.getLoad("Load alias"), load);
         assertFalse(network.getLoad("load1").getAliasType("Load alias").isPresent());
+
+        String alias = "alias2";
+        load.addAlias(alias, null);
+        assertTrue(load.getAliases().contains(alias));
+        assertTrue(load.getAliasType(alias).isEmpty());
+
+        alias = "alias3";
+        load.addAlias(alias, "");
+        assertTrue(load.getAliases().contains(alias));
+        assertTrue(load.getAliasType(alias).isEmpty());
     }
 
     @Test
@@ -133,6 +143,20 @@ public abstract class AbstractAliasesTest {
         Network network = NetworkTest1Factory.create();
         Load load = network.getLoad("load1");
         load.removeAlias("Load alias");
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void failWhenAliasTypeIsNull() {
+        Network network = NetworkTest1Factory.create();
+        Load load = network.getLoad("load1");
+        load.getAliasFromType(null);
+    }
+
+    @Test(expected = PowsyblException.class)
+    public void failWhenAliasTypeIsEmpty() {
+        Network network = NetworkTest1Factory.create();
+        Load load = network.getLoad("load1");
+        load.getAliasFromType("");
     }
 
     @Test(expected = PowsyblException.class)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The IIDM implementation considers allows empty strings for alias type. Call `addAlias("alias", "")` should be equivalent to call `addAlias("alias", null)` or `addAlias("alias")`. To sum up, empty strings should be consider as null strings for alias types.


**What is the new behavior (if this is a feature change)?**
This PR change the behaviour of `addAlias` and add unit tests


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
