### PR TITLE
Replace an exception thrown in Scalable.scale() by an error log

### DIFF
--- a/action/action-util/src/main/java/com/powsybl/action/util/GeneratorScalable.java
+++ b/action/action-util/src/main/java/com/powsybl/action/util/GeneratorScalable.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.action.util;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,8 +126,8 @@ class GeneratorScalable extends AbstractInjectionScalable {
         double minimumTargetP = minimumTargetP(g);
         double maximumTargetP = maximumTargetP(g);
         if (oldTargetP < minimumTargetP || oldTargetP > maximumTargetP) {
-            throw new PowsyblException("Error scaling GeneratorScalable " + id +
-                    " : Initial P is not in the range [Pmin, Pmax]");
+            LOGGER.error("Error scaling GeneratorScalable {}: Initial P is not in the range [Pmin, Pmax], skipped", id);
+            return 0.;
         }
 
         // We use natural generator convention to compute the limits.

--- a/action/action-util/src/main/java/com/powsybl/action/util/LoadScalable.java
+++ b/action/action-util/src/main/java/com/powsybl/action/util/LoadScalable.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.action.util;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,8 +123,8 @@ class LoadScalable extends AbstractInjectionScalable {
 
         double oldP0 = l.getP0();
         if (oldP0 < minValue || oldP0 > maxValue) {
-            throw new PowsyblException("Error scaling LoadScalable " + id +
-                    " : Initial P is not in the range [Pmin, Pmax]");
+            LOGGER.error("Error scaling LoadScalable {}: Initial P is not in the range [Pmin, Pmax]", id);
+            return 0.;
         }
 
         // We use natural load convention to compute the limits.

--- a/action/action-util/src/test/java/com/powsybl/action/util/GeneratorScalableTest.java
+++ b/action/action-util/src/test/java/com/powsybl/action/util/GeneratorScalableTest.java
@@ -165,14 +165,9 @@ public class GeneratorScalableTest {
         assertEquals(20, generator2.getTargetP(), 1e-3);
 
         g5.reset(network);
+        //Case 4 : generator.getTargetP() not in interval, skipped
         assertEquals(0, generator2.getTargetP(), 1e-3);
-        try {
-            g5.scale(network, 50);
-            fail("My method didn't throw when I expected it to");
-        } catch (PowsyblException e) {
-            assertEquals("Error scaling GeneratorScalable g2 : Initial P is not in the range [Pmin, Pmax]", e.getMessage());
-        }
-
+        assertEquals(0, g5.scale(network, 50), 1e-3);
     }
 
     @Test
@@ -224,14 +219,9 @@ public class GeneratorScalableTest {
         assertEquals(20, generator2.getTargetP(), 1e-3);
 
         g5.reset(network);
+        //Case 4 : generator.getTargetP() not in interval, skipped
         assertEquals(0, generator2.getTargetP(), 1e-3);
-        try {
-            g5.scale(network, 50, convention);
-            fail("My method didn't throw when I expected it to");
-        } catch (PowsyblException e) {
-            assertEquals("Error scaling GeneratorScalable g2 : Initial P is not in the range [Pmin, Pmax]", e.getMessage());
-        }
-
+        assertEquals(0, g5.scale(network, 50, convention), 1e-3);
     }
 
     @Test
@@ -283,14 +273,9 @@ public class GeneratorScalableTest {
         assertEquals(20, generator2.getTargetP(), 1e-3);
 
         g5.reset(network);
+        //Case 4 : generator.getTargetP() not in interval, skipped
         assertEquals(0, generator2.getTargetP(), 1e-3);
-        try {
-            g5.scale(network, -50, convention);
-            fail("My method didn't throw when I expected it to");
-        } catch (PowsyblException e) {
-            assertEquals("Error scaling GeneratorScalable g2 : Initial P is not in the range [Pmin, Pmax]", e.getMessage());
-        }
-
+        assertEquals(0, g5.scale(network, 50, convention), 1e-3);
     }
 
 }

--- a/action/action-util/src/test/java/com/powsybl/action/util/LoadScalableTest.java
+++ b/action/action-util/src/test/java/com/powsybl/action/util/LoadScalableTest.java
@@ -110,13 +110,9 @@ public class LoadScalableTest {
         assertEquals(20, load.getP0(), 1e-3);
 
         l3.reset(network);
+        //test with p0 outside interval
         assertEquals(0, load.getP0(), 1e-3);
-        try {
-            l3.scale(network, -40, convention);
-            fail("My method didn't throw when I expected it to");
-        } catch (PowsyblException e) {
-            assertEquals("Error scaling LoadScalable l1 : Initial P is not in the range [Pmin, Pmax]", e.getMessage());
-        }
+        assertEquals(0, l3.scale(network, -40, convention), 1e-3);
 
         //test LoadScalable with negative minValue
         l4.reset(network);
@@ -159,13 +155,9 @@ public class LoadScalableTest {
         assertEquals(20, load.getP0(), 1e-3);
 
         l3.reset(network);
+        //test with p0 outside interval
         assertEquals(0, load.getP0(), 1e-3);
-        try {
-            l3.scale(network, -40, convention);
-            fail("My method didn't throw when I expected it to");
-        } catch (PowsyblException e) {
-            assertEquals("Error scaling LoadScalable l1 : Initial P is not in the range [Pmin, Pmax]", e.getMessage());
-        }
+        assertEquals(0, l3.scale(network, -40, convention), 1e-3);
 
         //test LoadScalable with negative minValue
         l4.reset(network);


### PR DESCRIPTION
Signed-off-by: Sebastien Murgey <sebastien.murgey@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Current behaviour of the Scalable.scale() method is that if initial setpoint of a device is not included in a block's min/max interval, an exception is thrown.


**What is the new behavior (if this is a feature change)?**
Now, no scale is applied on the given block, and a log is generated, but no exception

