### PR TITLE
[WIP] Add SVC stand by automaton extension

### DIFF
--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/StandbyAutomaton.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/StandbyAutomaton.java
@@ -1,0 +1,80 @@
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.commons.extensions.Extension;
+import com.powsybl.iidm.network.StaticVarCompensator;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public interface StandbyAutomaton extends Extension<StaticVarCompensator> {
+
+    @Override
+    default String getName() {
+        return "standbyAutomaton";
+    }
+
+    /**
+     * @return true if the static var compensator behaves like a shunt compensator and monitors voltage
+     * at regulating terminal.
+     */
+    boolean isStandby();
+
+    /**
+     * Set to true if the static var compensator behaves like a shunt compensator and monitors voltage
+     * at regulating terminal, false otherwise.
+     */
+    StandbyAutomaton setStandby(boolean standby);
+
+    /**
+     * @return the susceptance of the static var compensator when it behaves like a shunt compensator (in S).
+     */
+    double getB0();
+
+    /**
+     * Set the susceptance of the static var compensator when it behaves like a shunt compensator (in S).
+     */
+    StandbyAutomaton setB0(double b0);
+
+    /**
+     * @return the voltage target when the voltage at regulating terminal becomes greater that the high voltage threshold
+     * in stand by mode.
+     */
+    double getHighVoltageSetPoint();
+
+    /**
+     * @return the voltage target when the voltage at regulating terminal becomes greater that the high voltage threshold
+     * in stand by mode.
+     */
+    StandbyAutomaton setHighVoltageSetPoint(double highVoltageSetPoint);
+
+    /**
+     * @return the high voltage threshold in kV.
+     */
+    double getHighVoltageThreshold();
+
+    /**
+     * Set the high voltage threshold in kV.
+     */
+    StandbyAutomaton setHighVoltageThreshold(double highVoltageThreshold);
+
+    /**
+     * @return the voltage target when the voltage at regulating terminal becomes lower that the low voltage threshold.
+     */
+    double getLowVoltageSetPoint();
+
+    /**
+     * Set the voltage target when the voltage at regulating terminal becomes lower that the low voltage threshold
+     * in stand by mode.
+     */
+    StandbyAutomaton setLowVoltageSetPoint(double lowVoltageSetPoint);
+
+    /**
+     * @return the low voltage threshold in kV.
+     */
+    double getLowVoltageThreshold();
+
+    /**
+     * Set the low voltage threshold in kV.
+     */
+    StandbyAutomaton setLowVoltageThreshold(double lowVoltageThreshold);
+}

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/StandbyAutomatonAdder.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/StandbyAutomatonAdder.java
@@ -1,0 +1,27 @@
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.commons.extensions.ExtensionAdder;
+import com.powsybl.iidm.network.StaticVarCompensator;
+
+/**
+ * @author Jérémy Labous <jlabous at silicom.fr>
+ */
+public interface StandbyAutomatonAdder extends ExtensionAdder<StaticVarCompensator, StandbyAutomaton> {
+
+    @Override
+    default Class<StandbyAutomaton> getExtensionClass() {
+        return StandbyAutomaton.class;
+    }
+
+    StandbyAutomatonAdder withStandbyStatus(boolean standby);
+
+    StandbyAutomatonAdder withB0(double b0);
+
+    StandbyAutomatonAdder withHighVoltageSetPoint(double highVoltageSetPoint);
+
+    StandbyAutomatonAdder withHighVoltageThreshold(double highVoltageThreshold);
+
+    StandbyAutomatonAdder withLowVoltageSetPoint(double lowVoltageSetPoint);
+
+    StandbyAutomatonAdder withLowVoltageThreshold(double lowVoltageThreshold);
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonAdderImpl.java
@@ -1,0 +1,71 @@
+package com.powsybl.iidm.network.impl.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtensionAdder;
+import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.iidm.network.extensions.StandbyAutomaton;
+import com.powsybl.iidm.network.extensions.StandbyAutomatonAdder;
+
+/**
+ * @author Jérémy Labous <jlabous at silicom.fr>
+ */
+public class StandbyAutomatonAdderImpl extends AbstractExtensionAdder<StaticVarCompensator, StandbyAutomaton>
+        implements StandbyAutomatonAdder {
+
+    private double b0;
+
+    private boolean standby;
+
+    private double lowVoltageSetPoint;
+
+    private double highVoltageSetPoint;
+
+    private double lowVoltageThreshold;
+
+    private double highVoltageThreshold;
+
+    public StandbyAutomatonAdderImpl(StaticVarCompensator svc) {
+        super(svc);
+    }
+
+    @Override
+    protected StandbyAutomaton createExtension(StaticVarCompensator staticVarCompensator) {
+        return new StandbyAutomatonImpl(staticVarCompensator, b0, standby,
+                lowVoltageSetPoint, highVoltageSetPoint, lowVoltageThreshold, highVoltageThreshold);
+    }
+
+    @Override
+    public StandbyAutomatonAdderImpl withStandbyStatus(boolean standby) {
+        this.standby = standby;
+        return this;
+    }
+
+    @Override
+    public StandbyAutomatonAdderImpl withB0(double b0) {
+        this.b0 = b0;
+        return this;
+    }
+
+    @Override
+    public StandbyAutomatonAdderImpl withHighVoltageSetPoint(double highVoltageSetPoint) {
+        this.highVoltageSetPoint = highVoltageSetPoint;
+        return this;
+    }
+
+    @Override
+    public StandbyAutomatonAdderImpl withHighVoltageThreshold(double highVoltageThreshold) {
+        this.highVoltageThreshold = highVoltageThreshold;
+        return this;
+    }
+
+    @Override
+    public StandbyAutomatonAdderImpl withLowVoltageSetPoint(double lowVoltageSetPoint) {
+        this.lowVoltageSetPoint = lowVoltageSetPoint;
+        return this;
+    }
+
+    @Override
+    public StandbyAutomatonAdderImpl withLowVoltageThreshold(double lowVoltageThreshold) {
+        this.lowVoltageThreshold = lowVoltageThreshold;
+        return this;
+    }
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonAdderImplProvider.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonAdderImplProvider.java
@@ -1,0 +1,29 @@
+package com.powsybl.iidm.network.impl.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionAdderProvider;
+import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.iidm.network.extensions.StandbyAutomaton;
+
+/**
+ * @author Jérémy Labous <jlabous at silicom.fr>
+ */
+@AutoService(ExtensionAdderProvider.class)
+public class StandbyAutomatonAdderImplProvider
+        implements ExtensionAdderProvider<StaticVarCompensator, StandbyAutomaton, StandbyAutomatonAdderImpl> {
+
+    @Override
+    public String getImplementationName() {
+        return "Default";
+    }
+
+    @Override
+    public Class<StandbyAutomatonAdderImpl> getAdderClass() {
+        return StandbyAutomatonAdderImpl.class;
+    }
+
+    @Override
+    public StandbyAutomatonAdderImpl newAdder(StaticVarCompensator extendable) {
+        return new StandbyAutomatonAdderImpl(extendable);
+    }
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonImpl.java
@@ -1,0 +1,162 @@
+package com.powsybl.iidm.network.impl.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.iidm.network.extensions.StandbyAutomaton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Jérémy Labous <jlabous at silicom.fr>
+ */
+public class StandbyAutomatonImpl extends AbstractExtension<StaticVarCompensator> implements StandbyAutomaton {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandbyAutomatonImpl.class);
+
+    /**
+     * b0 is the susceptance of the static var compensator when it behaves like a shunt compensator.
+     * This behaviour is active when following boolean standby is set to true.
+     * b0 should be greater than Bmin and lower than Bmax.
+     */
+    private double b0;
+
+    /**
+     * true if the static var compensator behaves like a shunt compensator of susceptance b0 and monitors
+     * voltage at regulating terminal.
+     */
+    private boolean standby;
+
+    /**
+     * Voltage target when the voltage at regulating terminal becomes lower that the low voltage threshold.
+     */
+    private double lowVoltageSetPoint;
+
+    /**
+     * Voltage target when the voltage at regulating terminal becomes greater that the high voltage threshold.
+     */
+    private double highVoltageSetPoint;
+
+    /**
+     * The low voltage threshold in kV.
+     */
+    private double lowVoltageThreshold;
+
+    /**
+     * The high voltage threshold in kV.
+     */
+    private double highVoltageThreshold;
+
+    private static double checkB0(double v) {
+        if (Double.isNaN(v)) {
+            throw new IllegalArgumentException("b0 is invalid");
+        }
+        return v;
+    }
+
+    private static void checkVoltageConfig(double lowVoltageSetPoint, double highVoltageSetPoint,
+                                           double lowVoltageThreshold, double highVoltageThreshold) {
+        if (Double.isNaN(lowVoltageSetPoint)) {
+            throw new IllegalArgumentException("lowVoltageSetPoint is invalid");
+        }
+        if (Double.isNaN(highVoltageSetPoint)) {
+            throw new IllegalArgumentException("highVoltageSetPoint is invalid");
+        }
+        if (Double.isNaN(lowVoltageThreshold)) {
+            throw new IllegalArgumentException("lowVoltageThreshold is invalid");
+        }
+        if (Double.isNaN(highVoltageThreshold)) {
+            throw new IllegalArgumentException("highVoltageThreshold is invalid");
+        }
+        if (lowVoltageThreshold >= highVoltageThreshold) {
+            throw new IllegalArgumentException("Inconsistent low (" + lowVoltageThreshold + ") and high (" + highVoltageThreshold + ") voltage thresholds");
+        }
+        if (lowVoltageSetPoint < lowVoltageThreshold) {
+            LOGGER.warn("Invalid low voltage setpoint {} < threshold {}", lowVoltageSetPoint, lowVoltageThreshold);
+        }
+        if (highVoltageSetPoint > highVoltageThreshold) {
+            LOGGER.warn("Invalid high voltage setpoint {} > threshold {}", highVoltageSetPoint, highVoltageThreshold);
+        }
+    }
+
+    public StandbyAutomatonImpl(StaticVarCompensator svc, double b0, boolean standby, double lowVoltageSetPoint, double highVoltageSetPoint,
+                                double lowVoltageThreshold, double highVoltageThreshold) {
+        super(svc);
+        this.b0 = checkB0(b0);
+        this.standby = standby;
+        checkVoltageConfig(lowVoltageSetPoint, highVoltageSetPoint, lowVoltageThreshold, highVoltageThreshold);
+        this.lowVoltageSetPoint = lowVoltageSetPoint;
+        this.highVoltageSetPoint = highVoltageSetPoint;
+        this.lowVoltageThreshold = lowVoltageThreshold;
+        this.highVoltageThreshold = highVoltageThreshold;
+    }
+
+    @Override
+    public boolean isStandby() {
+        return standby;
+    }
+
+    @Override
+    public StandbyAutomatonImpl setStandby(boolean standby) {
+        this.standby = standby;
+        return this;
+    }
+
+    @Override
+    public double getB0() {
+        return b0;
+    }
+
+    @Override
+    public StandbyAutomatonImpl setB0(double b0) {
+        this.b0 = checkB0(b0);
+        return this;
+    }
+
+    @Override
+    public double getHighVoltageSetPoint() {
+        return highVoltageSetPoint;
+    }
+
+    @Override
+    public StandbyAutomatonImpl setHighVoltageSetPoint(double highVoltageSetPoint) {
+        checkVoltageConfig(lowVoltageSetPoint, highVoltageSetPoint, lowVoltageThreshold, highVoltageThreshold);
+        this.highVoltageSetPoint = highVoltageSetPoint;
+        return this;
+    }
+
+    @Override
+    public double getHighVoltageThreshold() {
+        return highVoltageThreshold;
+    }
+
+    @Override
+    public StandbyAutomatonImpl setHighVoltageThreshold(double highVoltageThreshold) {
+        checkVoltageConfig(lowVoltageSetPoint, highVoltageSetPoint, lowVoltageThreshold, highVoltageThreshold);
+        this.highVoltageThreshold = highVoltageThreshold;
+        return this;
+    }
+
+    @Override
+    public double getLowVoltageSetPoint() {
+        return lowVoltageSetPoint;
+    }
+
+    @Override
+    public StandbyAutomatonImpl setLowVoltageSetPoint(double lowVoltageSetPoint) {
+        checkVoltageConfig(lowVoltageSetPoint, highVoltageSetPoint, lowVoltageThreshold, highVoltageThreshold);
+        this.lowVoltageSetPoint = lowVoltageSetPoint;
+        return this;
+    }
+
+    @Override
+    public double getLowVoltageThreshold() {
+        return lowVoltageThreshold;
+    }
+
+    @Override
+    public StandbyAutomatonImpl setLowVoltageThreshold(double lowVoltageThreshold) {
+        checkVoltageConfig(lowVoltageSetPoint, highVoltageSetPoint, lowVoltageThreshold, highVoltageThreshold);
+        this.lowVoltageThreshold = lowVoltageThreshold;
+        return this;
+    }
+}

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/StandbyAutomatonXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/StandbyAutomatonXmlSerializer.java
@@ -1,0 +1,84 @@
+package com.powsybl.iidm.xml.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionXmlSerializer;
+import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlUtil;
+import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.iidm.network.extensions.StandbyAutomaton;
+import com.powsybl.iidm.network.extensions.StandbyAutomatonAdder;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.InputStream;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+@AutoService(ExtensionXmlSerializer.class)
+public class StandbyAutomatonXmlSerializer implements ExtensionXmlSerializer<StaticVarCompensator, StandbyAutomaton> {
+
+    @Override
+    public String getExtensionName() {
+        return "standbyAutomaton";
+    }
+
+    @Override
+    public String getCategoryName() {
+        return "network";
+    }
+
+    @Override
+    public Class<? super StandbyAutomaton> getExtensionClass() {
+        return StandbyAutomaton.class;
+    }
+
+    @Override
+    public boolean hasSubElements() {
+        return false;
+    }
+
+    @Override
+    public InputStream getXsdAsStream() {
+        return getClass().getResourceAsStream("/xsd/standbyAutomaton.xsd");
+    }
+
+    @Override
+    public String getNamespaceUri() {
+        return "http://www.powsybl.org/schema/iidm/ext/standby_automaton/1_0";
+    }
+
+    @Override
+    public String getNamespacePrefix() {
+        return "sa";
+    }
+
+    @Override
+    public void write(StandbyAutomaton standbyAutomaton, XmlWriterContext context) throws XMLStreamException {
+        XmlUtil.writeDouble("b0", standbyAutomaton.getB0(), context.getExtensionsWriter());
+        context.getExtensionsWriter().writeAttribute("standby", Boolean.toString(standbyAutomaton.isStandby()));
+        XmlUtil.writeDouble("lowVoltageSetPoint", standbyAutomaton.getLowVoltageSetPoint(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("highVoltageSetPoint", standbyAutomaton.getHighVoltageSetPoint(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("lowVoltageThreshold", standbyAutomaton.getLowVoltageThreshold(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("highVoltageThreshold", standbyAutomaton.getHighVoltageThreshold(), context.getExtensionsWriter());
+    }
+
+    @Override
+    public StandbyAutomaton read(StaticVarCompensator svc, XmlReaderContext context) {
+        float b0 = XmlUtil.readFloatAttribute(context.getReader(), "b0");
+        boolean standby = XmlUtil.readBoolAttribute(context.getReader(), "standby");
+        float lowVoltageSetPoint = XmlUtil.readFloatAttribute(context.getReader(), "lowVoltageSetPoint");
+        float highVoltageSetPoint = XmlUtil.readFloatAttribute(context.getReader(), "highVoltageSetPoint");
+        float lowVoltageThreshold = XmlUtil.readFloatAttribute(context.getReader(), "lowVoltageThreshold");
+        float highVoltageThreshold = XmlUtil.readFloatAttribute(context.getReader(), "highVoltageThreshold");
+        svc.newExtension(StandbyAutomatonAdder.class)
+                .withB0(b0)
+                .withStandbyStatus(standby)
+                .withLowVoltageSetPoint(lowVoltageSetPoint)
+                .withHighVoltageSetPoint(highVoltageSetPoint)
+                .withLowVoltageThreshold(lowVoltageThreshold)
+                .withHighVoltageThreshold(highVoltageThreshold)
+                .add();
+        return svc.getExtension(StandbyAutomaton.class);
+    }
+}

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/StandbyAutomatonXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/StandbyAutomatonXmlSerializer.java
@@ -55,12 +55,12 @@ public class StandbyAutomatonXmlSerializer implements ExtensionXmlSerializer<Sta
 
     @Override
     public void write(StandbyAutomaton standbyAutomaton, XmlWriterContext context) throws XMLStreamException {
-        XmlUtil.writeDouble("b0", standbyAutomaton.getB0(), context.getExtensionsWriter());
-        context.getExtensionsWriter().writeAttribute("standby", Boolean.toString(standbyAutomaton.isStandby()));
-        XmlUtil.writeDouble("lowVoltageSetPoint", standbyAutomaton.getLowVoltageSetPoint(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("highVoltageSetPoint", standbyAutomaton.getHighVoltageSetPoint(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("lowVoltageThreshold", standbyAutomaton.getLowVoltageThreshold(), context.getExtensionsWriter());
-        XmlUtil.writeDouble("highVoltageThreshold", standbyAutomaton.getHighVoltageThreshold(), context.getExtensionsWriter());
+        XmlUtil.writeDouble("b0", standbyAutomaton.getB0(), context.getWriter());
+        context.getWriter().writeAttribute("standby", Boolean.toString(standbyAutomaton.isStandby()));
+        XmlUtil.writeDouble("lowVoltageSetPoint", standbyAutomaton.getLowVoltageSetPoint(), context.getWriter());
+        XmlUtil.writeDouble("highVoltageSetPoint", standbyAutomaton.getHighVoltageSetPoint(), context.getWriter());
+        XmlUtil.writeDouble("lowVoltageThreshold", standbyAutomaton.getLowVoltageThreshold(), context.getWriter());
+        XmlUtil.writeDouble("highVoltageThreshold", standbyAutomaton.getHighVoltageThreshold(), context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/resources/xsd/standbyAutomaton.xsd
+++ b/iidm/iidm-xml-converter/src/main/resources/xsd/standbyAutomaton.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_5"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/standby_automaton/1_0"
+           elementFormDefault="qualified">
+    <xs:element name="standbyAutomaton">
+        <xs:complexType>
+            <xs:attribute name="b0" use="required" type="xs:double"/>
+            <xs:attribute name="standby" use="required" type="xs:boolean"/>
+            <xs:attribute name="lowVoltageSetPoint" use="required" type="xs:double"/>
+            <xs:attribute name="highVoltageSetPoint" use="required" type="xs:double"/>
+            <xs:attribute name="lowVoltageThreshold" use="required" type="xs:double"/>
+            <xs:attribute name="highVoltageThreshold" use="required" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

This PR adds an extension to static var compensator to model an automaton that:
- behaves as a shunt compensator in stand by mode ;
- controls voltage when the voltage monitored becomes lower than a lower threshold or greater that a high threshold. 

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

I have added this extension to be able to implement this control in open loadflow. I will understand if it is not the good location in powsybl organization of this extension.  
