### PR TITLE
Fix report deserialize corner case

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReporterModelDeserializer.java
@@ -69,9 +69,10 @@ public class ReporterModelDeserializer extends StdDeserializer<ReporterModel> {
 
     private String getDictionaryName(DeserializationContext ctx) {
         try {
-            Object dicNameInjected = ctx.findInjectableValue(DICTIONARY_VALUE_ID, null, null);
+            BeanProperty bp = new BeanProperty.Std(new PropertyName("Language for dictionary"), null, null, null, null);
+            Object dicNameInjected = ctx.findInjectableValue(DICTIONARY_VALUE_ID, bp, null);
             return dicNameInjected instanceof String ? (String) dicNameInjected : DICTIONARY_DEFAULT_NAME;
-        } catch (JsonMappingException e) {
+        } catch (JsonMappingException | IllegalArgumentException e) {
             LOGGER.info("No injectable value found for id `{}` in DeserializationContext, therefore taking `{}` dictionary",
                 DICTIONARY_VALUE_ID, DICTIONARY_DEFAULT_NAME);
             return DICTIONARY_DEFAULT_NAME;

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReporterTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.ucte.converter;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
 import com.powsybl.commons.AbstractConverterTest;
@@ -89,6 +90,13 @@ public class UcteImporterReporterTest extends AbstractConverterTest {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new ReporterModelJsonModule());
         ReporterModel rm = mapper.readValue(getClass().getResource("/frVoltageRegulatingXnodeReport.json"), ReporterModel.class);
+        assertEquals(1, rm.getReports().size());
+        assertEquals("No value report", rm.getReports().iterator().next().getDefaultMessage());
+        assertEquals(4, rm.getSubReporters().size());
+        assertEquals("Reading UCTE network file", rm.getSubReporters().get(0).getDefaultName());
+
+        mapper.setInjectableValues(new InjectableValues.Std().addValue("foo", "bar"));
+        rm = mapper.readValue(getClass().getResource("/frVoltageRegulatingXnodeReport.json"), ReporterModel.class);
         assertEquals(1, rm.getReports().size());
         assertEquals("No value report", rm.getReports().iterator().next().getDefaultMessage());
         assertEquals(4, rm.getSubReporters().size());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
When deserializing a `ReporterModel` json, if the `ObjectMapper` contains injectable values but not the dictionary language, then a NPE is thrown, while trying to create a uncaught `RuntimeException` (`IllegalArgumentException`)


**What is the new behavior (if this is a feature change)?**
The NPE is avoided and the `IllegalArgumentException` is caught, taking the `"default"` value for the dictionary language


**Does this PR introduce a breaking change or deprecate an API?** 
No