### PR TITLE
Fix Matpower json read

### DIFF
--- a/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerModel.java
+++ b/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerModel.java
@@ -67,6 +67,8 @@ public class MatpowerModel {
     }
 
     public void setBuses(List<MBus> buses) {
+        Objects.requireNonNull(buses);
+        this.buses.clear();
         for (MBus bus : buses) {
             addBus(bus);
         }
@@ -81,6 +83,8 @@ public class MatpowerModel {
     }
 
     public void setGenerators(List<MGen> generators) {
+        Objects.requireNonNull(generators);
+        this.generators.clear();
         for (MGen generator : generators) {
             addGenerator(generator);
         }
@@ -102,6 +106,8 @@ public class MatpowerModel {
     }
 
     public void setBranches(List<MBranch> branches) {
+        Objects.requireNonNull(branches);
+        this.branches.clear();
         for (MBranch branch : branches) {
             addBranch(branch);
         }

--- a/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerModel.java
+++ b/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerModel.java
@@ -66,12 +66,24 @@ public class MatpowerModel {
         return buses;
     }
 
+    public void setBuses(List<MBus> buses) {
+        for (MBus bus : buses) {
+            addBus(bus);
+        }
+    }
+
     public MBus getBusByNum(int num) {
         return busByNum.get(num);
     }
 
     public List<MGen> getGenerators() {
         return generators;
+    }
+
+    public void setGenerators(List<MGen> generators) {
+        for (MGen generator : generators) {
+            addGenerator(generator);
+        }
     }
 
     public void addGenerator(MGen generator) {
@@ -87,6 +99,12 @@ public class MatpowerModel {
 
     public List<MBranch> getBranches() {
         return branches;
+    }
+
+    public void setBranches(List<MBranch> branches) {
+        for (MBranch branch : branches) {
+            addBranch(branch);
+        }
     }
 
     public void addBranch(MBranch branch) {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
For unit testing, matpower files are stored in json (unofficial matpower format) and loaded to re-create a .mat file.
In the matpower model, elements like buses and generators are double indexed and when it is created from a json file using jackson object mapper, the double indexing is not done.

**What is the new behavior (if this is a feature change)?**
Double indexing is fixed.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
