### PR TITLE
Sanitize file names for files data sources

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/datasource/DataSourceUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/DataSourceUtil.java
@@ -18,7 +18,19 @@ public interface DataSourceUtil {
 
     static String getFileName(String baseName, String suffix, String ext) {
         Objects.requireNonNull(baseName);
-        return baseName + (suffix != null ? suffix : "") + (ext == null || ext.isEmpty() ? "" : "." + ext);
+        return sanitizeFileName(baseName + (suffix != null ? suffix : "") + (ext == null || ext.isEmpty() ? "" : "." + ext));
+    }
+
+    /**
+     * Replace forbidden character that may render the file name impossible to use
+     * Pretty much any character is acceptable for Linux OS, but Windows forbids the following : \ / ? * < > : |
+     * Using this methods ensures that both platforms will accept the file
+     *
+     * @param fileName a file name to sanitize
+     * @return a cross-platform ready file name
+     */
+    private static String sanitizeFileName(String fileName) {
+        return fileName.replaceAll("[\\\\/?*<>:|]", "_");
     }
 
     static OpenOption[] getOpenOptions(boolean append) {


### PR DESCRIPTION
Signed-off-by: amichaut <arthur.michaut@artelys.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines

Fix for issue #1638.

**Changes**
This PR allows sanitizing the files names when exporting a network. Forbidden characters such as colons ":" are replaced by underscores "_".

**Current behavior**
Currently, no change is performed for the file name creation. The network ID is used as is.
