### PR TITLE
Delete redundant dangling line current limits methods (already defined in FlowLimitsHolder)

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DanglingLine.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DanglingLine.java
@@ -274,10 +274,6 @@ public interface DanglingLine extends Injection<DanglingLine>, FlowsLimitsHolder
      */
     String getUcteXnodeCode();
 
-    CurrentLimits getCurrentLimits();
-
-    CurrentLimitsAdder newCurrentLimits();
-
     default Boundary getBoundary() {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug/API fix


**What is the current behavior?** *(You can also link to an open issue here)*
Current Limits methods are defined twice in Dangling Line


**What is the new behavior (if this is a feature change)?**
They are only defined in `FlowLimitsHolder`


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
