### PR TITLE
When the PTC is not regulating, do not throw exception if some info is missing

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -363,17 +363,19 @@ public final class ValidationUtil {
         if (regulationMode == null) {
             throw new ValidationException(validable, "phase regulation mode is not set");
         }
-        if (regulationMode != PhaseTapChanger.RegulationMode.FIXED_TAP && Double.isNaN(regulationValue)) {
-            throw new ValidationException(validable, "phase regulation is on and threshold/setpoint value is not set");
-        }
-        if (regulationMode != PhaseTapChanger.RegulationMode.FIXED_TAP && regulationTerminal == null) {
-            throw new ValidationException(validable, "phase regulation is on and regulated terminal is not set");
+        if (regulating) {
+            if (regulationMode != PhaseTapChanger.RegulationMode.FIXED_TAP && Double.isNaN(regulationValue)) {
+                throw new ValidationException(validable, "phase regulation is on and threshold/setpoint value is not set");
+            }
+            if (regulationMode != PhaseTapChanger.RegulationMode.FIXED_TAP && regulationTerminal == null) {
+                throw new ValidationException(validable, "phase regulation is on and regulated terminal is not set");
+            }
+            if (regulationMode == PhaseTapChanger.RegulationMode.FIXED_TAP) {
+                throw new ValidationException(validable, "phase regulation cannot be on if mode is FIXED");
+            }
         }
         if (regulationTerminal != null && regulationTerminal.getVoltageLevel().getNetwork() != network) {
             throw new ValidationException(validable, "phase regulation terminal is not part of the network");
-        }
-        if (regulationMode == PhaseTapChanger.RegulationMode.FIXED_TAP && regulating) {
-            throw new ValidationException(validable, "phase regulation cannot be on if mode is FIXED");
         }
     }
 


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix? It seems weird to throw an exception for missing regulation information when regulation is not activated.

