### PR TITLE
add new constructor with inputStream for GroovyDynamicModelsSupplier

### DIFF
--- a/dynamic-simulation/dynamic-simulation-dsl/src/main/java/com/powsybl/dynamicsimulation/groovy/GroovyDynamicModelsSupplier.java
+++ b/dynamic-simulation/dynamic-simulation-dsl/src/main/java/com/powsybl/dynamicsimulation/groovy/GroovyDynamicModelsSupplier.java
@@ -7,6 +7,7 @@
 
 package com.powsybl.dynamicsimulation.groovy;
 
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,6 +41,11 @@ public class GroovyDynamicModelsSupplier implements DynamicModelsSupplier {
 
     public GroovyDynamicModelsSupplier(Path path, List<DynamicModelGroovyExtension> extensions) {
         this.codeSource = GroovyScripts.load(path);
+        this.extensions = Objects.requireNonNull(extensions);
+    }
+
+    public GroovyDynamicModelsSupplier(InputStream is, List<DynamicModelGroovyExtension> extensions) {
+        this.codeSource = GroovyScripts.load(is);
         this.extensions = Objects.requireNonNull(extensions);
     }
 

--- a/dynamic-simulation/dynamic-simulation-dsl/src/test/java/com/powsybl/dynamicsimulation/groovy/GroovyDynamicModelSupplierTest.java
+++ b/dynamic-simulation/dynamic-simulation-dsl/src/test/java/com/powsybl/dynamicsimulation/groovy/GroovyDynamicModelSupplierTest.java
@@ -54,19 +54,7 @@ public class GroovyDynamicModelSupplierTest {
         assertTrue(extensions.get(0) instanceof DynamicModelGroovyExtension);
 
         DynamicModelsSupplier supplier = new GroovyDynamicModelsSupplier(fileSystem.getPath("/dynamicModels.groovy"), extensions);
-
-        List<DynamicModel> dynamicModels = supplier.get(network);
-        assertEquals(2, dynamicModels.size());
-
-        assertTrue(dynamicModels.get(0) instanceof DummyDynamicModel);
-        DummyDynamicModel dynamicModel1 = (DummyDynamicModel) dynamicModels.get(0);
-        assertEquals("id", dynamicModel1.getId());
-        assertEquals("parameterSetId", dynamicModel1.getParameterSetId());
-
-        assertTrue(dynamicModels.get(1) instanceof DummyDynamicModel);
-        DummyDynamicModel dynamicModel2 = (DummyDynamicModel) dynamicModels.get(1);
-        assertEquals("LOAD", dynamicModel2.getId());
-        assertEquals("LOAD", dynamicModel2.getParameterSetId());
+        testDynamicModels(supplier, network);
     }
 
     @Test
@@ -78,7 +66,10 @@ public class GroovyDynamicModelSupplierTest {
         assertTrue(extensions.get(0) instanceof DynamicModelGroovyExtension);
 
         DynamicModelsSupplier supplier = new GroovyDynamicModelsSupplier(getClass().getResourceAsStream("/dynamicModels.groovy"), extensions);
+        testDynamicModels(supplier, network);
+    }
 
+    public void testDynamicModels(DynamicModelsSupplier supplier, Network network) {
         List<DynamicModel> dynamicModels = supplier.get(network);
         assertEquals(2, dynamicModels.size());
 

--- a/dynamic-simulation/dynamic-simulation-dsl/src/test/java/com/powsybl/dynamicsimulation/groovy/GroovyDynamicModelSupplierTest.java
+++ b/dynamic-simulation/dynamic-simulation-dsl/src/test/java/com/powsybl/dynamicsimulation/groovy/GroovyDynamicModelSupplierTest.java
@@ -68,4 +68,28 @@ public class GroovyDynamicModelSupplierTest {
         assertEquals("LOAD", dynamicModel2.getId());
         assertEquals("LOAD", dynamicModel2.getParameterSetId());
     }
+
+    @Test
+    public void testWithInputStream() {
+        Network network = EurostagTutorialExample1Factory.create();
+
+        List<DynamicModelGroovyExtension> extensions = GroovyExtension.find(DynamicModelGroovyExtension.class, "dummy");
+        assertEquals(1, extensions.size());
+        assertTrue(extensions.get(0) instanceof DynamicModelGroovyExtension);
+
+        DynamicModelsSupplier supplier = new GroovyDynamicModelsSupplier(getClass().getResourceAsStream("/dynamicModels.groovy"), extensions);
+
+        List<DynamicModel> dynamicModels = supplier.get(network);
+        assertEquals(2, dynamicModels.size());
+
+        assertTrue(dynamicModels.get(0) instanceof DummyDynamicModel);
+        DummyDynamicModel dynamicModel1 = (DummyDynamicModel) dynamicModels.get(0);
+        assertEquals("id", dynamicModel1.getId());
+        assertEquals("parameterSetId", dynamicModel1.getParameterSetId());
+
+        assertTrue(dynamicModels.get(1) instanceof DummyDynamicModel);
+        DummyDynamicModel dynamicModel2 = (DummyDynamicModel) dynamicModels.get(1);
+        assertEquals("LOAD", dynamicModel2.getId());
+        assertEquals("LOAD", dynamicModel2.getParameterSetId());
+    }
 }


### PR DESCRIPTION
Signed-off-by: AbdelHedhili <abdelsalem.hedhili@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
It adds a new constructor taking an InputStream for the GroovyDynamicModelsSupplier so we don't need a file.


**What is the current behavior?** *(You can also link to an open issue here)*
no constructor with IS


**What is the new behavior (if this is a feature change)?**
constructor with IS