### PR TITLE
CGMES - IIDM mapping: serialization loop must be done over BusView buses

### DIFF
--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesIidmMappingXmlSerializer.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesIidmMappingXmlSerializer.java
@@ -41,7 +41,7 @@ public class CgmesIidmMappingXmlSerializer extends AbstractExtensionXmlSerialize
         if (!extension.getUnmappedTopologicalNodes().isEmpty()) {
             context.getWriter().writeAttribute("unmappedTopologicalNodeIds", String.join(","));
         }
-        extension.getExtendable().getBusBreakerView().getBusStream()
+        extension.getExtendable().getBusView().getBusStream()
                 .filter(b -> extension.isMapped(b.getId()))
                 .forEach(b -> {
                     try {


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
the loop for the serialization of the mapping between IIDM buses and CGMES topological nodes must be done over all the BusView buses, not the BusBreakerView buses.


**What is the current behavior?** *(You can also link to an open issue here)*
There is an issue with current behavior, using BusBreakerView buses, if the following conditions are met:
* In a node/breaker voltage level, a `BusView` bus contains two `BusBreakerView` buses.
* The two `BusBreakerView` buses are separated by a retained switch. It may come, for example, for an internal zero impedance line that has been mapped to a fictitious retained switch.
* The first `BusBreakerView` bus only contains switches and busbar sections. It does not have any other connected equipment. The first `BusBreakerView` bus and the `BusView` bus have the same id (suffix `_0` added to the voltage level id).

If these conditions are found, we are trying to obtain the first connected equipment in the first `BusBreakerView` bus, but this bus does not have any connected terminal.

**What is the new behavior (if this is a feature change)?**
The loop to serialize the mapping that has been built between CGMES topological nodes and IIDM `BusView` buses is properly done over IIDM network `BusView` buses.

**Other information**:
The following diagram shows the situation where the issue was raised. There is a single bus in the `BusView` calculated topology, but there are two buses in the `BusBreakerView`, separated by the inner zero impedance line. The `BusBreakerView` to the right of the inner line does not have connected terminals.

![image](https://user-images.githubusercontent.com/3374819/111989609-4a784400-8b12-11eb-85c2-aaa8cb4c971f.png)
