### PR TITLE
Initialize XmlStreamWriter based on Writer

### DIFF
--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
@@ -36,6 +36,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -144,14 +145,13 @@ public class StateVariablesExportTest extends AbstractConverterTest {
 
     private String exportSvAsString(Network network, int svVersion) throws XMLStreamException, IOException {
         CgmesExportContext context = new CgmesExportContext(network);
-        Path file = fileSystem.getPath("/work/" + network.getId() + ".xml");
-        OutputStream os = Files.newOutputStream(file);
-        XMLStreamWriter writer = XmlUtil.initializeWriter(true, "    ", os);
+        StringWriter stringWriter = new StringWriter();
+        XMLStreamWriter writer = XmlUtil.initializeWriter(true, "    ", stringWriter);
         context.getSvModelDescription().setVersion(svVersion);
         context.setExportBoundaryPowerFlows(true);
         StateVariablesExport.write(network, writer, context);
 
-        return Files.readString(file);
+        return stringWriter.toString();
     }
 
     private static String getCgmesTerminal(Terminal terminal) {

--- a/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
@@ -13,6 +13,7 @@ import javanet.staxutils.IndentingXMLStreamWriter;
 
 import javax.xml.stream.*;
 import java.io.OutputStream;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -235,14 +236,25 @@ public final class XmlUtil {
     }
 
     public static XMLStreamWriter initializeWriter(boolean indent, String indentString, OutputStream os) throws XMLStreamException {
-        XMLStreamWriter writer;
-        writer = XML_OUTPUT_FACTORY_SUPPLIER.get().createXMLStreamWriter(os, StandardCharsets.UTF_8.toString());
+        XMLStreamWriter writer = XML_OUTPUT_FACTORY_SUPPLIER.get().createXMLStreamWriter(os, StandardCharsets.UTF_8.toString());
+        return initializeWriter(indent, indentString, writer);
+    }
+
+    public static XMLStreamWriter initializeWriter(boolean indent, String indentString, Writer writer) throws XMLStreamException {
+        XMLStreamWriter xmlWriter = XML_OUTPUT_FACTORY_SUPPLIER.get().createXMLStreamWriter(writer);
+        return initializeWriter(indent, indentString, xmlWriter);
+    }
+
+    private static XMLStreamWriter initializeWriter(boolean indent, String indentString, XMLStreamWriter initialXmlWriter) throws XMLStreamException {
+        XMLStreamWriter xmlWriter;
         if (indent) {
-            IndentingXMLStreamWriter indentingWriter = new IndentingXMLStreamWriter(writer);
+            IndentingXMLStreamWriter indentingWriter = new IndentingXMLStreamWriter(initialXmlWriter);
             indentingWriter.setIndent(indentString);
-            writer = indentingWriter;
+            xmlWriter = indentingWriter;
+        } else {
+            xmlWriter = initialXmlWriter;
         }
-        writer.writeStartDocument(StandardCharsets.UTF_8.toString(), "1.0");
-        return writer;
+        xmlWriter.writeStartDocument(StandardCharsets.UTF_8.toString(), "1.0");
+        return xmlWriter;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The `XMLStreamWriter` returned by `XmlUtil::intializeWriter` cannot be created from a `Writer` but only from an `OutputStream`.


**What is the new behavior (if this is a feature change)?**
The `XMLStreamWriter` returned by `XmlUtil::intializeWriter` can either be created from a `Writer` or an `OutputStream`


**Does this PR introduce a breaking change or deprecate an API?**
No