### PR TITLE
Fix BusBreakerVoltageLevel export style for switch edges

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -965,7 +965,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
             ConfiguredBus bus2 = graph.getVertexObject(v2);
             // Assign an id to the edge to allow parallel edges (multigraph)
             GraphVizEdge edge = gvGraph.edge(scope, bus1.getId(), bus2.getId(), sw.getId())
-                    .style(sw.isOpen() ? "solid" : "dotted");
+                    .style(sw.isOpen() ? "dotted" : "solid");
             if (DRAW_SWITCH_ID) {
                 String label = sw.getKind().toString()
                     + System.lineSeparator() + sw.getId()


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
In graph export for BusBreakerVoltageLevel the style for edges corresponding to open switches is dotted, consistent with dotted style for disconnected terminals.

**What is the current behavior?** *(You can also link to an open issue here)*
switches open where drawn as solid edges, and closed switches as dotted.

