### PR TITLE
Fix Java 17 build

### DIFF
--- a/dsl/pom.xml
+++ b/dsl/pom.xml
@@ -18,6 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powsybl-dsl</artifactId>
+    <name>DSL</name>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
         <gdata.version>1.41.1_1</gdata.version>
         <graphviz-builder.version>1.0.11</graphviz-builder.version>
-        <groovy.version>3.0.7</groovy.version>
+        <groovy.version>3.0.9</groovy.version>
         <guava.version>30.0-jre</guava.version>
         <jackson.version>2.10.5</jackson.version>
         <jackson-databind.version>2.10.5.1</jackson-databind.version>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Compilation fails using JDK 17 (current LTS), because of groovy 3.0.7 not supporting Java 17.

```java
[ERROR] Failed to execute goal org.codehaus.gmavenplus:gmavenplus-plugin:1.11.1:generateStubs (default) on project powsybl-dsl: Error occurred while calling a method on a Groovy class from classpath.: InvocationTargetException: startup failed:
[ERROR] General error during conversion: Unsupported class file major version 61
[ERROR] 
[ERROR] java.lang.IllegalArgumentException: Unsupported class file major version 61
[ERROR] 	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:189)
[ERROR] 	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:170)
[ERROR] 	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:156)
[ERROR] 	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:277)
[ERROR] 	at org.codehaus.groovy.ast.decompiled.AsmDecompiler.parseClass(AsmDecompiler.java:81)
[ERROR] 	at org.codehaus.groovy.control.ClassNodeResolver.findDecompiled(ClassNodeResolver.java:251)
[ERROR] 	at org.codehaus.groovy.control.ClassNodeResolver.tryAsLoaderClassOrScript(ClassNodeResolver.java:189)
[ERROR] 	at org.codehaus.groovy.control.ClassNodeResolver.findClassNode(ClassNodeResolver.java:169)
[ERROR] 	at org.codehaus.groovy.control.ClassNodeResolver.resolveName(ClassNodeResolver.java:125)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.resolveToOuter(ResolveVisitor.java:871)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.resolve(ResolveVisitor.java:506)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.resolveFromDefaultImports(ResolveVisitor.java:663)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.resolveFromDefaultImports(ResolveVisitor.java:626)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.resolve(ResolveVisitor.java:505)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.resolve(ResolveVisitor.java:468)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.resolveOrFail(ResolveVisitor.java:338)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.resolveOrFail(ResolveVisitor.java:330)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.resolveOrFail(ResolveVisitor.java:326)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.visitConstructorOrMethod(ResolveVisitor.java:283)
[ERROR] 	at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitConstructor(ClassCodeVisitorSupport.java:101)
[ERROR] 	at org.codehaus.groovy.tools.javac.JavaAwareResolveVisitor.visitConstructor(JavaAwareResolveVisitor.java:38)
[ERROR] 	at org.codehaus.groovy.ast.ClassNode.visitContents(ClassNode.java:1089)
[ERROR] 	at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitClass(ClassCodeVisitorSupport.java:52)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.visitClass(ResolveVisitor.java:1473)
[ERROR] 	at org.codehaus.groovy.control.ResolveVisitor.startResolving(ResolveVisitor.java:262)
[ERROR] 	at org.codehaus.groovy.tools.javac.JavaStubCompilationUnit.lambda$new$0(JavaStubCompilationUnit.java:58)
[ERROR] 	at org.codehaus.groovy.control.CompilationUnit$IPrimaryClassNodeOperation.doPhaseOperation(CompilationUnit.java:942)
[ERROR] 	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:671)
[ERROR] 	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:635)
[ERROR] 	at org.codehaus.groovy.tools.javac.JavaStubCompilationUnit.compile(JavaStubCompilationUnit.java:82)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[ERROR] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[ERROR] 	at org.codehaus.gmavenplus.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:214)
[ERROR] 	at org.codehaus.gmavenplus.mojo.AbstractGenerateStubsMojo.doStubGeneration(AbstractGenerateStubsMojo.java:269)
[ERROR] 	at org.codehaus.gmavenplus.mojo.GenerateStubsMojo.execute(GenerateStubsMojo.java:72)
[ERROR] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
[ERROR] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
[ERROR] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:957)
[ERROR] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:289)
[ERROR] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:193)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[ERROR] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
[ERROR] 	at org.codehaus.classworlds.Launcher.main(Launcher.java:47)
```

**What is the new behavior (if this is a feature change)?**
Groovy dependency has been updated to 3.0.9 to support JDK 17.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
