### PR TITLE
Fix current limits javadoc comment defining a temporary limit

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/CurrentLimits.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/CurrentLimits.java
@@ -12,7 +12,7 @@ package com.powsybl.iidm.network;
  *     <li>A permanent limit (A)</li>
  *     <li>
  * Any number of temporary limits.
- * A permanent limit (A) has an acceptable duration (s).
+ * A temporary limit has an acceptable duration (s).
  * The branch can safely stay between the previous limit (could be another temporary limit or the permanent limit) and
  * this limit during the acceptable duration.
  * A NaN temporay limit value means infinite.


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix in javadoc comment


**What is the current behavior?** *(You can also link to an open issue here)*
Temporary limit was being defined, but wording related to permanent limit was used.


**What is the new behavior (if this is a feature change)?**
Fixed definition of temporary limit.


