### PR TITLE
Fix bus breaker view cache

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -790,7 +790,7 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
         //because thoses buses are already indexed in the NetworkIndex
         private final BusCache busBreakerViewCache = new BusCache(() -> getVoltageLevelStream()
                 .filter(vl -> vl.getTopologyKind() != TopologyKind.BUS_BREAKER)
-                .flatMap(vl -> getBusBreakerView().getBusStream()));
+                .flatMap(vl -> vl.getBusBreakerView().getBusStream()));
 
         @Override
         public VariantImpl copy() {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerTest.java
@@ -267,4 +267,16 @@ public abstract class AbstractNodeBreakerTest {
         assertNull(getBus(network.getLoad("L4")));
         assertNull(getConnectableBus(network.getLoad("L4")));
     }
+
+    @Test
+    public void testCalculatedBus() {
+        Network network = createIsolatedLoadNetwork();
+
+        Bus busL0 = network.getLoad("L0").getTerminal().getBusBreakerView().getBus();
+        assertNotNull(busL0);
+        assertEquals("VL", busL0.getVoltageLevel().getId());
+        assertEquals("VL_0", busL0.getId());
+
+        assertNull(network.getBusBreakerView().getBus("unknownBus"));
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** 
Bug fix


**What is the current behavior?**
Bus breaker view cache cannot be build if more than one voltage level in the network: `java.lang.IllegalArgumentException` is thrown with `"Multiple entries with same key"` message. Indeed, the buses in the cached map are duplicated for each voltage level, leading to this exception.


**What is the new behavior (if this is a feature change)?**
Bus breaker view cache can be build.


**Does this PR introduce a breaking change or deprecate an API?**
No
