### PR TITLE
Correct randomness of voltage level import order in UCTE import

### DIFF
--- a/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/ext/UcteNetworkExt.java
+++ b/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/ext/UcteNetworkExt.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -214,12 +215,11 @@ public class UcteNetworkExt implements UcteNetwork {
             node2voltageLevel = new TreeMap<>();
             Graph<UcteNodeCode, Object> graph = createSubstationGraph(network);
             for (Set<UcteNodeCode> substationNodes : new ConnectivityInspector<>(graph).connectedSets()) {
-                UcteNodeCode mainNode = substationNodes.stream()
-                        .min(UcteNetworkExt::compareUcteNodeCode)
-                        .orElseThrow(AssertionError::new);
+                List<UcteNodeCode> sortedNodes = substationNodes.stream().sorted(UcteNetworkExt::compareUcteNodeCode).collect(Collectors.toList());
+                UcteNodeCode mainNode = sortedNodes.stream().findFirst().orElseThrow(AssertionError::new);
 
                 Multimap<UcteVoltageLevelCode, UcteNodeCode> nodesByVoltageLevel
-                        = Multimaps.index(substationNodes, UcteNodeCode::getVoltageLevelCode);
+                        = Multimaps.index(sortedNodes, UcteNodeCode::getVoltageLevelCode);
 
                 String substationName = mainNode.getUcteCountryCode().getUcteCode() + mainNode.getGeographicalSpot();
                 List<UcteVoltageLevel> voltageLevels = new ArrayList<>();


### PR DESCRIPTION
Signed-off-by: Florian Dupuy <florian.dupuy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When importing a UCTE file, the voltage levels are imported in a random order


**What is the new behavior (if this is a feature change)?**
When importing a UCTE file, the voltage levels are imported in the order of their voltage level code



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

