### PR TITLE
Create slack terminal extension in Matpower importer

### DIFF
--- a/matpower/matpower-converter/pom.xml
+++ b/matpower/matpower-converter/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-extensions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-matpower-model</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
+++ b/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
@@ -171,7 +171,7 @@ public class MatpowerImporter implements Importer {
                         .add();
             }
             LOGGER.trace("Created generator {}", generator.getId());
-        });
+        }
     }
 
     private static Bus createBus(MBus mBus, VoltageLevel voltageLevel) {

--- a/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
+++ b/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
@@ -61,7 +61,7 @@ public class MatpowerImporter implements Importer {
 
         private final boolean ignoreBaseMva;
 
-        private Bus slackBus;
+        private final List<Bus> slackBuses = new ArrayList<>();
 
         private Context(double baseMva, boolean ignoreBaseMva) {
             this.baseMva = baseMva;
@@ -76,12 +76,8 @@ public class MatpowerImporter implements Importer {
             return baseMva;
         }
 
-        private Bus getSlackBus() {
-            return slackBus;
-        }
-
-        private void setSlackBus(Bus slackBus) {
-            this.slackBus = Objects.requireNonNull(slackBus);
+        private List<Bus> getSlackBuses() {
+            return slackBuses;
         }
     }
 
@@ -120,7 +116,7 @@ public class MatpowerImporter implements Importer {
             // create bus
             Bus bus = createBus(mBus, voltageLevel);
             if (mBus.getType() == MBus.Type.REF) {
-                context.setSlackBus(bus);
+                context.getSlackBuses().add(bus);
             }
 
             // create load
@@ -372,8 +368,8 @@ public class MatpowerImporter implements Importer {
 
                 createBranches(model, containerMapping, network, context);
 
-                if (context.getSlackBus() != null) {
-                    SlackTerminal.attach(context.getSlackBus());
+                for (Bus slackBus : context.getSlackBuses()) {
+                    SlackTerminal.attach(slackBus);
                 }
             }
         } catch (IOException e) {

--- a/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
+++ b/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
@@ -173,7 +173,7 @@ public class MatpowerImporter implements Importer {
                         .setMaxQ(mGen.getMaximumReactivePowerOutput())
                         .add();
             }
-            LOGGER.debug("Created generator {}", generator.getId());
+            LOGGER.trace("Created generator {}", generator.getId());
         });
     }
 
@@ -184,7 +184,7 @@ public class MatpowerImporter implements Importer {
                 .add();
         bus.setV(mBus.getVoltageMagnitude() * voltageLevel.getNominalV())
                 .setAngle(mBus.getVoltageAngle());
-        LOGGER.debug("Created bus {}", bus.getId());
+        LOGGER.trace("Created bus {}", bus.getId());
         return bus;
     }
 
@@ -194,7 +194,7 @@ public class MatpowerImporter implements Importer {
             substation = network.newSubstation()
                     .setId(substationId)
                     .add();
-            LOGGER.debug("Created substation {}", substation.getId());
+            LOGGER.trace("Created substation {}", substation.getId());
         }
         return substation;
     }
@@ -208,7 +208,7 @@ public class MatpowerImporter implements Importer {
                     .setNominalV(nominalV)
                     .setTopologyKind(TopologyKind.BUS_BREAKER)
                     .add();
-            LOGGER.debug("Created voltagelevel {}", voltageLevel.getId());
+            LOGGER.trace("Created voltagelevel {}", voltageLevel.getId());
         }
         return voltageLevel;
     }
@@ -224,7 +224,7 @@ public class MatpowerImporter implements Importer {
                 .setP0(mBus.getRealPowerDemand())
                 .setQ0(mBus.getReactivePowerDemand())
                 .add();
-            LOGGER.debug("Created load {}", newLoad.getId());
+            LOGGER.trace("Created load {}", newLoad.getId());
         }
     }
 
@@ -243,7 +243,7 @@ public class MatpowerImporter implements Importer {
                     .setMaximumSectionCount(1)
                     .add();
             ShuntCompensator newShunt = adder.add();
-            LOGGER.debug("Created shunt {}", newShunt.getId());
+            LOGGER.trace("Created shunt {}", newShunt.getId());
         }
     }
 
@@ -286,7 +286,7 @@ public class MatpowerImporter implements Importer {
                         .setG(0)
                         .setB(mBranch.getB() / zb)
                         .add();
-                LOGGER.debug("Created TwoWindingsTransformer {} {} {}", newTwt.getId(), bus1Id, bus2Id);
+                LOGGER.trace("Created TwoWindingsTransformer {} {} {}", newTwt.getId(), bus1Id, bus2Id);
             } else {
                 Line newLine = network.newLine()
                         .setId(getId(LINE_PREFIX, mBranch.getFrom(), mBranch.getTo()))
@@ -304,7 +304,7 @@ public class MatpowerImporter implements Importer {
                         .setG2(0)
                         .setB2(mBranch.getB() / zb / 2)
                         .add();
-                LOGGER.debug("Created line {} {} {}", newLine.getId(), bus1Id, bus2Id);
+                LOGGER.trace("Created line {} {} {}", newLine.getId(), bus1Id, bus2Id);
             }
         }
     }
@@ -360,7 +360,7 @@ public class MatpowerImporter implements Importer {
             try (InputStream iStream = dataSource.newInputStream(null, EXT)) {
 
                 MatpowerModel model = MatpowerReader.read(iStream, dataSource.getBaseName());
-                LOGGER.debug("MATPOWER model {}", model.getCaseName());
+                LOGGER.debug("MATPOWER model '{}'", model.getCaseName());
 
                 ContainersMapping containerMapping = ContainersMapping.create(model.getBuses(), model.getBranches(),
                     MBus::getNumber, MBranch::getFrom, MBranch::getTo, branch -> 0, MBranch::getR, MBranch::getX, branch -> isTransformer(model, branch),

--- a/matpower/matpower-converter/src/test/resources/ieee118mat.xiidm
+++ b/matpower/matpower-converter/src/test/resources/ieee118mat.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" id="ieee118" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" xmlns:slt="http://www.powsybl.org/schema/iidm/ext/slack_terminal/1_3" id="ieee118" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
     <iidm:substation id="SUB-105">
         <iidm:voltageLevel id="VL-1" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -1297,4 +1297,7 @@
     <iidm:line id="LINE-12-117" r="3.29E-4" x="0.0014000000000000002" g1="0.0" b1="1.7899999999999998" g2="0.0" b2="1.7899999999999998" bus1="BUS-12" connectableBus1="BUS-12" voltageLevelId1="VL-12" bus2="BUS-117" connectableBus2="BUS-117" voltageLevelId2="VL-117"/>
     <iidm:line id="LINE-75-118" r="1.45E-4" x="4.81E-4" g1="0.0" b1="0.599" g2="0.0" b2="0.599" bus1="BUS-75" connectableBus1="BUS-75" voltageLevelId1="VL-75" bus2="BUS-118" connectableBus2="BUS-118" voltageLevelId2="VL-118"/>
     <iidm:line id="LINE-76-118" r="1.6400000000000003E-4" x="5.44E-4" g1="0.0" b1="0.6779999999999999" g2="0.0" b2="0.6779999999999999" bus1="BUS-76" connectableBus1="BUS-76" voltageLevelId1="VL-76" bus2="BUS-118" connectableBus2="BUS-118" voltageLevelId2="VL-118"/>
+    <iidm:extension id="VL-69">
+        <slt:slackTerminal id="GEN-69"/>
+    </iidm:extension>
 </iidm:network>

--- a/matpower/matpower-converter/src/test/resources/ieee14mat.xiidm
+++ b/matpower/matpower-converter/src/test/resources/ieee14mat.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" id="ieee14" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" xmlns:slt="http://www.powsybl.org/schema/iidm/ext/slack_terminal/1_3" id="ieee14" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
     <iidm:substation id="SUB-8">
         <iidm:voltageLevel id="VL-1" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -141,4 +141,7 @@
     <iidm:line id="LINE-10-11" r="8.205E-4" x="0.0019207" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BUS-10" connectableBus1="BUS-10" voltageLevelId1="VL-10" bus2="BUS-11" connectableBus2="BUS-11" voltageLevelId2="VL-11"/>
     <iidm:line id="LINE-12-13" r="0.0022092" x="0.0019988000000000002" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BUS-12" connectableBus1="BUS-12" voltageLevelId1="VL-12" bus2="BUS-13" connectableBus2="BUS-13" voltageLevelId2="VL-13"/>
     <iidm:line id="LINE-13-14" r="0.0017093" x="0.0034802" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BUS-13" connectableBus1="BUS-13" voltageLevelId1="VL-13" bus2="BUS-14" connectableBus2="BUS-14" voltageLevelId2="VL-14"/>
+    <iidm:extension id="VL-1">
+        <slt:slackTerminal id="GEN-1"/>
+    </iidm:extension>
 </iidm:network>

--- a/matpower/matpower-converter/src/test/resources/ieee300mat.xiidm
+++ b/matpower/matpower-converter/src/test/resources/ieee300mat.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" id="ieee300" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" xmlns:slt="http://www.powsybl.org/schema/iidm/ext/slack_terminal/1_3" id="ieee300" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
     <iidm:substation id="SUB-78">
         <iidm:voltageLevel id="VL-1" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -2749,4 +2749,7 @@
     <iidm:line id="LINE-248-249" r="3.51E-4" x="0.0010040000000000001" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BUS-248" connectableBus1="BUS-248" voltageLevelId1="VL-248" bus2="BUS-249" connectableBus2="BUS-249" voltageLevelId2="VL-249"/>
     <iidm:line id="LINE-249-250" r="6.16E-4" x="0.0018570000000000001" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BUS-249" connectableBus1="BUS-249" voltageLevelId1="VL-249" bus2="BUS-250" connectableBus2="BUS-250" voltageLevelId2="VL-250"/>
     <iidm:line id="LINE-196-2040" r="1.0000000000000002E-6" x="2.0E-4" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BUS-196" connectableBus1="BUS-196" voltageLevelId1="VL-196" bus2="BUS-2040" connectableBus2="BUS-2040" voltageLevelId2="VL-2040"/>
+    <iidm:extension id="VL-7049">
+        <slt:slackTerminal id="GEN-7049"/>
+    </iidm:extension>
 </iidm:network>

--- a/matpower/matpower-converter/src/test/resources/ieee30mat.xiidm
+++ b/matpower/matpower-converter/src/test/resources/ieee30mat.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" id="ieee30" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" xmlns:slt="http://www.powsybl.org/schema/iidm/ext/slack_terminal/1_3" id="ieee30" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
     <iidm:substation id="SUB-23">
         <iidm:voltageLevel id="VL-1" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -288,4 +288,7 @@
     <iidm:line id="LINE-29-30" r="0.002399" x="0.004533" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BUS-29" connectableBus1="BUS-29" voltageLevelId1="VL-29" bus2="BUS-30" connectableBus2="BUS-30" voltageLevelId2="VL-30"/>
     <iidm:line id="LINE-8-28" r="6.360000000000001E-4" x="0.002" g1="0.0" b1="2.1399999999999997" g2="0.0" b2="2.1399999999999997" bus1="BUS-8" connectableBus1="BUS-8" voltageLevelId1="VL-8" bus2="BUS-28" connectableBus2="BUS-28" voltageLevelId2="VL-28"/>
     <iidm:line id="LINE-6-28" r="1.69E-4" x="5.99E-4" g1="0.0" b1="0.6499999999999999" g2="0.0" b2="0.6499999999999999" bus1="BUS-6" connectableBus1="BUS-6" voltageLevelId1="VL-6" bus2="BUS-28" connectableBus2="BUS-28" voltageLevelId2="VL-28"/>
+    <iidm:extension id="VL-1">
+        <slt:slackTerminal id="GEN-1"/>
+    </iidm:extension>
 </iidm:network>

--- a/matpower/matpower-converter/src/test/resources/ieee57mat.xiidm
+++ b/matpower/matpower-converter/src/test/resources/ieee57mat.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" id="ieee57" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" xmlns:slt="http://www.powsybl.org/schema/iidm/ext/slack_terminal/1_3" id="ieee57" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
     <iidm:substation id="SUB-39">
         <iidm:voltageLevel id="VL-1" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -523,4 +523,7 @@
     <iidm:line id="LINE-57-56" r="0.00174" x="0.0026000000000000003" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BUS-57" connectableBus1="BUS-57" voltageLevelId1="VL-57" bus2="BUS-56" connectableBus2="BUS-56" voltageLevelId2="VL-56"/>
     <iidm:line id="LINE-38-49" r="0.00115" x="0.0017699999999999999" g1="0.0" b1="0.15" g2="0.0" b2="0.15" bus1="BUS-38" connectableBus1="BUS-38" voltageLevelId1="VL-38" bus2="BUS-49" connectableBus2="BUS-49" voltageLevelId2="VL-49"/>
     <iidm:line id="LINE-38-48" r="3.12E-4" x="4.82E-4" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BUS-38" connectableBus1="BUS-38" voltageLevelId1="VL-38" bus2="BUS-48" connectableBus2="BUS-48" voltageLevelId2="VL-48"/>
+    <iidm:extension id="VL-1">
+        <slt:slackTerminal id="LOAD-1"/>
+    </iidm:extension>
 </iidm:network>

--- a/matpower/matpower-converter/src/test/resources/ieee9mat.xiidm
+++ b/matpower/matpower-converter/src/test/resources/ieee9mat.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" id="ieee9" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" xmlns:slt="http://www.powsybl.org/schema/iidm/ext/slack_terminal/1_3" id="ieee9" caseDate="2020-01-01T00:00:00.000Z" forecastDistance="0" sourceFormat="MATPOWER">
     <iidm:substation id="SUB-1">
         <iidm:voltageLevel id="VL-1" nominalV="1.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -84,4 +84,7 @@
     <iidm:line id="LINE-9-6" r="3.9E-4" x="0.0017000000000000001" g1="0.0" b1="17.9" g2="0.0" b2="17.9" bus1="BUS-9" connectableBus1="BUS-9" voltageLevelId1="VL-9" bus2="BUS-6" connectableBus2="BUS-6" voltageLevelId2="VL-6"/>
     <iidm:line id="LINE-5-4" r="1.0E-4" x="8.500000000000001E-4" g1="0.0" b1="8.799999999999999" g2="0.0" b2="8.799999999999999" bus1="BUS-5" connectableBus1="BUS-5" voltageLevelId1="VL-5" bus2="BUS-4" connectableBus2="BUS-4" voltageLevelId2="VL-4"/>
     <iidm:line id="LINE-6-4" r="1.7E-4" x="9.2E-4" g1="0.0" b1="7.9" g2="0.0" b2="7.9" bus1="BUS-6" connectableBus1="BUS-6" voltageLevelId1="VL-6" bus2="BUS-4" connectableBus2="BUS-4" voltageLevelId2="VL-4"/>
+    <iidm:extension id="VL-1">
+        <slt:slackTerminal id="GEN-1"/>
+    </iidm:extension>
 </iidm:network>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
When importing a matpower file, slack bus infos is lost.


**What is the new behavior (if this is a feature change)?**
A slack terminal extension is added to the network to keep track of initial (matpower file) slack bus.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
