### PR TITLE
Add backward compatibility to LoadFlowProvider.run and SensitivityAnalysisProvider.run with reporter

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
@@ -51,7 +51,7 @@ public interface LoadFlowProvider extends Versionable, PlatformConfigNamedProvid
      * @return a {@link CompletableFuture} on {@link LoadFlowResult]
      */
     default CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, Reporter reporter) {
-        throw new UnsupportedOperationException("Not implemented");
+        return run(network, computationManager, workingVariantId, parameters);
     }
 
 }

--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityAnalysisProvider.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityAnalysisProvider.java
@@ -79,6 +79,6 @@ public interface SensitivityAnalysisProvider extends Versionable, PlatformConfig
                                                      SensitivityAnalysisParameters parameters,
                                                      ComputationManager computationManager,
                                                      Reporter reporter) {
-        throw new UnsupportedOperationException("Not implemented");
+        return run(network, workingStateId, factorsProvider, contingencies, parameters, computationManager);
     }
 }


### PR DESCRIPTION

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
with old providers, the new run methods with reporters throw exceptions.


**What is the new behavior (if this is a feature change)?**
with old providers, the new run methods run without producing a report



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
for consistency with 3acd49606ea983699ef859760e0b7a5f2386bf2d (#1781)
