### PR TITLE
Allow bPerSection to be equals to zero and modify CGMES ShuntConversion

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
@@ -52,11 +52,6 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
         String shuntType = p.getId("type");
         if ("LinearShuntCompensator".equals(shuntType)) {
             double bPerSection = p.asDouble(CgmesNames.B_PER_SECTION, Float.MIN_VALUE);
-            if (bPerSection == 0) {
-                double bPerSectionFixed = Double.MIN_VALUE;
-                fixed(CgmesNames.B_PER_SECTION, "Can not be zero", bPerSection, bPerSectionFixed);
-                bPerSection = bPerSectionFixed;
-            }
             double gPerSection = p.asDouble("gPerSection", Double.NaN);
             adder.newLinearModel()
                     .setBPerSection(bPerSection)

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -232,6 +232,11 @@ public final class ValidationUtil {
         }
     }
 
+    /**
+     * @deprecated
+     * Use {@link #checkBPerSection(Validable, double)} instead.
+     */
+    @Deprecated
     public static void checkLinearBPerSection(Validable validable, double bPerSection) {
         checkBPerSection(validable, bPerSection);
         if (bPerSection == 0) {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorAdderImpl.java
@@ -87,7 +87,7 @@ class ShuntCompensatorAdderImpl extends AbstractInjectionAdder<ShuntCompensatorA
 
         @Override
         public ShuntCompensatorAdder add() {
-            ValidationUtil.checkLinearBPerSection(ShuntCompensatorAdderImpl.this, bPerSection);
+            ValidationUtil.checkBPerSection(ShuntCompensatorAdderImpl.this, bPerSection);
             ValidationUtil.checkMaximumSectionCount(ShuntCompensatorAdderImpl.this, maximumSectionCount);
             modelBuilder = this;
             return ShuntCompensatorAdderImpl.this;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorLinearModelImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorLinearModelImpl.java
@@ -49,7 +49,7 @@ class ShuntCompensatorLinearModelImpl implements ShuntCompensatorModelExt, Shunt
 
     @Override
     public ShuntCompensatorLinearModel setBPerSection(double bPerSection) {
-        ValidationUtil.checkLinearBPerSection(shuntCompensator, bPerSection);
+        ValidationUtil.checkBPerSection(shuntCompensator, bPerSection);
         double oldValue = this.bPerSection;
         this.bPerSection = bPerSection;
         shuntCompensator.notifyUpdate("bPerSection", oldValue, bPerSection);

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractShuntCompensatorTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractShuntCompensatorTest.java
@@ -137,14 +137,6 @@ public abstract class AbstractShuntCompensatorTest {
         }
 
         // for linear model
-
-        // bPerSection
-        try {
-            shuntLinearModel.setBPerSection(0.0);
-            fail();
-        } catch (ValidationException ignored) {
-            // ignore
-        }
         shuntLinearModel.setBPerSection(-1.0);
         assertEquals(-1.0, shuntLinearModel.getBPerSection(), 0.0);
         assertEquals(-6.0, shuntCompensator.getB(), 0.0);
@@ -195,13 +187,6 @@ public abstract class AbstractShuntCompensatorTest {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("section susceptance is invalid");
         createLinearShunt(INVALID, INVALID, Double.NaN, Double.NaN, 5, 10, null, false, Double.NaN, Double.NaN);
-    }
-
-    @Test
-    public void invalidZerobPerSection() {
-        thrown.expect(ValidationException.class);
-        thrown.expectMessage("susceptance per section is equal to zero");
-        createLinearShunt(INVALID, INVALID, 0.0, Double.NaN, 5, 10, null, false, Double.NaN, Double.NaN);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Change of validation check


**What is the current behavior?** *(You can also link to an open issue here)*
`bPerSection` of shunt compensators can never be equal to 0.


**What is the new behavior (if this is a feature change)?**
`bPerSection` of shunt compensators can be equal to 0.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


