### PR TITLE
fix quadratic performance regexp noticed by sonar

### DIFF
--- a/computation/src/main/java/com/powsybl/computation/Partition.java
+++ b/computation/src/main/java/com/powsybl/computation/Partition.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
  */
 public class Partition {
 
-    private static final Pattern PATTERN = Pattern.compile("\\d+/\\d+");
+    private static final Pattern PATTERN = Pattern.compile("^\\d+/\\d+$");
 
     private final int taskIndex;
 

--- a/computation/src/test/java/com/powsybl/computation/PartitionTest.java
+++ b/computation/src/test/java/com/powsybl/computation/PartitionTest.java
@@ -63,26 +63,17 @@ public class PartitionTest {
         assertPartitionInvalid("/1");
         assertPartitionInvalid("1/");
         assertPartitionInvalid("1|2");
+        assertPartitionInvalid("-1/2");
+        assertPartitionInvalid("+1/+2/foo0/0bar");
+        assertPartitionInvalid("foo/1/2");
+        assertPartitionInvalid("a1/2");
+        assertPartitionInvalid(" 1/2 ");
+        assertPartitionInvalid("+1/2");
+        assertPartitionInvalid("1/2/foo");
+        assertPartitionInvalid("-0/2");
 
-        //invalid values (but parses ok, bug or feature?)
+        //invalid values
         assertPartitionInvalid("2/1");
         assertPartitionInvalid("0/2");
-        assertPartitionInvalid("-1/2");
-
-        // Are the following bugs or features ?
-        assertThrows(NumberFormatException.class, () -> Partition.parse("foo/1/2"));
-        assertThrows(NumberFormatException.class, () -> Partition.parse("a1/2"));
-        assertThrows(NumberFormatException.class, () -> Partition.parse(" 1/2 "));
-        Partition.parse("+1/2");
-        Partition.parse("1/2/foo");
-        {
-            Partition p = Partition.parse("+1/+2/foo0/0bar");
-            assertEquals("1/2", p.toString());
-        }
-        {
-            PowsyblException exception = assertThrows(PowsyblException.class,
-                () -> Partition.parse("-0/2"));
-            assertEquals("0/2 is not valid", exception.getMessage());
-        }
     }
 }


### PR DESCRIPTION
For the quadratic performance, only the "^" is needed, but adding "$" for symmetry.

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bugfix

**What is the current behavior?** *(You can also link to an open issue here)*
quadratic performance (sonar detected bug)
weird accepted input

**What is the new behavior (if this is a feature change)?**
linear performance
no weird accepted input


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO