### PR TITLE
Fast matrix element re-update

### DIFF
--- a/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
@@ -135,6 +135,26 @@ public class DenseMatrix extends AbstractMatrix {
     }
 
     @Override
+    public int addAndGetIndex(int i, int j, double value) {
+        add(i, j, value);
+        return j * rowCount + i;
+    }
+
+    @Override
+    public void setAtIndex(int index, double value) {
+        int i = index % rowCount;
+        int j = index / rowCount;
+        set(i, j, value);
+    }
+
+    @Override
+    public void addAtIndex(int index, double value) {
+        int i = index % rowCount;
+        int j = index / rowCount;
+        add(i, j, value);
+    }
+
+    @Override
     public void reset() {
         for (int k = 0; k < rowCount * columnCount; k++) {
             buffer.putDouble(k * Double.BYTES, 0);

--- a/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
@@ -140,8 +140,15 @@ public class DenseMatrix extends AbstractMatrix {
         return j * rowCount + i;
     }
 
+    private void checkElementIndex(int index) {
+        if (index < 0 || index >= rowCount * columnCount) {
+            throw new IllegalArgumentException("Element index out of bound [0, " + (rowCount * columnCount - 1) + "]");
+        }
+    }
+
     @Override
     public void setAtIndex(int index, double value) {
+        checkElementIndex(index);
         int i = index % rowCount;
         int j = index / rowCount;
         set(i, j, value);
@@ -149,6 +156,7 @@ public class DenseMatrix extends AbstractMatrix {
 
     @Override
     public void addAtIndex(int index, double value) {
+        checkElementIndex(index);
         int i = index % rowCount;
         int j = index / rowCount;
         add(i, j, value);

--- a/math/src/main/java/com/powsybl/math/matrix/Matrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/Matrix.java
@@ -164,6 +164,32 @@ public interface Matrix {
     Element addAndGetElement(int i, int j, double value);
 
     /**
+     * Add value at row {@code i} and column {@code j} and get an element index to later update the element.
+     *
+     * @param i row index
+     * @param j column index
+     * @param value the value to add at row {@code i} and column {@code j}
+     * @return an element index corresponding to row {@code i} and column {@code j}
+     */
+    int addAndGetIndex(int i, int j, double value);
+
+    /**
+     * Set value at element index {@code index}.
+     *
+     * @param index element index
+     * @param value the value to set at element index {@code index}
+     */
+    void setAtIndex(int index, double value);
+
+    /**
+     * Add value at element index {@code index}.
+     *
+     * @param index element index
+     * @param value the value to add at element index {@code index}
+     */
+    void addAtIndex(int index, double value);
+
+    /**
      * @deprecated Use {@link #add(int, int, double)} instead.
      */
     @Deprecated

--- a/math/src/main/java/com/powsybl/math/matrix/SparseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/SparseMatrix.java
@@ -285,6 +285,30 @@ class SparseMatrix extends AbstractMatrix {
     }
 
     @Override
+    public int addAndGetIndex(int i, int j, double value) {
+        add(i, j, value);
+        return values.size() - 1;
+    }
+
+    private void checkElementIndex(int index) {
+        if (index < 0 || index >= values.size()) {
+            throw new IllegalArgumentException("Element index out of bound [0, " + (values.size() - 1) + "]");
+        }
+    }
+
+    @Override
+    public void setAtIndex(int index, double value) {
+        checkElementIndex(index);
+        values.set(index, value);
+    }
+
+    @Override
+    public void addAtIndex(int index, double value) {
+        checkElementIndex(index);
+        values.setQuick(index, values.getQuick(index) + value);
+    }
+
+    @Override
     public void reset() {
         values.fill(0d);
     }

--- a/math/src/test/java/com/powsybl/math/matrix/AbstractMatrixTest.java
+++ b/math/src/test/java/com/powsybl/math/matrix/AbstractMatrixTest.java
@@ -378,4 +378,42 @@ public abstract class AbstractMatrixTest {
         a.addValue(0, 1, 2d);
         assertEquals(3d, a.toDense().get(0, 1), 0d);
     }
+
+    @Test
+    public void testAddAndGetIndex() {
+        Matrix a = getMatrixFactory().create(3, 3, 3);
+        // 1 0 4
+        // 0 2 0
+        // 0 3 0
+        int index1 = a.addAndGetIndex(0, 0, 1d);
+        int index2 = a.addAndGetIndex(1, 1, 2d);
+        int index3 = a.addAndGetIndex(2, 1, 3d);
+        int index4 = a.addAndGetIndex(0, 2, 4d);
+
+        assertEquals(1d, a.toDense().get(0, 0), 0d);
+        assertEquals(0d, a.toDense().get(1, 0), 0d);
+        assertEquals(0d, a.toDense().get(2, 0), 0d);
+        assertEquals(0d, a.toDense().get(0, 1), 0d);
+        assertEquals(2d, a.toDense().get(1, 1), 0d);
+        assertEquals(3d, a.toDense().get(2, 1), 0d);
+        assertEquals(4d, a.toDense().get(0, 2), 0d);
+        assertEquals(0d, a.toDense().get(1, 2), 0d);
+        assertEquals(0d, a.toDense().get(2, 2), 0d);
+
+        a.setAtIndex(index1, 9);
+        a.addAtIndex(index2, 1);
+        a.setAtIndex(index3, 10);
+        a.addAtIndex(index4, 1);
+
+        assertEquals(9d, a.toDense().get(0, 0), 0d);
+        assertEquals(3d, a.toDense().get(1, 1), 0d);
+        assertEquals(10d, a.toDense().get(2, 1), 0d);
+        assertEquals(5d, a.toDense().get(0, 2), 0d);
+
+        try {
+            a.setAtIndex(10, 0);
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
There is already a method to create and later re-update an element but it require to create an extra `Matrix.Element` object for each element of the matrix. For large matrices, it could be responsible of performance issue (large memory allocation, gc loading).  


**What is the new behavior (if this is a feature change)?**
New methods to create and later re-update an element have been added based on just a int representing the internal index of the element. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
