### PR TITLE
Stopping traverser

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.network;
 
 import com.powsybl.iidm.network.util.ShortIdDictionary;
+import com.powsybl.math.graph.TraverseResult;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -603,7 +604,7 @@ public interface VoltageLevel extends Container<VoltageLevel> {
         BusbarSection getBusbarSection(String id);
 
         interface Traverser {
-            boolean traverse(int node1, Switch sw, int node2);
+            TraverseResult traverse(int node1, Switch sw, int node2);
         }
 
         /**

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableMap;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.io.table.*;
 import com.powsybl.iidm.network.*;
+import com.powsybl.math.graph.TraverseResult;
 import org.slf4j.Logger;
 
 import javax.script.*;
@@ -394,13 +395,13 @@ public final class Networks {
 
         VoltageLevel.NodeBreakerView.Traverser traverser = (node1, sw, node2) -> {
             if (sw != null && sw.isOpen()) {
-                return false;
+                return TraverseResult.TERMINATE;
             }
             Terminal t = voltageLevel.getNodeBreakerView().getTerminal(node2);
             if (t != null) {
                 equivalentTerminal[0] = t;
             }
-            return t == null;
+            return t == null ? TraverseResult.CONTINUE : TraverseResult.TERMINATE;
         };
 
         voltageLevel.getNodeBreakerView().traverse(node, traverser);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/NodeBreakerTopology.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/NodeBreakerTopology.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.network.util;
 import com.powsybl.iidm.network.BusbarSection;
 import com.powsybl.iidm.network.Switch;
 import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.math.graph.TraverseResult;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
 
@@ -49,7 +50,7 @@ public final class NodeBreakerTopology {
             topo.traverse(n, (n1, sw, n2) -> {
                 encountered.add(n2);
                 encounteredSwitches.add(sw);
-                return topo.getTerminal(n2) == null;
+                return topo.getTerminal(n2) == null ? TraverseResult.CONTINUE : TraverseResult.TERMINATE;
             });
         }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
+import com.powsybl.math.graph.TraverseResult;
 import gnu.trove.list.array.TIntArrayList;
 
 import java.util.*;
@@ -53,13 +54,13 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
         // Traverse the graph until a valid NodeTerminal is found
         VoltageLevel.NodeBreakerView.Traverser traverser = (node1, sw, node2) -> {
             if (terminal[0] != null) {
-                return false;
+                return TraverseResult.TERMINATE;
             }
             if (sw != null && sw.isOpen()) {
-                return false;
+                return TraverseResult.TERMINATE;
             }
             terminal[0] = (NodeTerminal) voltageLevel.getNodeBreakerView().getTerminal(node2);
-            return terminal[0] == null;
+            return terminal[0] == null ? TraverseResult.CONTINUE : TraverseResult.TERMINATE;
         };
 
         voltageLevel.getNodeBreakerView().traverse(nodes.getQuick(0), traverser);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -744,7 +744,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         private com.powsybl.math.graph.Traverser adapt(Traverser t) {
-            return (v1, e, v2) -> t.traverse(v1, graph.getEdgeObject(e), v2) ? TraverseResult.CONTINUE : TraverseResult.TERMINATE;
+            return (v1, e, v2) -> t.traverse(v1, graph.getEdgeObject(e), v2);
         }
 
         @Override

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerInternalConnectionsTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerInternalConnectionsTest.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.network.tck;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
+import com.powsybl.math.graph.TraverseResult;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
 import org.junit.Test;
@@ -231,7 +232,7 @@ public abstract class AbstractNodeBreakerInternalConnectionsTest {
                 if (sw == null) {
                     cs.add(n1, n2);
                 }
-                return topo.getTerminal(n2) == null;
+                return topo.getTerminal(n2) == null ? TraverseResult.CONTINUE : TraverseResult.TERMINATE;
             });
         }
         return cs;
@@ -253,7 +254,7 @@ public abstract class AbstractNodeBreakerInternalConnectionsTest {
                 if (sw == null) {
                     cs.add(n1, n2);
                 }
-                return true;
+                return TraverseResult.CONTINUE;
             });
         }
         return cs;

--- a/math/src/main/java/com/powsybl/math/graph/TraverseResult.java
+++ b/math/src/main/java/com/powsybl/math/graph/TraverseResult.java
@@ -11,6 +11,7 @@ package com.powsybl.math.graph;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public enum TraverseResult {
-    CONTINUE,
-    TERMINATE
+    CONTINUE,   // Traversing should continue
+    TERMINATE,  // Traversing should terminate on current path
+    BREAK       // Traversing should break, i.e., terminate on all paths
 }

--- a/math/src/main/java/com/powsybl/math/graph/TraverseResult.java
+++ b/math/src/main/java/com/powsybl/math/graph/TraverseResult.java
@@ -7,11 +7,22 @@
 package com.powsybl.math.graph;
 
 /**
+ * Result of graph traversal step, used to decide whether to pursue or not current traversal.
+ * <ul>
+ *     <li>{@link #CONTINUE} indicates that the traversal should go on,</li>
+ *     <li>{@link #TERMINATE} indicates that the current traversal path should stop,</li>
+ *     <li>{@link #BREAK} indicates that all the traversal paths should stop.</li>
+ * </ul>
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public enum TraverseResult {
-    CONTINUE,   // Traversing should continue
-    TERMINATE,  // Traversing should terminate on current path
-    BREAK       // Traversing should break, i.e., terminate on all paths
+    /** Indicates that traversal should continue */
+    CONTINUE,
+
+    /** Indicates that traversal should terminate on current path */
+    TERMINATE,
+
+    /** Indicates that traversal should break, i.e., terminate on all paths */
+    BREAK
 }

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
@@ -234,8 +234,9 @@ public interface UndirectedGraph<V, E> {
      * @param v the vertex index where the traverse has to start.
      * @param traverser the {@link Traverser} instance to use to know if the traverse should continue or stop.
      * @param encountered the list of traversed vertices.
+     * @return false if traversing the graph met a breaking clause, true otherwise
      */
-    void traverse(int v, Traverser traverser, boolean[] encountered);
+    boolean traverse(int v, Traverser traverser, boolean[] encountered);
 
     /**
      * Traverse the entire graph, starting at the specified vertex v.

--- a/math/src/test/java/com/powsybl/math/graph/UndirectedGraphImplTest.java
+++ b/math/src/test/java/com/powsybl/math/graph/UndirectedGraphImplTest.java
@@ -355,6 +355,7 @@ public class UndirectedGraphImplTest {
 
 
     /**
+     * <pre>
      *           0
      *           |
      *         ---------
@@ -368,7 +369,7 @@ public class UndirectedGraphImplTest {
      *           -------
      *              |
      *              5
-     *
+     * </pre>
      *  edges:
      *  0 <-> 1 : 0
      *  0 <-> 2 : 1
@@ -409,9 +410,27 @@ public class UndirectedGraphImplTest {
         boolean[] encountered = new boolean[graph.getVertexCount()];
         Arrays.fill(encountered, false);
         graph.traverse(5, traverser, encountered);
-        // Only vertex 4 and 5 encontered
+        // Only vertex 4 and 5 encountered
         assertArrayEquals(new boolean[] {false, false, false, false, true, true}, encountered);
-        graph.traverse(4, traverser);
+
+        Arrays.fill(encountered, false);
+        Traverser traverser2 = (v1, e, v2) -> {
+            encountered[v1] = true;
+            return v2 == 1 || v2 == 2 || v2 == 3 ? TraverseResult.TERMINATE : TraverseResult.CONTINUE;
+        };
+
+        graph.traverse(4, traverser2);
+        // Only vertex 4 and 5 encountered
+        assertArrayEquals(new boolean[] {false, false, false, false, true, true}, encountered);
+
+        Arrays.fill(encountered, false);
+        Traverser traverser3 = (v1, e, v2) -> {
+            return v2 == 0 ? TraverseResult.BREAK : TraverseResult.CONTINUE;
+        };
+
+        graph.traverse(5, traverser3, encountered);
+        // Only vertices on first path encountering 0 are encountered
+        assertArrayEquals(new boolean[] {false, true, false, false, true, true}, encountered);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** 
Feature



**What is the current behavior?** 
If the whole traversing process needs to be stopped, it needs to be done with a custom added state.



**What is the new behavior (if this is a feature change)?**
The whole traversing process can be stopped by returning `TraverseResult.BREAK` in `Traverser::traverse`



**Does this PR introduce a breaking change or deprecate an API?** yes
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

