### PR TITLE
Fix CGMES export node/breaker when building bus-TN mapping

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -10,6 +10,7 @@ import com.powsybl.cgmes.extensions.*;
 import com.powsybl.cgmes.model.CgmesNamespace;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.iidm.network.VoltageLevel;
 import org.joda.time.DateTime;
 
@@ -145,9 +146,19 @@ public class CgmesExportContext {
             Set<String> mappedTns = new HashSet<>();
             for (VoltageLevel vl : network.getVoltageLevels()) {
                 for (Bus configuredBus : vl.getBusBreakerView().getBuses()) {
-                    String topologicalNode = configuredBus.getId();
-                    Bus busViewBus = vl.getBusView().getMergedBus(configuredBus.getId());
-                    if (busViewBus != null) {
+                    Bus busViewBus;
+                    String topologicalNode;
+                    if (vl.getTopologyKind() == TopologyKind.BUS_BREAKER) {
+                        topologicalNode = configuredBus.getId();
+                        busViewBus = vl.getBusView().getMergedBus(configuredBus.getId());
+                    } else {
+                        // TODO (Luma) The mapping between buses and Topological Nodes established here ...
+                        // Must be [consistent with / used in] the future TP export
+                        // Here we are selecting as TN identifiers directly the bus/breaker identifiers created by IIDM
+                        topologicalNode = configuredBus.getId();
+                        busViewBus = vl.getBusView().getBus(configuredBus.getId());
+                    }
+                    if (busViewBus != null && topologicalNode != null) {
                         tnsFromBusBreaker.computeIfAbsent(busViewBus.getId(), b -> new HashSet<>()).add(topologicalNode);
                         mappedTns.add(topologicalNode);
                     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -148,8 +148,8 @@ public class CgmesExportContext {
             Set<String> mappedTns = new HashSet<>();
             for (VoltageLevel vl : network.getVoltageLevels()) {
                 for (Bus configuredBus : vl.getBusBreakerView().getBuses()) {
-                    Bus busViewBus = null;
-                    String topologicalNode = null;
+                    Bus busViewBus;
+                    String topologicalNode;
                     if (vl.getTopologyKind() == TopologyKind.BUS_BREAKER) {
                         // Bus/breaker IIDM networks have been created from bus/branch CGMES data
                         // CGMES Topological Nodes have been used as configured bus identifiers
@@ -161,7 +161,6 @@ public class CgmesExportContext {
                         // the identifiers for TN and the mapping Bus-TN should be established here.
                         // TP export should use TN identifiers defined in the mapping
                         // topologicalNode = ..
-                        busViewBus = vl.getBusView().getBus(configuredBus.getId());
                         // TODO (Luma) remove this exception when TN identifiers are assigned and TP file is exported
                         String problem = "Node/breaker model without explicit mapping between IIDM buses and CGMES Topological Nodes";
                         String solution = String.format("To be able to export you must import the CGMES data with the parameter %s set to true",


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix CGMES export for node/breaker networks when no mapping between IIDM buses and CGMES Topological Nodes has been created and stored during CGMES import.

**What is the current behavior?** *(You can also link to an open issue here)*
Current export throws a Null Pointer Exception for node/breaker voltage levels when building the mapping between IIDM BusView buses and CGMES Topological Nodes. 

**What is the new behavior (if this is a feature change)?**
The problem is fixed and a default mapping between IIDM BusView buses and CGMES Topological Nodes is established. 

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

**Other information**:
The mapping established should be respected in the future when TP profile is exported. 
