### PR TITLE
Check on RTC regulation only throws exception if loadTapChangingCapabilities is true, else it logs a warning

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -9,11 +9,15 @@ package com.powsybl.iidm.network;
 import java.util.Set;
 
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public final class ValidationUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ValidationUtil.class);
 
     private ValidationUtil() {
     }
@@ -317,24 +321,35 @@ public final class ValidationUtil {
         }
     }
 
-    public static void checkRatioTapChangerRegulation(Validable validable, boolean regulating,
+    private static void throwExceptionOrWarningForRtc(Validable validable, boolean loadTapChangingCapabilities, String message) {
+        if (loadTapChangingCapabilities) {
+            throw new ValidationException(validable, message);
+        } else {
+            LOGGER.warn(message);
+        }
+    }
+
+    public static void checkRatioTapChangerRegulation(Validable validable, boolean regulating, boolean loadTapChangingCapabilities,
                                                       Terminal regulationTerminal, double targetV, Network network) {
         if (regulating) {
             if (Double.isNaN(targetV)) {
-                throw new ValidationException(validable,
-                        "a target voltage has to be set for a regulating ratio tap changer");
+                throwExceptionOrWarningForRtc(validable, loadTapChangingCapabilities, "a target voltage has to be set for a regulating ratio tap changer");
             }
             if (targetV <= 0) {
-                throw new ValidationException(validable, "bad target voltage " + targetV);
+                throwExceptionOrWarningForRtc(validable, loadTapChangingCapabilities, "bad target voltage " + targetV);
             }
             if (regulationTerminal == null) {
-                throw new ValidationException(validable,
-                        "a regulation terminal has to be set for a regulating ratio tap changer");
+                throwExceptionOrWarningForRtc(validable, loadTapChangingCapabilities, "a regulation terminal has to be set for a regulating ratio tap changer");
             }
-            if (regulationTerminal.getVoltageLevel().getNetwork() != network) {
-                throw new ValidationException(validable, "regulation terminal is not part of the network");
+            if (regulationTerminal != null && regulationTerminal.getVoltageLevel().getNetwork() != network) {
+                throwExceptionOrWarningForRtc(validable, loadTapChangingCapabilities, "regulation terminal is not part of the network");
             }
         }
+    }
+
+    public static void checkRatioTapChangerRegulation(Validable validable, boolean regulating,
+                                                      Terminal regulationTerminal, double targetV, Network network) {
+        checkRatioTapChangerRegulation(validable, regulating, true, regulationTerminal, targetV, network);
     }
 
     public static void checkPhaseTapChangerRegulation(Validable validable, PhaseTapChanger.RegulationMode regulationMode,

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerAdderImpl.java
@@ -182,7 +182,7 @@ class RatioTapChangerAdderImpl implements RatioTapChangerAdder {
                     + tapPosition + " [" + lowTapPosition + ", "
                     + highTapPosition + "]");
         }
-        ValidationUtil.checkRatioTapChangerRegulation(parent, regulating, regulationTerminal, targetV, getNetwork());
+        ValidationUtil.checkRatioTapChangerRegulation(parent, regulating, loadTapChangingCapabilities, regulationTerminal, targetV, getNetwork());
         ValidationUtil.checkTargetDeadband(parent, "ratio tap changer", regulating, targetDeadband);
         RatioTapChangerImpl tapChanger
                 = new RatioTapChangerImpl(parent, lowTapPosition, steps, regulationTerminal, loadTapChangingCapabilities,

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerImpl.java
@@ -51,7 +51,7 @@ class RatioTapChangerImpl extends AbstractTapChanger<RatioTapChangerParent, Rati
 
     @Override
     public RatioTapChangerImpl setRegulating(boolean regulating) {
-        ValidationUtil.checkRatioTapChangerRegulation(parent, regulating, regulationTerminal, getTargetV(), getNetwork());
+        ValidationUtil.checkRatioTapChangerRegulation(parent, regulating, loadTapChangingCapabilities, regulationTerminal, getTargetV(), getNetwork());
 
         Set<TapChanger> tapChangers = new HashSet<TapChanger>();
         tapChangers.addAll(parent.getAllTapChangers());
@@ -68,7 +68,7 @@ class RatioTapChangerImpl extends AbstractTapChanger<RatioTapChangerParent, Rati
 
     @Override
     public RatioTapChangerImpl setLoadTapChangingCapabilities(boolean loadTapChangingCapabilities) {
-        ValidationUtil.checkRatioTapChangerRegulation(parent, isRegulating(), regulationTerminal, getTargetV(), getNetwork());
+        ValidationUtil.checkRatioTapChangerRegulation(parent, isRegulating(), loadTapChangingCapabilities, regulationTerminal, getTargetV(), getNetwork());
         boolean oldValue = this.loadTapChangingCapabilities;
         this.loadTapChangingCapabilities = loadTapChangingCapabilities;
         notifyUpdate(() -> getTapChangerAttribute() + ".loadTapChangingCapabilities", oldValue, loadTapChangingCapabilities);
@@ -82,7 +82,7 @@ class RatioTapChangerImpl extends AbstractTapChanger<RatioTapChangerParent, Rati
 
     @Override
     public RatioTapChangerImpl setTargetV(double targetV) {
-        ValidationUtil.checkRatioTapChangerRegulation(parent, isRegulating(), regulationTerminal, targetV, getNetwork());
+        ValidationUtil.checkRatioTapChangerRegulation(parent, isRegulating(), loadTapChangingCapabilities, regulationTerminal, targetV, getNetwork());
         int variantIndex = network.get().getVariantIndex();
         double oldValue = this.targetV.set(variantIndex, targetV);
         String variantId = network.get().getVariantManager().getVariantId(variantIndex);
@@ -92,7 +92,7 @@ class RatioTapChangerImpl extends AbstractTapChanger<RatioTapChangerParent, Rati
 
     @Override
     public RatioTapChangerImpl setRegulationTerminal(Terminal regulationTerminal) {
-        ValidationUtil.checkRatioTapChangerRegulation(parent, isRegulating(), regulationTerminal, getTargetV(), getNetwork());
+        ValidationUtil.checkRatioTapChangerRegulation(parent, isRegulating(), loadTapChangingCapabilities, regulationTerminal, getTargetV(), getNetwork());
         return super.setRegulationTerminal(regulationTerminal);
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTapChangerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTapChangerTest.java
@@ -464,10 +464,20 @@ public abstract class AbstractTapChangerTest {
     }
 
     @Test
-    public void invalidTargetV() {
+    public void undefinedTargetV() {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("a target voltage has to be set for a regulating ratio tap changer");
         createRatioTapChangerWith3Steps(0, 1, true, true, Double.NaN, 1.0, terminal);
+    }
+
+    @Test
+    public void undefinedTargetVOnlyWarning() {
+        createRatioTapChangerWith3Steps(0, 1, false, true, Double.NaN, 1.0, terminal);
+        RatioTapChanger rtc = twt.getRatioTapChanger();
+        assertNotNull(rtc);
+        assertFalse(rtc.hasLoadTapChangingCapabilities());
+        assertTrue(rtc.isRegulating());
+        assertTrue(Double.isNaN(rtc.getTargetV()));
     }
 
     @Test
@@ -475,6 +485,16 @@ public abstract class AbstractTapChangerTest {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("bad target voltage");
         createRatioTapChangerWith3Steps(0, 1, true, true, -10.0, 1.0, terminal);
+    }
+
+    @Test
+    public void negativeTargetVOnlyWarning() {
+        createRatioTapChangerWith3Steps(0, 1, false, true, -10.0, 1.0, terminal);
+        RatioTapChanger rtc = twt.getRatioTapChanger();
+        assertNotNull(rtc);
+        assertFalse(rtc.hasLoadTapChangingCapabilities());
+        assertTrue(rtc.isRegulating());
+        assertEquals(-10.0, rtc.getTargetV(), 0.0);
     }
 
     @Test
@@ -489,6 +509,16 @@ public abstract class AbstractTapChangerTest {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("a regulation terminal has to be set for a regulating ratio tap changer");
         createRatioTapChangerWith3Steps(0, 1, true, true, 10.0, 1.0, null);
+    }
+
+    @Test
+    public void nullRegulatingTerminalOnlyWarning() {
+        createRatioTapChangerWith3Steps(0, 1, false, true, 10.0, 1.0, null);
+        RatioTapChanger rtc = twt.getRatioTapChanger();
+        assertNotNull(rtc);
+        assertFalse(rtc.hasLoadTapChangingCapabilities());
+        assertTrue(rtc.isRegulating());
+        assertNull(rtc.getRegulationTerminal());
     }
 
     private void createRatioTapChangerWith3Steps(int low, int tap, boolean load, boolean regulating,


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Soften too restrictive checks


**What is the current behavior?** *(You can also link to an open issue here)*
An exception is thrown when RTC regulation attributes are not correctly set and the RTC is regulating


**What is the new behavior (if this is a feature change)?**
A warning is thrown when RTC regulation attributes are not correctly set and the RTC is regulating **and** `loadTapChangingCapabilities` is set to `false`


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:
Should be in a corrective release
