### PR TITLE
CGMES 3 - Fix query for synchronous machines in CIM100

### DIFF
--- a/cgmes/cgmes-model/src/main/resources/CIM100.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM100.sparql
@@ -59,7 +59,9 @@ OPTIONAL { GRAPH ?graphSSH {
         cim:RotatingMachine.q ?q ;
         cim:SynchronousMachine.referencePriority ?referencePriority ;
         cim:RegulatingCondEq.controlEnabled ?controlEnabled .
-    OPTIONAL { ?GeneratingUnit cim:GeneratingUnit.normalPF ?normalPF }
+}}
+OPTIONAL { GRAPH ?graphSSH {
+    ?GeneratingUnit cim:GeneratingUnit.normalPF ?normalPF
 }}
 }
 


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix performance of SPARQL query for synchronous machines in CGMES 3 import (CIM100).


**What is the current behavior?** *(You can also link to an open issue here)*
Query has low performance on big networks.


**What is the new behavior (if this is a feature change)?**
The performance problem was identified to a nested OPTIONAL clause sharing no variables with its parent clause. The statements in the query have been reorganised to avoid the issue. It is the same fix that was applied in #1891 to CIM16 set of queries.

