### PR TITLE
fix NodeBreakerVoltageLevel with optional substation

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -509,7 +509,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     NodeBreakerVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation, Ref<NetworkImpl> ref,
                             double nominalV, double lowVoltageLimit, double highVoltageLimit) {
         super(id, name, fictitious, substation, ref, nominalV, lowVoltageLimit, highVoltageLimit);
-        variants = new VariantArray<>(substation.getNetwork().getRef(), VariantImpl::new);
+        variants = new VariantArray<>(ref == null ? substation.getNetwork().getRef() : ref, VariantImpl::new);
     }
 
     @Override

--- a/iidm/iidm-scripting/src/test/groovy/com/powsybl/iidm/network/scripting/VoltageLevelExtensionTest.groovy
+++ b/iidm/iidm-scripting/src/test/groovy/com/powsybl/iidm/network/scripting/VoltageLevelExtensionTest.groovy
@@ -48,4 +48,14 @@ class VoltageLevelExtensionTest {
                 .setNominalV(340.0).add()
         assertNull(voltageLevel.substation)
     }
+
+    @Test
+    void getNullSubstationNodeBreakerTest() {
+        Network network = Network.create("test", "test")
+        VoltageLevel voltageLevel = network.newVoltageLevel()
+                .setId("VL")
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .setNominalV(340.0).add()
+        assertNull(voltageLevel.substation)
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**D**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Substation are optional to create voltage levels and transformers. If a voltage level without substation is defined for the Node Breaker type topology, an error occurs when trying to access the voltage level substation, a substation that does not exist


**What is the new behavior (if this is a feature change)?**
The same implementation that is used to create a voltage level for a Bus Breaker type topology is applied.
