### PR TITLE
Add CGMES import option to import control areas or not

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -251,6 +251,7 @@ public class CgmesImport implements Importer {
     public static final String CREATE_BUSBAR_SECTION_FOR_EVERY_CONNECTIVITY_NODE = "iidm.import.cgmes.create-busbar-section-for-every-connectivity-node";
     public static final String CREATE_CGMES_EXPORT_MAPPING = "iidm.import.cgmes.create-cgmes-export-mapping";
     public static final String ENSURE_ID_ALIAS_UNICITY = "iidm.import.cgmes.ensure-id-alias-unicity";
+    public static final String IMPORT_CONTROL_AREAS = "iidm.import.cgmes.import-control-areas";
     public static final String MERGE_BOUNDARIES_USING_TIE_LINES = "iidm.import.cgmes.merge-boundaries-using-tie-lines";
     public static final String POST_PROCESSORS = "iidm.import.cgmes.post-processors";
     public static final String POWSYBL_TRIPLESTORE = "iidm.import.cgmes.powsybl-triplestore";
@@ -296,6 +297,11 @@ public class CgmesImport implements Importer {
             ParameterType.BOOLEAN,
             "Ensure IDs and aliases are unique",
             Boolean.FALSE);
+    private static final Parameter IMPORT_CONTROL_AREAS_PARAMETER = new Parameter(
+            IMPORT_CONTROL_AREAS,
+            ParameterType.BOOLEAN,
+            "Import control areas",
+            Boolean.TRUE);
     private static final Parameter MERGE_BOUNDARIES_USING_TIE_LINES_PARAMETER = new Parameter(
             MERGE_BOUNDARIES_USING_TIE_LINES,
             ParameterType.BOOLEAN,
@@ -337,6 +343,7 @@ public class CgmesImport implements Importer {
             CREATE_CGMES_EXPORT_MAPPING_PARAMETER,
             CREATE_BUSBAR_SECTION_FOR_EVERY_CONNECTIVITY_NODE_PARAMETER,
             ENSURE_ID_ALIAS_UNICITY_PARAMETER,
+            IMPORT_CONTROL_AREAS_PARAMETER,
             POST_PROCESSORS_PARAMETER,
             POWSYBL_TRIPLESTORE_PARAMETER,
             STORE_CGMES_CONVERSION_CONTEXT_AS_NETWORK_EXTENSION_PARAMETER,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -204,11 +204,13 @@ public class Conversion {
         convert(cgmes.operationalLimits(), l -> new OperationalLimitConversion(l, context));
         context.loadingLimitsMapping().addAll();
 
-        network.newExtension(CgmesControlAreasAdder.class).add();
-        CgmesControlAreas cgmesControlAreas = network.getExtension(CgmesControlAreas.class);
-        cgmes.controlAreas().forEach(ca -> createControlArea(cgmesControlAreas, ca));
-        cgmes.tieFlows().forEach(tf -> addTieFlow(context, cgmesControlAreas, tf));
-        cgmesControlAreas.cleanIfEmpty();
+        if (config.importControlAreas()) {
+            network.newExtension(CgmesControlAreasAdder.class).add();
+            CgmesControlAreas cgmesControlAreas = network.getExtension(CgmesControlAreas.class);
+            cgmes.controlAreas().forEach(ca -> createControlArea(cgmesControlAreas, ca));
+            cgmes.tieFlows().forEach(tf -> addTieFlow(context, cgmesControlAreas, tf));
+            cgmesControlAreas.cleanIfEmpty();
+        }
 
         if (config.convertSvInjections()) {
             convert(cgmes.svInjections(), si -> new SvInjectionConversion(si, context));
@@ -668,6 +670,15 @@ public class Conversion {
             return this;
         }
 
+        public boolean importControlAreas() {
+            return importControlAreas;
+        }
+
+        public Config setImportControlAreas(boolean importControlAreas) {
+            this.importControlAreas = importControlAreas;
+            return this;
+        }
+
         public Xfmr2RatioPhaseInterpretationAlternative getXfmr2RatioPhase() {
             return xfmr2RatioPhase;
         }
@@ -730,6 +741,7 @@ public class Conversion {
         private boolean storeCgmesConversionContextAsNetworkExtension = false;
 
         private boolean ensureIdAliasUnicity = false;
+        private boolean importControlAreas = true;
 
         private boolean createCgmesExportMapping = false;
 


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
CGMES control areas are always imported


**What is the new behavior (if this is a feature change)?**
There is an import option to skip CGMES control area import


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
