### PR TITLE
Delete check if one of CGMES file with suffix EQ exists

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -39,10 +39,7 @@ public class CgmesOnDataSource {
         if (!foundNamespaces.contains(RDF_NAMESPACE)) {
             return false;
         }
-        if (!(foundNamespaces.contains(CIM_16_NAMESPACE) || foundNamespaces.contains(CIM_100_NAMESPACE))) {
-            return false;
-        }
-        return names().stream().anyMatch(CgmesSubset.EQUIPMENT::isValidName);
+        return foundNamespaces.contains(CIM_16_NAMESPACE) || foundNamespaces.contains(CIM_100_NAMESPACE);
     }
 
     public boolean existsCim14() {


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Change: strictly speaking, we cannot say a CGMES without EQ profile is not CGMES; it is not a **correct** CGMES but this is not what the method `CgmesExport.exists()` should check.


**What is the current behavior?** *(You can also link to an open issue here)*
Fails if the CGMES file(s) do(es) not contain at least one file with the suffix EQ.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
