### PR TITLE
Fix VscConverterStation setters return type

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VscConverterStation.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VscConverterStation.java
@@ -83,7 +83,7 @@ public interface VscConverterStation extends HvdcConverterStation<VscConverterSt
      * @param voltageRegulatorOn the new voltage regulator status
      * @return the converter itself to allow method chaining
      */
-    HvdcConverterStation setVoltageRegulatorOn(boolean voltageRegulatorOn);
+    VscConverterStation setVoltageRegulatorOn(boolean voltageRegulatorOn);
 
     /**
      * Get the voltage setpoint (Kv).
@@ -96,7 +96,7 @@ public interface VscConverterStation extends HvdcConverterStation<VscConverterSt
      * @param voltageSetpoint the voltage setpoint
      * @return the converter itself to allow method chaining
      */
-    HvdcConverterStation setVoltageSetpoint(double voltageSetpoint);
+    VscConverterStation setVoltageSetpoint(double voltageSetpoint);
 
     /**
      * Get the reactive power setpoint (MVar).
@@ -109,7 +109,7 @@ public interface VscConverterStation extends HvdcConverterStation<VscConverterSt
      * @param reactivePowerSetpoint the reactive power setpoint
      * @return the converter itself to allow method chaining
      */
-    HvdcConverterStation setReactivePowerSetpoint(double reactivePowerSetpoint);
+    VscConverterStation setReactivePowerSetpoint(double reactivePowerSetpoint);
 
     /**
      * Get the terminal used for regulation.

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VscConverterStationAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/VscConverterStationAdapter.java
@@ -18,18 +18,18 @@ public class VscConverterStationAdapter extends AbstractHvdcConverterStationAdap
     }
 
     @Override
-    public HvdcConverterStation setVoltageRegulatorOn(final boolean voltageRegulatorOn) {
-        return getIndex().getHvdcConverterStation(getDelegate().setVoltageRegulatorOn(voltageRegulatorOn));
+    public VscConverterStation setVoltageRegulatorOn(final boolean voltageRegulatorOn) {
+        return getIndex().getVscConverterStation(getDelegate().setVoltageRegulatorOn(voltageRegulatorOn));
     }
 
     @Override
-    public HvdcConverterStation setVoltageSetpoint(final double voltageSetpoint) {
-        return getIndex().getHvdcConverterStation(getDelegate().setVoltageSetpoint(voltageSetpoint));
+    public VscConverterStation setVoltageSetpoint(final double voltageSetpoint) {
+        return getIndex().getVscConverterStation(getDelegate().setVoltageSetpoint(voltageSetpoint));
     }
 
     @Override
-    public HvdcConverterStation setReactivePowerSetpoint(final double reactivePowerSetpoint) {
-        return getIndex().getHvdcConverterStation(getDelegate().setReactivePowerSetpoint(reactivePowerSetpoint));
+    public VscConverterStation setReactivePowerSetpoint(final double reactivePowerSetpoint) {
+        return getIndex().getVscConverterStation(getDelegate().setReactivePowerSetpoint(reactivePowerSetpoint));
     }
 
     // -------------------------------


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Return type for method chaining is not correct for `VscConverterStation` setters 


**What is the new behavior (if this is a feature change)?**
It is fixed!


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
