### PR TITLE
Fix new three parameters of LoadFlowParameters

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -371,17 +371,17 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
         return this;
     }
 
-    public boolean getDcUseTransformerRatio() {
+    public boolean isDcUseTransformerRatio() {
         return dcUseTransformerRatio;
     }
 
     public LoadFlowParameters setCountriesToBalance(Set<Country> countriesToBalance) {
-        this.countriesToBalance = countriesToBalance;
+        this.countriesToBalance = Objects.requireNonNull(countriesToBalance);
         return this;
     }
 
     public Set<Country> getCountriesToBalance() {
-        return countriesToBalance;
+        return Collections.unmodifiableSet(countriesToBalance);
     }
 
     public ConnectedComponentMode getConnectedComponentMode() {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersSerializer.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersSerializer.java
@@ -41,7 +41,7 @@ public class LoadFlowParametersSerializer extends StdSerializer<LoadFlowParamete
         jsonGenerator.writeBooleanField("dc", parameters.isDc());
         jsonGenerator.writeBooleanField("distributedSlack", parameters.isDistributedSlack());
         jsonGenerator.writeStringField("balanceType", parameters.getBalanceType().name());
-        jsonGenerator.writeBooleanField("dcUseTransformerRatio", parameters.getDcUseTransformerRatio());
+        jsonGenerator.writeBooleanField("dcUseTransformerRatio", parameters.isDcUseTransformerRatio());
         jsonGenerator.writeArrayFieldStart("countriesToBalance");
         for (Country arg : parameters.getCountriesToBalance()) {
             jsonGenerator.writeString(arg.name());

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
@@ -74,7 +74,7 @@ public class LoadFlowParametersTest {
         assertEquals(parameters.isDc(), dc);
         assertEquals(parameters.isDistributedSlack(), distributedSlack);
         assertEquals(parameters.getBalanceType(), balanceType);
-        assertEquals(parameters.getDcUseTransformerRatio(), dcUseTransformerRatio);
+        assertEquals(parameters.isDcUseTransformerRatio(), dcUseTransformerRatio);
         assertEquals(parameters.getCountriesToBalance(), countriesToBalance);
         assertEquals(parameters.getConnectedComponentMode(), computedConnectedComponent);
     }
@@ -299,7 +299,7 @@ public class LoadFlowParametersTest {
         checkValues(parametersCloned, parameters.getVoltageInitMode(), parameters.isTransformerVoltageControlOn(),
                 parameters.isNoGeneratorReactiveLimits(), parameters.isPhaseShifterRegulationOn(), parameters.isTwtSplitShuntAdmittance(),
                 parameters.isSimulShunt(), parameters.isReadSlackBus(), parameters.isWriteSlackBus(),
-                parameters.isDc(), parameters.isDistributedSlack(), parameters.getBalanceType(), parameters.getDcUseTransformerRatio(),
+                parameters.isDc(), parameters.isDistributedSlack(), parameters.getBalanceType(), parameters.isDcUseTransformerRatio(),
                 parameters.getCountriesToBalance(), parameters.getConnectedComponentMode());
     }
 

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
@@ -112,7 +112,7 @@ public class JsonLoadFlowParametersTest extends AbstractConverterTest {
     public void readJsonVersion15() {
         LoadFlowParameters parameters = JsonLoadFlowParameters
                 .read(getClass().getResourceAsStream("/LoadFlowParametersVersion15.json"));
-        assertTrue(parameters.getDcUseTransformerRatio());
+        assertTrue(parameters.isDcUseTransformerRatio());
         assertEquals(2, parameters.getCountriesToBalance().size());
         assertTrue(parameters.getCountriesToBalance().contains(Country.FR));
         assertTrue(parameters.getCountriesToBalance().contains(Country.KI));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

I have renamed the setter from `getDcUseTransformerRatio` to `isDcUseTransformerRatio`. Small changes also after integrating the previous PR (#1724) to our Hades2 simulator.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
