### PR TITLE
CGMES control areas extension: use linked hash sets to have predictable iteration order

### DIFF
--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesControlAreaImpl.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesControlAreaImpl.java
@@ -10,10 +10,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Boundary;
 import com.powsybl.iidm.network.Terminal;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>
@@ -22,8 +19,8 @@ class CgmesControlAreaImpl implements CgmesControlArea {
     private final String id;
     private final String name;
     private final String energyIdentificationCodeEic;
-    private final Set<Terminal> terminals = new HashSet<>();
-    private final Set<Boundary> boundaries = new HashSet<>();
+    private final Set<Terminal> terminals = new LinkedHashSet<>();
+    private final Set<Boundary> boundaries = new LinkedHashSet<>();
     private final double netInterchange;
 
     CgmesControlAreaImpl(String id, String name, String energyIdentificationCodeEic, double netInterchange, CgmesControlAreasImpl mapping) {


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
CGMES control areas stored in the IIDM extension used linked hash sets to store terminals and boundaries to have predictable iteration order.


**What is the current behavior?** *(You can also link to an open issue here)*
XML serialization of the extension was writing boundaries in different order when created from CGMES or read from previous XIIDM file.


**What is the new behavior (if this is a feature change)?**
serialization order of terminals and boundaries is always the same.


