### PR TITLE
Make substations optional

### DIFF
--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
@@ -14,37 +14,10 @@ import com.powsybl.commons.extensions.Extension;
 import com.powsybl.commons.io.table.Column;
 import com.powsybl.commons.io.table.TableFormatter;
 import com.powsybl.commons.util.StringToIntMapper;
-import com.powsybl.iidm.network.Battery;
-import com.powsybl.iidm.network.Branch;
-import com.powsybl.iidm.network.Bus;
-import com.powsybl.iidm.network.ComponentConstants;
-import com.powsybl.iidm.network.CurrentLimits;
-import com.powsybl.iidm.network.DanglingLine;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.HvdcConverterStation;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.LoadingLimits.TemporaryLimit;
 import com.powsybl.iidm.network.HvdcConverterStation.HvdcType;
-import com.powsybl.iidm.network.HvdcLine;
-import com.powsybl.iidm.network.Identifiable;
-import com.powsybl.iidm.network.LccConverterStation;
-import com.powsybl.iidm.network.Line;
-import com.powsybl.iidm.network.Load;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.PhaseTapChanger;
-import com.powsybl.iidm.network.PhaseTapChangerStep;
-import com.powsybl.iidm.network.RatioTapChanger;
-import com.powsybl.iidm.network.RatioTapChangerStep;
-import com.powsybl.iidm.network.ShuntCompensator;
-import com.powsybl.iidm.network.ShuntCompensatorLinearModel;
-import com.powsybl.iidm.network.ShuntCompensatorModelType;
-import com.powsybl.iidm.network.StaticVarCompensator;
 import com.powsybl.iidm.network.StaticVarCompensator.RegulationMode;
-import com.powsybl.iidm.network.Terminal;
-import com.powsybl.iidm.network.ThreeWindingsTransformer;
-import com.powsybl.iidm.network.TieLine;
-import com.powsybl.iidm.network.TwoWindingsTransformer;
-import com.powsybl.iidm.network.VoltageLevel;
-import com.powsybl.iidm.network.VscConverterStation;
 import com.powsybl.iidm.network.util.ConnectedComponents;
 import com.powsybl.iidm.network.util.SV;
 import org.slf4j.Logger;
@@ -279,7 +252,7 @@ public class AmplNetworkWriter {
                         .writeCell(maxV)
                         .writeCell(faultNum)
                         .writeCell(actionNum)
-                        .writeCell(vl.getSubstation().getCountry().map(Enum::toString).orElse(""))
+                        .writeCell(vl.getOptionalSubstation().flatMap(Substation::getCountry).map(Enum::toString).orElse(""))
                         .writeCell(vl.getId())
                         .writeCell(vl.getNameOrId());
                 addExtensions(num, vl);
@@ -299,7 +272,7 @@ public class AmplNetworkWriter {
                         .writeCell(Float.NaN)
                         .writeCell(faultNum)
                         .writeCell(actionNum)
-                        .writeCell(vl1.getSubstation().getCountry().map(Enum::toString).orElse(""))
+                        .writeCell(vl1.getOptionalSubstation().flatMap(Substation::getCountry).map(Enum::toString).orElse(""))
                         .writeCell(vlId)
                         .writeCell("");
                 addExtensions(num, twt);
@@ -321,7 +294,7 @@ public class AmplNetworkWriter {
                         .writeCell(maxV)
                         .writeCell(faultNum)
                         .writeCell(actionNum)
-                        .writeCell(vl.getSubstation().getCountry().map(Enum::toString).orElse(""))
+                        .writeCell(vl.getOptionalSubstation().flatMap(Substation::getCountry).map(Enum::toString).orElse(""))
                         .writeCell(dl.getId() + "_voltageLevel")
                         .writeCell("");
                 addExtensions(num, dl);

--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
@@ -252,7 +252,7 @@ public class AmplNetworkWriter {
                         .writeCell(maxV)
                         .writeCell(faultNum)
                         .writeCell(actionNum)
-                        .writeCell(vl.getOptionalSubstation().flatMap(Substation::getCountry).map(Enum::toString).orElse(""))
+                        .writeCell(vl.getSubstation().flatMap(Substation::getCountry).map(Enum::toString).orElse(""))
                         .writeCell(vl.getId())
                         .writeCell(vl.getNameOrId());
                 addExtensions(num, vl);
@@ -272,7 +272,7 @@ public class AmplNetworkWriter {
                         .writeCell(Float.NaN)
                         .writeCell(faultNum)
                         .writeCell(actionNum)
-                        .writeCell(vl1.getOptionalSubstation().flatMap(Substation::getCountry).map(Enum::toString).orElse(""))
+                        .writeCell(vl1.getSubstation().flatMap(Substation::getCountry).map(Enum::toString).orElse(""))
                         .writeCell(vlId)
                         .writeCell("");
                 addExtensions(num, twt);
@@ -294,7 +294,7 @@ public class AmplNetworkWriter {
                         .writeCell(maxV)
                         .writeCell(faultNum)
                         .writeCell(actionNum)
-                        .writeCell(vl.getOptionalSubstation().flatMap(Substation::getCountry).map(Enum::toString).orElse(""))
+                        .writeCell(vl.getSubstation().flatMap(Substation::getCountry).map(Enum::toString).orElse(""))
                         .writeCell(dl.getId() + "_voltageLevel")
                         .writeCell("");
                 addExtensions(num, dl);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -530,7 +530,7 @@ public class Conversion {
 
     private void debugTopology(Context context) {
         context.network().getVoltageLevels().forEach(vl -> {
-            String name = vl.getSubstation().getNameOrId() + "-" + vl.getNameOrId();
+            String name = vl.getOptionalSubstation().map(s -> s.getNameOrId() + "-").orElse("") + vl.getNameOrId();
             name = name.replace('/', '-');
             Path file = Paths.get(System.getProperty("java.io.tmpdir"), "temp-cgmes-" + name + ".dot");
             try {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -530,7 +530,7 @@ public class Conversion {
 
     private void debugTopology(Context context) {
         context.network().getVoltageLevels().forEach(vl -> {
-            String name = vl.getOptionalSubstation().map(s -> s.getNameOrId() + "-").orElse("") + vl.getNameOrId();
+            String name = vl.getSubstation().map(s -> s.getNameOrId() + "-").orElse("") + vl.getNameOrId();
             name = name.replace('/', '-');
             Path file = Paths.get(System.getProperty("java.io.tmpdir"), "temp-cgmes-" + name + ".dot");
             try {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
@@ -398,8 +398,8 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
         }
     }
 
-    protected Substation substation() {
-        return (terminals[0].voltageLevel != null) ? terminals[0].voltageLevel.getSubstation() : null;
+    protected Optional<Substation> substation() {
+        return (terminals[0].voltageLevel != null) ? terminals[0].voltageLevel.getOptionalSubstation() : Optional.empty();
     }
 
     private PowerFlow stateVariablesPowerFlow() {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
@@ -399,7 +399,7 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
     }
 
     protected Optional<Substation> substation() {
-        return (terminals[0].voltageLevel != null) ? terminals[0].voltageLevel.getOptionalSubstation() : Optional.empty();
+        return (terminals[0].voltageLevel != null) ? terminals[0].voltageLevel.getSubstation() : Optional.empty();
     }
 
     private PowerFlow stateVariablesPowerFlow() {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
@@ -214,7 +214,7 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
                 ? "No bus"
                 : String.format("Bus %s, %sVoltage level %s",
                     bus.getId(),
-                    bus.getVoltageLevel().getOptionalSubstation().map(s -> "Substation " + s.getNameOrId() + ", ").orElse(""),
+                    bus.getVoltageLevel().getSubstation().map(s -> "Substation " + s.getNameOrId() + ", ").orElse(""),
                     bus.getVoltageLevel().getNameOrId());
             Supplier<String> message = () -> reason.get() + ". " + location.get();
             context.invalid("SvVoltage", message);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
@@ -212,9 +212,9 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
                 id);
             Supplier<String> location = () -> bus == null
                 ? "No bus"
-                : String.format("Bus %s, Substation %s, Voltage level %s",
+                : String.format("Bus %s, %sVoltage level %s",
                     bus.getId(),
-                    bus.getVoltageLevel().getSubstation().getNameOrId(),
+                    bus.getVoltageLevel().getOptionalSubstation().map(s -> "Substation " + s.getNameOrId() + ", ").orElse(""),
                     bus.getVoltageLevel().getNameOrId());
             Supplier<String> message = () -> reason.get() + ". " + location.get();
             context.invalid("SvVoltage", message);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/ThreeWindingsTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/ThreeWindingsTransformerConversion.java
@@ -12,10 +12,7 @@ import com.powsybl.cgmes.conversion.Conversion;
 import com.powsybl.cgmes.conversion.RegulatingControlMappingForTransformers.CgmesRegulatingControlPhase;
 import com.powsybl.cgmes.conversion.RegulatingControlMappingForTransformers.CgmesRegulatingControlRatio;
 import com.powsybl.cgmes.model.CgmesNames;
-import com.powsybl.iidm.network.PhaseTapChangerAdder;
-import com.powsybl.iidm.network.RatioTapChangerAdder;
-import com.powsybl.iidm.network.ThreeWindingsTransformer;
-import com.powsybl.iidm.network.ThreeWindingsTransformerAdder;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.ThreeWindingsTransformerAdder.LegAdder;
 import com.powsybl.triplestore.api.PropertyBags;
 
@@ -70,8 +67,10 @@ public class ThreeWindingsTransformerConversion extends AbstractTransformerConve
     }
 
     private void setToIidm(ConvertedT3xModel convertedT3xModel) {
-        ThreeWindingsTransformerAdder txadder = substation().newThreeWindingsTransformer()
-            .setRatedU0(convertedT3xModel.ratedU0);
+        ThreeWindingsTransformerAdder txadder = substation()
+                .map(Substation::newThreeWindingsTransformer)
+                .orElseGet(() -> context.network().newThreeWindingsTransformer())
+                .setRatedU0(convertedT3xModel.ratedU0);
         identify(txadder);
 
         LegAdder l1adder = txadder.newLeg1();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TwoWindingsTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TwoWindingsTransformerConversion.java
@@ -7,6 +7,7 @@
 
 package com.powsybl.cgmes.conversion.elements.transformers;
 
+import com.powsybl.iidm.network.*;
 import org.apache.commons.math3.complex.Complex;
 import org.apache.commons.math3.complex.ComplexUtils;
 
@@ -18,10 +19,6 @@ import com.powsybl.cgmes.conversion.RegulatingControlMappingForTransformers.Cgme
 import com.powsybl.cgmes.conversion.elements.BoundaryLine;
 import com.powsybl.cgmes.conversion.elements.EquipmentAtBoundaryConversion;
 import com.powsybl.cgmes.model.CgmesNames;
-import com.powsybl.iidm.network.PhaseTapChangerAdder;
-import com.powsybl.iidm.network.RatioTapChangerAdder;
-import com.powsybl.iidm.network.TwoWindingsTransformer;
-import com.powsybl.iidm.network.TwoWindingsTransformerAdder;
 import com.powsybl.triplestore.api.PropertyBags;
 
 /**
@@ -147,13 +144,15 @@ public class TwoWindingsTransformerConversion extends AbstractTransformerConvers
     }
 
     private void setToIidm(ConvertedT2xModel convertedT2xModel) {
-        TwoWindingsTransformerAdder adder = substation().newTwoWindingsTransformer()
-            .setR(convertedT2xModel.r)
-            .setX(convertedT2xModel.x)
-            .setG(convertedT2xModel.end1.g)
-            .setB(convertedT2xModel.end1.b)
-            .setRatedU1(convertedT2xModel.end1.ratedU)
-            .setRatedU2(convertedT2xModel.end2.ratedU);
+        TwoWindingsTransformerAdder adder = substation()
+                .map(Substation::newTwoWindingsTransformer)
+                .orElseGet(() -> context.network().newTwoWindingsTransformer())
+                .setR(convertedT2xModel.r)
+                .setX(convertedT2xModel.x)
+                .setG(convertedT2xModel.end1.g)
+                .setB(convertedT2xModel.end1.b)
+                .setRatedU1(convertedT2xModel.end1.ratedU)
+                .setRatedU2(convertedT2xModel.end2.ratedU);
         identify(adder);
         connect(adder);
         TwoWindingsTransformer tx = adder.add();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/JoinVoltageLevelTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/JoinVoltageLevelTest.java
@@ -45,7 +45,7 @@ public class JoinVoltageLevelTest {
 
         Switch sw = n.getSwitch("_5e9f0079-647e-46da-b0ee-f5f24e127602");
         VoltageLevel voltageLevel = sw.getVoltageLevel();
-        Substation substation = voltageLevel.getOptionalSubstation().orElse(null);
+        Substation substation = voltageLevel.getSubstation().orElse(null);
 
         boolean ok = compareVoltageLevelSubstation("_d6056127-34f1-43a9-b029-23fddb913bd5", "_a43d15db-44a6-4fda-a525-2402ff43226f", substation.getId(), voltageLevel.getId());
         assertTrue(ok);
@@ -66,7 +66,7 @@ public class JoinVoltageLevelTest {
         assertTrue(isOpen);
 
         VoltageLevel voltageLevel = sw.getVoltageLevel();
-        Substation substation = voltageLevel.getOptionalSubstation().orElse(null);
+        Substation substation = voltageLevel.getSubstation().orElse(null);
 
         boolean ok = compareVoltageLevelSubstation("_d6056127-34f1-43a9-b029-23fddb913bd5", "_a43d15db-44a6-4fda-a525-2402ff43226f", substation.getId(), voltageLevel.getId());
         assertTrue(ok);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/JoinVoltageLevelTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/JoinVoltageLevelTest.java
@@ -83,7 +83,7 @@ public class JoinVoltageLevelTest {
         Terminal t2 = t2x.getTerminal(Side.TWO);
         VoltageLevel voltageLevel2 = t2.getVoltageLevel();
 
-        Substation substation = t2x.getSubstation();
+        Substation substation = t2x.getOptionalSubstation().orElse(null);
 
         boolean ok = compareVoltageLevelSubstation("_d6056127-34f1-43a9-b029-23fddb913bd5",
             "_a43d15db-44a6-4fda-a525-2402ff43226f", "_0d68ac81-124d-4d21-afa8-6c503feef5b8", substation.getId(),

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/JoinVoltageLevelTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/JoinVoltageLevelTest.java
@@ -83,7 +83,7 @@ public class JoinVoltageLevelTest {
         Terminal t2 = t2x.getTerminal(Side.TWO);
         VoltageLevel voltageLevel2 = t2.getVoltageLevel();
 
-        Substation substation = t2x.getOptionalSubstation().orElse(null);
+        Substation substation = t2x.getSubstation().orElse(null);
 
         boolean ok = compareVoltageLevelSubstation("_d6056127-34f1-43a9-b029-23fddb913bd5",
             "_a43d15db-44a6-4fda-a525-2402ff43226f", "_0d68ac81-124d-4d21-afa8-6c503feef5b8", substation.getId(),

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/JoinVoltageLevelTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/JoinVoltageLevelTest.java
@@ -45,7 +45,7 @@ public class JoinVoltageLevelTest {
 
         Switch sw = n.getSwitch("_5e9f0079-647e-46da-b0ee-f5f24e127602");
         VoltageLevel voltageLevel = sw.getVoltageLevel();
-        Substation substation = voltageLevel.getSubstation();
+        Substation substation = voltageLevel.getOptionalSubstation().orElse(null);
 
         boolean ok = compareVoltageLevelSubstation("_d6056127-34f1-43a9-b029-23fddb913bd5", "_a43d15db-44a6-4fda-a525-2402ff43226f", substation.getId(), voltageLevel.getId());
         assertTrue(ok);
@@ -66,7 +66,7 @@ public class JoinVoltageLevelTest {
         assertTrue(isOpen);
 
         VoltageLevel voltageLevel = sw.getVoltageLevel();
-        Substation substation = voltageLevel.getSubstation();
+        Substation substation = voltageLevel.getOptionalSubstation().orElse(null);
 
         boolean ok = compareVoltageLevelSubstation("_d6056127-34f1-43a9-b029-23fddb913bd5", "_a43d15db-44a6-4fda-a525-2402ff43226f", substation.getId(), voltageLevel.getId());
         assertTrue(ok);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -258,7 +258,7 @@ public class Comparison {
     }
 
     private void compareVoltageLevels(VoltageLevel expected, VoltageLevel actual) {
-        equivalent("Substation", expected.getOptionalSubstation().orElse(null), actual.getOptionalSubstation().orElse(null));
+        equivalent("Substation", expected.getSubstation().orElse(null), actual.getSubstation().orElse(null));
         compare("nominalV", expected.getNominalV(), actual.getNominalV());
         if (config.checkVoltageLevelLimits) {
             compare("lowVoltageLimit",

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/network/compare/Comparison.java
@@ -258,7 +258,7 @@ public class Comparison {
     }
 
     private void compareVoltageLevels(VoltageLevel expected, VoltageLevel actual) {
-        equivalent("Substation", expected.getSubstation(), actual.getSubstation());
+        equivalent("Substation", expected.getOptionalSubstation().orElse(null), actual.getOptionalSubstation().orElse(null));
         compare("nominalV", expected.getNominalV(), actual.getNominalV());
         if (config.checkVoltageLevelLimits) {
             compare("lowVoltageLimit",

--- a/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
+++ b/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
@@ -327,7 +327,8 @@ public class IeeeCdfImporter implements Importer {
         VoltageLevel voltageLevel1 = network.getVoltageLevel(voltageLevel1Id);
         VoltageLevel voltageLevel2 = network.getVoltageLevel(voltageLevel2Id);
         double zb = Math.pow(voltageLevel2.getNominalV(), 2) / perUnitContext.getSb();
-        return voltageLevel2.getSubstation().newTwoWindingsTransformer()
+        return voltageLevel2.getOptionalSubstation().map(Substation::newTwoWindingsTransformer)
+                .orElseGet(network::newTwoWindingsTransformer)
                 .setId(id)
                 .setBus1(bus1Id)
                 .setConnectableBus1(bus1Id)

--- a/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
+++ b/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
@@ -327,7 +327,7 @@ public class IeeeCdfImporter implements Importer {
         VoltageLevel voltageLevel1 = network.getVoltageLevel(voltageLevel1Id);
         VoltageLevel voltageLevel2 = network.getVoltageLevel(voltageLevel2Id);
         double zb = Math.pow(voltageLevel2.getNominalV(), 2) / perUnitContext.getSb();
-        return voltageLevel2.getOptionalSubstation().map(Substation::newTwoWindingsTransformer)
+        return voltageLevel2.getSubstation().map(Substation::newTwoWindingsTransformer)
                 .orElseGet(network::newTwoWindingsTransformer)
                 .setId(id)
                 .setBus1(bus1Id)

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
@@ -388,6 +388,15 @@ public interface Network extends Container<Network> {
      */
     TieLineAdder newTieLine();
 
+    default TwoWindingsTransformerAdder newTwoWindingsTransformer() {
+        return newSubstation()
+                .setId("FICTITIOUS_SUBSTATION")
+                .setEnsureIdUnicity(true)
+                .setFictitious(true)
+                .add()
+                .newTwoWindingsTransformer();
+    }
+
     /**
      * Get all two windings transformers.
      */
@@ -409,6 +418,15 @@ public interface Network extends Container<Network> {
      * @param id the id or an alias of the two windings transformer
      */
     TwoWindingsTransformer getTwoWindingsTransformer(String id);
+
+    default ThreeWindingsTransformerAdder newThreeWindingsTransformer() {
+        return newSubstation()
+                .setId("FICTITIOUS_SUBSTATION")
+                .setEnsureIdUnicity(true)
+                .setFictitious(true)
+                .add()
+                .newThreeWindingsTransformer();
+    }
 
     /**
      * Get all 3 windings transformers.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
@@ -303,6 +303,7 @@ public interface Network extends Container<Network> {
 
     /**
      * Get a builder to create a new voltage level (without substation).
+     * Note: if this method is not implemented, it will create an intermediary fictitious {@link Substation}.
      */
     default VoltageLevelAdder newVoltageLevel() {
         return newSubstation()
@@ -388,6 +389,12 @@ public interface Network extends Container<Network> {
      */
     TieLineAdder newTieLine();
 
+    /**
+     * Get a builder to create a two windings transformer.
+     * Only use if at least one of the transformer's ends does not belong to any substation.
+     * Else use {@link Substation#newTwoWindingsTransformer()}.
+     * Note: if this method is not implemented, it will create an intermediary fictitious {@link Substation}.
+     */
     default TwoWindingsTransformerAdder newTwoWindingsTransformer() {
         return newSubstation()
                 .setId("FICTITIOUS_SUBSTATION")
@@ -419,6 +426,12 @@ public interface Network extends Container<Network> {
      */
     TwoWindingsTransformer getTwoWindingsTransformer(String id);
 
+    /**
+     * Get a builder to create a three windings transformer.
+     * Only use this builder if at least one of the transformer's ends does not belong to any substation.
+     * Else use {@link Substation#newThreeWindingsTransformer()}.
+     * Note: if this method is not implemented, it will create an intermediary fictitious {@link Substation}.
+     */
     default ThreeWindingsTransformerAdder newThreeWindingsTransformer() {
         return newSubstation()
                 .setId("FICTITIOUS_SUBSTATION")

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
@@ -302,6 +302,18 @@ public interface Network extends Container<Network> {
     Substation getSubstation(String id);
 
     /**
+     * Get a builder to create a new voltage level (without substation).
+     */
+    default VoltageLevelAdder newVoltageLevel() {
+        return newSubstation()
+                .setId("FICTITIOUS_SUBSTATION")
+                .setEnsureIdUnicity(true)
+                .setFictitious(true)
+                .add()
+                .newVoltageLevel();
+    }
+
+    /**
      * Get all substation voltage levels.
      */
     Iterable<VoltageLevel> getVoltageLevels();

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Substation.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Substation.java
@@ -122,6 +122,8 @@ public interface Substation extends Container<Substation> {
 
     /**
      * Get a builder to create a new two windings transformer in the substation.
+     * Only use this builder if the two ends of the transformer are in the substation.
+     * Else use {@link Network#newTwoWindingsTransformer()}.
      */
     TwoWindingsTransformerAdder newTwoWindingsTransformer();
 
@@ -142,6 +144,8 @@ public interface Substation extends Container<Substation> {
 
     /**
      * Get a builder to create a new 3 windings transformer in the substation.
+     * Only use this builder if the three ends of the transformer are in the substation.
+     * Else use {@link Network#newThreeWindingsTransformer()}.
      */
     ThreeWindingsTransformerAdder newThreeWindingsTransformer();
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.network;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -301,6 +302,10 @@ public interface ThreeWindingsTransformer extends Connectable<ThreeWindingsTrans
      * Get the substation to which the transformer belongs.
      */
     Substation getSubstation();
+
+    default Optional<Substation> getOptionalSubstation() {
+        return Optional.ofNullable(getSubstation());
+    }
 
     /**
      * Get the leg at the primary side.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
@@ -298,16 +298,7 @@ public interface ThreeWindingsTransformer extends Connectable<ThreeWindingsTrans
      */
     Side getSide(Terminal terminal);
 
-    /**
-     * Get the substation to which the transformer belongs.
-     */
-    default Substation getSubstation() {
-        throw new UnsupportedOperationException();
-    }
-
-    default Optional<Substation> getOptionalSubstation() {
-        return Optional.ofNullable(getSubstation());
-    }
+    Optional<Substation> getSubstation();
 
     /**
      * Get the leg at the primary side.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
@@ -300,6 +300,10 @@ public interface ThreeWindingsTransformer extends Connectable<ThreeWindingsTrans
 
     Optional<Substation> getSubstation();
 
+    default Substation getNullableSubstation() {
+        return getSubstation().orElse(null);
+    }
+
     /**
      * Get the leg at the primary side.
      */

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
@@ -301,7 +301,9 @@ public interface ThreeWindingsTransformer extends Connectable<ThreeWindingsTrans
     /**
      * Get the substation to which the transformer belongs.
      */
-    Substation getSubstation();
+    default Substation getSubstation() {
+        throw new UnsupportedOperationException();
+    }
 
     default Optional<Substation> getOptionalSubstation() {
         return Optional.ofNullable(getSubstation());

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TwoWindingsTransformer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TwoWindingsTransformer.java
@@ -141,16 +141,7 @@ import java.util.Optional;
  */
 public interface TwoWindingsTransformer extends Branch<TwoWindingsTransformer>, RatioTapChangerHolder, PhaseTapChangerHolder {
 
-    /**
-     * Get the substation to which the transformer belongs.
-     */
-    default Substation getSubstation() {
-        throw new UnsupportedOperationException();
-    }
-
-    default Optional<Substation> getOptionalSubstation() {
-        return Optional.ofNullable(getSubstation());
-    }
+    Optional<Substation> getSubstation();
 
     /**
      * Get the nominal series resistance specified in &#937; at the secondary

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TwoWindingsTransformer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TwoWindingsTransformer.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.iidm.network;
 
+import java.util.Optional;
+
 /**
  * A two windings power transformer.
  * <p>The equivalent &#960; model used is:
@@ -109,28 +111,29 @@ package com.powsybl.iidm.network;
  * <p>b, g, r, x, &#961; and &#945; variables in the model can be computed with
  * the following Java code supposing <code>transfo</code> is an instance of
  * <code>TwoWindingsTransformer</code>.
- *<pre>
- *r = transfo.getR()
+ * <pre>
+ * r = transfo.getR()
  *    * (1 + (transfo.getRatioTapChanger() != null ? transfo.getRatioTapChanger().getCurrentStep().getR() / 100 : 0)
  *       + (transfo.getPhaseTapChanger() != null ? transfo.getPhaseTapChanger().getCurrentStep().getR() / 100 : 0));
- *x = transfo.getX()
+ * x = transfo.getX()
  *    * (1 + (transfo.getRatioTapChanger() != null ? transfo.getRatioTapChanger().getCurrentStep().getX() / 100 : 0)
  *       + (transfo.getPhaseTapChanger() != null ? transfo.getPhaseTapChanger().getCurrentStep().getX() / 100 : 0));
- *g = transfo.getG()
+ * g = transfo.getG()
  *    * (1 + (transfo.getRatioTapChanger() != null ? transfo.getRatioTapChanger().getCurrentStep().getG() / 100 : 0)
  *       + (transfo.getPhaseTapChanger() != null ? transfo.getPhaseTapChanger().getCurrentStep().getG() / 100 : 0));
- *b = transfo.getB()
+ * b = transfo.getB()
  *    * (1 + (transfo.getRatioTapChanger() != null ? transfo.getRatioTapChanger().getCurrentStep().getB() / 100 : 0)
  *       + (transfo.getPhaseTapChanger() != null ? transfo.getPhaseTapChanger().getCurrentStep().getB() / 100 : 0));
- *rho = transfo.getRatedU2() / transfo.getRatedU1()
+ * rho = transfo.getRatedU2() / transfo.getRatedU1()
  *    * (transfo.getRatioTapChanger() != null ? transfo.getRatioTapChanger().getCurrentStep().getRho() : 1);
  *    * (transfo.getPhaseTapChanger() != null ? transfo.getPhaseTapChanger().getCurrentStep().getRho() : 1);
- *alpha = (transfo.getPhaseTapChanger() != null ? transfo.getPhaseTapChanger().getCurrentStep().getAlpha() : 0);
+ * alpha = (transfo.getPhaseTapChanger() != null ? transfo.getPhaseTapChanger().getCurrentStep().getAlpha() : 0);
  *
- *</pre>
+ * </pre>
  * A 2 windings transformer is connected to 2 voltage levels (side 1 and side 2)
  * that belong to the same substation.
  * <p>To create a 2 windings transformer, see {@link TwoWindingsTransformerAdder}
+ *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  * @see RatioTapChanger
  * @see PhaseTapChanger
@@ -142,6 +145,10 @@ public interface TwoWindingsTransformer extends Branch<TwoWindingsTransformer>, 
      * Get the substation to which the transformer belongs.
      */
     Substation getSubstation();
+
+    default Optional<Substation> getOptionalSubstation() {
+        return Optional.ofNullable(getSubstation());
+    }
 
     /**
      * Get the nominal series resistance specified in &#937; at the secondary

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TwoWindingsTransformer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TwoWindingsTransformer.java
@@ -143,6 +143,10 @@ public interface TwoWindingsTransformer extends Branch<TwoWindingsTransformer>, 
 
     Optional<Substation> getSubstation();
 
+    default Substation getNullableSubstation() {
+        return getSubstation().orElse(null);
+    }
+
     /**
      * Get the nominal series resistance specified in &#937; at the secondary
      * voltage side.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TwoWindingsTransformer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TwoWindingsTransformer.java
@@ -144,7 +144,9 @@ public interface TwoWindingsTransformer extends Branch<TwoWindingsTransformer>, 
     /**
      * Get the substation to which the transformer belongs.
      */
-    Substation getSubstation();
+    default Substation getSubstation() {
+        throw new UnsupportedOperationException();
+    }
 
     default Optional<Substation> getOptionalSubstation() {
         return Optional.ofNullable(getSubstation());

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -821,6 +821,10 @@ public interface VoltageLevel extends Container<VoltageLevel> {
      */
     Substation getSubstation();
 
+    default Optional<Substation> getOptionalSubstation() {
+        return Optional.ofNullable(getSubstation());
+    }
+
     /**
      * Get the nominal voltage in KV.
      */

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -818,6 +818,10 @@ public interface VoltageLevel extends Container<VoltageLevel> {
 
     Optional<Substation> getSubstation();
 
+    default Substation getNullableSubstation() {
+        return getSubstation().orElse(null);
+    }
+
     /**
      * Get the nominal voltage in KV.
      */

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -819,7 +819,9 @@ public interface VoltageLevel extends Container<VoltageLevel> {
     /**
      * Get the substation to which the voltage level belongs.
      */
-    Substation getSubstation();
+    default Substation getSubstation() {
+        throw new UnsupportedOperationException();
+    }
 
     default Optional<Substation> getOptionalSubstation() {
         return Optional.ofNullable(getSubstation());

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -816,16 +816,7 @@ public interface VoltageLevel extends Container<VoltageLevel> {
 
     }
 
-    /**
-     * Get the substation to which the voltage level belongs.
-     */
-    default Substation getSubstation() {
-        throw new UnsupportedOperationException();
-    }
-
-    default Optional<Substation> getOptionalSubstation() {
-        return Optional.ofNullable(getSubstation());
-    }
+    Optional<Substation> getSubstation();
 
     /**
      * Get the nominal voltage in KV.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/GraphvizConnectivity.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/GraphvizConnectivity.java
@@ -78,7 +78,7 @@ public class GraphvizConnectivity {
                     .attr(GraphVizAttribute.fillcolor, colors[b.getConnectedComponent().getNum()])
                     .attr(GraphVizAttribute.tooltip, tooltip);
             if (countryCluster) {
-                b.getVoltageLevel().getOptionalSubstation().flatMap(Substation::getCountry)
+                b.getVoltageLevel().getSubstation().flatMap(Substation::getCountry)
                         .ifPresent(country -> graph.cluster(scope, country)
                         .label(country.name())
                         .attr(GraphVizAttribute.style, "rounded")

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/GraphvizConnectivity.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/GraphvizConnectivity.java
@@ -78,13 +78,11 @@ public class GraphvizConnectivity {
                     .attr(GraphVizAttribute.fillcolor, colors[b.getConnectedComponent().getNum()])
                     .attr(GraphVizAttribute.tooltip, tooltip);
             if (countryCluster) {
-                Country country = b.getVoltageLevel().getSubstation().getNullableCountry();
-                if (country != null) {
-                    graph.cluster(scope, country)
-                            .label(country.name())
-                            .attr(GraphVizAttribute.style, "rounded")
-                            .add(node);
-                }
+                b.getVoltageLevel().getOptionalSubstation().flatMap(Substation::getCountry)
+                        .ifPresent(country -> graph.cluster(scope, country)
+                        .label(country.name())
+                        .attr(GraphVizAttribute.style, "rounded")
+                        .add(node));
             }
         }
         for (Branch branch : network.getBranches()) {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
@@ -9,10 +9,13 @@ package com.powsybl.iidm.network.impl;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.impl.util.Ref;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -20,6 +23,8 @@ import java.util.stream.Stream;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> implements VoltageLevelExt {
+
+    private final Ref<NetworkImpl> networkRef;
 
     private final SubstationImpl substation;
 
@@ -29,10 +34,11 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
 
     private double highVoltageLimit;
 
-    AbstractVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation,
+    AbstractVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation, Ref<NetworkImpl> networkRef,
                          double nominalV, double lowVoltageLimit, double highVoltageLimit) {
         super(id, name, fictitious);
         this.substation = substation;
+        this.networkRef = networkRef;
         this.nominalV = nominalV;
         this.lowVoltageLimit = lowVoltageLimit;
         this.highVoltageLimit = highVoltageLimit;
@@ -49,8 +55,17 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     }
 
     @Override
+    public Optional<Substation> getOptionalSubstation() {
+        return Optional.ofNullable(substation);
+    }
+
+    @Override
     public NetworkImpl getNetwork() {
-        return substation.getNetwork();
+        return Optional.ofNullable(networkRef)
+                .map(Ref::get)
+                .orElseGet(() -> Optional.ofNullable(substation)
+                        .map(SubstationImpl::getNetwork)
+                        .orElseThrow(() -> new PowsyblException(String.format("Voltage level %s has no container", id))));
     }
 
     private void notifyUpdate(String attribute, Object oldValue, Object newValue) {
@@ -103,7 +118,14 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     public <T extends Connectable> T getConnectable(String id, Class<T> aClass) {
         // the fastest way to get the equipment is to look in the index
         // and then check if it is connected to this substation
-        T connectable = substation.getNetwork().getIndex().get(id, aClass);
+        T connectable;
+        if (substation != null) {
+            connectable = substation.getNetwork().getIndex().get(id, aClass);
+        } else if (networkRef != null) {
+            connectable = networkRef.get().getIndex().get(id, aClass);
+        } else {
+            throw new PowsyblException(String.format("Voltage level %s has no container", id));
+        }
         if (connectable == null) {
             return null;
         } else if (connectable instanceof Injection) {
@@ -383,7 +405,7 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
         removeTopology();
 
         // Remove this voltage level from the network
-        getSubstation().remove(this);
+        getOptionalSubstation().map(s -> (SubstationImpl) s).ifPresent(s -> s.remove(this));
         getNetwork().getIndex().remove(this);
 
         getNetwork().getListeners().notifyRemoval(this);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
@@ -55,6 +55,11 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     }
 
     @Override
+    public Substation getNullableSubstation() {
+        return substation;
+    }
+
+    @Override
     public NetworkImpl getNetwork() {
         return Optional.ofNullable(networkRef)
                 .map(Ref::get)

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
@@ -50,11 +50,6 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     }
 
     @Override
-    public SubstationImpl getSubstation() {
-        return substation;
-    }
-
-    @Override
     public Optional<Substation> getOptionalSubstation() {
         return Optional.ofNullable(substation);
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
@@ -50,7 +50,7 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     }
 
     @Override
-    public Optional<Substation> getOptionalSubstation() {
+    public Optional<Substation> getSubstation() {
         return Optional.ofNullable(substation);
     }
 
@@ -403,7 +403,7 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
         removeTopology();
 
         // Remove this voltage level from the network
-        getOptionalSubstation().map(SubstationImpl.class::cast).ifPresent(s -> s.remove(this));
+        getSubstation().map(SubstationImpl.class::cast).ifPresent(s -> s.remove(this));
         getNetwork().getIndex().remove(this);
 
         getNetwork().getListeners().notifyRemoval(this);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -317,7 +317,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     BusBreakerVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation, Ref<NetworkImpl> ref,
                            double nominalV, double lowVoltageLimit, double highVoltageLimit) {
         super(id, name, fictitious, substation, ref, nominalV, lowVoltageLimit, highVoltageLimit);
-        variants = new VariantArray<>(substation.getNetwork().getRef(), VariantImpl::new);
+        variants = new VariantArray<>(ref == null ? substation.getNetwork().getRef() : ref, VariantImpl::new);
         // invalidate topology and connected components
         graph.addListener(this::invalidateCache);
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Iterables;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.util.Colors;
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.impl.util.Ref;
 import com.powsybl.iidm.network.util.Networks;
 import com.powsybl.iidm.network.util.ShortIdDictionary;
 import com.powsybl.math.graph.TraverseResult;
@@ -110,7 +111,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         Integer v = buses.get(busId);
         if (throwException && v == null) {
             throw new PowsyblException("Bus " + busId
-                    + " not found in substation voltage level "
+                    + " not found in voltage level "
                     + BusBreakerVoltageLevel.this.id);
         }
         return v;
@@ -133,7 +134,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         Integer e = switches.get(switchId);
         if (throwException && e == null) {
             throw new PowsyblException("Switch " + switchId
-                    + " not found in substation voltage level"
+                    + " not found in voltage level"
                     + BusBreakerVoltageLevel.this.id);
         }
         return e;
@@ -281,7 +282,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
             MergedBus bus = variants.get().cache.getMergedBus(mergedBusId);
             if (throwException && bus == null) {
                 throw new PowsyblException("Bus " + mergedBusId
-                        + " not found in substation voltage level "
+                        + " not found in voltage level "
                         + BusBreakerVoltageLevel.this.id);
             }
             return bus;
@@ -313,9 +314,9 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
     protected final VariantArray<VariantImpl> variants;
 
-    BusBreakerVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation,
+    BusBreakerVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation, Ref<NetworkImpl> ref,
                            double nominalV, double lowVoltageLimit, double highVoltageLimit) {
-        super(id, name, fictitious, substation, nominalV, lowVoltageLimit, highVoltageLimit);
+        super(id, name, fictitious, substation, ref, nominalV, lowVoltageLimit, highVoltageLimit);
         variants = new VariantArray<>(substation.getNetwork().getRef(), VariantImpl::new);
         // invalidate topology and connected components
         graph.addListener(this::invalidateCache);
@@ -687,7 +688,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         Integer e = switches.remove(switchId);
         if (e == null) {
             throw new PowsyblException("Switch '" + switchId
-                    + "' not found in substation voltage level '" + id + "'");
+                    + "' not found in voltage level '" + id + "'");
         }
         SwitchImpl aSwitch = graph.removeEdge(e);
         getNetwork().getIndex().remove(aSwitch);
@@ -821,7 +822,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
                     .filter(t -> traverser.traverse(t, t.isConnected()))
                     .forEach(t -> addNextTerminals(t, nextTerminals));
 
-            // then go through other buses of the substation
+            // then go through other buses of the voltage level
             graph.traverse(v, (v1, e, v2) -> {
                 SwitchImpl aSwitch = graph.getEdgeObject(e);
                 ConfiguredBus otherBus = graph.getVertexObject(v2);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -250,6 +250,11 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
     }
 
     @Override
+    public VoltageLevelAdder newVoltageLevel() {
+        return new VoltageLevelAdderImpl(ref);
+    }
+
+    @Override
     public Iterable<VoltageLevel> getVoltageLevels() {
         return Iterables.concat(index.getAll(BusBreakerVoltageLevel.class),
                 index.getAll(NodeBreakerVoltageLevel.class));

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 class NetworkImpl extends AbstractIdentifiable<Network> implements Network, VariantManagerHolder, MultiVariantObject {
@@ -337,6 +336,11 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
     }
 
     @Override
+    public TwoWindingsTransformerAdderImpl newTwoWindingsTransformer() {
+        return new TwoWindingsTransformerAdderImpl(ref);
+    }
+
+    @Override
     public Iterable<TwoWindingsTransformer> getTwoWindingsTransformers() {
         return Collections.unmodifiableCollection(index.getAll(TwoWindingsTransformerImpl.class));
     }
@@ -354,6 +358,11 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
     @Override
     public TwoWindingsTransformer getTwoWindingsTransformer(String id) {
         return index.get(id, TwoWindingsTransformerImpl.class);
+    }
+
+    @Override
+    public ThreeWindingsTransformerAdderImpl newThreeWindingsTransformer() {
+        return new ThreeWindingsTransformerAdderImpl(ref);
     }
 
     @Override
@@ -780,8 +789,8 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
         //For bus breaker view, we exclude bus breaker topologies from the cache,
         //because thoses buses are already indexed in the NetworkIndex
         private final BusCache busBreakerViewCache = new BusCache(() -> getVoltageLevelStream()
-            .filter(vl -> vl.getTopologyKind() != TopologyKind.BUS_BREAKER)
-            .flatMap(vl -> getBusBreakerView().getBusStream()));
+                .filter(vl -> vl.getTopologyKind() != TopologyKind.BUS_BREAKER)
+                .flatMap(vl -> getBusBreakerView().getBusStream()));
 
         @Override
         public VariantImpl copy() {
@@ -1021,24 +1030,24 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
                     .setVoltageLevel1(mergedLine.voltageLevel1)
                     .setVoltageLevel2(mergedLine.voltageLevel2)
                     .newHalfLine1().setId(mergedLine.half1.id)
-                        .setName(mergedLine.half1.name)
-                        .setR(mergedLine.half1.r)
-                        .setX(mergedLine.half1.x)
-                        .setG1(mergedLine.half1.g1)
-                        .setG2(mergedLine.half1.g2)
-                        .setB1(mergedLine.half1.b1)
-                        .setB2(mergedLine.half1.b2)
-                        .setFictitious(mergedLine.half1.fictitious)
+                    .setName(mergedLine.half1.name)
+                    .setR(mergedLine.half1.r)
+                    .setX(mergedLine.half1.x)
+                    .setG1(mergedLine.half1.g1)
+                    .setG2(mergedLine.half1.g2)
+                    .setB1(mergedLine.half1.b1)
+                    .setB2(mergedLine.half1.b2)
+                    .setFictitious(mergedLine.half1.fictitious)
                     .add()
                     .newHalfLine2().setId(mergedLine.half2.id)
-                        .setName(mergedLine.half2.name)
-                        .setR(mergedLine.half2.r)
-                        .setX(mergedLine.half2.x)
-                        .setG1(mergedLine.half2.g1)
-                        .setG2(mergedLine.half2.g2)
-                        .setB1(mergedLine.half2.b1)
-                        .setB2(mergedLine.half2.b2)
-                        .setFictitious(mergedLine.half2.fictitious)
+                    .setName(mergedLine.half2.name)
+                    .setR(mergedLine.half2.r)
+                    .setX(mergedLine.half2.x)
+                    .setG1(mergedLine.half2.g1)
+                    .setG2(mergedLine.half2.g2)
+                    .setB1(mergedLine.half2.b1)
+                    .setB2(mergedLine.half2.b2)
+                    .setFictitious(mergedLine.half2.fictitious)
                     .add()
                     .setUcteXnodeCode(mergedLine.xnode);
             if (mergedLine.bus1 != null) {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -986,8 +986,8 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
             l.q1 = t1.getQ();
             l.p2 = t2.getP();
             l.q2 = t2.getQ();
-            l.country1 = vl1.getOptionalSubstation().flatMap(Substation::getCountry).orElse(null);
-            l.country2 = vl2.getOptionalSubstation().flatMap(Substation::getCountry).orElse(null);
+            l.country1 = vl1.getSubstation().flatMap(Substation::getCountry).orElse(null);
+            l.country2 = vl2.getSubstation().flatMap(Substation::getCountry).orElse(null);
             mergeProperties(dl1, dl2, l.properties);
             lines.add(l);
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -986,8 +986,8 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
             l.q1 = t1.getQ();
             l.p2 = t2.getP();
             l.q2 = t2.getQ();
-            l.country1 = vl1.getSubstation().getCountry().orElse(null);
-            l.country2 = vl2.getSubstation().getCountry().orElse(null);
+            l.country1 = vl1.getOptionalSubstation().flatMap(Substation::getCountry).orElse(null);
+            l.country2 = vl2.getOptionalSubstation().flatMap(Substation::getCountry).orElse(null);
             mergeProperties(dl1, dl2, l.properties);
             lines.add(l);
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -15,6 +15,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.util.Colors;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.VoltageLevel.NodeBreakerView.SwitchAdder;
+import com.powsybl.iidm.network.impl.util.Ref;
 import com.powsybl.iidm.network.util.ShortIdDictionary;
 import com.powsybl.math.graph.GraphUtil;
 import com.powsybl.math.graph.TraverseResult;
@@ -505,9 +506,9 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
     }
 
-    NodeBreakerVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation,
+    NodeBreakerVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation, Ref<NetworkImpl> ref,
                             double nominalV, double lowVoltageLimit, double highVoltageLimit) {
-        super(id, name, fictitious, substation, nominalV, lowVoltageLimit, highVoltageLimit);
+        super(id, name, fictitious, substation, ref, nominalV, lowVoltageLimit, highVoltageLimit);
         variants = new VariantArray<>(substation.getNetwork().getRef(), VariantImpl::new);
     }
 
@@ -709,7 +710,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             Integer e = switches.remove(switchId);
             if (e == null) {
                 throw new PowsyblException("Switch '" + switchId
-                        + "' not found in substation voltage level '" + id + "'");
+                        + "' not found in voltage level '" + id + "'");
             }
             SwitchImpl aSwitch = graph.removeEdge(e);
             clean();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
@@ -48,7 +48,6 @@ final class Substations {
      * substation.
      */
     static void checkRemovability(Substation substation) {
-        Objects.requireNonNull(substation);
         for (VoltageLevel vl : substation.getVoltageLevels()) {
             for (Connectable connectable : vl.getConnectables()) {
                 if (connectable instanceof Branch) {
@@ -91,6 +90,7 @@ final class Substations {
     }
 
     private static PowsyblException createIsolationException(Substation substation) {
+        Objects.requireNonNull(substation);
         return new PowsyblException("The substation " + substation.getId() + " is still connected to another substation");
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.network.impl;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -47,6 +48,7 @@ final class Substations {
      * substation.
      */
     static void checkRemovability(Substation substation) {
+        Objects.requireNonNull(substation);
         for (VoltageLevel vl : substation.getVoltageLevels()) {
             for (Connectable connectable : vl.getConnectables()) {
                 if (connectable instanceof Branch) {
@@ -90,6 +92,5 @@ final class Substations {
 
     private static PowsyblException createIsolationException(Substation substation) {
         return new PowsyblException("The substation " + substation.getId() + " is still connected to another substation");
-
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
@@ -61,17 +61,17 @@ final class Substations {
     }
 
     private static void checkRemovability(Substation substation, Branch branch) {
-        Substation s1 = branch.getTerminal1().getVoltageLevel().getOptionalSubstation().orElse(null);
-        Substation s2 = branch.getTerminal2().getVoltageLevel().getOptionalSubstation().orElse(null);
+        Substation s1 = branch.getTerminal1().getVoltageLevel().getSubstation().orElse(null);
+        Substation s2 = branch.getTerminal2().getVoltageLevel().getSubstation().orElse(null);
         if ((s1 != substation) || (s2 != substation)) {
             throw createIsolationException(substation);
         }
     }
 
     private static void checkRemovability(Substation substation, ThreeWindingsTransformer twt) {
-        Substation s1 = twt.getLeg1().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
-        Substation s2 = twt.getLeg2().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
-        Substation s3 = twt.getLeg3().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
+        Substation s1 = twt.getLeg1().getTerminal().getVoltageLevel().getSubstation().orElse(null);
+        Substation s2 = twt.getLeg2().getTerminal().getVoltageLevel().getSubstation().orElse(null);
+        Substation s3 = twt.getLeg3().getTerminal().getVoltageLevel().getSubstation().orElse(null);
         if ((s1 != substation) || (s2 != substation) || (s3 != substation)) {
             throw createIsolationException(substation);
         }
@@ -80,8 +80,8 @@ final class Substations {
     private static void checkRemovability(Substation substation, HvdcConverterStation station) {
         HvdcLine hvdcLine = substation.getNetwork().getHvdcLine(station);
         if (hvdcLine != null) {
-            Substation s1 = hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
-            Substation s2 = hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
+            Substation s1 = hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getSubstation().orElse(null);
+            Substation s2 = hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getSubstation().orElse(null);
             if ((s1 != substation) || (s2 != substation)) {
                 throw createIsolationException(substation);
             }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
@@ -61,17 +61,17 @@ final class Substations {
     }
 
     private static void checkRemovability(Substation substation, Branch branch) {
-        Substation s1 = branch.getTerminal1().getVoltageLevel().getSubstation();
-        Substation s2 = branch.getTerminal2().getVoltageLevel().getSubstation();
+        Substation s1 = branch.getTerminal1().getVoltageLevel().getOptionalSubstation().orElse(null);
+        Substation s2 = branch.getTerminal2().getVoltageLevel().getOptionalSubstation().orElse(null);
         if ((s1 != substation) || (s2 != substation)) {
             throw createIsolationException(substation);
         }
     }
 
     private static void checkRemovability(Substation substation, ThreeWindingsTransformer twt) {
-        Substation s1 = twt.getLeg1().getTerminal().getVoltageLevel().getSubstation();
-        Substation s2 = twt.getLeg2().getTerminal().getVoltageLevel().getSubstation();
-        Substation s3 = twt.getLeg3().getTerminal().getVoltageLevel().getSubstation();
+        Substation s1 = twt.getLeg1().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
+        Substation s2 = twt.getLeg2().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
+        Substation s3 = twt.getLeg3().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
         if ((s1 != substation) || (s2 != substation) || (s3 != substation)) {
             throw createIsolationException(substation);
         }
@@ -80,8 +80,8 @@ final class Substations {
     private static void checkRemovability(Substation substation, HvdcConverterStation station) {
         HvdcLine hvdcLine = substation.getNetwork().getHvdcLine(station);
         if (hvdcLine != null) {
-            Substation s1 = hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getSubstation();
-            Substation s2 = hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getSubstation();
+            Substation s1 = hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
+            Substation s2 = hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getOptionalSubstation().orElse(null);
             if ((s1 != substation) || (s2 != substation)) {
                 throw createIsolationException(substation);
             }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
@@ -138,7 +138,7 @@ class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder<ThreeW
                 throw new ValidationException(this, "voltage level '" + voltageLevelId
                     + "' not found");
             }
-            if (substation != null && voltageLevel.getOptionalSubstation().map(s -> s != substation).orElse(false)) {
+            if (substation != null && voltageLevel.getSubstation().map(s -> s != substation).orElse(false)) {
                 throw new ValidationException(this,
                     "voltage level shall belong to the substation '"
                         + substation.getId() + "'");
@@ -271,14 +271,14 @@ class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder<ThreeW
         }
 
         if (substation != null) {
-            if (voltageLevel1.getOptionalSubstation().map(s -> s != substation).orElse(true) || voltageLevel2.getOptionalSubstation().map(s -> s != substation).orElse(true) || voltageLevel3.getOptionalSubstation().map(s -> s != substation).orElse(true)) {
+            if (voltageLevel1.getSubstation().map(s -> s != substation).orElse(true) || voltageLevel2.getSubstation().map(s -> s != substation).orElse(true) || voltageLevel3.getSubstation().map(s -> s != substation).orElse(true)) {
                 throw new ValidationException(this,
                         "the 3 windings of the transformer shall belong to the substation '"
-                                + substation.getId() + "' ('" + voltageLevel1.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
-                                + voltageLevel2.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
-                                + voltageLevel3.getOptionalSubstation().map(Substation::getId).orElse("null") + "')");
+                                + substation.getId() + "' ('" + voltageLevel1.getSubstation().map(Substation::getId).orElse("null") + "', '"
+                                + voltageLevel2.getSubstation().map(Substation::getId).orElse("null") + "', '"
+                                + voltageLevel3.getSubstation().map(Substation::getId).orElse("null") + "')");
             }
-        } else if (voltageLevel1.getOptionalSubstation().isPresent() && voltageLevel2.getOptionalSubstation().isPresent() && voltageLevel3.getOptionalSubstation().isPresent()) {
+        } else if (voltageLevel1.getSubstation().isPresent() && voltageLevel2.getSubstation().isPresent() && voltageLevel3.getSubstation().isPresent()) {
             throw new ValidationException(this,
                     "the 3 windings of the transformer shall belong to a substation since there are located in voltage levels with substations ('"
                             + voltageLevel1.getId() + "', '" + voltageLevel2.getId() + "', '" + voltageLevel3.getId() + "')");

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
@@ -270,11 +270,18 @@ class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder<ThreeW
             throw new ValidationException(this, "Leg3 is not set");
         }
 
-        if (substation == null) {
-            Substation substationRef = null;
-            substationRef = checkSubstations(substationRef, voltageLevel1.getSubstation());
-            substationRef = checkSubstations(substationRef, voltageLevel2.getSubstation());
-            checkSubstations(substationRef, voltageLevel3.getSubstation());
+        if (substation != null) {
+            if (voltageLevel1.getSubstation() != substation || voltageLevel2.getSubstation() != substation || voltageLevel3.getSubstation() != substation) {
+                throw new ValidationException(this,
+                        "the 3 windings of the transformer shall belong to the substation '"
+                                + substation.getId() + "' ('" + voltageLevel1.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
+                                + voltageLevel2.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
+                                + voltageLevel3.getOptionalSubstation().map(Substation::getId).orElse("null") + "')");
+            }
+        } else if (voltageLevel1.getSubstation() != null || voltageLevel2.getSubstation() != null || voltageLevel3.getSubstation() != null) {
+            throw new ValidationException(this,
+                    "the 3 windings of the transformer shall belong to a substation since there are located in voltage levels with substations ('"
+                            + voltageLevel1.getId() + "', '" + voltageLevel2.getId() + "', '" + voltageLevel3.getId() + "')");
         }
 
         // check that the 3 windings transformer is attachable on the 3 sides (only
@@ -310,15 +317,5 @@ class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder<ThreeW
         getNetwork().getListeners().notifyCreation(transformer);
 
         return transformer;
-    }
-
-    private Substation checkSubstations(Substation expected, Substation actual) {
-        if (expected != null && actual != null && expected != actual) {
-            throw new ValidationException(this, "voltage levels should belong to the same substation ('" + expected.getId() + "', '" + actual.getId() + "')");
-        }
-        if (expected != null) {
-            return expected;
-        }
-        return actual;
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
@@ -316,6 +316,9 @@ class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder<ThreeW
         if (expected != null && actual != null && expected != actual) {
             throw new ValidationException(this, "voltage levels should belong to the same substation ('" + expected.getId() + "', '" + actual.getId() + "')");
         }
+        if (expected != null) {
+            return expected;
+        }
         return actual;
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
@@ -138,7 +138,7 @@ class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder<ThreeW
                 throw new ValidationException(this, "voltage level '" + voltageLevelId
                     + "' not found");
             }
-            if (substation != null && voltageLevel.getSubstation() != null && voltageLevel.getSubstation() != substation) {
+            if (substation != null && voltageLevel.getOptionalSubstation().map(s -> s != substation).orElse(false)) {
                 throw new ValidationException(this,
                     "voltage level shall belong to the substation '"
                         + substation.getId() + "'");
@@ -271,14 +271,14 @@ class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder<ThreeW
         }
 
         if (substation != null) {
-            if (voltageLevel1.getSubstation() != substation || voltageLevel2.getSubstation() != substation || voltageLevel3.getSubstation() != substation) {
+            if (voltageLevel1.getOptionalSubstation().map(s -> s != substation).orElse(true) || voltageLevel2.getOptionalSubstation().map(s -> s != substation).orElse(true) || voltageLevel3.getOptionalSubstation().map(s -> s != substation).orElse(true)) {
                 throw new ValidationException(this,
                         "the 3 windings of the transformer shall belong to the substation '"
                                 + substation.getId() + "' ('" + voltageLevel1.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
                                 + voltageLevel2.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
                                 + voltageLevel3.getOptionalSubstation().map(Substation::getId).orElse("null") + "')");
             }
-        } else if (voltageLevel1.getSubstation() != null || voltageLevel2.getSubstation() != null || voltageLevel3.getSubstation() != null) {
+        } else if (voltageLevel1.getOptionalSubstation().isPresent() && voltageLevel2.getOptionalSubstation().isPresent() && voltageLevel3.getOptionalSubstation().isPresent()) {
             throw new ValidationException(this,
                     "the 3 windings of the transformer shall belong to a substation since there are located in voltage levels with substations ('"
                             + voltageLevel1.getId() + "', '" + voltageLevel2.getId() + "', '" + voltageLevel3.getId() + "')");

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
@@ -287,8 +287,16 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public SubstationImpl getSubstation() {
-        return leg1.getTerminal().getVoltageLevel().getSubstation();
+    public Substation getSubstation() {
+        return getOptionalSubstation().orElse(null);
+    }
+
+    @Override
+    public Optional<Substation> getOptionalSubstation() {
+        return getLegStream()
+                .map(leg -> leg.getTerminal().getVoltageLevel().getSubstation())
+                .filter(Objects::nonNull)
+                .findFirst();
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
@@ -294,7 +294,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     @Override
     public Optional<Substation> getOptionalSubstation() {
         return getLegStream()
-                .map(leg -> leg.getTerminal().getVoltageLevel().getOptionalSubstation())
+                .map(leg -> leg.getTerminal().getVoltageLevel().getSubstation())
                 .filter(Optional::isPresent)
                 .findFirst()
                 .orElseGet(Optional::empty);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
@@ -294,9 +294,10 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     @Override
     public Optional<Substation> getOptionalSubstation() {
         return getLegStream()
-                .map(leg -> leg.getTerminal().getVoltageLevel().getSubstation())
-                .filter(Objects::nonNull)
-                .findFirst();
+                .map(leg -> leg.getTerminal().getVoltageLevel().getOptionalSubstation())
+                .filter(Optional::isPresent)
+                .findFirst()
+                .orElseGet(Optional::empty);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
@@ -287,11 +287,6 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public Substation getSubstation() {
-        return getOptionalSubstation().orElse(null);
-    }
-
-    @Override
     public Optional<Substation> getOptionalSubstation() {
         return getLegStream()
                 .map(leg -> leg.getTerminal().getVoltageLevel().getSubstation())

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
@@ -287,7 +287,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public Optional<Substation> getOptionalSubstation() {
+    public Optional<Substation> getSubstation() {
         return getLegStream()
                 .map(leg -> leg.getTerminal().getVoltageLevel().getSubstation())
                 .filter(Optional::isPresent)

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
@@ -296,6 +296,15 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
+    public Substation getNullableSubstation() {
+        return getLegStream()
+                .map(leg -> leg.getTerminal().getVoltageLevel().getNullableSubstation())
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
     public LegImpl getLeg1() {
         return leg1;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
@@ -106,13 +106,13 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
         VoltageLevelExt voltageLevel1 = checkAndGetVoltageLevel1();
         VoltageLevelExt voltageLevel2 = checkAndGetVoltageLevel2();
         if (substation != null) {
-            if (voltageLevel1.getSubstation() != substation || voltageLevel2.getSubstation() != substation) {
+            if (voltageLevel1.getOptionalSubstation().map(s -> s != substation).orElse(true) || voltageLevel2.getOptionalSubstation().map(s -> s != substation).orElse(true)) {
                 throw new ValidationException(this,
                         "the 2 windings of the transformer shall belong to the substation '"
                                 + substation.getId() + "' ('" + voltageLevel1.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
                                 + voltageLevel2.getOptionalSubstation().map(Substation::getId).orElse("null") + "')");
             }
-        } else if (voltageLevel1.getSubstation() != null && voltageLevel2.getSubstation() != null) {
+        } else if (voltageLevel1.getOptionalSubstation().isPresent() && voltageLevel2.getOptionalSubstation().isPresent()) {
             throw new ValidationException(this,
                     "the 2 windings of the transformer shall belong to a substation since there are located in voltage levels with substations ('"
                             + voltageLevel1.getId() + "', '" + voltageLevel2.getId() + "')");
@@ -130,7 +130,7 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
 
         TwoWindingsTransformerImpl transformer
                 = new TwoWindingsTransformerImpl(substation != null ? substation.getNetwork().getRef() : networkRef, id, getName(), isFictitious(),
-                voltageLevel1.getSubstation(),
+                (SubstationImpl) voltageLevel1.getOptionalSubstation().orElse(null),
                 r, x, g, b,
                 ratedU1, ratedU2, ratedS);
         terminal1.setNum(1);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
@@ -7,10 +7,7 @@
 package com.powsybl.iidm.network.impl;
 
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.iidm.network.TwoWindingsTransformer;
-import com.powsybl.iidm.network.TwoWindingsTransformerAdder;
-import com.powsybl.iidm.network.ValidationException;
-import com.powsybl.iidm.network.ValidationUtil;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.impl.util.Ref;
 
 import java.util.Optional;
@@ -113,8 +110,8 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
                     || (voltageLevel2.getSubstation() != null && voltageLevel2.getSubstation() != substation)) {
                 throw new ValidationException(this,
                         "the 2 windings of the transformer shall belong to the substation '"
-                                + substation.getId() + "' ('" + voltageLevel1.getSubstation().getId() + "', '"
-                                + voltageLevel2.getSubstation().getId() + "')");
+                                + substation.getId() + "' ('" + voltageLevel1.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
+                                + voltageLevel2.getOptionalSubstation().map(Substation::getId).orElse("null") + "')");
             }
         } else if (voltageLevel1.getSubstation() != null && voltageLevel2.getSubstation() != null
                 && voltageLevel1.getSubstation() != voltageLevel2.getSubstation()) {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
@@ -106,19 +106,16 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
         VoltageLevelExt voltageLevel1 = checkAndGetVoltageLevel1();
         VoltageLevelExt voltageLevel2 = checkAndGetVoltageLevel2();
         if (substation != null) {
-            if ((voltageLevel1.getSubstation() != null && voltageLevel1.getSubstation() != substation)
-                    || (voltageLevel2.getSubstation() != null && voltageLevel2.getSubstation() != substation)) {
+            if (voltageLevel1.getSubstation() != substation || voltageLevel2.getSubstation() != substation) {
                 throw new ValidationException(this,
                         "the 2 windings of the transformer shall belong to the substation '"
                                 + substation.getId() + "' ('" + voltageLevel1.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
                                 + voltageLevel2.getOptionalSubstation().map(Substation::getId).orElse("null") + "')");
             }
-        } else if (voltageLevel1.getSubstation() != null && voltageLevel2.getSubstation() != null
-                && voltageLevel1.getSubstation() != voltageLevel2.getSubstation()) {
+        } else if (voltageLevel1.getSubstation() != null && voltageLevel2.getSubstation() != null) {
             throw new ValidationException(this,
-                    "the 2 windings of the transformer shall belong to the same substation ('"
-                            + voltageLevel1.getSubstation().getId() + "', '"
-                            + voltageLevel2.getSubstation().getId() + "')");
+                    "the 2 windings of the transformer shall belong to a substation since there are located in voltage levels with substations ('"
+                            + voltageLevel1.getId() + "', '" + voltageLevel2.getId() + "')");
         }
         TerminalExt terminal1 = checkAndGetTerminal1();
         TerminalExt terminal2 = checkAndGetTerminal2();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
@@ -106,13 +106,13 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
         VoltageLevelExt voltageLevel1 = checkAndGetVoltageLevel1();
         VoltageLevelExt voltageLevel2 = checkAndGetVoltageLevel2();
         if (substation != null) {
-            if (voltageLevel1.getOptionalSubstation().map(s -> s != substation).orElse(true) || voltageLevel2.getOptionalSubstation().map(s -> s != substation).orElse(true)) {
+            if (voltageLevel1.getSubstation().map(s -> s != substation).orElse(true) || voltageLevel2.getSubstation().map(s -> s != substation).orElse(true)) {
                 throw new ValidationException(this,
                         "the 2 windings of the transformer shall belong to the substation '"
-                                + substation.getId() + "' ('" + voltageLevel1.getOptionalSubstation().map(Substation::getId).orElse("null") + "', '"
-                                + voltageLevel2.getOptionalSubstation().map(Substation::getId).orElse("null") + "')");
+                                + substation.getId() + "' ('" + voltageLevel1.getSubstation().map(Substation::getId).orElse("null") + "', '"
+                                + voltageLevel2.getSubstation().map(Substation::getId).orElse("null") + "')");
             }
-        } else if (voltageLevel1.getOptionalSubstation().isPresent() && voltageLevel2.getOptionalSubstation().isPresent()) {
+        } else if (voltageLevel1.getSubstation().isPresent() && voltageLevel2.getSubstation().isPresent()) {
             throw new ValidationException(this,
                     "the 2 windings of the transformer shall belong to a substation since there are located in voltage levels with substations ('"
                             + voltageLevel1.getId() + "', '" + voltageLevel2.getId() + "')");
@@ -130,7 +130,7 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
 
         TwoWindingsTransformerImpl transformer
                 = new TwoWindingsTransformerImpl(substation != null ? substation.getNetwork().getRef() : networkRef, id, getName(), isFictitious(),
-                (SubstationImpl) voltageLevel1.getOptionalSubstation().orElse(null),
+                (SubstationImpl) voltageLevel1.getSubstation().orElse(null),
                 r, x, g, b,
                 ratedU1, ratedU2, ratedS);
         terminal1.setNum(1);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
@@ -6,17 +6,21 @@
  */
 package com.powsybl.iidm.network.impl;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.iidm.network.TwoWindingsTransformerAdder;
 import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.ValidationUtil;
+import com.powsybl.iidm.network.impl.util.Ref;
+
+import java.util.Optional;
 
 /**
- *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTransformerAdderImpl> implements TwoWindingsTransformerAdder {
 
+    private final Ref<NetworkImpl> networkRef;
     private final SubstationImpl substation;
 
     private double r = Double.NaN;
@@ -34,12 +38,22 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
     private double ratedS = Double.NaN;
 
     TwoWindingsTransformerAdderImpl(SubstationImpl substation) {
+        networkRef = null;
         this.substation = substation;
+    }
+
+    TwoWindingsTransformerAdderImpl(Ref<NetworkImpl> networkRef) {
+        this.networkRef = networkRef;
+        substation = null;
     }
 
     @Override
     protected NetworkImpl getNetwork() {
-        return substation.getNetwork();
+        return Optional.ofNullable(networkRef)
+                .map(Ref::get)
+                .orElseGet(() -> Optional.ofNullable(substation)
+                        .map(SubstationImpl::getNetwork)
+                        .orElseThrow(() -> new PowsyblException("Two windings transformer has no container")));
     }
 
     @Override
@@ -94,11 +108,20 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
         String id = checkAndGetUniqueId();
         VoltageLevelExt voltageLevel1 = checkAndGetVoltageLevel1();
         VoltageLevelExt voltageLevel2 = checkAndGetVoltageLevel2();
-        if (voltageLevel1.getSubstation() != substation || voltageLevel2.getSubstation() != substation) {
+        if (substation != null) {
+            if ((voltageLevel1.getSubstation() != null && voltageLevel1.getSubstation() != substation)
+                    || (voltageLevel2.getSubstation() != null && voltageLevel2.getSubstation() != substation)) {
+                throw new ValidationException(this,
+                        "the 2 windings of the transformer shall belong to the substation '"
+                                + substation.getId() + "' ('" + voltageLevel1.getSubstation().getId() + "', '"
+                                + voltageLevel2.getSubstation().getId() + "')");
+            }
+        } else if (voltageLevel1.getSubstation() != null && voltageLevel2.getSubstation() != null
+                && voltageLevel1.getSubstation() != voltageLevel2.getSubstation()) {
             throw new ValidationException(this,
-                    "the 2 windings of the transformer shall belong to the substation '"
-                    + substation.getId() + "' ('" + voltageLevel1.getSubstation().getId() + "', '"
-                    + voltageLevel2.getSubstation().getId() + "')");
+                    "the 2 windings of the transformer shall belong to the same substation ('"
+                            + voltageLevel1.getSubstation().getId() + "', '"
+                            + voltageLevel2.getSubstation().getId() + "')");
         }
         TerminalExt terminal1 = checkAndGetTerminal1();
         TerminalExt terminal2 = checkAndGetTerminal2();
@@ -112,10 +135,10 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
         ValidationUtil.checkRatedS(this, ratedS);
 
         TwoWindingsTransformerImpl transformer
-                = new TwoWindingsTransformerImpl(getNetwork().getRef(), id, getName(), isFictitious(),
-                                                 voltageLevel1.getSubstation(),
-                                                 r, x, g, b,
-                                                 ratedU1, ratedU2, ratedS);
+                = new TwoWindingsTransformerImpl(substation != null ? substation.getNetwork().getRef() : networkRef, id, getName(), isFictitious(),
+                voltageLevel1.getSubstation(),
+                r, x, g, b,
+                ratedU1, ratedU2, ratedS);
         terminal1.setNum(1);
         terminal2.setNum(2);
         transformer.addTerminal(terminal1);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerImpl.java
@@ -65,6 +65,11 @@ class TwoWindingsTransformerImpl extends AbstractBranch<TwoWindingsTransformer>
     }
 
     @Override
+    public Optional<Substation> getOptionalSubstation() {
+        return Optional.ofNullable(substation);
+    }
+
+    @Override
     public double getR() {
         return r;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerImpl.java
@@ -60,11 +60,6 @@ class TwoWindingsTransformerImpl extends AbstractBranch<TwoWindingsTransformer>
     }
 
     @Override
-    public SubstationImpl getSubstation() {
-        return substation;
-    }
-
-    @Override
     public Optional<Substation> getOptionalSubstation() {
         return Optional.ofNullable(substation);
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerImpl.java
@@ -60,7 +60,7 @@ class TwoWindingsTransformerImpl extends AbstractBranch<TwoWindingsTransformer>
     }
 
     @Override
-    public Optional<Substation> getOptionalSubstation() {
+    public Optional<Substation> getSubstation() {
         return Optional.ofNullable(substation);
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerImpl.java
@@ -65,6 +65,11 @@ class TwoWindingsTransformerImpl extends AbstractBranch<TwoWindingsTransformer>
     }
 
     @Override
+    public Substation getNullableSubstation() {
+        return substation;
+    }
+
+    @Override
     public double getR() {
         return r;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
@@ -36,8 +36,6 @@ interface VoltageLevelExt extends VoltageLevel, MultiVariantObject {
 
     @Override BusViewExt getBusView();
 
-    @Override SubstationImpl getSubstation();
-
     NetworkImpl getNetwork();
 
     /**

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractVoltageLevelAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractVoltageLevelAdapter.java
@@ -18,6 +18,7 @@ import java.io.Writer;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -58,8 +59,8 @@ abstract class AbstractVoltageLevelAdapter extends AbstractIdentifiableAdapter<V
     }
 
     @Override
-    public Substation getSubstation() {
-        return getIndex().getSubstation(getDelegate().getSubstation());
+    public Optional<Substation> getOptionalSubstation() {
+        return getDelegate().getOptionalSubstation().map(s -> getIndex().getSubstation(s));
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractVoltageLevelAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractVoltageLevelAdapter.java
@@ -59,8 +59,8 @@ abstract class AbstractVoltageLevelAdapter extends AbstractIdentifiableAdapter<V
     }
 
     @Override
-    public Optional<Substation> getOptionalSubstation() {
-        return getDelegate().getOptionalSubstation().map(s -> getIndex().getSubstation(s));
+    public Optional<Substation> getSubstation() {
+        return getDelegate().getSubstation().map(s -> getIndex().getSubstation(s));
     }
 
     @Override

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapter.java
@@ -219,8 +219,8 @@ public class ThreeWindingsTransformerAdapter extends AbstractIdentifiableAdapter
     }
 
     @Override
-    public Optional<Substation> getOptionalSubstation() {
-        return getDelegate().getOptionalSubstation().map(s -> getIndex().getSubstation(s));
+    public Optional<Substation> getSubstation() {
+        return getDelegate().getSubstation().map(s -> getIndex().getSubstation(s));
     }
 
     // -------------------------------

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapter.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.*;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -218,8 +219,8 @@ public class ThreeWindingsTransformerAdapter extends AbstractIdentifiableAdapter
     }
 
     @Override
-    public Substation getSubstation() {
-        return getIndex().getSubstation(getDelegate().getSubstation());
+    public Optional<Substation> getOptionalSubstation() {
+        return getDelegate().getOptionalSubstation().map(s -> getIndex().getSubstation(s));
     }
 
     // -------------------------------

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapter.java
@@ -40,8 +40,8 @@ public class TwoWindingsTransformerAdapter extends AbstractBranchAdapter<TwoWind
     }
 
     @Override
-    public Optional<Substation> getOptionalSubstation() {
-        return getDelegate().getOptionalSubstation().map(s -> getIndex().getSubstation(s));
+    public Optional<Substation> getSubstation() {
+        return getDelegate().getSubstation().map(s -> getIndex().getSubstation(s));
     }
 
     // -------------------------------

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapter.java
@@ -8,6 +8,8 @@ package com.powsybl.iidm.mergingview;
 
 import com.powsybl.iidm.network.*;
 
+import java.util.Optional;
+
 /**
  * @author Thomas Adam <tadam at silicom.fr>
  */
@@ -38,8 +40,8 @@ public class TwoWindingsTransformerAdapter extends AbstractBranchAdapter<TwoWind
     }
 
     @Override
-    public Substation getSubstation() {
-        return getIndex().getSubstation(getDelegate().getSubstation());
+    public Optional<Substation> getOptionalSubstation() {
+        return getDelegate().getOptionalSubstation().map(s -> getIndex().getSubstation(s));
     }
 
     // -------------------------------

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapterTest.java
@@ -35,7 +35,7 @@ public class ThreeWindingsTransformerAdapterTest {
         assertTrue(twt instanceof ThreeWindingsTransformerAdapter);
         assertSame(mergingView, twt.getNetwork());
 
-        assertTrue(twt.getOptionalSubstation().isPresent());
+        assertTrue(twt.getSubstation().isPresent());
         assertEquals(ConnectableType.THREE_WINDINGS_TRANSFORMER, twt.getType());
 
         assertEquals(twt.getLeg1().getTerminal(), twt.getTerminal(Side.ONE));

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapterTest.java
@@ -36,6 +36,7 @@ public class ThreeWindingsTransformerAdapterTest {
         assertSame(mergingView, twt.getNetwork());
 
         assertTrue(twt.getSubstation().isPresent());
+        assertNotNull(twt.getNullableSubstation());
         assertEquals(ConnectableType.THREE_WINDINGS_TRANSFORMER, twt.getType());
 
         assertEquals(twt.getLeg1().getTerminal(), twt.getTerminal(Side.ONE));

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/ThreeWindingsTransformerAdapterTest.java
@@ -35,7 +35,7 @@ public class ThreeWindingsTransformerAdapterTest {
         assertTrue(twt instanceof ThreeWindingsTransformerAdapter);
         assertSame(mergingView, twt.getNetwork());
 
-        assertNotNull(twt.getSubstation());
+        assertTrue(twt.getOptionalSubstation().isPresent());
         assertEquals(ConnectableType.THREE_WINDINGS_TRANSFORMER, twt.getType());
 
         assertEquals(twt.getLeg1().getTerminal(), twt.getTerminal(Side.ONE));

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapterTest.java
@@ -54,7 +54,7 @@ public class TwoWindingsTransformerAdapterTest {
         assertSame(mergingView, twt.getNetwork());
 
         assertEquals(ConnectableType.TWO_WINDINGS_TRANSFORMER, twt.getType());
-        assertSame(substation, twt.getSubstation());
+        assertSame(substation, twt.getOptionalSubstation().orElse(null));
         assertEquals(7.0, twt.getRatedS(), 0.0);
 
         final RatioTapChanger ratioTapChanger = twt.newRatioTapChanger()

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapterTest.java
@@ -55,6 +55,7 @@ public class TwoWindingsTransformerAdapterTest {
 
         assertEquals(ConnectableType.TWO_WINDINGS_TRANSFORMER, twt.getType());
         assertSame(substation, twt.getSubstation().orElse(null));
+        assertSame(substation, twt.getNullableSubstation());
         assertEquals(7.0, twt.getRatedS(), 0.0);
 
         final RatioTapChanger ratioTapChanger = twt.newRatioTapChanger()

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/TwoWindingsTransformerAdapterTest.java
@@ -54,7 +54,7 @@ public class TwoWindingsTransformerAdapterTest {
         assertSame(mergingView, twt.getNetwork());
 
         assertEquals(ConnectableType.TWO_WINDINGS_TRANSFORMER, twt.getType());
-        assertSame(substation, twt.getOptionalSubstation().orElse(null));
+        assertSame(substation, twt.getSubstation().orElse(null));
         assertEquals(7.0, twt.getRatedS(), 0.0);
 
         final RatioTapChanger ratioTapChanger = twt.newRatioTapChanger()

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/VoltageLevelAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/VoltageLevelAdapterTest.java
@@ -46,7 +46,7 @@ public class VoltageLevelAdapterTest {
         // Setter / Getter
         assertTrue(vlActual instanceof BusBreakerVoltageLevelAdapter);
         assertSame(mergingView, vlActual.getNetwork());
-        assertSame(mergingView.getSubstation("sub"), vlActual.getSubstation());
+        assertSame(mergingView.getSubstation("sub"), vlActual.getOptionalSubstation().orElse(null));
         assertSame(mergingView.getIdentifiable(vlId), vlActual);
         assertEquals(vlExpected.getContainerType(), vlActual.getContainerType());
 

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/VoltageLevelAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/VoltageLevelAdapterTest.java
@@ -46,7 +46,7 @@ public class VoltageLevelAdapterTest {
         // Setter / Getter
         assertTrue(vlActual instanceof BusBreakerVoltageLevelAdapter);
         assertSame(mergingView, vlActual.getNetwork());
-        assertSame(mergingView.getSubstation("sub"), vlActual.getOptionalSubstation().orElse(null));
+        assertSame(mergingView.getSubstation("sub"), vlActual.getSubstation().orElse(null));
         assertSame(mergingView.getIdentifiable(vlId), vlActual);
         assertEquals(vlExpected.getContainerType(), vlActual.getContainerType());
 

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/IdentifierNetworkPredicate.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/IdentifierNetworkPredicate.java
@@ -53,6 +53,6 @@ public class IdentifierNetworkPredicate implements NetworkPredicate {
     @Override
     public boolean test(VoltageLevel voltageLevel) {
         Objects.requireNonNull(voltageLevel);
-        return ids.contains(voltageLevel.getId()) || voltageLevel.getOptionalSubstation().map(sub -> ids.contains(sub.getId())).orElse(false);
+        return ids.contains(voltageLevel.getId()) || voltageLevel.getSubstation().map(sub -> ids.contains(sub.getId())).orElse(false);
     }
 }

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/IdentifierNetworkPredicate.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/IdentifierNetworkPredicate.java
@@ -53,6 +53,6 @@ public class IdentifierNetworkPredicate implements NetworkPredicate {
     @Override
     public boolean test(VoltageLevel voltageLevel) {
         Objects.requireNonNull(voltageLevel);
-        return ids.contains(voltageLevel.getId()) || ids.contains(voltageLevel.getSubstation().getId());
+        return ids.contains(voltageLevel.getId()) || voltageLevel.getOptionalSubstation().map(sub -> ids.contains(sub.getId())).orElse(false);
     }
 }

--- a/iidm/iidm-scripting/src/main/groovy/com/powsybl/iidm/network/scripting/ThreeWindingsTransformerExtension.groovy
+++ b/iidm/iidm-scripting/src/main/groovy/com/powsybl/iidm/network/scripting/ThreeWindingsTransformerExtension.groovy
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.scripting
+
+import com.powsybl.iidm.network.ThreeWindingsTransformer
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class ThreeWindingsTransformerExtension {
+
+    static Object getSubstation(ThreeWindingsTransformer self) {
+        self.getNullableSubstation()
+    }
+}

--- a/iidm/iidm-scripting/src/main/groovy/com/powsybl/iidm/network/scripting/TwoWindingsTransformerExtension.groovy
+++ b/iidm/iidm-scripting/src/main/groovy/com/powsybl/iidm/network/scripting/TwoWindingsTransformerExtension.groovy
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.scripting
+
+import com.powsybl.iidm.network.TwoWindingsTransformer
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class TwoWindingsTransformerExtension {
+
+    static Object getSubstation(TwoWindingsTransformer self) {
+        self.getNullableSubstation()
+    }
+}

--- a/iidm/iidm-scripting/src/main/groovy/com/powsybl/iidm/network/scripting/VoltageLevelExtension.groovy
+++ b/iidm/iidm-scripting/src/main/groovy/com/powsybl/iidm/network/scripting/VoltageLevelExtension.groovy
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.scripting
+
+import com.powsybl.iidm.network.VoltageLevel
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class VoltageLevelExtension {
+
+    static Object getSubstation(VoltageLevel self) {
+        self.getNullableSubstation()
+    }
+}

--- a/iidm/iidm-scripting/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/iidm/iidm-scripting/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,3 +1,3 @@
 moduleName = powsybl-iidm-scripting-module
 moduleVersion = 1.0
-extensionClasses = com.powsybl.iidm.network.scripting.IdentifiableExtension  com.powsybl.iidm.network.scripting.NetworkExtension com.powsybl.iidm.network.scripting.SubstationExtension com.powsybl.iidm.network.scripting.ShuntCompensatorExtension
+extensionClasses = com.powsybl.iidm.network.scripting.IdentifiableExtension  com.powsybl.iidm.network.scripting.NetworkExtension com.powsybl.iidm.network.scripting.SubstationExtension com.powsybl.iidm.network.scripting.ShuntCompensatorExtension com.powsybl.iidm.network.scripting.VoltageLevelExtension com.powsybl.iidm.network.scripting.TwoWindingsTransformerExtension com.powsybl.iidm.network.scripting.ThreeWindingsTransformerExtension

--- a/iidm/iidm-scripting/src/test/groovy/com/powsybl/iidm/network/scripting/ThreeWindingsTransformerExtensionTest.groovy
+++ b/iidm/iidm-scripting/src/test/groovy/com/powsybl/iidm/network/scripting/ThreeWindingsTransformerExtensionTest.groovy
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.scripting
+
+import com.powsybl.iidm.network.Network
+import com.powsybl.iidm.network.Substation
+import com.powsybl.iidm.network.ThreeWindingsTransformer
+import com.powsybl.iidm.network.TopologyKind
+import com.powsybl.iidm.network.VoltageLevel
+import org.junit.Test
+
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertSame
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class ThreeWindingsTransformerExtensionTest {
+
+    @Test
+    void getSubstationTest() {
+        Network network = Network.create("test", "test")
+        Substation substation = network.newSubstation()
+                .setId("sub")
+                .add()
+        VoltageLevel vlA = substation.newVoltageLevel()
+                .setId("vlA")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(200)
+                .add()
+        vlA.getBusBreakerView().newBus().setId("busA").add()
+        VoltageLevel vlB = substation.newVoltageLevel()
+                .setId("vlB")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(340)
+                .add()
+        vlB.getBusBreakerView().newBus().setId("busB").add()
+        vlB.getBusBreakerView().newBus().setId("busC").add()
+        ThreeWindingsTransformer twt = substation.newThreeWindingsTransformer()
+                .setId("3WT")
+                .setRatedU0(132.0)
+                .newLeg1()
+                .setR(17.424)
+                .setX(1.7424)
+                .setG(0.00573921028466483)
+                .setB(0.000573921028466483)
+                .setRatedU(200.0)
+                .setVoltageLevel("vlA")
+                .setBus("busA")
+                .add()
+                .newLeg2()
+                .setR(1.089)
+                .setX(0.1089)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(320.0)
+                .setVoltageLevel("vlB")
+                .setBus("busB")
+                .add()
+                .newLeg3()
+                .setR(0.121)
+                .setX(0.0121)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(340.0)
+                .setVoltageLevel("vlB")
+                .setBus("busC")
+                .add()
+                .add()
+        assertSame(substation, twt.substation)
+    }
+
+    @Test
+    void getNullSubstationTest() {
+        Network network = Network.create("test", "test")
+        VoltageLevel vlA = network.newVoltageLevel()
+                .setId("vlA")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(200)
+                .add()
+        vlA.getBusBreakerView().newBus().setId("busA").add()
+        VoltageLevel vlB = network.newVoltageLevel()
+                .setId("vlB")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(340)
+                .add()
+        vlB.getBusBreakerView().newBus().setId("busB").add()
+        vlB.getBusBreakerView().newBus().setId("busC").add()
+        ThreeWindingsTransformer twt = network.newThreeWindingsTransformer()
+                .setId("3WT")
+                .setRatedU0(132.0)
+                .newLeg1()
+                .setR(17.424)
+                .setX(1.7424)
+                .setG(0.00573921028466483)
+                .setB(0.000573921028466483)
+                .setRatedU(200.0)
+                .setVoltageLevel("vlA")
+                .setBus("busA")
+                .add()
+                .newLeg2()
+                .setR(1.089)
+                .setX(0.1089)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(320.0)
+                .setVoltageLevel("vlB")
+                .setBus("busB")
+                .add()
+                .newLeg3()
+                .setR(0.121)
+                .setX(0.0121)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(340.0)
+                .setVoltageLevel("vlB")
+                .setBus("busC")
+                .add()
+                .add()
+        assertNull(twt.substation)
+    }
+}

--- a/iidm/iidm-scripting/src/test/groovy/com/powsybl/iidm/network/scripting/TwoWindingsTransformerExtensionTest.groovy
+++ b/iidm/iidm-scripting/src/test/groovy/com/powsybl/iidm/network/scripting/TwoWindingsTransformerExtensionTest.groovy
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.scripting
+
+import com.powsybl.iidm.network.Network
+import com.powsybl.iidm.network.Substation
+import com.powsybl.iidm.network.TopologyKind
+import com.powsybl.iidm.network.TwoWindingsTransformer
+import com.powsybl.iidm.network.VoltageLevel
+import org.junit.Test
+
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertSame
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class TwoWindingsTransformerExtensionTest {
+
+    @Test
+    void getSubstationTest() {
+        Network network = Network.create("test", "test")
+        Substation substation = network.newSubstation()
+                .setId("sub")
+                .add()
+        VoltageLevel vlA = substation.newVoltageLevel()
+                .setId("vlA")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(200)
+                .add()
+        vlA.getBusBreakerView().newBus().setId("busA").add()
+        VoltageLevel vlB = substation.newVoltageLevel()
+                .setId("vlB")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(340)
+                .add()
+        vlB.getBusBreakerView().newBus().setId("busB").add()
+        TwoWindingsTransformer twt = substation.newTwoWindingsTransformer()
+                .setId("NHV2_NLOAD")
+                .setVoltageLevel1("vlA")
+                .setBus1("busA")
+                .setRatedU1(200)
+                .setVoltageLevel2("vlB")
+                .setConnectableBus2("busB")
+                .setRatedU2(340)
+                .setR(0.21 / 1000)
+                .setX(Math.sqrt(18 * 18 - 0.21 * 0.21) / 1000)
+                .setG(0.0)
+                .setB(0.0)
+                .add()
+        assertSame(substation, twt.substation)
+    }
+
+    @Test
+    void getNullSubstationTest() {
+        Network network = Network.create("test", "test")
+        VoltageLevel vlA = network.newVoltageLevel()
+                .setId("vlA")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(200)
+                .add()
+        vlA.getBusBreakerView().newBus().setId("busA").add()
+        VoltageLevel vlB = network.newVoltageLevel()
+                .setId("vlB")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(340)
+                .add()
+        vlB.getBusBreakerView().newBus().setId("busB").add()
+        TwoWindingsTransformer twt = network.newTwoWindingsTransformer()
+                .setId("NHV2_NLOAD")
+                .setVoltageLevel1("vlA")
+                .setBus1("busA")
+                .setRatedU1(200)
+                .setVoltageLevel2("vlB")
+                .setConnectableBus2("busB")
+                .setRatedU2(340)
+                .setR(0.21 / 1000)
+                .setX(Math.sqrt(18 * 18 - 0.21 * 0.21) / 1000)
+                .setG(0.0)
+                .setB(0.0)
+                .add()
+        assertNull(twt.substation)
+    }
+}

--- a/iidm/iidm-scripting/src/test/groovy/com/powsybl/iidm/network/scripting/VoltageLevelExtensionTest.groovy
+++ b/iidm/iidm-scripting/src/test/groovy/com/powsybl/iidm/network/scripting/VoltageLevelExtensionTest.groovy
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.scripting
+
+import com.powsybl.iidm.network.Country
+import com.powsybl.iidm.network.Network
+import com.powsybl.iidm.network.Substation
+import com.powsybl.iidm.network.TopologyKind
+import com.powsybl.iidm.network.VoltageLevel
+import org.junit.Test
+
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertSame
+
+/**
+ * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ */
+class VoltageLevelExtensionTest {
+
+    @Test
+    void getSubstationTest() {
+        Network network = Network.create("test", "test")
+        Substation substation = network.newSubstation()
+                .setCountry(Country.AF)
+                .setTso("tso")
+                .setName("sub")
+                .setId("subId")
+                .add()
+        VoltageLevel voltageLevel = substation.newVoltageLevel()
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setId("bbVL")
+                .setName("bbVL_name")
+                .setNominalV(200.0f)
+                .add()
+        assertSame(substation, voltageLevel.substation)
+    }
+
+    @Test
+    void getNullSubstationTest() {
+        Network network = Network.create("test", "test")
+        VoltageLevel voltageLevel = network.newVoltageLevel()
+                .setId("VL")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(340.0).add()
+        assertNull(voltageLevel.substation)
+    }
+}

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractNetworkTest {
         assertNotNull(voltageLevel1);
         assertEquals(VOLTAGE_LEVEL1, voltageLevel1.getId());
         assertEquals(400.0, voltageLevel1.getNominalV(), 0.0);
-        assertSame(substation1, voltageLevel1.getOptionalSubstation().orElse(null));
+        assertSame(substation1, voltageLevel1.getSubstation().orElse(null));
         assertSame(TopologyKind.NODE_BREAKER, voltageLevel1.getTopologyKind());
 
         NodeBreakerView topology1 = voltageLevel1.getNodeBreakerView();
@@ -239,7 +239,7 @@ public abstract class AbstractNetworkTest {
         assertNotNull(voltageLevel1);
         assertEquals(VLGEN, voltageLevel1.getId());
         assertEquals(400.0, voltageLevel1.getNominalV(), 0.0);
-        assertSame(substation1, voltageLevel1.getOptionalSubstation().orElse(null));
+        assertSame(substation1, voltageLevel1.getSubstation().orElse(null));
         assertSame(TopologyKind.BUS_BREAKER, voltageLevel1.getTopologyKind());
 
         Bus bus1 = voltageLevel1.getBusBreakerView().getBus("NGEN");
@@ -270,7 +270,7 @@ public abstract class AbstractNetworkTest {
         assertNotNull(voltageLevel2);
         assertEquals(VLBAT, voltageLevel2.getId());
         assertEquals(400.0, voltageLevel2.getNominalV(), 0.0);
-        assertSame(substation2, voltageLevel2.getOptionalSubstation().orElse(null));
+        assertSame(substation2, voltageLevel2.getSubstation().orElse(null));
         assertSame(TopologyKind.BUS_BREAKER, voltageLevel2.getTopologyKind());
 
         Bus bus2 = voltageLevel2.getBusBreakerView().getBus("NBAT");

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractNetworkTest {
         assertNotNull(voltageLevel1);
         assertEquals(VOLTAGE_LEVEL1, voltageLevel1.getId());
         assertEquals(400.0, voltageLevel1.getNominalV(), 0.0);
-        assertSame(substation1, voltageLevel1.getSubstation());
+        assertSame(substation1, voltageLevel1.getOptionalSubstation().orElse(null));
         assertSame(TopologyKind.NODE_BREAKER, voltageLevel1.getTopologyKind());
 
         NodeBreakerView topology1 = voltageLevel1.getNodeBreakerView();
@@ -239,7 +239,7 @@ public abstract class AbstractNetworkTest {
         assertNotNull(voltageLevel1);
         assertEquals(VLGEN, voltageLevel1.getId());
         assertEquals(400.0, voltageLevel1.getNominalV(), 0.0);
-        assertSame(substation1, voltageLevel1.getSubstation());
+        assertSame(substation1, voltageLevel1.getOptionalSubstation().orElse(null));
         assertSame(TopologyKind.BUS_BREAKER, voltageLevel1.getTopologyKind());
 
         Bus bus1 = voltageLevel1.getBusBreakerView().getBus("NGEN");
@@ -270,7 +270,7 @@ public abstract class AbstractNetworkTest {
         assertNotNull(voltageLevel2);
         assertEquals(VLBAT, voltageLevel2.getId());
         assertEquals(400.0, voltageLevel2.getNominalV(), 0.0);
-        assertSame(substation2, voltageLevel2.getSubstation());
+        assertSame(substation2, voltageLevel2.getOptionalSubstation().orElse(null));
         assertSame(TopologyKind.BUS_BREAKER, voltageLevel2.getTopologyKind());
 
         Bus bus2 = voltageLevel2.getBusBreakerView().getBus("NBAT");

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
@@ -187,6 +187,94 @@ public abstract class AbstractThreeWindingsTransformerTest extends AbstractTrans
     }
 
     @Test
+    public void invalidSubstationContainer() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("3 windings transformer 'twt': the 3 windings of the transformer shall belong to the substation 'sub'");
+        network.newVoltageLevel()
+                .setId("no_substation")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(200.0)
+                .setLowVoltageLimit(180.0)
+                .setHighVoltageLimit(220.0)
+                .add()
+                .getBusBreakerView().newBus().setId("no_substation_bus").add();
+        substation.newThreeWindingsTransformer()
+                .setId("twt")
+                .setName(TWT_NAME)
+                .newLeg1()
+                .setR(1.3)
+                .setX(1.4)
+                .setG(1.6)
+                .setB(1.7)
+                .setRatedU(1.1)
+                .setRatedS(1.2)
+                .setVoltageLevel("no_substation")
+                .setBus("no_substation_bus")
+                .add()
+                .newLeg2()
+                .setR(2.03)
+                .setX(2.04)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(2.05)
+                .setRatedS(2.06)
+                .setVoltageLevel("vl2")
+                .setBus("busB")
+                .add()
+                .newLeg3()
+                .setR(3.3)
+                .setX(3.4)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(3.5)
+                .setRatedS(3.6)
+                .setVoltageLevel("vl2")
+                .setBus("busB")
+                .add()
+                .add();
+    }
+
+    @Test
+    public void missingSubstationContainer() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("3 windings transformer 'twt': the 3 windings of the transformer shall belong to a substation since there are located in voltage levels with substations");
+        network.newThreeWindingsTransformer()
+                .setId("twt")
+                .setName(TWT_NAME)
+                .newLeg1()
+                .setR(1.3)
+                .setX(1.4)
+                .setG(1.6)
+                .setB(1.7)
+                .setRatedU(1.1)
+                .setRatedS(1.2)
+                .setVoltageLevel("vl1")
+                .setBus("busA")
+                .add()
+                .newLeg2()
+                .setR(2.03)
+                .setX(2.04)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(2.05)
+                .setRatedS(2.06)
+                .setVoltageLevel("vl2")
+                .setBus("busB")
+                .add()
+                .newLeg3()
+                .setR(3.3)
+                .setX(3.4)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(3.5)
+                .setRatedS(3.6)
+                .setVoltageLevel("vl2")
+                .setBus("busB")
+                .add()
+                .add();
+    }
+
+    @Test
     public void leg1SetTwoRegulatingControlsEnabled() {
         ThreeWindingsTransformer transformer = createThreeWindingsTransformer();
         ThreeWindingsTransformer.Leg leg1 = transformer.getLeg1();

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractThreeWindingsTransformerTest extends AbstractTrans
         assertEquals("twt", transformer.getId());
         assertEquals(TWT_NAME, transformer.getOptionalName().orElse(null));
         assertEquals(TWT_NAME, transformer.getNameOrId());
-        assertEquals(substation, transformer.getSubstation());
+        assertEquals(substation, transformer.getOptionalSubstation().orElse(null));
         assertEquals(ConnectableType.THREE_WINDINGS_TRANSFORMER, transformer.getType());
 
         assertEquals(substation.getThreeWindingsTransformerStream().count(), substation.getThreeWindingsTransformerCount());

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractThreeWindingsTransformerTest extends AbstractTrans
         assertEquals("twt", transformer.getId());
         assertEquals(TWT_NAME, transformer.getOptionalName().orElse(null));
         assertEquals(TWT_NAME, transformer.getNameOrId());
-        assertEquals(substation, transformer.getOptionalSubstation().orElse(null));
+        assertEquals(substation, transformer.getSubstation().orElse(null));
         assertEquals(ConnectableType.THREE_WINDINGS_TRANSFORMER, transformer.getType());
 
         assertEquals(substation.getThreeWindingsTransformerStream().count(), substation.getThreeWindingsTransformerCount());

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
@@ -86,6 +86,35 @@ public abstract class AbstractTwoWindingsTransformerTest extends AbstractTransfo
     }
 
     @Test
+    public void invalidContainer() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("2 windings transformer 'twt': the 2 windings of the transformer shall belong to the substation 'sub'");
+        network.newVoltageLevel()
+                .setId("no_substation")
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setNominalV(200.0)
+                .setLowVoltageLimit(180.0)
+                .setHighVoltageLimit(220.0)
+                .add()
+                .getBusBreakerView().newBus().setId("no_substation_bus").add();
+        substation.newTwoWindingsTransformer()
+                .setId("twt")
+                .setName(TWT_NAME)
+                .setR(1.0)
+                .setX(2.0)
+                .setG(3.0)
+                .setB(4.0)
+                .setRatedU1(5.0)
+                .setRatedU2(6.0)
+                .setRatedS(7.0)
+                .setVoltageLevel1("no_substation")
+                .setVoltageLevel2("vl2")
+                .setConnectableBus1("no_substation_bus")
+                .setConnectableBus2("busB")
+                .add();
+    }
+
+    @Test
     public void testInvalidR() {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("r is invalid");

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
@@ -86,7 +86,7 @@ public abstract class AbstractTwoWindingsTransformerTest extends AbstractTransfo
     }
 
     @Test
-    public void invalidContainer() {
+    public void invalidSubstationContainer() {
         thrown.expect(ValidationException.class);
         thrown.expectMessage("2 windings transformer 'twt': the 2 windings of the transformer shall belong to the substation 'sub'");
         network.newVoltageLevel()
@@ -110,6 +110,27 @@ public abstract class AbstractTwoWindingsTransformerTest extends AbstractTransfo
                 .setVoltageLevel1("no_substation")
                 .setVoltageLevel2("vl2")
                 .setConnectableBus1("no_substation_bus")
+                .setConnectableBus2("busB")
+                .add();
+    }
+
+    @Test
+    public void missingSubstationContainer() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("the 2 windings of the transformer shall belong to a substation since there are located in voltage levels with substations");
+        network.newTwoWindingsTransformer()
+                .setId("twt")
+                .setName(TWT_NAME)
+                .setR(1.0)
+                .setX(2.0)
+                .setG(3.0)
+                .setB(4.0)
+                .setRatedU1(5.0)
+                .setRatedU2(6.0)
+                .setRatedS(7.0)
+                .setVoltageLevel1("vl1")
+                .setVoltageLevel2("vl2")
+                .setConnectableBus1("busA")
                 .setConnectableBus2("busB")
                 .add();
     }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractTwoWindingsTransformerTest extends AbstractTransfo
         assertEquals(6.0, twoWindingsTransformer.getRatedU2(), 0.0);
         assertEquals(7.0, twoWindingsTransformer.getRatedS(), 0.0);
         assertEquals(ConnectableType.TWO_WINDINGS_TRANSFORMER, twoWindingsTransformer.getType());
-        assertSame(substation, twoWindingsTransformer.getSubstation());
+        assertSame(substation, twoWindingsTransformer.getOptionalSubstation().orElse(null));
 
         // setter getter
         double r = 0.5;

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractTwoWindingsTransformerTest extends AbstractTransfo
         assertEquals(6.0, twoWindingsTransformer.getRatedU2(), 0.0);
         assertEquals(7.0, twoWindingsTransformer.getRatedS(), 0.0);
         assertEquals(ConnectableType.TWO_WINDINGS_TRANSFORMER, twoWindingsTransformer.getType());
-        assertSame(substation, twoWindingsTransformer.getOptionalSubstation().orElse(null));
+        assertSame(substation, twoWindingsTransformer.getSubstation().orElse(null));
 
         // setter getter
         double r = 0.5;

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVoltageLevelTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVoltageLevelTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractVoltageLevelTest {
         assertEquals(100.0, voltageLevel.getLowVoltageLimit(), 0.0);
         assertEquals(200.0, voltageLevel.getHighVoltageLimit(), 0.0);
         assertEquals(ContainerType.VOLTAGE_LEVEL, voltageLevel.getContainerType());
-        assertSame(substation, voltageLevel.getOptionalSubstation().orElse(null));
+        assertSame(substation, voltageLevel.getSubstation().orElse(null));
 
         // setter getter
         voltageLevel.setHighVoltageLimit(300.0);
@@ -81,7 +81,7 @@ public abstract class AbstractVoltageLevelTest {
         assertEquals(100.0, voltageLevel.getLowVoltageLimit(), 0.0);
         assertEquals(200.0, voltageLevel.getHighVoltageLimit(), 0.0);
         assertEquals(ContainerType.VOLTAGE_LEVEL, voltageLevel.getContainerType());
-        assertTrue(voltageLevel.getOptionalSubstation().isEmpty());
+        assertTrue(voltageLevel.getSubstation().isEmpty());
 
         assertTrue(Iterables.isEmpty(voltageLevel.getConnectables()));
         voltageLevel.getBusBreakerView().newBus().setId("bbVL_1").add();

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVoltageLevelTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVoltageLevelTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.network.tck;
 
+import com.google.common.collect.Iterables;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import org.junit.Before;
@@ -13,8 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 
 public abstract class AbstractVoltageLevelTest {
 
@@ -25,11 +25,12 @@ public abstract class AbstractVoltageLevelTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    private Network network;
     private Substation substation;
 
     @Before
     public void setUp() {
-        Network network = Network.create("test", "test");
+        network = Network.create("test", "test");
         substation = network.newSubstation()
                                 .setCountry(Country.AF)
                                 .setTso("tso")
@@ -62,6 +63,36 @@ public abstract class AbstractVoltageLevelTest {
         assertEquals(200.0, voltageLevel.getLowVoltageLimit(), 0.0);
         voltageLevel.setNominalV(500.0);
         assertEquals(500.0, voltageLevel.getNominalV(), 0.0);
+    }
+
+    @Test
+    public void testWithoutSubstation() {
+        network.newVoltageLevel()
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setId("bbVL")
+                .setName("bbVL_name")
+                .setNominalV(200.0)
+                .setLowVoltageLimit(100.0)
+                .setHighVoltageLimit(200.0)
+                .add();
+        VoltageLevel voltageLevel = network.getVoltageLevel("bbVL");
+        assertNotNull(voltageLevel);
+        assertEquals(200.0, voltageLevel.getNominalV(), 0.0);
+        assertEquals(100.0, voltageLevel.getLowVoltageLimit(), 0.0);
+        assertEquals(200.0, voltageLevel.getHighVoltageLimit(), 0.0);
+        assertEquals(ContainerType.VOLTAGE_LEVEL, voltageLevel.getContainerType());
+        assertTrue(voltageLevel.getOptionalSubstation().isEmpty());
+
+        assertTrue(Iterables.isEmpty(voltageLevel.getConnectables()));
+        voltageLevel.getBusBreakerView().newBus().setId("bbVL_1").add();
+        Load load = voltageLevel.newLoad()
+                .setId("LOAD")
+                .setBus("bbVL_1")
+                .setP0(600.0)
+                .setQ0(200.0)
+                .add();
+        assertEquals(1, Iterables.size(voltageLevel.getConnectables()));
+        assertTrue(Iterables.contains(voltageLevel.getConnectables(), load));
     }
 
     @Test

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVoltageLevelTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractVoltageLevelTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractVoltageLevelTest {
         assertEquals(100.0, voltageLevel.getLowVoltageLimit(), 0.0);
         assertEquals(200.0, voltageLevel.getHighVoltageLimit(), 0.0);
         assertEquals(ContainerType.VOLTAGE_LEVEL, voltageLevel.getContainerType());
-        assertSame(substation, voltageLevel.getSubstation());
+        assertSame(substation, voltageLevel.getOptionalSubstation().orElse(null));
 
         // setter getter
         voltageLevel.setHighVoltageLimit(300.0);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
@@ -19,7 +19,7 @@ import java.util.function.DoubleConsumer;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-abstract class AbstractTransformerXml<T extends Connectable, A extends IdentifiableAdder<A>> extends AbstractConnectableXml<T, A, Substation> {
+abstract class AbstractTransformerXml<T extends Connectable, A extends IdentifiableAdder<A>> extends AbstractConnectableXml<T, A, Container<? extends Identifiable<?>>> {
 
     private interface StepConsumer {
         void accept(double r, double x, double g, double b, double rho);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -264,6 +264,15 @@ public final class NetworkXml {
         AliasesXml.write(n, NETWORK_ROOT_ELEMENT_NAME, context);
         PropertiesXml.write(n, context);
 
+        writeVoltageLevels(n, context);
+        writeSubstations(n, context);
+        writeTransformers(filter, n, context);
+        writeLines(filter, n, context);
+        writeHvdcLines(filter, n, context);
+        return context;
+    }
+
+    private static void writeVoltageLevels(Network n, NetworkXmlWriterContext context) throws XMLStreamException {
         for (VoltageLevel voltageLevel : IidmXmlUtil.sorted(n.getVoltageLevels(), context.getOptions())) {
             if (voltageLevel.getOptionalSubstation().isEmpty()) {
                 IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, VoltageLevelXml.ROOT_ELEMENT_NAME,
@@ -271,23 +280,32 @@ public final class NetworkXml {
                 VoltageLevelXml.INSTANCE.write(voltageLevel, n, context);
             }
         }
+    }
+
+    private static void writeSubstations(Network n, NetworkXmlWriterContext context) throws XMLStreamException {
         for (Substation s : IidmXmlUtil.sorted(n.getSubstations(), context.getOptions())) {
             SubstationXml.INSTANCE.write(s, n, context);
         }
+    }
+
+    private static void writeTransformers(BusFilter filter, Network n, NetworkXmlWriterContext context) throws XMLStreamException {
         for (TwoWindingsTransformer twt : IidmXmlUtil.sorted(n.getTwoWindingsTransformers(), context.getOptions())) {
-            if (twt.getOptionalSubstation().isEmpty()) {
+            if (twt.getOptionalSubstation().isEmpty() && filter.test(twt)) {
                 IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, TwoWindingsTransformerXml.ROOT_ELEMENT_NAME,
                         IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
                 TwoWindingsTransformerXml.INSTANCE.write(twt, n, context);
             }
         }
         for (ThreeWindingsTransformer twt : IidmXmlUtil.sorted(n.getThreeWindingsTransformers(), context.getOptions())) {
-            if (twt.getOptionalSubstation().isEmpty()) {
+            if (twt.getOptionalSubstation().isEmpty() && filter.test(twt)) {
                 IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, ThreeWindingsTransformerXml.ROOT_ELEMENT_NAME,
                         IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
                 ThreeWindingsTransformerXml.INSTANCE.write(twt, n, context);
             }
         }
+    }
+
+    private static void writeLines(BusFilter filter, Network n, NetworkXmlWriterContext context) throws XMLStreamException {
         for (Line l : IidmXmlUtil.sorted(n.getLines(), context.getOptions())) {
             if (!filter.test(l)) {
                 continue;
@@ -298,13 +316,15 @@ public final class NetworkXml {
                 LineXml.INSTANCE.write(l, n, context);
             }
         }
+    }
+
+    private static void writeHvdcLines(BusFilter filter, Network n, NetworkXmlWriterContext context) throws XMLStreamException {
         for (HvdcLine l : IidmXmlUtil.sorted(n.getHvdcLines(), context.getOptions())) {
             if (!filter.test(l.getConverterStation1()) || !filter.test(l.getConverterStation2())) {
                 continue;
             }
             HvdcLineXml.INSTANCE.write(l, n, context);
         }
-        return context;
     }
 
     public static Anonymizer write(Network n, ExportOptions options, OutputStream os) {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -274,7 +274,7 @@ public final class NetworkXml {
 
     private static void writeVoltageLevels(Network n, NetworkXmlWriterContext context) throws XMLStreamException {
         for (VoltageLevel voltageLevel : IidmXmlUtil.sorted(n.getVoltageLevels(), context.getOptions())) {
-            if (voltageLevel.getOptionalSubstation().isEmpty()) {
+            if (voltageLevel.getSubstation().isEmpty()) {
                 IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, VoltageLevelXml.ROOT_ELEMENT_NAME,
                         IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
                 VoltageLevelXml.INSTANCE.write(voltageLevel, n, context);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -290,7 +290,7 @@ public final class NetworkXml {
 
     private static void writeTransformers(BusFilter filter, Network n, NetworkXmlWriterContext context) throws XMLStreamException {
         for (TwoWindingsTransformer twt : IidmXmlUtil.sorted(n.getTwoWindingsTransformers(), context.getOptions())) {
-            if (twt.getOptionalSubstation().isEmpty() && filter.test(twt)) {
+            if (twt.getSubstation().isEmpty() && filter.test(twt)) {
                 IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, TwoWindingsTransformerXml.ROOT_ELEMENT_NAME,
                         IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
                 TwoWindingsTransformerXml.INSTANCE.write(twt, n, context);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -268,11 +268,25 @@ public final class NetworkXml {
             if (voltageLevel.getOptionalSubstation().isEmpty()) {
                 IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, VoltageLevelXml.ROOT_ELEMENT_NAME,
                         IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
-                VoltageLevelXml.INSTANCE.write(voltageLevel, null, context);
+                VoltageLevelXml.INSTANCE.write(voltageLevel, n, context);
             }
         }
         for (Substation s : IidmXmlUtil.sorted(n.getSubstations(), context.getOptions())) {
-            SubstationXml.INSTANCE.write(s, null, context);
+            SubstationXml.INSTANCE.write(s, n, context);
+        }
+        for (TwoWindingsTransformer twt : IidmXmlUtil.sorted(n.getTwoWindingsTransformers(), context.getOptions())) {
+            if (twt.getOptionalSubstation().isEmpty()) {
+                IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, TwoWindingsTransformerXml.ROOT_ELEMENT_NAME,
+                        IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
+                TwoWindingsTransformerXml.INSTANCE.write(twt, n, context);
+            }
+        }
+        for (ThreeWindingsTransformer twt : IidmXmlUtil.sorted(n.getThreeWindingsTransformers(), context.getOptions())) {
+            if (twt.getOptionalSubstation().isEmpty()) {
+                IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, ThreeWindingsTransformerXml.ROOT_ELEMENT_NAME,
+                        IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
+                ThreeWindingsTransformerXml.INSTANCE.write(twt, n, context);
+            }
         }
         for (Line l : IidmXmlUtil.sorted(n.getLines(), context.getOptions())) {
             if (!filter.test(l)) {
@@ -400,6 +414,18 @@ public final class NetworkXml {
 
                     case SubstationXml.ROOT_ELEMENT_NAME:
                         SubstationXml.INSTANCE.read(network, context);
+                        break;
+
+                    case TwoWindingsTransformerXml.ROOT_ELEMENT_NAME:
+                        IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, TwoWindingsTransformerXml.ROOT_ELEMENT_NAME,
+                                IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
+                        TwoWindingsTransformerXml.INSTANCE.read(network, context);
+                        break;
+
+                    case ThreeWindingsTransformerXml.ROOT_ELEMENT_NAME:
+                        IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, ThreeWindingsTransformerXml.ROOT_ELEMENT_NAME,
+                                IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
+                        ThreeWindingsTransformerXml.INSTANCE.read(network, context);
                         break;
 
                     case LineXml.ROOT_ELEMENT_NAME:

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -264,6 +264,13 @@ public final class NetworkXml {
         AliasesXml.write(n, NETWORK_ROOT_ELEMENT_NAME, context);
         PropertiesXml.write(n, context);
 
+        for (VoltageLevel voltageLevel : IidmXmlUtil.sorted(n.getVoltageLevels(), context.getOptions())) {
+            if (voltageLevel.getOptionalSubstation().isEmpty()) {
+                IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, VoltageLevelXml.ROOT_ELEMENT_NAME,
+                        IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
+                VoltageLevelXml.INSTANCE.write(voltageLevel, null, context);
+            }
+        }
         for (Substation s : IidmXmlUtil.sorted(n.getSubstations(), context.getOptions())) {
             SubstationXml.INSTANCE.write(s, null, context);
         }
@@ -383,6 +390,12 @@ public final class NetworkXml {
 
                     case PropertiesXml.PROPERTY:
                         PropertiesXml.read(network, context);
+                        break;
+
+                    case VoltageLevelXml.ROOT_ELEMENT_NAME:
+                        IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, VoltageLevelXml.ROOT_ELEMENT_NAME,
+                                IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
+                        VoltageLevelXml.INSTANCE.read(network, context);
                         break;
 
                     case SubstationXml.ROOT_ELEMENT_NAME:

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXml.java
@@ -297,7 +297,7 @@ public final class NetworkXml {
             }
         }
         for (ThreeWindingsTransformer twt : IidmXmlUtil.sorted(n.getThreeWindingsTransformers(), context.getOptions())) {
-            if (twt.getOptionalSubstation().isEmpty() && filter.test(twt)) {
+            if (twt.getSubstation().isEmpty() && filter.test(twt)) {
                 IidmXmlUtil.assertMinimumVersion(NETWORK_ROOT_ELEMENT_NAME, ThreeWindingsTransformerXml.ROOT_ELEMENT_NAME,
                         IidmXmlUtil.ErrorMessage.NOT_SUPPORTED, IidmXmlVersion.V_1_6, context);
                 ThreeWindingsTransformerXml.INSTANCE.write(twt, n, context);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
@@ -53,7 +53,7 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
     }
 
     @Override
-    protected void writeRootElementAttributes(ThreeWindingsTransformer twt, Substation s, NetworkXmlWriterContext context) throws XMLStreamException {
+    protected void writeRootElementAttributes(ThreeWindingsTransformer twt, Container<? extends Identifiable<?>> c, NetworkXmlWriterContext context) throws XMLStreamException {
         XmlUtil.writeDouble("r1", twt.getLeg1().getR(), context.getWriter());
         XmlUtil.writeDouble("x1", twt.getLeg1().getX(), context.getWriter());
         XmlUtil.writeDouble("g1", twt.getLeg1().getG(), context.getWriter());
@@ -89,7 +89,7 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
     }
 
     @Override
-    protected void writeSubElements(ThreeWindingsTransformer twt, Substation s, NetworkXmlWriterContext context) throws XMLStreamException {
+    protected void writeSubElements(ThreeWindingsTransformer twt, Container<? extends Identifiable<?>> c, NetworkXmlWriterContext context) throws XMLStreamException {
         IidmXmlUtil.assertMinimumVersionAndRunIfNotDefault(twt.getLeg1().hasRatioTapChanger(), ROOT_ELEMENT_NAME, RATIO_TAP_CHANGER_1,
                 IidmXmlUtil.ErrorMessage.NOT_NULL_NOT_SUPPORTED, IidmXmlVersion.V_1_1, context, () -> writeRatioTapChanger(twt.getLeg1().getRatioTapChanger(), 1, context));
         IidmXmlUtil.assertMinimumVersionAndRunIfNotDefault(twt.getLeg1().hasPhaseTapChanger(), ROOT_ELEMENT_NAME, PHASE_TAP_CHANGER_1,
@@ -131,8 +131,14 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
     }
 
     @Override
-    protected ThreeWindingsTransformerAdder createAdder(Substation s) {
-        return s.newThreeWindingsTransformer();
+    protected ThreeWindingsTransformerAdder createAdder(Container<? extends Identifiable<?>> c) {
+        if (c instanceof Network) {
+            return ((Network) c).newThreeWindingsTransformer();
+        }
+        if (c instanceof Substation) {
+            return ((Substation) c).newThreeWindingsTransformer();
+        }
+        throw new AssertionError();
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TwoWindingsTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/TwoWindingsTransformerXml.java
@@ -38,7 +38,7 @@ class TwoWindingsTransformerXml extends AbstractTransformerXml<TwoWindingsTransf
     }
 
     @Override
-    protected void writeRootElementAttributes(TwoWindingsTransformer twt, Substation s, NetworkXmlWriterContext context) throws XMLStreamException {
+    protected void writeRootElementAttributes(TwoWindingsTransformer twt, Container<? extends Identifiable<?>> c, NetworkXmlWriterContext context) throws XMLStreamException {
         XmlUtil.writeDouble("r", twt.getR(), context.getWriter());
         XmlUtil.writeDouble("x", twt.getX(), context.getWriter());
         XmlUtil.writeDouble("g", twt.getG(), context.getWriter());
@@ -55,7 +55,7 @@ class TwoWindingsTransformerXml extends AbstractTransformerXml<TwoWindingsTransf
     }
 
     @Override
-    protected void writeSubElements(TwoWindingsTransformer twt, Substation s, NetworkXmlWriterContext context) throws XMLStreamException {
+    protected void writeSubElements(TwoWindingsTransformer twt, Container<? extends Identifiable<?>> c, NetworkXmlWriterContext context) throws XMLStreamException {
         RatioTapChanger rtc = twt.getRatioTapChanger();
         if (rtc != null) {
             writeRatioTapChanger("ratioTapChanger", rtc, context);
@@ -89,8 +89,14 @@ class TwoWindingsTransformerXml extends AbstractTransformerXml<TwoWindingsTransf
     }
 
     @Override
-    protected TwoWindingsTransformerAdder createAdder(Substation s) {
-        return s.newTwoWindingsTransformer();
+    protected TwoWindingsTransformerAdder createAdder(Container<? extends Identifiable<?>> c) {
+        if (c instanceof Network) {
+            return ((Network) c).newTwoWindingsTransformer();
+        }
+        if (c instanceof Substation) {
+            return ((Substation) c).newTwoWindingsTransformer();
+        }
+        throw new AssertionError();
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -22,7 +22,7 @@ import java.util.Set;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevelAdder, Substation> {
+class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevelAdder, Container<? extends Identifiable<?>>> {
 
     static final VoltageLevelXml INSTANCE = new VoltageLevelXml();
 
@@ -45,7 +45,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     }
 
     @Override
-    protected void writeRootElementAttributes(VoltageLevel vl, Substation s, NetworkXmlWriterContext context) throws XMLStreamException {
+    protected void writeRootElementAttributes(VoltageLevel vl, Container<? extends Identifiable<?>> c, NetworkXmlWriterContext context) throws XMLStreamException {
         XmlUtil.writeDouble("nominalV", vl.getNominalV(), context.getWriter());
         XmlUtil.writeDouble("lowVoltageLimit", vl.getLowVoltageLimit(), context.getWriter());
         XmlUtil.writeDouble("highVoltageLimit", vl.getHighVoltageLimit(), context.getWriter());
@@ -55,7 +55,7 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     }
 
     @Override
-    protected void writeSubElements(VoltageLevel vl, Substation s, NetworkXmlWriterContext context) throws XMLStreamException {
+    protected void writeSubElements(VoltageLevel vl, Container<? extends Identifiable<?>> c, NetworkXmlWriterContext context) throws XMLStreamException {
         TopologyLevel topologyLevel = TopologyLevel.min(vl.getTopologyKind(), context.getOptions().getTopologyLevel());
         switch (topologyLevel) {
             case NODE_BREAKER:
@@ -227,8 +227,14 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
     }
 
     @Override
-    protected VoltageLevelAdder createAdder(Substation s) {
-        return s.newVoltageLevel();
+    protected VoltageLevelAdder createAdder(Container<? extends Identifiable<?>> c) {
+        if (c instanceof Network) {
+            return ((Network) c).newVoltageLevel();
+        }
+        if (c instanceof Substation) {
+            return ((Substation) c).newVoltageLevel();
+        }
+        throw new AssertionError();
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/resources/xsd/iidm_V1_6.xsd
+++ b/iidm/iidm-xml-converter/src/main/resources/xsd/iidm_V1_6.xsd
@@ -7,7 +7,7 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 -->
-<xs:schema version="1.5"
+<xs:schema version="1.6"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6"
            targetNamespace="http://www.powsybl.org/schema/iidm/1_6"
@@ -22,7 +22,12 @@
             <xs:sequence>
                 <xs:element name="alias" type="iidm:Alias" minOccurs="0" maxOccurs="unbounded" />
                 <xs:element name="property" type="iidm:Property" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="voltageLevel" type="iidm:VoltageLevel" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="substation" type="iidm:Substation" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="twoWindingsTransformer" type="iidm:TwoWindingsTransformer"/>
+                    <xs:element name="threeWindingsTransformer" type="iidm:ThreeWindingsTransformer"/>
+                </xs:choice>
                 <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element name="line" type="iidm:Line"/>
                     <xs:element name="tieLine" type="iidm:TieLine"/>

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
@@ -125,18 +125,71 @@ public class NetworkXmlTest extends AbstractXmlConverterTest {
     public void testOptionalSubstation() throws IOException {
         Network network = EurostagTutorialExample1Factory.create();
         network.setCaseDate(DateTime.parse("2021-08-20T12:02:48.504+02:00"));
+        String vlId = "ADDITIONAL_VL";
         VoltageLevel vl = network.newVoltageLevel()
-                .setId("ADDITIONAL")
+                .setId(vlId)
                 .setNominalV(200)
                 .setTopologyKind(TopologyKind.BUS_BREAKER)
                 .setHighVoltageLimit(280)
                 .setLowVoltageLimit(160)
                 .add();
-        vl.getBusBreakerView().newBus().setId("TEST").add();
+        String bus1Id = "ADDITIONAL_BUS1";
+        String bus2Id = "ADDITIONAL_BUS2";
+        String bus3Id = "ADDITIONAL_BUS3";
+        vl.getBusBreakerView().newBus().setId(bus1Id).add();
+        vl.getBusBreakerView().newBus().setId(bus2Id).add();
+        vl.getBusBreakerView().newBus().setId(bus3Id).add();
+        network.newTwoWindingsTransformer()
+                .setId("ADDITIONAL_T2WT")
+                .setVoltageLevel1(vlId)
+                .setBus1(bus1Id)
+                .setRatedU1(220.0)
+                .setVoltageLevel2(vlId)
+                .setBus2(bus2Id)
+                .setRatedU2(158.0)
+                .setR(0.21)
+                .setX(Math.sqrt(18 * 18 - 0.21 * 0.21))
+                .setG(0.0)
+                .setB(0.0)
+                .add();
+        network.newThreeWindingsTransformer()
+                .setId("ADDITIONAL_T3WT")
+                .setRatedU0(132.0)
+                .newLeg1()
+                .setR(17.424)
+                .setX(1.7424)
+                .setG(0.00573921028466483)
+                .setB(0.000573921028466483)
+                .setRatedU(132.0)
+                .setVoltageLevel(vlId)
+                .setBus(bus1Id)
+                .add()
+                .newLeg2()
+                .setR(1.089)
+                .setX(0.1089)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(33.0)
+                .setVoltageLevel(vlId)
+                .setBus(bus2Id)
+                .add()
+                .newLeg3()
+                .setR(0.121)
+                .setX(0.0121)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(11.0)
+                .setVoltageLevel(vlId)
+                .setBus(bus3Id)
+                .add()
+                .add();
 
-        roundTripTest(network,
+        roundTripXmlTest(network,
                 NetworkXml::writeAndValidate,
-                NetworkXml::read,
+                NetworkXml::validateAndRead,
                 getVersionedNetworkPath("eurostag-tutorial-example1-opt-sub.xml", CURRENT_IIDM_XML_VERSION));
+
+        // backward compatibility
+        roundTripVersionedXmlFromMinToCurrentVersionTest("eurostag-tutorial-example1-opt-sub.xml", IidmXmlVersion.V_1_6);
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
@@ -12,9 +12,7 @@ import com.powsybl.commons.extensions.ExtensionXmlSerializer;
 import com.powsybl.commons.xml.XmlReaderContext;
 import com.powsybl.commons.xml.XmlWriterContext;
 import com.powsybl.iidm.export.ExportOptions;
-import com.powsybl.iidm.network.BusbarSection;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.TopologyLevel;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.BusbarSectionExt;
 import com.powsybl.iidm.network.test.NetworkTest1Factory;
@@ -123,4 +121,22 @@ public class NetworkXmlTest extends AbstractXmlConverterTest {
         assertNull(busBreakerNetwork.getBusbarSection("voltageLevel1BusbarSection1"));
     }
 
+    @Test
+    public void testOptionalSubstation() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.setCaseDate(DateTime.parse("2021-08-20T12:02:48.504+02:00"));
+        VoltageLevel vl = network.newVoltageLevel()
+                .setId("ADDITIONAL")
+                .setNominalV(200)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setHighVoltageLimit(280)
+                .setLowVoltageLimit(160)
+                .add();
+        vl.getBusBreakerView().newBus().setId("TEST").add();
+
+        roundTripTest(network,
+                NetworkXml::writeAndValidate,
+                NetworkXml::read,
+                getVersionedNetworkPath("eurostag-tutorial-example1-opt-sub.xml", CURRENT_IIDM_XML_VERSION));
+    }
 }

--- a/iidm/iidm-xml-converter/src/test/resources/V1_6/eurostag-tutorial-example1-opt-sub.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_6/eurostag-tutorial-example1-opt-sub.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" id="sim1" caseDate="2021-08-20T12:02:48.504+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:voltageLevel id="ADDITIONAL" nominalV="200.0" lowVoltageLimit="160.0" highVoltageLimit="280.0" topologyKind="BUS_BREAKER">
+        <iidm:busBreakerTopology>
+            <iidm:bus id="TEST"/>
+        </iidm:busBreakerTopology>
+    </iidm:voltageLevel>
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+</iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_6/eurostag-tutorial-example1-opt-sub.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_6/eurostag-tutorial-example1-opt-sub.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" id="sim1" caseDate="2021-08-20T12:02:48.504+02:00" forecastDistance="0" sourceFormat="test">
-    <iidm:voltageLevel id="ADDITIONAL" nominalV="200.0" lowVoltageLimit="160.0" highVoltageLimit="280.0" topologyKind="BUS_BREAKER">
+    <iidm:voltageLevel id="ADDITIONAL_VL" nominalV="200.0" lowVoltageLimit="160.0" highVoltageLimit="280.0" topologyKind="BUS_BREAKER">
         <iidm:busBreakerTopology>
-            <iidm:bus id="TEST"/>
+            <iidm:bus id="ADDITIONAL_BUS1"/>
+            <iidm:bus id="ADDITIONAL_BUS2"/>
+            <iidm:bus id="ADDITIONAL_BUS3"/>
         </iidm:busBreakerTopology>
     </iidm:voltageLevel>
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
@@ -42,6 +44,8 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
+    <iidm:twoWindingsTransformer id="ADDITIONAL_T2WT" r="0.21" x="17.998774958313135" g="0.0" b="0.0" ratedU1="220.0" ratedU2="158.0" bus1="ADDITIONAL_BUS1" connectableBus1="ADDITIONAL_BUS1" voltageLevelId1="ADDITIONAL_VL" bus2="ADDITIONAL_BUS2" connectableBus2="ADDITIONAL_BUS2" voltageLevelId2="ADDITIONAL_VL"/>
+    <iidm:threeWindingsTransformer id="ADDITIONAL_T3WT" r1="17.424" x1="1.7424" g1="0.00573921028466483" b1="5.73921028466483E-4" ratedU1="132.0" r2="1.089" x2="0.1089" g2="0.0" b2="0.0" ratedU2="33.0" r3="0.121" x3="0.0121" g3="0.0" b3="0.0" ratedU3="11.0" ratedU0="132.0" bus1="ADDITIONAL_BUS1" connectableBus1="ADDITIONAL_BUS1" voltageLevelId1="ADDITIONAL_VL" bus2="ADDITIONAL_BUS2" connectableBus2="ADDITIONAL_BUS2" voltageLevelId2="ADDITIONAL_VL" bus3="ADDITIONAL_BUS3" connectableBus3="ADDITIONAL_BUS3" voltageLevelId3="ADDITIONAL_VL"/>
     <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
     <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
 </iidm:network>

--- a/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
+++ b/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
@@ -256,7 +256,7 @@ public class MatpowerImporter implements Importer {
             String connectedBus2 = isInService ? bus2Id : null;
 
             if (isTransformer(model, mBranch)) {
-                TwoWindingsTransformer newTwt = voltageLevel2.getSubstation().newTwoWindingsTransformer()
+                TwoWindingsTransformer newTwt = voltageLevel2.getOptionalSubstation().map(Substation::newTwoWindingsTransformer).orElseGet(network::newTwoWindingsTransformer)
                         .setId(getId(TRANSFORMER_PREFIX, mBranch.getFrom(), mBranch.getTo()))
                         .setEnsureIdUnicity(true)
                         .setBus1(connectedBus1)

--- a/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
+++ b/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
@@ -256,7 +256,7 @@ public class MatpowerImporter implements Importer {
             String connectedBus2 = isInService ? bus2Id : null;
 
             if (isTransformer(model, mBranch)) {
-                TwoWindingsTransformer newTwt = voltageLevel2.getOptionalSubstation().map(Substation::newTwoWindingsTransformer).orElseGet(network::newTwoWindingsTransformer)
+                TwoWindingsTransformer newTwt = voltageLevel2.getSubstation().map(Substation::newTwoWindingsTransformer).orElseGet(network::newTwoWindingsTransformer)
                         .setId(getId(TRANSFORMER_PREFIX, mBranch.getFrom(), mBranch.getTo()))
                         .setEnsureIdUnicity(true)
                         .setBus1(connectedBus1)

--- a/psse/psse-converter/src/main/java/com/powsybl/psse/converter/TransformerConverter.java
+++ b/psse/psse-converter/src/main/java/com/powsybl/psse/converter/TransformerConverter.java
@@ -92,7 +92,7 @@ public class TransformerConverter extends AbstractConverter {
         // move ysh between w1 and z
         TapChanger tapChangerAdjustedYsh = tapChangerAdjustmentAfterMovingShuntAdmittance(tapChangerAdjustedRatio);
 
-        TwoWindingsTransformerAdder adder = voltageLevel2.getOptionalSubstation().map(Substation::newTwoWindingsTransformer).orElseGet(() -> voltageLevel2.getNetwork().newTwoWindingsTransformer())
+        TwoWindingsTransformerAdder adder = voltageLevel2.getSubstation().map(Substation::newTwoWindingsTransformer).orElseGet(() -> voltageLevel2.getNetwork().newTwoWindingsTransformer())
             .setId(id)
             .setEnsureIdUnicity(true)
             .setConnectableBus1(bus1Id)
@@ -173,7 +173,7 @@ public class TransformerConverter extends AbstractConverter {
         // move ysh between w1 and z
         TapChanger tapChanger1AdjustedYsh = tapChangerAdjustmentAfterMovingShuntAdmittance(tapChanger1);
 
-        ThreeWindingsTransformerAdder adder = voltageLevel1.getOptionalSubstation().map(Substation::newThreeWindingsTransformer).orElseGet(() -> voltageLevel2.getNetwork().newThreeWindingsTransformer())
+        ThreeWindingsTransformerAdder adder = voltageLevel1.getSubstation().map(Substation::newThreeWindingsTransformer).orElseGet(() -> voltageLevel2.getNetwork().newThreeWindingsTransformer())
             .setRatedU0(v0)
             .setEnsureIdUnicity(true)
             .setId(id)

--- a/psse/psse-converter/src/main/java/com/powsybl/psse/converter/TransformerConverter.java
+++ b/psse/psse-converter/src/main/java/com/powsybl/psse/converter/TransformerConverter.java
@@ -11,24 +11,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.powsybl.iidm.network.*;
 import org.apache.commons.math3.complex.Complex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.powsybl.iidm.network.Bus;
-import com.powsybl.iidm.network.CurrentLimitsAdder;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.PhaseTapChanger;
-import com.powsybl.iidm.network.PhaseTapChangerAdder;
-import com.powsybl.iidm.network.RatioTapChanger;
-import com.powsybl.iidm.network.RatioTapChangerAdder;
-import com.powsybl.iidm.network.Terminal;
-import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.iidm.network.ThreeWindingsTransformer.Leg;
-import com.powsybl.iidm.network.ThreeWindingsTransformerAdder;
-import com.powsybl.iidm.network.TwoWindingsTransformer;
-import com.powsybl.iidm.network.TwoWindingsTransformerAdder;
-import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.util.ContainersMapping;
 import com.powsybl.psse.converter.PsseImporter.PerUnitContext;
 import com.powsybl.psse.model.PsseException;
@@ -104,7 +92,7 @@ public class TransformerConverter extends AbstractConverter {
         // move ysh between w1 and z
         TapChanger tapChangerAdjustedYsh = tapChangerAdjustmentAfterMovingShuntAdmittance(tapChangerAdjustedRatio);
 
-        TwoWindingsTransformerAdder adder = voltageLevel2.getSubstation().newTwoWindingsTransformer()
+        TwoWindingsTransformerAdder adder = voltageLevel2.getOptionalSubstation().map(Substation::newTwoWindingsTransformer).orElseGet(() -> voltageLevel2.getNetwork().newTwoWindingsTransformer())
             .setId(id)
             .setEnsureIdUnicity(true)
             .setConnectableBus1(bus1Id)
@@ -185,7 +173,7 @@ public class TransformerConverter extends AbstractConverter {
         // move ysh between w1 and z
         TapChanger tapChanger1AdjustedYsh = tapChangerAdjustmentAfterMovingShuntAdmittance(tapChanger1);
 
-        ThreeWindingsTransformerAdder adder = voltageLevel1.getSubstation().newThreeWindingsTransformer()
+        ThreeWindingsTransformerAdder adder = voltageLevel1.getOptionalSubstation().map(Substation::newThreeWindingsTransformer).orElseGet(() -> voltageLevel2.getNetwork().newThreeWindingsTransformer())
             .setRatedU0(v0)
             .setEnsureIdUnicity(true)
             .setId(id)

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationHelper.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationHelper.java
@@ -43,7 +43,7 @@ public final class LimitViolationHelper {
     public static Optional<Country> getCountry(LimitViolation limitViolation, Network network) {
         VoltageLevel voltageLevel = getVoltageLevel(limitViolation, network);
 
-        return voltageLevel.getSubstation().getCountry();
+        return voltageLevel.getOptionalSubstation().flatMap(Substation::getCountry);
     }
 
     public static String getVoltageLevelId(LimitViolation limitViolation, Network network) {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationHelper.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationHelper.java
@@ -43,7 +43,7 @@ public final class LimitViolationHelper {
     public static Optional<Country> getCountry(LimitViolation limitViolation, Network network) {
         VoltageLevel voltageLevel = getVoltageLevel(limitViolation, network);
 
-        return voltageLevel.getOptionalSubstation().flatMap(Substation::getCountry);
+        return voltageLevel.getSubstation().flatMap(Substation::getCountry);
     }
 
     public static String getVoltageLevelId(LimitViolation limitViolation, Network network) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Substation are mandatory to create voltage levels and transformers.


**What is the new behavior (if this is a feature change)?**
Substations are optional. You can create voltage levels directly from the network. You can also create transformers directly from the network **if and only if** at least one end of the transformer is in a voltage level without substation.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
Yes (must be discussed if the API should be really broken or no).
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
