### PR TITLE
Fix CGMES import exists method

### DIFF
--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/Cgmes3ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/Cgmes3ConversionTest.java
@@ -25,18 +25,28 @@ import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.triplestore.api.TripleStoreFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.util.Properties;
 
 import org.junit.Test;
 
+import static org.junit.Assert.*;
+
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
 public class Cgmes3ConversionTest {
+
+    @Test
+    public void loadNetworkMicroGrid() {
+        // Check that CGMES importer supports check existence of valid CGMES 3 (CIM100) files
+        CgmesImport importer = new CgmesImport();
+        ReadOnlyDataSource ds = Cgmes3Catalog.microGrid().dataSource();
+        assertTrue(importer.exists(ds));
+        Network network = importer.importData(ds, NetworkFactory.findDefault(), null);
+        assertNotNull(network);
+    }
+
     @Test
     public void microGrid() throws IOException {
         Properties importParams = new Properties();

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -39,7 +39,7 @@ public class CgmesOnDataSource {
         if (!foundNamespaces.contains(RDF_NAMESPACE)) {
             return false;
         }
-        if (!foundNamespaces.contains(CIM_16_NAMESPACE)) {
+        if (!(foundNamespaces.contains(CIM_16_NAMESPACE) || foundNamespaces.contains(CIM_100_NAMESPACE))) {
             return false;
         }
         return names().stream().anyMatch(CgmesSubset.EQUIPMENT::isValidName);


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Accept CIM 100 namespace as valid to allow import of CGMES 3 models.

**What is the current behavior?** *(You can also link to an open issue here)*
CGMES 3 models were not imported because the CGMES importer only considered CIM 16 files as valid.

