### PR TITLE
Fix query for operational limits in CIM100 (CGMES 3)

### DIFF
--- a/cgmes/cgmes-model/src/main/resources/CIM100.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM100.sparql
@@ -68,10 +68,13 @@ SELECT *
 WHERE {
 { GRAPH ?graph {
     ?OperationalLimit
-        a $OperationalLimitSubclass ;
-        cim:IdentifiedObject.name ?name ;
+        cim:OperationalLimit.OperationalLimitType ?OperationalLimitType ;
         cim:OperationalLimit.OperationalLimitSet ?OperationalLimitSet ;
-        cim:OperationalLimit.OperationalLimitType ?OperationalLimitType .
+        cim:IdentifiedObject.name ?name ;
+        a ?OperationalLimitSubclass .
+    ?OperationalLimitType
+        a cim:OperationalLimitType ;
+        cim:IdentifiedObject.name ?operationalLimitTypeName .
     OPTIONAL { ?OperationalLimit cim:CurrentLimit.normalValue ?normalValue }
     OPTIONAL { ?OperationalLimit cim:ApparentPowerLimit.normalValue ?normalValue }
     OPTIONAL { ?OperationalLimit cim:VoltageLimit.normalValue ?normalValue }
@@ -81,14 +84,11 @@ WHERE {
         ?OperationalLimitSet cim:OperationalLimitSet.Equipment ?Equipment .
         ?Equipment cim:Equipment.EquipmentContainer ?EquipmentContainer
     }}
-    ?OperationalLimitType
-        a cim:OperationalLimitType ;
-        cim:IdentifiedObject.name ?operationalLimitTypeName .
     OPTIONAL { ?OperationalLimitType cim:OperationalLimitType.direction ?direction }
     OPTIONAL { ?OperationalLimitType eu:OperationalLimitType.kind ?limitType }
     OPTIONAL { ?OperationalLimitType cim:OperationalLimitType.acceptableDuration ?acceptableDuration }
 }}
-OPTIONAL { GRAPH ?graphSSH {
+{ GRAPH ?graphSSH {
    OPTIONAL {?OperationalLimit cim:CurrentLimit.value ?value }
    OPTIONAL {?OperationalLimit cim:ApparentPowerLimit.value ?value }
    OPTIONAL {?OperationalLimit cim:VoltageLimit.value ?value }


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix.


**What is the current behavior?** *(You can also link to an open issue here)*

When CGMES 3.0 RealCase is imported the program gets stuck converting the OperationalLimits from the tripleStore.

**What is the new behavior (if this is a feature change)?**

CGMES 3.0 RealCase is well imported.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
