### PR TITLE
Add the possibility to specify the scaling convention when creating dangling line scalables

### DIFF
--- a/action/action-util/src/main/java/com/powsybl/action/util/DanglingLineScalable.java
+++ b/action/action-util/src/main/java/com/powsybl/action/util/DanglingLineScalable.java
@@ -6,14 +6,17 @@
  */
 package com.powsybl.action.util;
 
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.DanglingLine;
+import com.powsybl.iidm.network.Injection;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Terminal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
 
-import static com.powsybl.action.util.Scalable.ScalingConvention.*;
+import static com.powsybl.action.util.Scalable.ScalingConvention.LOAD;
 
 /**
  * @author Coline Piloquet <coline.piloquet at rte-france.com>
@@ -21,12 +24,23 @@ import static com.powsybl.action.util.Scalable.ScalingConvention.*;
 public class DanglingLineScalable extends AbstractInjectionScalable {
     private static final Logger LOGGER = LoggerFactory.getLogger(DanglingLineScalable.class);
 
+    private final ScalingConvention scalingConvention;
+
     DanglingLineScalable(String id) {
-        super(id, -Double.MAX_VALUE, Double.MAX_VALUE);
+        this(id, -Double.MAX_VALUE, Double.MAX_VALUE);
+    }
+
+    DanglingLineScalable(String id, ScalingConvention scalingConvention) {
+        this(id, -Double.MAX_VALUE, Double.MAX_VALUE, scalingConvention);
     }
 
     DanglingLineScalable(String id, double minValue, double maxValue) {
+        this(id, minValue, maxValue, ScalingConvention.GENERATOR);
+    }
+
+    DanglingLineScalable(String id, double minValue, double maxValue, ScalingConvention scalingConvention) {
         super(id, minValue, maxValue);
+        this.scalingConvention = Objects.requireNonNull(scalingConvention);
     }
 
     @Override
@@ -41,7 +55,7 @@ public class DanglingLineScalable extends AbstractInjectionScalable {
 
     /**
      * {@inheritDoc}
-     *
+     * <p>
      * There is no default value for the maximum value.
      */
     @Override
@@ -59,7 +73,7 @@ public class DanglingLineScalable extends AbstractInjectionScalable {
 
     /**
      * {@inheritDoc}
-     *
+     * <p>
      * There is no default value for the minimum value.
      */
     @Override
@@ -90,7 +104,7 @@ public class DanglingLineScalable extends AbstractInjectionScalable {
 
     /**
      * {@inheritDoc}
-     *
+     * <p>
      * If scalingConvention is LOAD, the load active power increases for positive "asked" and decreases inversely
      * If scalingConvention is GENERATOR, the load active power decreases for positive "asked" and increases inversely
      */
@@ -136,5 +150,20 @@ public class DanglingLineScalable extends AbstractInjectionScalable {
                 dl.getId(), oldP0, dl.getP0());
 
         return done;
+    }
+
+    @Override
+    public double maximumValue(Network n) {
+        return maximumValue(n, scalingConvention);
+    }
+
+    @Override
+    public double minimumValue(Network n) {
+        return minimumValue(n, scalingConvention);
+    }
+
+    @Override
+    public double scale(Network n, double asked) {
+        return scale(n, asked, scalingConvention);
     }
 }

--- a/action/action-util/src/main/java/com/powsybl/action/util/Scalable.java
+++ b/action/action-util/src/main/java/com/powsybl/action/util/Scalable.java
@@ -186,17 +186,33 @@ public interface Scalable {
     }
 
     /**
-     * create DanglingLineScalable with id
+     * create DanglingLineScalable with id.
+     * The generator scaling convention is used by default.
      */
     static DanglingLineScalable onDanglingLine(String id) {
         return new DanglingLineScalable(id);
     }
 
     /**
-     * create DanglingLineScalable with id, min and max power values for scaling
+     * create DanglingLineScalable with id and the scaling convention that will be used.
+     */
+    static DanglingLineScalable onDanglingLine(String id, ScalingConvention scalingConvention) {
+        return new DanglingLineScalable(id, scalingConvention);
+    }
+
+    /**
+     * create DanglingLineScalable with id, min and max power values for scaling.
+     * The generator scaling convention is used by default.
      */
     static DanglingLineScalable onDanglingLine(String id, double minValue, double maxValue) {
         return new DanglingLineScalable(id, minValue, maxValue);
+    }
+
+    /**
+     * create DanglingLineScalable with id, min and max power values for scaling and the scaling convention that will be used.
+     */
+    static DanglingLineScalable onDanglingLine(String id, double minValue, double maxValue, ScalingConvention scalingConvention) {
+        return new DanglingLineScalable(id, minValue, maxValue, scalingConvention);
     }
 
     static Scalable scalable(String id) {

--- a/action/action-util/src/test/java/com/powsybl/action/util/DanglingLineScalableTest.java
+++ b/action/action-util/src/test/java/com/powsybl/action/util/DanglingLineScalableTest.java
@@ -43,8 +43,8 @@ public class DanglingLineScalableTest {
         dl3 = new DanglingLineScalable("dl2", 20, 100);
         dl4 = new DanglingLineScalable("dl2", -10, 100);
 
-        dl5 = new DanglingLineScalable("dl2", ScalingConvention.LOAD);
-        dl6 = new DanglingLineScalable("dl2", 20, 100, ScalingConvention.LOAD);
+        dl5 = Scalable.onDanglingLine("dl2", ScalingConvention.LOAD);
+        dl6 = Scalable.onDanglingLine("dl2", 20, 100, ScalingConvention.LOAD);
     }
 
     @Test(expected = NullPointerException.class)

--- a/action/action-util/src/test/java/com/powsybl/action/util/DanglingLineScalableTest.java
+++ b/action/action-util/src/test/java/com/powsybl/action/util/DanglingLineScalableTest.java
@@ -8,7 +8,9 @@ package com.powsybl.action.util;
 
 import com.powsybl.action.util.Scalable.ScalingConvention;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.DanglingLine;
+import com.powsybl.iidm.network.Injection;
+import com.powsybl.iidm.network.Network;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,8 +31,9 @@ public class DanglingLineScalableTest {
     private Scalable dl2;
     private Scalable dl3;
     private Scalable dl4;
+    private Scalable dl5;
+    private Scalable dl6;
     private ScalingConvention convention;
-    private Scalable g1;
 
     @Before
     public void setUp() {
@@ -40,7 +43,8 @@ public class DanglingLineScalableTest {
         dl3 = new DanglingLineScalable("dl2", 20, 100);
         dl4 = new DanglingLineScalable("dl2", -10, 100);
 
-        g1 = Scalable.onGenerator("g1");
+        dl5 = new DanglingLineScalable("dl2", ScalingConvention.LOAD);
+        dl6 = new DanglingLineScalable("dl2", 20, 100, ScalingConvention.LOAD);
     }
 
     @Test(expected = NullPointerException.class)
@@ -64,6 +68,8 @@ public class DanglingLineScalableTest {
         assertEquals(-20, dl3.maximumValue(network), 0.);
         assertEquals(-20, dl3.maximumValue(network, GENERATOR), 0.);
         assertEquals(100, dl3.maximumValue(network, LOAD), 0.);
+        assertEquals(Double.MAX_VALUE, dl5.maximumValue(network));
+        assertEquals(100, dl6.maximumValue(network));
     }
 
     @Test
@@ -72,6 +78,8 @@ public class DanglingLineScalableTest {
         assertEquals(-100, dl3.minimumValue(network), 0.);
         assertEquals(-100, dl3.minimumValue(network, GENERATOR), 0.);
         assertEquals(20, dl3.minimumValue(network, LOAD), 0.);
+        assertEquals(-Double.MAX_VALUE, dl5.minimumValue(network));
+        assertEquals(-20, dl6.minimumValue(network));
     }
 
     @Test

--- a/action/action-util/src/test/java/com/powsybl/action/util/DanglingLineScalableTest.java
+++ b/action/action-util/src/test/java/com/powsybl/action/util/DanglingLineScalableTest.java
@@ -68,8 +68,8 @@ public class DanglingLineScalableTest {
         assertEquals(-20, dl3.maximumValue(network), 0.);
         assertEquals(-20, dl3.maximumValue(network, GENERATOR), 0.);
         assertEquals(100, dl3.maximumValue(network, LOAD), 0.);
-        assertEquals(Double.MAX_VALUE, dl5.maximumValue(network));
-        assertEquals(100, dl6.maximumValue(network));
+        assertEquals(Double.MAX_VALUE, dl5.maximumValue(network), 0.);
+        assertEquals(100, dl6.maximumValue(network), 0.);
     }
 
     @Test
@@ -78,8 +78,8 @@ public class DanglingLineScalableTest {
         assertEquals(-100, dl3.minimumValue(network), 0.);
         assertEquals(-100, dl3.minimumValue(network, GENERATOR), 0.);
         assertEquals(20, dl3.minimumValue(network, LOAD), 0.);
-        assertEquals(-Double.MAX_VALUE, dl5.minimumValue(network));
-        assertEquals(-20, dl6.minimumValue(network));
+        assertEquals(-Double.MAX_VALUE, dl5.minimumValue(network), 0.);
+        assertEquals(20, dl6.minimumValue(network), 0.);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature: when creating a dangling line scalable, the user can specify the scaling convention used


**What is the current behavior?** *(You can also link to an open issue here)*
The scaling convention is always GENERATOR


**What is the new behavior (if this is a feature change)?**
The scaling convention can be LOAD or GENERATOR


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
