### PR TITLE
CGMES. Optimize verification of model is node/breaker

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -44,6 +44,8 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
 
     @Override
     public void read(InputStream is, String baseName, String contextName) {
+        // Reset cached isNodeBreaker everytime we read new data
+        isNodeBreakerComputed = false;
         tripleStore.read(is, baseName, contextName);
     }
 
@@ -145,6 +147,14 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
 
     @Override
     public boolean isNodeBreaker() {
+        if (!isNodeBreakerComputed) {
+            isNodeBreaker = computeIsNodeBreaker();
+            isNodeBreakerComputed = true;
+        }
+        return isNodeBreaker;
+    }
+
+    private boolean computeIsNodeBreaker() {
         // Optimization hint: consider caching the results of the query for model
         // profiles
         if (!queryCatalog.containsKey(MODEL_PROFILES)) {
@@ -688,6 +698,8 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
     private final int cimVersion;
     private final TripleStore tripleStore;
     private final QueryCatalog queryCatalog;
+    private boolean isNodeBreaker;
+    private boolean isNodeBreakerComputed = false;
 
     private static final String MODEL_PROFILES = "modelProfiles";
     private static final String PROFILE = "profile";

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -44,8 +44,8 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
 
     @Override
     public void read(InputStream is, String baseName, String contextName) {
-        // Reset cached isNodeBreaker everytime we read new data
-        nodeBreakerComputed = false;
+        // Reset cached nodeBreaker value everytime we read new data
+        nodeBreaker = null;
         tripleStore.read(is, baseName, contextName);
     }
 
@@ -147,9 +147,8 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
 
     @Override
     public boolean isNodeBreaker() {
-        if (!nodeBreakerComputed) {
+        if (nodeBreaker == null) {
             nodeBreaker = computeIsNodeBreaker();
-            nodeBreakerComputed = true;
         }
         return nodeBreaker;
     }
@@ -169,6 +168,13 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
         // also have EquipmentOperation or EquipmentBoundaryOperation
         Map<String, Boolean> modelHasOperationProfile = computeEqModelHasEquipmentOperationProfile(r);
         boolean consideredNodeBreaker = modelHasOperationProfile.values().stream().allMatch(Boolean::valueOf);
+        if (LOG.isInfoEnabled()) {
+            logNodeBreaker(consideredNodeBreaker, modelHasOperationProfile);
+        }
+        return consideredNodeBreaker;
+    }
+
+    private void logNodeBreaker(boolean consideredNodeBreaker, Map<String, Boolean> modelHasOperationProfile) {
         if (consideredNodeBreaker) {
             LOG.info(
                     "All FullModel objects have EquipmentOperation profile, so conversion will be considered node-breaker");
@@ -181,7 +187,6 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
                 }
             });
         }
-        return consideredNodeBreaker;
     }
 
     private Map<String, Boolean> computeEqModelHasEquipmentOperationProfile(PropertyBags modelProfiles) {
@@ -703,8 +708,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
     private final int cimVersion;
     private final TripleStore tripleStore;
     private final QueryCatalog queryCatalog;
-    private boolean nodeBreaker;
-    private boolean nodeBreakerComputed = false;
+    private Boolean nodeBreaker = null;
 
     private static final String MODEL_PROFILES = "modelProfiles";
     private static final String PROFILE = "profile";


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
A model is considered node/breaker based on the profiles defined in its files. Recompute if the model is node/breaker only when new files are added to the triplestore.


**What is the current behavior?** *(You can also link to an open issue here)*
The model profiles are queried and reviewed everytime the model is checked for node/breaker.


**What is the new behavior (if this is a feature change)?**
The flag that stores if a model is node/breaker is cached and only recomputed when new data is added to the triplestore. 

