### PR TITLE
Fix XML serialization of dangling line's generation's active power limits

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/DanglingLineXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/DanglingLineXml.java
@@ -71,8 +71,8 @@ class DanglingLineXml extends AbstractConnectableXml<DanglingLine, DanglingLineA
         XmlUtil.writeDouble("b", dl.getB(), context.getWriter());
         if (generation != null) {
             IidmXmlUtil.runFromMinimumVersion(IidmXmlVersion.V_1_3, context, () -> {
-                XmlUtil.writeDouble("generationMinP", generation.getMinP(), context.getWriter());
-                XmlUtil.writeDouble("generationMaxP", generation.getMaxP(), context.getWriter());
+                XmlUtil.writeOptionalDouble("generationMinP", generation.getMinP(), -Double.MAX_VALUE, context.getWriter());
+                XmlUtil.writeOptionalDouble("generationMaxP", generation.getMaxP(), Double.MAX_VALUE, context.getWriter());
                 context.getWriter().writeAttribute("generationVoltageRegulationOn", Boolean.toString(generation.isVoltageRegulationOn()));
                 XmlUtil.writeDouble("generationTargetP", generation.getTargetP(), context.getWriter());
                 XmlUtil.writeDouble("generationTargetV", generation.getTargetV(), context.getWriter());


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix in serialization


**What is the current behavior?** *(You can also link to an open issue here)*
When minP and maxP of dangling lines' generations are -Double.MAX_VALUE and Double.MAX_VALUE (default values), they are written


**What is the new behavior (if this is a feature change)?**
They are not written anymore (implicit)


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


