### PR TITLE
Reporter POC: fix deserialization with no specified dictionary

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/reporter/AbstractReporter.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/AbstractReporter.java
@@ -14,7 +14,9 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * An abstract class providing some default method implementations for {@link Reporter} implementations.
+ * <i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
+ * <p>An abstract class providing some default method implementations for {@link Reporter} implementations.
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public abstract class AbstractReporter implements Reporter {

--- a/commons/src/main/java/com/powsybl/commons/reporter/Report.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/Report.java
@@ -17,7 +17,9 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * A class representing a functional log, consisting of a key identifying the report, a map of {@link TypedValue} indexed
+ * <i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
+ * <p>A class representing a functional log, consisting of a key identifying the report, a map of {@link TypedValue} indexed
  * by their keys, and a default report message string, which may contain references to those values or to the values
  * of corresponding {@link Reporter}.
  * @author Florian Dupuy <florian.dupuy at rte-france.com>

--- a/commons/src/main/java/com/powsybl/commons/reporter/ReportBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReportBuilder.java
@@ -10,7 +10,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A builder to create {@link Report} objects.
+ * <i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
+ * <p>A builder to create {@link Report} objects.
  *
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */

--- a/commons/src/main/java/com/powsybl/commons/reporter/Reporter.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/Reporter.java
@@ -10,7 +10,9 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * A <code>Reporter</code> allows building up functional reports with a hierarchy reflecting task/subtasks of processes.
+ * <i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
+ * <p>A <code>Reporter</code> allows building up functional reports with a hierarchy reflecting task/subtasks of processes.
  * The enclosed reports are based on {@link Report} class.
  *
  * <p>A <code>Reporter</code> can create sub-reporters to separate from current reports the reports from that task.

--- a/commons/src/main/java/com/powsybl/commons/reporter/ReporterModel.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReporterModel.java
@@ -19,7 +19,9 @@ import java.nio.file.Path;
 import java.util.*;
 
 /**
- * An in-memory implementation of {@link Reporter}.
+ * <i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
+ * <p>An in-memory implementation of {@link Reporter}.
  *
  * <p>Being an implementation of {@link Reporter}, instances of <code>ReporterModel</code> are not thread-safe.
  * A reporterModel is not meant to be shared with other threads nor to be saved as a class parameter, but should instead

--- a/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 public class ReporterModelDeserializer extends StdDeserializer<ReporterModel> {
 
     public static final String DICTIONARY_VALUE_ID = "dictionary";
+    public static final String DICTIONARY_DEFAULT_NAME = "default";
 
     ReporterModelDeserializer() {
         super(ReporterModel.class);
@@ -41,7 +42,7 @@ public class ReporterModelDeserializer extends StdDeserializer<ReporterModel> {
         Map<String, String> dictionary = Collections.emptyMap();
         JsonNode dicsNode = root.get("dics");
         if (dicsNode != null) {
-            JsonNode dicNode = dicsNode.get(getDicName(ctx));
+            JsonNode dicNode = dicsNode.get(getDictionaryName(ctx));
             if (dicNode != null) {
                 dictionary = codec.readValue(dicNode.traverse(), new TypeReference<HashMap<String, String>>() {
                 });
@@ -50,13 +51,17 @@ public class ReporterModelDeserializer extends StdDeserializer<ReporterModel> {
         return ReporterModel.parseJsonNode(root.get("reportTree"), dictionary, codec);
     }
 
-    private String getDicName(DeserializationContext ctx) throws JsonMappingException {
-        Object dicNameInjected = ctx.findInjectableValue(DICTIONARY_VALUE_ID, null, null);
-        return dicNameInjected instanceof String ? (String) dicNameInjected : "default";
+    private String getDictionaryName(DeserializationContext ctx) {
+        try {
+            Object dicNameInjected = ctx.findInjectableValue(DICTIONARY_VALUE_ID, null, null);
+            return dicNameInjected instanceof String ? (String) dicNameInjected : DICTIONARY_DEFAULT_NAME;
+        } catch (JsonMappingException e) {
+            return DICTIONARY_DEFAULT_NAME;
+        }
     }
 
     public static ReporterModel read(Path jsonFile) {
-        return read(jsonFile, "default");
+        return read(jsonFile, DICTIONARY_DEFAULT_NAME);
     }
 
     public static ReporterModel read(Path jsonFile, String dictionary) {

--- a/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
@@ -56,7 +56,11 @@ public class ReporterModelDeserializer extends StdDeserializer<ReporterModel> {
             if (dicNode != null) {
                 dictionary = codec.readValue(dicNode.traverse(), new TypeReference<HashMap<String, String>>() {
                 });
+            } else {
+                LOGGER.warn("No dictionary found! `dics` root entry is empty");
             }
+        } else {
+            LOGGER.warn("No dictionary found! `dics` root entry is missing");
         }
         return ReporterModel.parseJsonNode(root.get("reportTree"), dictionary, codec);
     }

--- a/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
+ * <i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public class ReporterModelDeserializer extends StdDeserializer<ReporterModel> {

--- a/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
@@ -70,6 +70,8 @@ public class ReporterModelDeserializer extends StdDeserializer<ReporterModel> {
             Object dicNameInjected = ctx.findInjectableValue(DICTIONARY_VALUE_ID, null, null);
             return dicNameInjected instanceof String ? (String) dicNameInjected : DICTIONARY_DEFAULT_NAME;
         } catch (JsonMappingException e) {
+            LOGGER.info("No injectable value found for id `{}` in DeserializationContext, therefore taking `{}` dictionary",
+                DICTIONARY_VALUE_ID, DICTIONARY_DEFAULT_NAME);
             return DICTIONARY_DEFAULT_NAME;
         }
     }

--- a/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelJsonModule.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelJsonModule.java
@@ -9,6 +9,8 @@ package com.powsybl.commons.reporter;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 /**
+ * <i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public class ReporterModelJsonModule extends SimpleModule {

--- a/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelSerializer.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelSerializer.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
+ * <i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public class ReporterModelSerializer extends StdSerializer<ReporterModel> {

--- a/commons/src/main/java/com/powsybl/commons/reporter/TypedValue.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/TypedValue.java
@@ -11,7 +11,9 @@ import com.powsybl.commons.PowsyblException;
 import java.util.Objects;
 
 /**
- * A class associating a value with a type.
+ * <i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
+ * <p>A class associating a value with a type.
  * The value should be an instance of any of the following classes: Integer, Long, Float, Double, Boolean or String.
  * The type is given by a string. Some generic types are provided by public constants of current class.
  * @author Florian Dupuy <florian.dupuy at rte-france.com>

--- a/commons/src/main/java/com/powsybl/commons/reporter/package-info.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Reporter API for functional logs beta-feature and default in-memory implementation
+ *
+ * <p><i>WARNING:</i> <code>Reporter</code> <i>is still a beta feature, structural changes might occur in the future releases</i>
+ *
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+package com.powsybl.commons.reporter;

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReporterTest.java
@@ -75,8 +75,15 @@ public class UcteImporterReporterTest extends AbstractConverterTest {
         reporter.report("novalueReport", "No value report");
         Importers.loadNetwork(filename, getClass().getResourceAsStream("/" + filename), reporter);
         roundTripTest(reporter, ReporterModelSerializer::write, ReporterModelDeserializer::read, "/frVoltageRegulatingXnodeReport.json");
+
+        // Testing deserializing with unknown specified dictionary
+        ReporterModel rm = ReporterModelDeserializer.read(getClass().getResourceAsStream("/frVoltageRegulatingXnodeReport.json"), "de");
+        assertEquals(1, rm.getReports().size());
+        assertEquals("No value report", rm.getReports().iterator().next().getDefaultMessage());
+        assertEquals(4, rm.getSubReporters().size());
+        assertEquals("Reading UCTE network file", rm.getSubReporters().get(0).getDefaultName());
     }
-    
+
     @Test
     public void jsonDeserializeNoSpecifiedDictionary() throws Exception {
         ObjectMapper mapper = new ObjectMapper();

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReporterTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.ucte.converter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.PowsyblException;
@@ -74,6 +75,17 @@ public class UcteImporterReporterTest extends AbstractConverterTest {
         reporter.report("novalueReport", "No value report");
         Importers.loadNetwork(filename, getClass().getResourceAsStream("/" + filename), reporter);
         roundTripTest(reporter, ReporterModelSerializer::write, ReporterModelDeserializer::read, "/frVoltageRegulatingXnodeReport.json");
+    }
+    
+    @Test
+    public void jsonDeserializeNoSpecifiedDictionary() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new ReporterModelJsonModule());
+        ReporterModel rm = mapper.readValue(getClass().getResource("/frVoltageRegulatingXnodeReport.json"), ReporterModel.class);
+        assertEquals(1, rm.getReports().size());
+        assertEquals("No value report", rm.getReports().iterator().next().getDefaultMessage());
+        assertEquals(4, rm.getSubReporters().size());
+        assertEquals("Reading UCTE network file", rm.getSubReporters().get(0).getDefaultName());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?** *(You can also link to an open issue here)*
Dictionary name needs to be specified through injectable value, fallback to default name fails


**What is the new behavior (if this is a feature change)?**
    - If dictionary name missing falls back to "default" name
    - If dictionary name specified is not in the "dics" root entry, falls back to first entry of dics and warns the user
    - if "dics" root entry is missing or empty, warns the user


**Does this PR introduce a breaking change or deprecate an API?** 
No