### PR TITLE
CGMES switches: add ground disconnectors, read normal open attribute

### DIFF
--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -333,9 +333,12 @@ WHERE {
         a ?type ;
         cim:IdentifiedObject.name ?name ;
         cim:Equipment.EquipmentContainer ?EquipmentContainer .
-    VALUES ?type { cim:Switch cim:Breaker cim:Disconnector cim:LoadBreakSwitch cim:ProtectedSwitch } .
+    VALUES ?type { cim:Switch cim:Breaker cim:Disconnector cim:LoadBreakSwitch cim:ProtectedSwitch cim:GroundDisconnector } .
     OPTIONAL {
         ?Switch cim:Switch.retained ?retained
+    }
+    OPTIONAL {
+        ?Switch cim:Switch.normalOpen ?normalOpen
     }
     ?Terminal1
         a cim:Terminal ;


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Includes the additional type of switch `GroundDisconnector`.
Reads the attribute `normalOpen` defined in CGMES EQ profile (considering it optional: if not found, the conversion works like before, setting the state of switch by default to "closed").

