### PR TITLE
Voltage level export : must iterate over graph vertex capacity

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -1147,7 +1147,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             busColor.put(bus.getId(), colors[i]);
         }
 
-        for (int n = 0; n < graph.getVertexCount(); n++) {
+        for (int n = 0; n < graph.getVertexCapacity(); n++) {
             if (!graph.vertexExists(n)) {
                 continue;
             }


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
`NodeBreakerLevel::exportTopology` iterates over the first `graph.vertexCount` vertices of the graph.

**What is the new behavior (if this is a feature change)?**
Iteration must include all potential vertices, it must be done over `graph.vertexCapacity`. There could be "holes" in the array of vertices, the loop already was checking if the vertex was really used with `graph.vertexExists`.
