### PR TITLE
Optimise getBus in Bus/Breaker view for default Network implementation

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -76,6 +76,10 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
 
         @Override
         public Bus getBus(String id) {
+            Bus bus = index.get(id, Bus.class);
+            if (bus != null) {
+                return bus;
+            }
             return getVoltageLevelStream().map(vl -> vl.getBusBreakerView().getBus(id))
                     .filter(Objects::nonNull)
                     .findFirst()


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Optimisation


**What is the current behavior?** *(You can also link to an open issue here)*
Current lookup of bus by identifier in `BusBreakerView` is always done iterating through the voltage level stream of the network. As calculated buses are not included in the network index, bus/breaker buses created from node/breaker topologies have to be searched looking in every voltage level. But buses created directly at the bus/breaker topology level are added to the index, and could be located faster.

**What is the new behavior (if this is a feature change)?**
When looking for a bus with a given identifier in the `BusBreakerView`, first the index is checked. If the bus is not found, the previous search through all voltage levels of the network is performed.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
It is not a breaking change.
