### PR TITLE
Fix javadoc formatting

### DIFF
--- a/computation/src/main/java/com/powsybl/computation/SimpleCommandBuilder.java
+++ b/computation/src/main/java/com/powsybl/computation/SimpleCommandBuilder.java
@@ -66,7 +66,7 @@ public class SimpleCommandBuilder extends AbstractCommandBuilder<SimpleCommandBu
     }
 
     /**
-     * Adds a flag if {@param flagValue} is true.
+     * Adds a flag if {@code flagValue} is true.
      */
     public SimpleCommandBuilder flag(String flagName, boolean flagValue) {
         Objects.requireNonNull(flagName);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -504,15 +504,15 @@ public interface VoltageLevel extends Container<VoltageLevel> {
         int getNode2(String switchId);
 
         /**
-         * Get the terminal corresponding to the {@param node}.
+         * Get the terminal corresponding to the {@code node}.
          *
          * @throws com.powsybl.commons.PowsyblException if node is not found.
          */
         Terminal getTerminal(int node);
 
         /**
-         * Get the terminal corresponding to the {@param node} if the {@param node} is valid.
-         * Return an empty optional if no existing terminal corresponds to {@param node}.
+         * Get the terminal corresponding to the {@code node} if the {@code node} is valid.
+         * Return an empty optional if no existing terminal corresponds to {@code node}.
          *
          * @throws com.powsybl.commons.PowsyblException if node is not valid.
          */
@@ -530,7 +530,7 @@ public interface VoltageLevel extends Container<VoltageLevel> {
         }
 
         /**
-         * Get the first terminal corresponding to the {@param switchId}.
+         * Get the first terminal corresponding to the {@code switchId}.
          * May return null.
          *
          * @throws com.powsybl.commons.PowsyblException if switch is not found.
@@ -538,7 +538,7 @@ public interface VoltageLevel extends Container<VoltageLevel> {
         Terminal getTerminal1(String switchId);
 
         /**
-         * Get the second terminal corresponding to the {@param switchId}.
+         * Get the second terminal corresponding to the {@code switchId}.
          * May return null.
          *
          * @throws com.powsybl.commons.PowsyblException if switch is not found.
@@ -608,8 +608,8 @@ public interface VoltageLevel extends Container<VoltageLevel> {
 
         /**
          * Performs a depth-first traversal of the topology graph,
-         * starting from {@param node}.
-         * The {@param traverser} callback is called every time an edge is traversed.
+         * starting from {@code node}.
+         * The {@code traverser} callback is called every time an edge is traversed.
          */
         void traverse(int node, Traverser traverser);
     }

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/CandidateComputation.java
@@ -29,7 +29,7 @@ public interface CandidateComputation {
     String getName();
 
     /**
-     * A computation carried out on the {@param network}.
+     * A computation carried out on the {@code network}.
      */
     void run(Network network, ComputationManager computationManager);
 

--- a/math/src/main/java/com/powsybl/math/graph/GraphUtil.java
+++ b/math/src/main/java/com/powsybl/math/graph/GraphUtil.java
@@ -105,7 +105,7 @@ public final class GraphUtil {
     }
 
     /**
-     * Remove from the {@param graph} vertices which are not connected to any edge,
+     * Remove from the {@code graph} vertices which are not connected to any edge,
      * and which have no associated object.
      */
     public static <V, E> void removeIsolatedVertices(UndirectedGraph<V, E> graph) {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/package-info.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/package-info.java
@@ -3,9 +3,10 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- *
- * <p>Classes used for the security analysis distribution or simple forwarding
+ */
+
+/**
+ * Classes used for the security analysis distribution or simple forwarding
  * to other {@literal itools} process(es).
  *
  * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/execution/package-info.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/execution/package-info.java
@@ -3,8 +3,9 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- *
+ */
+
+/**
  * Explicits the common interface for executing security analysis either in this preprocess
  * or by delegating it to other itools processes. For that purpose, input data need to be serializable.
  *

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/preprocessor/package-info.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/preprocessor/package-info.java
@@ -3,8 +3,9 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- *
+ */
+
+/**
  * Utilities to preprocess security analysis inputs before the actual execution.
  *
  * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** 
Docs update



**What is the current behavior?**
- License appears in the package info java doc (see com.powsybl.security.distributed in [javadoc package list](https://javadoc.io/doc/com.powsybl/powsybl-core/latest/index.html))
- Referring to a method parameter with `{@param parameter}` is not supported (see [javadoc](https://javadoc.io/doc/com.powsybl/powsybl-core/latest/com/powsybl/iidm/network/VoltageLevel.NodeBreakerView.html) & intellij)



**What is the new behavior (if this is a feature change)?**
- License does not appear anymore in the package info java doc
- Referring to a method parameter has been replaced with `{@code parameter}`


**Does this PR introduce a breaking change or deprecate an API?**
No
