### PR TITLE
Fix name of the adder of RemoteReactivePowerControl extension

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/RemoteReactivePowerControlAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/RemoteReactivePowerControlAdderImpl.java
@@ -15,7 +15,7 @@ import com.powsybl.iidm.network.extensions.RemoteReactivePowerControlAdder;
 /**
  * @author Bertrand Rix <bertrand.rix at artelys.com>
  */
-public class RemoteReactivePowerAdderImpl extends AbstractExtensionAdder<Generator, RemoteReactivePowerControl> implements RemoteReactivePowerControlAdder {
+public class RemoteReactivePowerControlAdderImpl extends AbstractExtensionAdder<Generator, RemoteReactivePowerControl> implements RemoteReactivePowerControlAdder {
 
     private double targetQ;
 
@@ -23,7 +23,7 @@ public class RemoteReactivePowerAdderImpl extends AbstractExtensionAdder<Generat
 
     private boolean enabled;
 
-    protected RemoteReactivePowerAdderImpl(final Generator extendable) {
+    protected RemoteReactivePowerControlAdderImpl(final Generator extendable) {
         super(extendable);
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/RemoteReactivePowerControlAdderImplProvider.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/RemoteReactivePowerControlAdderImplProvider.java
@@ -15,7 +15,7 @@ import com.powsybl.iidm.network.extensions.RemoteReactivePowerControl;
  * @author Bertrand Rix <bertrand.rix at artelys.com>
  */
 @AutoService(ExtensionAdderProvider.class)
-public class RemoteReactivePowerControlAdderImplProvider implements ExtensionAdderProvider<Generator, RemoteReactivePowerControl, RemoteReactivePowerAdderImpl> {
+public class RemoteReactivePowerControlAdderImplProvider implements ExtensionAdderProvider<Generator, RemoteReactivePowerControl, RemoteReactivePowerControlAdderImpl> {
 
     @Override
     public String getImplementationName() {
@@ -23,12 +23,12 @@ public class RemoteReactivePowerControlAdderImplProvider implements ExtensionAdd
     }
 
     @Override
-    public Class<RemoteReactivePowerAdderImpl> getAdderClass() {
-        return RemoteReactivePowerAdderImpl.class;
+    public Class<RemoteReactivePowerControlAdderImpl> getAdderClass() {
+        return RemoteReactivePowerControlAdderImpl.class;
     }
 
     @Override
-    public RemoteReactivePowerAdderImpl newAdder(Generator extendable) {
-        return new RemoteReactivePowerAdderImpl(extendable);
+    public RemoteReactivePowerControlAdderImpl newAdder(Generator extendable) {
+        return new RemoteReactivePowerControlAdderImpl(extendable);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactor


**What is the current behavior?** *(You can also link to an open issue here)*
The name of the RemoteReactivePowerControl extension's adder is not compliant with the name of the extension.


**What is the new behavior (if this is a feature change)?**
The name of the adder have been changed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
