### PR TITLE
Fix Windows build

### DIFF
--- a/cim-anonymiser/pom.xml
+++ b/cim-anonymiser/pom.xml
@@ -86,6 +86,13 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-commons</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-tools</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/cim-anonymiser/src/test/java/com/powsybl/cim/CimAnonymizerTest.java
+++ b/cim-anonymiser/src/test/java/com/powsybl/cim/CimAnonymizerTest.java
@@ -10,6 +10,7 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.TestUtil;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.junit.After;
 import org.junit.Before;
@@ -21,7 +22,6 @@ import org.xmlunit.diff.Diff;
 import javax.xml.transform.Source;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -82,7 +82,7 @@ public class CimAnonymizerTest {
             }
         }
 
-        assertEquals(CharStreams.toString(new InputStreamReader(getClass().getResourceAsStream("/sample.csv"))),
-                     new String(Files.readAllBytes(dictionaryFile), StandardCharsets.UTF_8));
+        assertEquals(TestUtil.normalizeLineSeparator(CharStreams.toString(new InputStreamReader(getClass().getResourceAsStream("/sample.csv")))),
+                TestUtil.normalizeLineSeparator(Files.readString(dictionaryFile)));
     }
 }

--- a/cim-anonymiser/src/test/java/com/powsybl/cim/CimAnonymizerTest.java
+++ b/cim-anonymiser/src/test/java/com/powsybl/cim/CimAnonymizerTest.java
@@ -22,6 +22,7 @@ import org.xmlunit.diff.Diff;
 import javax.xml.transform.Source;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -83,6 +84,6 @@ public class CimAnonymizerTest {
         }
 
         assertEquals(TestUtil.normalizeLineSeparator(CharStreams.toString(new InputStreamReader(getClass().getResourceAsStream("/sample.csv")))),
-                TestUtil.normalizeLineSeparator(Files.readString(dictionaryFile)));
+                TestUtil.normalizeLineSeparator(Files.readString(dictionaryFile, StandardCharsets.UTF_8)));
     }
 }

--- a/commons/src/test/java/com/powsybl/commons/AbstractConverterTest.java
+++ b/commons/src/test/java/com/powsybl/commons/AbstractConverterTest.java
@@ -63,11 +63,6 @@ public abstract class AbstractConverterTest {
         assertFalse(hasDiff);
     }
 
-    private static String normalizeLineSeparator(String str) {
-        return str.replace("\r\n", "\n")
-                .replace("\r", "\n");
-    }
-
     protected static void compareTxt(InputStream expected, InputStream actual) {
         try {
             compareTxt(expected, new String(ByteStreams.toByteArray(actual), StandardCharsets.UTF_8));
@@ -91,8 +86,8 @@ public abstract class AbstractConverterTest {
 
     protected static void compareTxt(InputStream expected, String actual) {
         try {
-            String expectedStr = normalizeLineSeparator(new String(ByteStreams.toByteArray(expected), StandardCharsets.UTF_8));
-            String actualStr = normalizeLineSeparator(actual);
+            String expectedStr = TestUtil.normalizeLineSeparator(new String(ByteStreams.toByteArray(expected), StandardCharsets.UTF_8));
+            String actualStr = TestUtil.normalizeLineSeparator(actual);
             assertEquals(expectedStr, actualStr);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/commons/src/test/java/com/powsybl/commons/TestUtil.java
+++ b/commons/src/test/java/com/powsybl/commons/TestUtil.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.commons;
 
+import java.util.Objects;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -15,7 +17,7 @@ public final class TestUtil {
     }
 
     public static String normalizeLineSeparator(String str) {
-        return str.replace("\r\n", "\n")
+        return Objects.requireNonNull(str).replace("\r\n", "\n")
                 .replace("\r", "\n");
     }
 }

--- a/commons/src/test/java/com/powsybl/commons/TestUtil.java
+++ b/commons/src/test/java/com/powsybl/commons/TestUtil.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.commons;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public final class TestUtil {
+
+    private TestUtil() {
+    }
+
+    public static String normalizeLineSeparator(String str) {
+        return str.replace("\r\n", "\n")
+                .replace("\r", "\n");
+    }
+}

--- a/psse/psse-model/src/test/java/com/powsybl/psse/model/PsseRawDataTest.java
+++ b/psse/psse-model/src/test/java/com/powsybl/psse/model/PsseRawDataTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.google.common.io.ByteStreams;
 import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.commons.TestUtil;
 import com.powsybl.commons.datasource.FileDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
@@ -28,17 +29,17 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static com.powsybl.psse.model.PsseVersion.fromRevision;
 import static com.powsybl.psse.model.pf.io.PowerFlowRecordGroup.*;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -111,12 +112,22 @@ public class PsseRawDataTest extends AbstractConverterTest {
             }
         };
         FilterProvider filters = new SimpleFilterProvider().addFilter("PsseVersionFilter", filter);
-        return new ObjectMapper().writerWithDefaultPrettyPrinter().with(filters).writeValueAsString(rawData);
+        String json = new ObjectMapper().writerWithDefaultPrettyPrinter().with(filters).writeValueAsString(rawData);
+        return TestUtil.normalizeLineSeparator(json);
+    }
+
+    private static String loadReference(String path) {
+        try {
+            InputStream is = Objects.requireNonNull(PsseRawDataTest.class.getResourceAsStream(path));
+            return TestUtil.normalizeLineSeparator(new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Test
     public void ieee14BusTest() throws IOException {
-        String expectedJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_14_bus.json")), StandardCharsets.UTF_8);
+        String expectedJson = loadReference("/IEEE_14_bus.json");
         PssePowerFlowModel rawData = new PowerFlowRawData33().read(ieee14Raw(), "raw", new Context());
         assertNotNull(rawData);
         assertEquals(expectedJson, toJson(rawData));
@@ -266,7 +277,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
 
     @Test
     public void ieee14BusWhitespaceAsDelimiterTest() throws IOException {
-        String expectedJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_14_bus.json")), StandardCharsets.UTF_8);
+        String expectedJson = loadReference("/IEEE_14_bus.json");
         PssePowerFlowModel rawData = new PowerFlowRawData33().read(ieee14WhitespaceAsDelimiterRaw(), "raw", new Context());
         assertNotNull(rawData);
         assertEquals(expectedJson, toJson(rawData));
@@ -274,7 +285,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
 
     @Test
     public void ieee14IsolatedBusesTest() throws IOException {
-        String expectedJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_14_isolated_buses.json")), StandardCharsets.UTF_8);
+        String expectedJson = loadReference("/IEEE_14_isolated_buses.json");
         PssePowerFlowModel rawData = new PowerFlowRawData33().read(ieee14IsolatedBusesRaw(), "raw", new Context());
         assertNotNull(rawData);
         assertEquals(expectedJson, toJson(rawData));
@@ -343,7 +354,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
     @Test
     public void ieee14BusRev35RawxTest() throws IOException {
         PssePowerFlowModel rawData = new PowerFlowRawxData35().read(ieee14Rawx35(), "rawx", new Context());
-        String jsonRef = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_14_bus_rev35.json")), StandardCharsets.UTF_8);
+        String jsonRef = loadReference("/IEEE_14_bus_rev35.json");
         assertEquals(jsonRef, toJson(rawData));
     }
 
@@ -405,7 +416,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
     public void ieee14BusRev35Test() throws IOException {
         PssePowerFlowModel rawData = new PowerFlowRawData35().read(ieee14Raw35(), "raw", new Context());
         assertNotNull(rawData);
-        String jsonRef = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_14_bus_rev35.json")), StandardCharsets.UTF_8);
+        String jsonRef = loadReference("/IEEE_14_bus_rev35.json");
         assertEquals(jsonRef, toJson(rawData));
     }
 
@@ -552,7 +563,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
 
     @Test
     public void ieee24BusTest() throws IOException {
-        String expectedJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_24_bus.json")), StandardCharsets.UTF_8);
+        String expectedJson = loadReference("/IEEE_24_bus.json");
         PssePowerFlowModel rawData = new PowerFlowRawData33().read(ieee24Raw(), "raw", new Context());
         assertNotNull(rawData);
         assertEquals(expectedJson, toJson(rawData));
@@ -571,7 +582,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
 
     @Test
     public void ieee24BusRev35Test() throws IOException {
-        String expectedJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_24_bus_rev35.json")), StandardCharsets.UTF_8);
+        String expectedJson = loadReference("/IEEE_24_bus_rev35.json");
         PssePowerFlowModel rawData = new PowerFlowRawData35().read(ieee24Raw35(), "raw", new Context());
         assertNotNull(rawData);
         assertEquals(expectedJson, toJson(rawData));
@@ -590,7 +601,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
 
     @Test
     public void ieee24BusRev35RawxTest() throws IOException {
-        String expectedJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_24_bus_rev35.json")), StandardCharsets.UTF_8);
+        String expectedJson = loadReference("/IEEE_24_bus_rev35.json");
         PssePowerFlowModel rawData = new PowerFlowRawxData35().read(ieee24Rawx35(), "rawx", new Context());
         assertNotNull(rawData);
         assertEquals(expectedJson, toJson(rawData));
@@ -648,7 +659,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
 
     @Test
     public void ieee14BusCompletedTest() throws IOException {
-        String expectedJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_14_bus_completed.json")), StandardCharsets.UTF_8);
+        String expectedJson = loadReference("/IEEE_14_bus_completed.json");
         PssePowerFlowModel rawData = new PowerFlowRawData33().read(ieee14CompletedRaw(), "raw", new Context());
         assertNotNull(rawData);
         assertEquals(expectedJson, toJson(rawData));
@@ -656,7 +667,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
 
     @Test
     public void ieee14BusCompletedRev35Test() throws IOException {
-        String expectedJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_14_bus_completed_rev35.json")), StandardCharsets.UTF_8);
+        String expectedJson = loadReference("/IEEE_14_bus_completed_rev35.json");
         PssePowerFlowModel rawData = new PowerFlowRawData35().read(ieee14CompletedRaw35(), "raw", new Context());
         assertNotNull(rawData);
         assertEquals(expectedJson, toJson(rawData));
@@ -664,7 +675,7 @@ public class PsseRawDataTest extends AbstractConverterTest {
 
     @Test
     public void ieee14BusCompletedRev35RawxTest() throws IOException {
-        String expectedJson = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_14_bus_completed_rev35.json")), StandardCharsets.UTF_8);
+        String expectedJson = loadReference("/IEEE_14_bus_completed_rev35.json");
         PssePowerFlowModel rawData = new PowerFlowRawxData35().read(ieee14CompletedRawx35(), "rawx", new Context());
         assertNotNull(rawData);
         assertEquals(expectedJson, toJson(rawData));
@@ -722,8 +733,8 @@ public class PsseRawDataTest extends AbstractConverterTest {
             String s = String.format("%s%n", warning);
             sb.append(s);
         });
-        String warningsRef = new String(ByteStreams.toByteArray(getClass().getResourceAsStream("/IEEE_14_bus_invalid.txt")), StandardCharsets.UTF_8);
-        assertEquals(warningsRef, sb.toString());
+        String warningsRef = loadReference("/IEEE_14_bus_invalid.txt");
+        assertEquals(warningsRef, TestUtil.normalizeLineSeparator(sb.toString()));
         assertFalse(psseValidation.isValidCase());
     }
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -83,6 +83,12 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-commons</artifactId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
             <scope>test</scope>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -86,6 +86,7 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-commons</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/tools/src/test/java/com/powsybl/tools/autocompletion/BashCompletionGeneratorTest.java
+++ b/tools/src/test/java/com/powsybl/tools/autocompletion/BashCompletionGeneratorTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.tools.autocompletion;
 
+import com.powsybl.commons.TestUtil;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,8 +50,9 @@ public class BashCompletionGeneratorTest {
     private void checkGeneratedScript(String referencePath, BashCommand... commands) throws IOException {
         try (StringWriter sw = new StringWriter()) {
             generator.generateCommands("itools", Arrays.asList(commands), sw);
-            String script = sw.toString();
-            assertEquals(readResource(referencePath), script);
+            String script = TestUtil.normalizeLineSeparator(sw.toString());
+            String refScript = TestUtil.normalizeLineSeparator(readResource(referencePath));
+            assertEquals(refScript, script);
         }
     }
 

--- a/tools/src/test/java/com/powsybl/tools/autocompletion/BashCompletionToolTest.java
+++ b/tools/src/test/java/com/powsybl/tools/autocompletion/BashCompletionToolTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.tools.autocompletion;
 
 import com.google.common.collect.ImmutableList;
+import com.powsybl.commons.TestUtil;
 import com.powsybl.tools.AbstractToolTest;
 import com.powsybl.tools.Command;
 import com.powsybl.tools.Tool;
@@ -57,7 +58,7 @@ public class BashCompletionToolTest extends AbstractToolTest {
 
     private String expectedScript() throws IOException {
         try (InputStream is = getClass().getResourceAsStream("tool-output.sh")) {
-            return IOUtils.toString(is, StandardCharsets.UTF_8);
+            return TestUtil.normalizeLineSeparator(IOUtils.toString(is, StandardCharsets.UTF_8));
         }
     }
 
@@ -76,7 +77,7 @@ public class BashCompletionToolTest extends AbstractToolTest {
 
         tool.generateCompletionScript(ImmutableList.of(tool2, tool1), fileSystem.getPath("/output.sh"));
 
-        String outputScript = Files.readString(fileSystem.getPath("/output.sh"), StandardCharsets.UTF_8);
+        String outputScript = TestUtil.normalizeLineSeparator(Files.readString(fileSystem.getPath("/output.sh"), StandardCharsets.UTF_8));
         assertEquals(expectedScript(), outputScript);
     }
 

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReporterTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.TestUtil;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
 import com.powsybl.commons.datasource.ResourceSet;
@@ -38,10 +39,6 @@ public class UcteImporterReporterTest extends AbstractConverterTest {
 
     private static final String WORK_DIR = "/tmp";
 
-    protected static String normalizeLineSeparator(String str) {
-        return str.replace("\r\n", "\n").replace("\r", "\n");
-    }
-
     @Test
     public void testReportElementName() throws Exception {
         ReadOnlyDataSource dataSource = new ResourceDataSource("elementName", new ResourceSet("/", "elementName.uct"));
@@ -64,8 +61,8 @@ public class UcteImporterReporterTest extends AbstractConverterTest {
         reporter.export(sw);
 
         InputStream refStream = getClass().getResourceAsStream("/elementNameImportReport.txt");
-        String refLogExport = normalizeLineSeparator(new String(ByteStreams.toByteArray(refStream), StandardCharsets.UTF_8));
-        String logExport = normalizeLineSeparator(sw.toString());
+        String refLogExport = TestUtil.normalizeLineSeparator(new String(ByteStreams.toByteArray(refStream), StandardCharsets.UTF_8));
+        String logExport = TestUtil.normalizeLineSeparator(sw.toString());
         assertEquals(refLogExport, logExport);
     }
 


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Windows build is broken because of a few unit tests that are dependent of git carriage return configuration. If 'input' is configured so that all files are checkout with LF instead of CRLF (default behaviour), some unit tests based of reference file comparison fail.
```properties
[core]
	autocrlf = input
```

**What is the new behavior (if this is a feature change)?**
Files carriage return are normalized everywhere before comparison.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
