### PR TITLE
Add backward compatibility to Importer.importData(ReadOnlyDataSource, NetworkFactory, Properties, Reporter)

### DIFF
--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importer.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importer.java
@@ -87,7 +87,7 @@ public interface Importer {
      * @return the model
      */
     default Network importData(ReadOnlyDataSource dataSource, NetworkFactory networkFactory, Properties parameters, Reporter reporter) {
-        throw new UnsupportedOperationException("Not implemented");
+        return importData(dataSource, networkFactory, parameters);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add backward compatibility to Importer.importData(ReadOnlyDataSource, NetworkFactory, Properties, Reporter): the method does not throw an exception at runtime anymore




**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

