### PR TITLE
Fix CGMES voltage limit import: if inconsistent, ignore

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
@@ -213,10 +213,18 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
         String limitType = p.getLocal(LIMIT_TYPE);
         if (limitTypeName.equalsIgnoreCase("highvoltage") || "LimitTypeKind.highVoltage".equals(limitType)) {
             if (value < vl.getHighVoltageLimit() || Double.isNaN(vl.getHighVoltageLimit())) {
+                if (value < vl.getLowVoltageLimit()) {
+                    context.ignored("HighVoltageLimit", "Inconsistent with low voltage limit (" + vl.getLowVoltageLimit() + "kV)");
+                    return;
+                }
                 vl.setHighVoltageLimit(value);
             }
         } else if (limitTypeName.equalsIgnoreCase("lowvoltage") || "LimitTypeKind.lowVoltage".equals(limitType)) {
             if (value > vl.getLowVoltageLimit() || Double.isNaN(vl.getLowVoltageLimit())) {
+                if (value > vl.getHighVoltageLimit()) {
+                    context.ignored("LowVoltageLimit", "Inconsistent with high voltage limit (" + vl.getHighVoltageLimit() + "kV)");
+                    return;
+                }
                 vl.setLowVoltageLimit(value);
             }
         } else {


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If inconsistent voltage limit during CGMES import, an exception is thrown


**What is the new behavior (if this is a feature change)?**
If inconsistent voltage limit during CGMES import, it is ignored


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
