### PR TITLE
Values for measurements and discrete measurements should be optional

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/DiscreteMeasurementsXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/DiscreteMeasurementsXmlSerializer.java
@@ -107,18 +107,20 @@ public class DiscreteMeasurementsXmlSerializer<I extends Identifiable<I>> extend
             adder.setTapChanger(DiscreteMeasurement.TapChanger.valueOf(tapChanger));
         }
         DiscreteMeasurement.ValueType valueType = DiscreteMeasurement.ValueType.valueOf(reader.getAttributeValue(null, "valueType"));
-        switch (valueType) {
-            case BOOLEAN:
-                adder.setValue(XmlUtil.readBoolAttribute(reader, VALUE));
-                break;
-            case INT:
-                adder.setValue(XmlUtil.readIntAttribute(reader, VALUE));
-                break;
-            case STRING:
-                adder.setValue(reader.getAttributeValue(null, VALUE));
-                break;
-            default:
-                throw new PowsyblException("Unsupported value type: " + valueType);
+        if (reader.getAttributeValue(null, VALUE) != null) {
+            switch (valueType) {
+                case BOOLEAN:
+                    adder.setValue(XmlUtil.readBoolAttribute(reader, VALUE));
+                    break;
+                case INT:
+                    adder.setValue(XmlUtil.readIntAttribute(reader, VALUE));
+                    break;
+                case STRING:
+                    adder.setValue(reader.getAttributeValue(null, VALUE));
+                    break;
+                default:
+                    throw new PowsyblException("Unsupported value type: " + valueType);
+            }
         }
         XmlUtil.readUntilEndElement(DISCRETE_MEASUREMENT, reader, () -> {
             if (reader.getLocalName().equals("property")) {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/MeasurementsXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/MeasurementsXmlSerializer.java
@@ -78,7 +78,7 @@ public class MeasurementsXmlSerializer<C extends Connectable<C>> extends Abstrac
                 MeasurementAdder adder = measurements.newMeasurement()
                         .setId(reader.getAttributeValue(null, "id"))
                         .setType(Measurement.Type.valueOf(reader.getAttributeValue(null, "type")))
-                        .setValue(XmlUtil.readDoubleAttribute(reader, VALUE))
+                        .setValue(XmlUtil.readOptionalDoubleAttribute(reader, VALUE))
                         .setStandardDeviation(XmlUtil.readOptionalDoubleAttribute(reader, "standardDeviation"))
                         .setValid(XmlUtil.readBoolAttribute(reader, "valid"));
                 String side = reader.getAttributeValue(null, "side");


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Values for measurements and discrete measurements are optional in the XSD and the checks but not during deserialization.


**What is the new behavior (if this is a feature change)?**
Deserializers do not try to read undefined values.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
