### PR TITLE
Add Line, 2wt, 3wt convenience getters to VoltagelLevel

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -1134,6 +1134,69 @@ public interface VoltageLevel extends Container<VoltageLevel> {
     int getLccConverterStationCount();
 
     /**
+     * Get all lines connected to this voltage level.
+     *
+     * @return all lines connected to this voltage level
+     */
+    Iterable<Line> getLines();
+
+    /**
+     * Get all lines connected to this voltage level.
+     *
+     * @return all lines connected to this voltage level
+     */
+    Stream<Line> getLineStream();
+
+    /**
+     * Get line count connected to this voltage level.
+     *
+     * @return line count connected to this voltage level
+     */
+    int getLineCount();
+
+    /**
+     * Get all two windings transformers connected to this voltage level.
+     *
+     * @return all two windings transformers connected to this voltage level
+     */
+    Iterable<TwoWindingsTransformer> getTwoWindingsTransformers();
+
+    /**
+     * Get all two windings transformers connected to this voltage level.
+     *
+     * @return all two windings transformers connected to this voltage level
+     */
+    Stream<TwoWindingsTransformer> getTwoWindingsTransformerStream();
+
+    /**
+     * Get two windings transformer count connected to this voltage level.
+     *
+     * @return two windings transformer count connected to this voltage level
+     */
+    int getTwoWindingsTransformerCount();
+
+    /**
+     * Get all three windings transformers connected to this voltage level.
+     *
+     * @return all three windings transformers connected to this voltage level
+     */
+    Iterable<ThreeWindingsTransformer> getThreeWindingsTransformers();
+
+    /**
+     * Get all three windings transformers connected to this voltage level.
+     *
+     * @return all three windings transformers connected to this voltage level
+     */
+    Stream<ThreeWindingsTransformer> getThreeWindingsTransformerStream();
+
+    /**
+     * Get three windings transformer count connected to this voltage level.
+     *
+     * @return three windings transformer count connected to this voltage level
+     */
+    int getThreeWindingsTransformerCount();
+
+    /**
      * Remove this voltage level from the network.
      */
     default void remove() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractVoltageLevel.java
@@ -351,6 +351,51 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     }
 
     @Override
+    public int getLineCount() {
+        return getConnectableCount(Line.class);
+    }
+
+    @Override
+    public Iterable<Line> getLines() {
+        return getConnectables(Line.class);
+    }
+
+    @Override
+    public Stream<Line> getLineStream() {
+        return getConnectableStream(Line.class);
+    }
+
+    @Override
+    public int getTwoWindingsTransformerCount() {
+        return getConnectableCount(TwoWindingsTransformer.class);
+    }
+
+    @Override
+    public Iterable<TwoWindingsTransformer> getTwoWindingsTransformers() {
+        return getConnectables(TwoWindingsTransformer.class);
+    }
+
+    @Override
+    public Stream<TwoWindingsTransformer> getTwoWindingsTransformerStream() {
+        return getConnectableStream(TwoWindingsTransformer.class);
+    }
+
+    @Override
+    public int getThreeWindingsTransformerCount() {
+        return getConnectableCount(ThreeWindingsTransformer.class);
+    }
+
+    @Override
+    public Iterable<ThreeWindingsTransformer> getThreeWindingsTransformers() {
+        return getConnectables(ThreeWindingsTransformer.class);
+    }
+
+    @Override
+    public Stream<ThreeWindingsTransformer> getThreeWindingsTransformerStream() {
+        return getConnectableStream(ThreeWindingsTransformer.class);
+    }
+
+    @Override
     protected String getTypeDescription() {
         return "Voltage level";
     }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractVoltageLevelAdapter.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/AbstractVoltageLevelAdapter.java
@@ -344,6 +344,54 @@ abstract class AbstractVoltageLevelAdapter extends AbstractIdentifiableAdapter<V
     }
 
     @Override
+    public Iterable<Line> getLines() {
+        return Iterables.transform(getDelegate().getLines(),
+                getIndex()::getLine);
+    }
+
+    @Override
+    public Stream<Line> getLineStream() {
+        return getDelegate().getLineStream().map(getIndex()::getLine);
+    }
+
+    @Override
+    public int getLineCount() {
+        return getDelegate().getLineCount();
+    }
+
+    @Override
+    public Iterable<TwoWindingsTransformer> getTwoWindingsTransformers() {
+        return Iterables.transform(getDelegate().getTwoWindingsTransformers(),
+                getIndex()::getTwoWindingsTransformer);
+    }
+
+    @Override
+    public Stream<TwoWindingsTransformer> getTwoWindingsTransformerStream() {
+        return getDelegate().getTwoWindingsTransformerStream().map(getIndex()::getTwoWindingsTransformer);
+    }
+
+    @Override
+    public int getTwoWindingsTransformerCount() {
+        return getDelegate().getTwoWindingsTransformerCount();
+    }
+
+    @Override
+    public Iterable<ThreeWindingsTransformer> getThreeWindingsTransformers() {
+        return Iterables.transform(getDelegate().getThreeWindingsTransformers(),
+                getIndex()::getThreeWindingsTransformer);
+    }
+
+    @Override
+    public Stream<ThreeWindingsTransformer> getThreeWindingsTransformerStream() {
+        return getDelegate().getThreeWindingsTransformerStream().map(getIndex()::getThreeWindingsTransformer);
+    }
+
+    @Override
+    public int getThreeWindingsTransformerCount() {
+        return getDelegate().getThreeWindingsTransformerCount();
+    }
+
+    @Override
     public void remove() {
         // TODO(mathbagu)
         throw  MergingView.createNotImplementedException();

--- a/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/VoltageLevelAdapterTest.java
+++ b/iidm/iidm-mergingview/src/test/java/com/powsybl/iidm/mergingview/VoltageLevelAdapterTest.java
@@ -187,6 +187,98 @@ public class VoltageLevelAdapterTest {
         assertEquals(vlExpected.getLccConverterStationCount(), vlActual.getLccConverterStationCount());
         assertEquals(vlExpected.getLccConverterStationStream().count(), vlActual.getLccConverterStationStream().count());
 
+        // Line
+        mergingView.newLine()
+                .setId("l1")
+                .setName("line1")
+                .setR(1.0)
+                .setX(2.0)
+                .setG1(3.0)
+                .setG2(4.0)
+                .setB1(5.0)
+                .setB2(6.0)
+                .setVoltageLevel1("vl1")
+                .setVoltageLevel2("vl2")
+                .setBus1("busA")
+                .setBus2("busB")
+                .setConnectableBus1("busA")
+                .setConnectableBus2("busB")
+                .add();
+        vlActual.getLines().forEach(b -> {
+            assertTrue(b instanceof LineAdapter);
+            assertNotNull(b);
+        });
+        assertEquals(vlExpected.getLineCount(), vlActual.getLineCount());
+        assertEquals(vlExpected.getLineStream().count(), vlActual.getLineStream().count());
+        assertEquals(Iterables.size(vlExpected.getLines()), Iterables.size(vlActual.getLines()));
+
+        // TwoWindingsTransformer
+        TwoWindingsTransformer twoWindingsTransformer = vlActual.getSubstation().get().newTwoWindingsTransformer()
+                .setId("2wt")
+                .setName("TwoWindingsTransformer")
+                .setR(1.0)
+                .setX(2.0)
+                .setG(3.0)
+                .setB(4.0)
+                .setRatedU1(5.0)
+                .setRatedU2(6.0)
+                .setRatedS(7.0)
+                .setVoltageLevel1("vl1")
+                .setVoltageLevel2("vl2")
+                .setConnectableBus1("busA")
+                .setConnectableBus2("busB")
+            .add();
+        vlActual.getTwoWindingsTransformers().forEach(b -> {
+            assertTrue(b instanceof TwoWindingsTransformerAdapter);
+            assertNotNull(b);
+        });
+        assertEquals(vlExpected.getTwoWindingsTransformerCount(), vlActual.getTwoWindingsTransformerCount());
+        assertEquals(vlExpected.getTwoWindingsTransformerStream().count(), vlActual.getTwoWindingsTransformerStream().count());
+        assertEquals(Iterables.size(vlExpected.getTwoWindingsTransformers()), Iterables.size(vlActual.getTwoWindingsTransformers()));
+
+        // ThreeWindingsTransformer
+        ThreeWindingsTransformer threeWindingsTransformer = vlActual.getSubstation().get().newThreeWindingsTransformer()
+                .setId("3wt")
+                .setName("ThreeWindingsTransformer")
+                .newLeg1()
+                .setR(1.3)
+                .setX(1.4)
+                .setG(1.6)
+                .setB(1.7)
+                .setRatedU(1.1)
+                .setRatedS(1.2)
+                .setVoltageLevel("vl1")
+                .setBus("busA")
+                .add()
+                .newLeg2()
+                .setR(2.03)
+                .setX(2.04)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(2.05)
+                .setRatedS(2.06)
+                .setVoltageLevel("vl2")
+                .setBus("busB")
+                .add()
+                .newLeg3()
+                .setR(3.3)
+                .setX(3.4)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU(3.5)
+                .setRatedS(3.6)
+                .setVoltageLevel("vl2")
+                .setBus("busB")
+                .add()
+                .add();
+        vlActual.getThreeWindingsTransformers().forEach(b -> {
+            assertTrue(b instanceof ThreeWindingsTransformerAdapter);
+            assertNotNull(b);
+        });
+        assertEquals(vlExpected.getThreeWindingsTransformerCount(), vlActual.getThreeWindingsTransformerCount());
+        assertEquals(vlExpected.getThreeWindingsTransformerStream().count(), vlActual.getThreeWindingsTransformerStream().count());
+        assertEquals(Iterables.size(vlExpected.getThreeWindingsTransformers()), Iterables.size(vlActual.getThreeWindingsTransformers()));
+
         // Switch
         vlActual.getSwitches().forEach(s -> {
             assertTrue(s instanceof SwitchAdapter);
@@ -242,8 +334,11 @@ public class VoltageLevelAdapterTest {
         assertEquals(1, Iterables.size(vlActual.getConnectables(Battery.class)));
         assertSame(dl, vlActual.getConnectable("DLL1", DanglingLine.class));
         assertEquals(1, Iterables.size(vlActual.getConnectables(DanglingLine.class)));
-        assertEquals(8, Iterables.size(vlActual.getConnectables()));
-        assertEquals(8, vlActual.getConnectableStream().count());
+        assertEquals(1, Iterables.size(vlActual.getConnectables(Line.class)));
+        assertEquals(1, Iterables.size(vlActual.getConnectables(TwoWindingsTransformer.class)));
+        assertEquals(1, Iterables.size(vlActual.getConnectables(ThreeWindingsTransformer.class)));
+        assertEquals(11, Iterables.size(vlActual.getConnectables()));
+        assertEquals(11, vlActual.getConnectableStream().count());
 
         MergingView cgm = MergingViewFactory.createCGM(null);
         VoltageLevel vl1 = cgm.getVoltageLevel("VL1");

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLineTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.network.tck;
 
+import com.google.common.collect.Iterables;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
@@ -75,6 +76,12 @@ public abstract class AbstractLineTest {
         assertEquals(3.5, acLine.getG2(), 0.0);
         assertEquals(4.0, acLine.getB1(), 0.0);
         assertEquals(4.5, acLine.getB2(), 0.0);
+
+        assertEquals(1, Iterables.size(voltageLevelA.getLines()));
+        assertEquals(1, voltageLevelA.getLineStream().count());
+        assertEquals(1, voltageLevelA.getLineCount());
+        assertSame(acLine, voltageLevelA.getLines().iterator().next());
+        assertSame(acLine, voltageLevelA.getLineStream().findFirst().get());
 
         Bus busA = voltageLevelA.getBusBreakerView().getBus("busA");
         Bus busB = voltageLevelB.getBusBreakerView().getBus("busB");

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.network.tck;
 
+import com.google.common.collect.Iterables;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.PhaseTapChanger.RegulationMode;
 import com.powsybl.iidm.network.ThreeWindingsTransformer.Leg;
@@ -52,6 +53,12 @@ public abstract class AbstractThreeWindingsTransformerTest extends AbstractTrans
         assertEquals(ConnectableType.THREE_WINDINGS_TRANSFORMER, transformer.getType());
 
         assertEquals(substation.getThreeWindingsTransformerStream().count(), substation.getThreeWindingsTransformerCount());
+        VoltageLevel vl1 = network.getVoltageLevel("vl1");
+        assertEquals(1, Iterables.size(vl1.getThreeWindingsTransformers()));
+        assertEquals(1, vl1.getThreeWindingsTransformerStream().count());
+        assertEquals(1, vl1.getThreeWindingsTransformerCount());
+        assertSame(transformer, vl1.getThreeWindingsTransformers().iterator().next());
+        assertSame(transformer, vl1.getThreeWindingsTransformerStream().findFirst().get());
 
         // leg1 adder
         ThreeWindingsTransformer.Leg leg1 = transformer.getLeg1();

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.network.tck;
 
+import com.google.common.collect.Iterables;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.tck.internal.AbstractTransformerTest;
 import org.junit.Test;
@@ -73,6 +74,12 @@ public abstract class AbstractTwoWindingsTransformerTest extends AbstractTransfo
         assertEquals(ratedS, twoWindingsTransformer.getRatedS(), 0.0);
 
         assertEquals(substation.getTwoWindingsTransformerStream().count(), substation.getTwoWindingsTransformerCount());
+        VoltageLevel vl1 = network.getVoltageLevel("vl1");
+        assertEquals(1, Iterables.size(vl1.getTwoWindingsTransformers()));
+        assertEquals(1, vl1.getTwoWindingsTransformerStream().count());
+        assertEquals(1, vl1.getTwoWindingsTransformerCount());
+        assertSame(twoWindingsTransformer, vl1.getTwoWindingsTransformers().iterator().next());
+        assertSame(twoWindingsTransformer, vl1.getTwoWindingsTransformerStream().findFirst().get());
 
         RatioTapChanger ratioTapChangerInLeg1 = createRatioTapChanger(twoWindingsTransformer,
                 twoWindingsTransformer.getTerminal(TwoWindingsTransformer.Side.ONE));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
to get lines or 2wt or 3wt from connected to a vl, you must call getConnectable(Line.class) (resp 2wt.class, 3wt.class)


**What is the new behavior (if this is a feature change)?**
to get them you call getLines() etc 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO. Other iidm implementations must implement the new methods
