### PR TITLE
SensitivityFactorsProvider backward compatibility

### DIFF
--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFactorsProvider.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFactorsProvider.java
@@ -32,7 +32,6 @@ public interface SensitivityFactorsProvider {
      */
     List<SensitivityFactor> getFactors(Network network);
 
-
     /**
      * Get the list of factors generated based on the given network and a contingency
      *

--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFactorsProvider.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFactorsProvider.java
@@ -8,6 +8,7 @@ package com.powsybl.sensitivity;
 
 import com.powsybl.iidm.network.Network;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -39,5 +40,7 @@ public interface SensitivityFactorsProvider {
      * @param contingencyId Id of the contingency for which we want the factors. Set to null for base case factors.
      * @return A list of sensitivity factors
      */
-    List<SensitivityFactor> getFactors(Network network, String contingencyId);
+    default List<SensitivityFactor> getFactors(Network network, String contingencyId) {
+        return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
`SensitivityFactorsProvider` has recently been updated by adding a way to specify a list of factors for a specific contingency. This has been done by breaking the API. Not everybody needs this feature and furthermore it does not allow lambda style anymore (more than one method in the interface).


**What is the new behavior (if this is a feature change)?**
Added method has now a default implementation.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
