### PR TITLE
Add a bus cache to network implementation

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -324,6 +324,8 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     @Override
     public void invalidateCache() {
         calculatedBusTopology.invalidateCache();
+        getNetwork().getBusView().invalidateCache();
+        getNetwork().getBusBreakerView().invalidateCache();
         getNetwork().getConnectedComponentsManager().invalidate();
         getNetwork().getSynchronousComponentsManager().invalidate();
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -767,9 +767,11 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
 
         private final BusCache busViewCache = new BusCache(() -> getVoltageLevelStream().flatMap(vl -> vl.getBusView().getBusStream()));
 
-        private final BusCache busBreakerViewCache = new BusCache(() ->
-            getVoltageLevelStream().filter(vl -> vl.getTopologyKind() != TopologyKind.BUS_BREAKER)
-                .flatMap(vl -> getBusBreakerView().getBusStream()));
+        //For bus breaker view, we exclude bus breaker topologies from the cache,
+        //because thoses buses are already indexed in the NetworkIndex
+        private final BusCache busBreakerViewCache = new BusCache(() -> getVoltageLevelStream()
+            .filter(vl -> vl.getTopologyKind() != TopologyKind.BUS_BREAKER)
+            .flatMap(vl -> getBusBreakerView().getBusStream()));
 
         @Override
         public VariantImpl copy() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -515,6 +515,8 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     public void invalidateCache() {
         variants.get().calculatedBusBreakerTopology.invalidateCache();
         variants.get().calculatedBusTopology.invalidateCache();
+        getNetwork().getBusView().invalidateCache();
+        getNetwork().getBusBreakerView().invalidateCache();
         getNetwork().getConnectedComponentsManager().invalidate();
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

See original issue on powsybl-open-loadflow https://github.com/powsybl/powsybl-open-loadflow/issues/296 .

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Perf improvement (in most cases)

**What is the current behavior?** *(You can also link to an open issue here)*

When using method `Bus getBus(String busId)` of the network bus and bus-breaker views, a linear search is performed through voltages levels.
This is very, very, inefficient as soon as you start using the method multiple times. There is nothing to discourage such use (such as javadoc), and no real reason to do so.

**What is the new behavior (if this is a feature change)?**

When searching for a bus by its ID, a cache (map) of all buses of the network is built.
It's a very basic approach : the cache is invalidated as soon as one voltage level cache is invalidated.
However, it should behave fine in most use cases. 
It could be refined in the future if needed (for example, only invalidate part of the cache when only some voltage levels are invalidated).