### PR TITLE
Making WorkingDirectory.close() idempotent.

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/io/WorkingDirectory.java
+++ b/commons/src/main/java/com/powsybl/commons/io/WorkingDirectory.java
@@ -16,12 +16,13 @@ import java.nio.file.Path;
 public class WorkingDirectory implements AutoCloseable {
 
     private final Path path;
-
     private final boolean debug;
+    private boolean closed;
 
     public WorkingDirectory(Path parentDir, String prefix, boolean debug) throws IOException {
-        path = Files.createTempDirectory(parentDir, prefix);
+        this.path = Files.createTempDirectory(parentDir, prefix);
         this.debug = debug;
+        this.closed = false;
     }
 
     public Path toPath() {
@@ -33,9 +34,10 @@ public class WorkingDirectory implements AutoCloseable {
     }
 
     @Override
-    public void close() throws IOException {
-        if (!debug) {
+    public synchronized void close() throws IOException {
+        if (!debug && !closed) {
             FileUtil.removeDir(path);
+            closed = true;
         }
     }
 }

--- a/commons/src/test/java/com/powsybl/commons/io/WorkingDirectoryTest.java
+++ b/commons/src/test/java/com/powsybl/commons/io/WorkingDirectoryTest.java
@@ -1,0 +1,65 @@
+package com.powsybl.commons.io;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ */
+public class WorkingDirectoryTest {
+
+    private FileSystem fileSystem;
+
+    private Path path;
+
+    @Before
+    public void setUp() throws Exception {
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
+        path = fileSystem.getPath("/tmp");
+        Files.createDirectories(path);
+    }
+
+    @Test
+    public void testDebug() throws IOException {
+        Path workingDirPath;
+        try (WorkingDirectory dir = new WorkingDirectory(path, "test-", true)) {
+            workingDirPath = dir.toPath();
+            assertTrue(workingDirPath.toString().startsWith("/tmp/test-"));
+            assertTrue(Files.isDirectory(workingDirPath));
+        }
+        //must still exist
+        assertTrue(Files.isDirectory(workingDirPath));
+    }
+
+    @Test
+    public void testDirDeletion() throws IOException {
+        Path workingDirPath;
+        try (WorkingDirectory dir = new WorkingDirectory(path, "test-", false)) {
+            workingDirPath = dir.toPath();
+            assertTrue(workingDirPath.toString().startsWith("/tmp/test-"));
+            assertTrue(Files.isDirectory(workingDirPath));
+        }
+        //must be deleted
+        assertFalse(Files.exists(workingDirPath));
+    }
+
+    @Test
+    public void closeShouldBeIdemPotent() throws IOException {
+        Path workingDirPath;
+        try (WorkingDirectory dir = new WorkingDirectory(path, "test-", false)) {
+            workingDirPath = dir.toPath();
+            assertTrue(Files.isDirectory(workingDirPath));
+            //Must not throw
+            dir.close();
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sylvain Leclerc <sylvain.leclerc@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

When closing twice a `WorkingDirectory`, we get an exception. In particular, this happens when using the same instance of `LocalComputationManager` in 2 places.

**What is the new behavior (if this is a feature change)?**

Closing is idempotent : closing a second time does not do anything.

