### PR TITLE
Ignore voltage level with nominal voltage equal to zero during CGMES import

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/VoltageLevelConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/VoltageLevelConversion.java
@@ -28,6 +28,11 @@ public class VoltageLevelConversion extends AbstractIdentifiedObjectConversion {
 
     @Override
     public boolean valid() {
+        double nominalVoltage = p.asDouble("nominalVoltage");
+        if (nominalVoltage == 0) {
+            ignored("Voltage level", () -> String.format("nominal voltage of %s is equal to 0", id));
+            return false;
+        }
         if (substation == null) {
             missing(String.format("Substation %s (IIDM id: %s)",
                     cgmesSubstationId,


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.vede@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Ignoring voltage level with nominal voltage equal to zero during CGMES import


**What is the current behavior?** *(You can also link to an open issue here)*
Throwing an exception

