### PR TITLE
PSS/E importer: store star bus voltage in properties

### DIFF
--- a/psse/psse-converter/src/main/java/com/powsybl/psse/converter/TransformerConverter.java
+++ b/psse/psse-converter/src/main/java/com/powsybl/psse/converter/TransformerConverter.java
@@ -222,6 +222,9 @@ public class TransformerConverter extends AbstractConverter {
 
         ThreeWindingsTransformer twt = adder.add();
 
+        twt.setProperty("v", Double.toString(psseTransformer.getVmstar() * v0));
+        twt.setProperty("angle", Double.toString(psseTransformer.getAnstar()));
+
         tapChangersToIidm(tapChanger1AdjustedYsh, tapChanger2, tapChanger3, twt);
         defineOperationalLimits(twt, voltageLevel1.getNominalV(), voltageLevel2.getNominalV(), voltageLevel3.getNominalV());
     }

--- a/psse/psse-converter/src/test/resources/ThreeMIB_T3W_modified.xiidm
+++ b/psse/psse-converter/src/test/resources/ThreeMIB_T3W_modified.xiidm
@@ -34,6 +34,8 @@
             <iidm:currentLimits2 permanentLimit="11708.663459165611"/>
         </iidm:twoWindingsTransformer>
         <iidm:threeWindingsTransformer id="T-4-2-7-1 " r1="-7.799051701646568E-7" x1="1.1395911508266792E-4" g1="0.144572" b1="-0.1079031826036656" ratedU1="500.0" r2="2.506552897437384E-6" x2="1.913087291200171E-4" g2="0.0" b2="0.0" ratedU2="18.0" r3="8.39084857664657E-7" x3="5.51790882287039E-4" g3="0.0" b3="0.0" ratedU3="16.0" ratedU0="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B2" connectableBus2="B2" voltageLevelId2="VL2" bus3="B7" connectableBus3="B7" voltageLevelId3="VL7">
+            <iidm:property name="v" value="0.98627"/>
+            <iidm:property name="angle" value="-10.1187"/>
             <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.987004441519987"/>
             </iidm:ratioTapChanger2>

--- a/psse/psse-converter/src/test/resources/ThreeMIB_T3W_phase.xiidm
+++ b/psse/psse-converter/src/test/resources/ThreeMIB_T3W_phase.xiidm
@@ -34,6 +34,8 @@
             <iidm:currentLimits2 permanentLimit="11708.663459165611"/>
         </iidm:twoWindingsTransformer>
         <iidm:threeWindingsTransformer id="T-4-2-7-1 " r1="-7.799051701646568E-7" x1="1.1395911508266792E-4" g1="0.144572" b1="-0.1079031826036656" ratedU1="500.0" r2="2.506552897437384E-6" x2="1.913087291200171E-4" g2="0.0" b2="0.0" ratedU2="18.0" r3="8.39084857664657E-7" x3="5.51790882287039E-4" g3="0.0" b3="0.0" ratedU3="16.0" ratedU0="1.0" bus1="B4" connectableBus1="B4" voltageLevelId1="VL4" bus2="B2" connectableBus2="B2" voltageLevelId2="VL2" bus3="B7" connectableBus3="B7" voltageLevelId3="VL7">
+            <iidm:property name="v" value="0.98627"/>
+            <iidm:property name="angle" value="-10.1187"/>
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="2" targetDeadband="2.0" regulationMode="ACTIVE_POWER_CONTROL" regulationValue="9.0" regulating="true">
                 <iidm:terminalRef id="B2-G1 "/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
We cannot run a load flow with a warm start, so using voltage magnitude and angle from PSS/E file because voltage from 3 windings transformers star bus is lost. 


**What is the new behavior (if this is a feature change)?**
In OLF, we have taken as a convention to define 2 properties "v" and "angle" in the 3 windings transformer to store star bus voltage magnitude and angle.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
