### PR TITLE
Replace CGMES tap changers properties by extensions

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
@@ -146,7 +146,7 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
             if (tch != null) {
                 tapChangers.newTapChanger()
                         .setId(tch.getId())
-                        .setDifferentIidmId(tc.getId())
+                        .setCombinedTapChangerId(tc.getId())
                         .setHiddenStatus(true)
                         .setStep(tch.getTapPosition())
                         .setType(tch.getType())

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
@@ -12,10 +12,10 @@ import com.powsybl.cgmes.conversion.Conversion;
 import com.powsybl.cgmes.conversion.RegulatingControlMappingForTransformers.CgmesRegulatingControlPhase;
 import com.powsybl.cgmes.conversion.RegulatingControlMappingForTransformers.CgmesRegulatingControlRatio;
 import com.powsybl.cgmes.conversion.elements.AbstractConductingEquipmentConversion;
+import com.powsybl.cgmes.extensions.CgmesTapChangers;
+import com.powsybl.cgmes.extensions.CgmesTapChangersAdder;
 import com.powsybl.cgmes.model.CgmesNames;
-import com.powsybl.iidm.network.Identifiable;
-import com.powsybl.iidm.network.PhaseTapChangerAdder;
-import com.powsybl.iidm.network.RatioTapChangerAdder;
+import com.powsybl.iidm.network.*;
 import com.powsybl.triplestore.api.PropertyBags;
 
 import java.util.List;
@@ -47,12 +47,12 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
             // double g2 = step.getG2();
             // Only b1 and g1 instead of b1 + b2 and g1 + g2
             rtca.beginStep()
-                .setRho(1 / ratio)
-                .setR(r)
-                .setX(x)
-                .setB(b1)
-                .setG(g1)
-                .endStep();
+                    .setRho(1 / ratio)
+                    .setR(r)
+                    .setX(x)
+                    .setB(b1)
+                    .setG(g1)
+                    .endStep();
         });
         rtca.add();
     }
@@ -77,13 +77,13 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
             // double g2 = step.getG2();
             // Only b1 and g1 instead of b1 + b2 and g1 + g2
             ptca.beginStep()
-                .setRho(1 / ratio)
-                .setAlpha(-angle)
-                .setR(r)
-                .setX(x)
-                .setB(b1)
-                .setG(g1)
-                .endStep();
+                    .setRho(1 / ratio)
+                    .setAlpha(-angle)
+                    .setR(r)
+                    .setX(x)
+                    .setB(b1)
+                    .setG(g1)
+                    .endStep();
         });
         ptca.add();
     }
@@ -92,7 +92,7 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
         CgmesRegulatingControlRatio rcRtc = null;
         if (tc != null) {
             rcRtc = context.regulatingControlMapping().forTransformers().buildRegulatingControlRatio(tc.getId(),
-                tc.getRegulatingControlId(), tc.getTculControlMode(), tc.isTapChangerControlEnabled());
+                    tc.getRegulatingControlId(), tc.getTculControlMode(), tc.isTapChangerControlEnabled());
         }
         return rcRtc;
     }
@@ -101,7 +101,7 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
         CgmesRegulatingControlPhase rcPtc = null;
         if (tc != null) {
             return context.regulatingControlMapping().forTransformers().buildRegulatingControlPhase(
-                tc.getId(), tc.getRegulatingControlId(), tc.isTapChangerControlEnabled(), tc.isLtcFlag());
+                    tc.getId(), tc.getRegulatingControlId(), tc.isTapChangerControlEnabled(), tc.isLtcFlag());
         }
         return rcPtc;
     }
@@ -111,7 +111,7 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
         super.addAliasesAndProperties(identifiable);
         List<String> ptcs = context.cgmes().phaseTapChangerListForPowerTransformer(identifiable.getId());
         if (ptcs != null) {
-            for (int  i = 0; i < ptcs.size(); i++) {
+            for (int i = 0; i < ptcs.size(); i++) {
                 int index = i + 1;
                 Optional.ofNullable(ptcs.get(i)).ifPresent(ptc -> identifiable.addAlias(ptc, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.PHASE_TAP_CHANGER + index, context.config().isEnsureIdAliasUnicity()));
             }
@@ -125,29 +125,33 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
         }
     }
 
-    protected static void addCgmesReferences(Identifiable<?> transformer, TapChanger tc) {
+    protected static <C extends Connectable<C>> void addCgmesReferences(C transformer, TapChanger tc) {
         if (tc == null || tc.getId() == null) {
             return;
         }
-        if (tc.getRegulatingControlId() != null) {
-            transformer.setProperty(cgmesReferenceKey(tc.getId(), "TapChangerControl"), tc.getRegulatingControlId());
-        }
-        if (tc.getType() != null) {
-            transformer.setProperty(cgmesReferenceKey(tc.getId(), "type"), tc.getType());
-        }
         TapChanger tch = tc.getHiddenCombinedTapChanger();
-        if (tch != null) {
-            // All the tap changers have already been added as aliases,
-            // Through properties we only label which one has been combined and kept hidden
-            transformer.setProperty(cgmesReferenceKey(tc.getId(), "hiddenTapChangerId"), tch.getId());
-            transformer.setProperty(cgmesReferenceKey(tch.getId(), "step"), String.valueOf(tch.getTapPosition()));
-            if (tch.getType() != null) {
-                transformer.setProperty(cgmesReferenceKey(tch.getId(), "type"), tch.getType());
+        if (tc.getRegulatingControlId() != null || tc.getType() != null || tch != null) {
+            CgmesTapChangers<C> tapChangers = transformer.getExtension(CgmesTapChangers.class);
+            if (tapChangers == null) {
+                transformer.newExtension(CgmesTapChangersAdder.class).add();
+                tapChangers = transformer.getExtension(CgmesTapChangers.class);
+            }
+            if (tc.getRegulatingControlId() != null || tc.getType() != null) {
+                tapChangers.newTapChanger()
+                        .setId(tc.getId())
+                        .setType(tc.getType())
+                        .setControlId(tc.getRegulatingControlId())
+                        .add();
+            }
+            if (tch != null) {
+                tapChangers.newTapChanger()
+                        .setId(tch.getId())
+                        .setDifferentIidmId(tc.getId())
+                        .setHiddenStatus(true)
+                        .setStep(tch.getTapPosition())
+                        .setType(tch.getType())
+                        .add();
             }
         }
-    }
-
-    private static String cgmesReferenceKey(String id, String property) {
-        return String.format("%s%s.%s", Conversion.CGMES_PREFIX_ALIAS_PROPERTIES, id, property);
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
@@ -154,8 +154,8 @@ public final class SteadyStateHypothesisExport {
         addRegulatingControlView(tc, cgmesTc, regulatingControlViews);
         if (cgmesTcs != null) {
             for (CgmesTapChanger tapChanger : cgmesTcs.getTapChangers()) {
-                if (tapChanger.isHidden() && tapChanger.getDifferentIidmId().equals(tcId)) {
-                    writeHiddenTapChanger(eq, tapChanger, defaultType, cimNamespace, writer);
+                if (tapChanger.isHidden() && tapChanger.getCombinedTapChangerId().equals(tcId)) {
+                    writeHiddenTapChanger(tapChanger, defaultType, cimNamespace, writer);
                 }
             }
         }
@@ -334,7 +334,7 @@ public final class SteadyStateHypothesisExport {
         }
     }
 
-    private static void writeHiddenTapChanger(Identifiable<?> eq, CgmesTapChanger cgmesTc, String defaultType, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {
+    private static void writeHiddenTapChanger(CgmesTapChanger cgmesTc, String defaultType, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {
         writeTapChanger(Optional.ofNullable(cgmesTc.getType()).orElse(defaultType), cgmesTc.getId(), false,
                 cgmesTc.getStep().orElseThrow(() -> new PowsyblException("Non null step expected for tap changer " + cgmesTc.getId())),
                 cimNamespace, writer);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
@@ -7,6 +7,8 @@
 package com.powsybl.cgmes.conversion.export;
 
 import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.cgmes.extensions.CgmesTapChanger;
+import com.powsybl.cgmes.extensions.CgmesTapChangers;
 import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
@@ -138,11 +140,25 @@ public final class SteadyStateHypothesisExport {
         }
     }
 
-    private static void writeTapChanger(Identifiable<?> eq, String tcId, TapChanger<?, ?> tc, String defaultType, Map<String, List<RegulatingControlView>> regulatingControlViews, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {
-        String type = eq.getProperty(cgmesTapChangerReferenceKey(tcId, "type"), defaultType);
+    private static <C extends Connectable<C>> void writeTapChanger(C eq, String tcId, TapChanger<?, ?> tc, String defaultType, Map<String, List<RegulatingControlView>> regulatingControlViews, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {
+        CgmesTapChangers<C> cgmesTcs = eq.getExtension(CgmesTapChangers.class);
+        String type = defaultType;
+        CgmesTapChanger cgmesTc = null;
+        if (cgmesTcs != null) {
+            cgmesTc = cgmesTcs.getTapChanger(tcId);
+            if (cgmesTc != null) {
+                type = Optional.ofNullable(cgmesTc.getType()).orElse(defaultType);
+            }
+        }
         writeTapChanger(type, tcId, tc, cimNamespace, writer);
-        addRegulatingControlView(tc, tcId, eq, regulatingControlViews);
-        writeHiddenTapChanger(eq, tcId, defaultType, cimNamespace, writer);
+        addRegulatingControlView(tc, cgmesTc, regulatingControlViews);
+        if (cgmesTcs != null) {
+            for (CgmesTapChanger tapChanger : cgmesTcs.getTapChangers()) {
+                if (tapChanger.isHidden() && tapChanger.getDifferentIidmId().equals(tcId)) {
+                    writeHiddenTapChanger(eq, tapChanger, defaultType, cimNamespace, writer);
+                }
+            }
+        }
     }
 
     private static void writeShuntCompensators(Network network, String cimNamespace, Map<String, List<RegulatingControlView>> regulatingControlViews, XMLStreamWriter writer) throws XMLStreamException {
@@ -287,12 +303,11 @@ public final class SteadyStateHypothesisExport {
         writer.writeEndElement();
     }
 
-    private static void addRegulatingControlView(TapChanger tc, String tcId, Identifiable<?> eq, Map<String, List<RegulatingControlView>> regulatingControlViews) {
+    private static void addRegulatingControlView(TapChanger<?, ?> tc, CgmesTapChanger cgmesTc, Map<String, List<RegulatingControlView>> regulatingControlViews) {
         // Multiple tap changers can be stored at the same equipment
         // We use the tap changer id as part of the key for storing the tap changer control id
-        String key = String.format("%s%s.TapChangerControl", Conversion.CGMES_PREFIX_ALIAS_PROPERTIES, tcId);
-        if (eq.hasProperty(key)) {
-            String controlId = eq.getProperty(key);
+        if (cgmesTc != null && cgmesTc.getControlId() != null) {
+            String controlId = cgmesTc.getControlId();
             RegulatingControlView rcv = null;
             if (tc instanceof RatioTapChanger) {
                 rcv = new RegulatingControlView(controlId,
@@ -319,19 +334,10 @@ public final class SteadyStateHypothesisExport {
         }
     }
 
-    private static String cgmesTapChangerReferenceKey(String tcId, String property) {
-        return String.format("%s%s.%s", Conversion.CGMES_PREFIX_ALIAS_PROPERTIES, tcId, property);
-    }
-
-    private static void writeHiddenTapChanger(Identifiable<?> eq, String tcId, String defaultType, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {
-        String key = cgmesTapChangerReferenceKey(tcId, "hiddenTapChangerId");
-        if (!eq.hasProperty(key)) {
-            return;
-        }
-        String hiddenTcId = eq.getProperty(key);
-        int step = Integer.parseInt(eq.getProperty(cgmesTapChangerReferenceKey(hiddenTcId, "step")));
-        String type = eq.getProperty(cgmesTapChangerReferenceKey(hiddenTcId, "type"), defaultType);
-        writeTapChanger(type, hiddenTcId, false, step, cimNamespace, writer);
+    private static void writeHiddenTapChanger(Identifiable<?> eq, CgmesTapChanger cgmesTc, String defaultType, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {
+        writeTapChanger(Optional.ofNullable(cgmesTc.getType()).orElse(defaultType), cgmesTc.getId(), false,
+                cgmesTc.getStep().orElseThrow(() -> new PowsyblException("Non null step expected for tap changer " + cgmesTc.getId())),
+                cimNamespace, writer);
     }
 
     private static void writeRegulatingControls(Map<String, List<RegulatingControlView>> regulatingControlViews, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChanger.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChanger.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+import java.util.OptionalInt;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+public interface CgmesTapChanger {
+
+    String getId();
+
+    String getDifferentIidmId();
+
+    String getType();
+
+    boolean isHidden();
+
+    OptionalInt getStep();
+
+    String getControlId();
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChanger.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChanger.java
@@ -15,7 +15,7 @@ public interface CgmesTapChanger {
 
     String getId();
 
-    String getDifferentIidmId();
+    String getCombinedTapChangerId();
 
     String getType();
 

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerAdder.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerAdder.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+public interface CgmesTapChangerAdder {
+
+    CgmesTapChangerAdder setId(String id);
+
+    CgmesTapChangerAdder setDifferentIidmId(String iidmId);
+
+    CgmesTapChangerAdder setType(String type);
+
+    CgmesTapChangerAdder setHiddenStatus(boolean hidden);
+
+    CgmesTapChangerAdder setStep(int step);
+
+    CgmesTapChangerAdder setControlId(String id);
+
+    CgmesTapChanger add();
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerAdder.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerAdder.java
@@ -13,7 +13,7 @@ public interface CgmesTapChangerAdder {
 
     CgmesTapChangerAdder setId(String id);
 
-    CgmesTapChangerAdder setDifferentIidmId(String iidmId);
+    CgmesTapChangerAdder setCombinedTapChangerId(String combinedTapChangerId);
 
     CgmesTapChangerAdder setType(String type);
 

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerAdderImpl.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerAdderImpl.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+import com.powsybl.commons.PowsyblException;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+class CgmesTapChangerAdderImpl implements CgmesTapChangerAdder {
+
+    private final CgmesTapChangersImpl<?> mapping;
+
+    private String id = null;
+    private String iidmId = null;
+    private String type = null;
+    private boolean hidden = false;
+    private Integer step = null;
+    private String controlId = null;
+
+    CgmesTapChangerAdderImpl(CgmesTapChangersImpl<?> mapping) {
+        this.mapping = mapping;
+    }
+
+    @Override
+    public CgmesTapChangerAdder setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @Override
+    public CgmesTapChangerAdder setDifferentIidmId(String iidmId) {
+        this.iidmId = iidmId;
+        return this;
+    }
+
+    @Override
+    public CgmesTapChangerAdder setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    @Override
+    public CgmesTapChangerAdder setHiddenStatus(boolean hidden) {
+        this.hidden = hidden;
+        return this;
+    }
+
+    @Override
+    public CgmesTapChangerAdder setStep(int step) {
+        this.step = step;
+        return this;
+    }
+
+    @Override
+    public CgmesTapChangerAdder setControlId(String controlId) {
+        this.controlId = controlId;
+        return this;
+    }
+
+    @Override
+    public CgmesTapChanger add() {
+        if (id == null) {
+            throw new PowsyblException("Tap changer ID should not be null");
+        }
+        if (!hidden) {
+            if (step != null) {
+                throw new PowsyblException("Non-hidden tap changers step positions can be directly found on the tap changer" +
+                        " and should not be forced");
+            }
+            if (iidmId != null) {
+                throw new PowsyblException("Non-hidden tap changers do not have an IIDM ID different from their ID");
+            }
+        }
+        if (hidden) {
+            if (step == null) {
+                throw new PowsyblException("Hidden tap changers step positions should be explicit");
+            }
+            if (iidmId == null) {
+                throw new PowsyblException("Hidden tap changers should have a different IIDM ID");
+            }
+        }
+        return new CgmesTapChangerImpl(id, iidmId, type, hidden, step, controlId, mapping);
+    }
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerAdderImpl.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerAdderImpl.java
@@ -16,7 +16,7 @@ class CgmesTapChangerAdderImpl implements CgmesTapChangerAdder {
     private final CgmesTapChangersImpl<?> mapping;
 
     private String id = null;
-    private String iidmId = null;
+    private String combinedTapChangerId = null;
     private String type = null;
     private boolean hidden = false;
     private Integer step = null;
@@ -33,8 +33,8 @@ class CgmesTapChangerAdderImpl implements CgmesTapChangerAdder {
     }
 
     @Override
-    public CgmesTapChangerAdder setDifferentIidmId(String iidmId) {
-        this.iidmId = iidmId;
+    public CgmesTapChangerAdder setCombinedTapChangerId(String combinedTapChangerId) {
+        this.combinedTapChangerId = combinedTapChangerId;
         return this;
     }
 
@@ -72,18 +72,18 @@ class CgmesTapChangerAdderImpl implements CgmesTapChangerAdder {
                 throw new PowsyblException("Non-hidden tap changers step positions can be directly found on the tap changer" +
                         " and should not be forced");
             }
-            if (iidmId != null) {
-                throw new PowsyblException("Non-hidden tap changers do not have an IIDM ID different from their ID");
+            if (combinedTapChangerId != null) {
+                throw new PowsyblException("Non-hidden tap changers do not have a different ID for the combined tap changer");
             }
         }
         if (hidden) {
             if (step == null) {
                 throw new PowsyblException("Hidden tap changers step positions should be explicit");
             }
-            if (iidmId == null) {
-                throw new PowsyblException("Hidden tap changers should have a different IIDM ID");
+            if (combinedTapChangerId == null) {
+                throw new PowsyblException("Hidden tap changers should have an ID for the combined tap changer");
             }
         }
-        return new CgmesTapChangerImpl(id, iidmId, type, hidden, step, controlId, mapping);
+        return new CgmesTapChangerImpl(id, combinedTapChangerId, type, hidden, step, controlId, mapping);
     }
 }

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerImpl.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerImpl.java
@@ -14,15 +14,15 @@ import java.util.OptionalInt;
 class CgmesTapChangerImpl implements CgmesTapChanger {
 
     private final String id;
-    private final String iidmId;
+    private final String combinedTapChangerId;
     private final String type;
     private final boolean hidden;
     private final Integer step;
     private final String controlId;
 
-    CgmesTapChangerImpl(String id, String iidmId, String type, boolean hidden, Integer step, String controlId, CgmesTapChangersImpl<?> mapping) {
+    CgmesTapChangerImpl(String id, String combinedTapChangerId, String type, boolean hidden, Integer step, String controlId, CgmesTapChangersImpl<?> mapping) {
         this.id = id;
-        this.iidmId = iidmId;
+        this.combinedTapChangerId = combinedTapChangerId;
         this.type = type;
         this.hidden = hidden;
         this.step = step;
@@ -40,8 +40,8 @@ class CgmesTapChangerImpl implements CgmesTapChanger {
     }
 
     @Override
-    public String getDifferentIidmId() {
-        return iidmId;
+    public String getCombinedTapChangerId() {
+        return combinedTapChangerId;
     }
 
     @Override

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerImpl.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangerImpl.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+import java.util.OptionalInt;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+class CgmesTapChangerImpl implements CgmesTapChanger {
+
+    private final String id;
+    private final String iidmId;
+    private final String type;
+    private final boolean hidden;
+    private final Integer step;
+    private final String controlId;
+
+    CgmesTapChangerImpl(String id, String iidmId, String type, boolean hidden, Integer step, String controlId, CgmesTapChangersImpl<?> mapping) {
+        this.id = id;
+        this.iidmId = iidmId;
+        this.type = type;
+        this.hidden = hidden;
+        this.step = step;
+        this.controlId = controlId;
+        attach(mapping);
+    }
+
+    private void attach(CgmesTapChangersImpl<?> mapping) {
+        mapping.putTapChanger(this);
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getDifferentIidmId() {
+        return iidmId;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public boolean isHidden() {
+        return hidden;
+    }
+
+    @Override
+    public OptionalInt getStep() {
+        return step != null ? OptionalInt.of(step) : OptionalInt.empty();
+    }
+
+    @Override
+    public String getControlId() {
+        return controlId;
+    }
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangers.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangers.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+import com.powsybl.commons.extensions.Extension;
+import com.powsybl.iidm.network.Connectable;
+
+import java.util.Set;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+public interface CgmesTapChangers<C extends Connectable<C>> extends Extension<C> {
+
+    Set<CgmesTapChanger> getTapChangers();
+
+    CgmesTapChanger getTapChanger(String id);
+
+    CgmesTapChangerAdder newTapChanger();
+
+    @Override
+    default String getName() {
+        return "cgmesTapChangers";
+    }
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersAdder.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersAdder.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+import com.powsybl.commons.extensions.ExtensionAdder;
+import com.powsybl.iidm.network.Connectable;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+public interface CgmesTapChangersAdder<C extends Connectable<C>> extends ExtensionAdder<C, CgmesTapChangers<C>> {
+
+    @Override
+    default Class<CgmesTapChangers> getExtensionClass() {
+        return CgmesTapChangers.class;
+    }
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersAdderImpl.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersAdderImpl.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.extensions.AbstractExtensionAdder;
+import com.powsybl.iidm.network.Connectable;
+import com.powsybl.iidm.network.ThreeWindingsTransformer;
+import com.powsybl.iidm.network.TwoWindingsTransformer;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+class CgmesTapChangersAdderImpl<C extends Connectable<C>> extends AbstractExtensionAdder<C, CgmesTapChangers<C>> implements CgmesTapChangersAdder<C> {
+
+    CgmesTapChangersAdderImpl(C extendable) {
+        super(extendable);
+    }
+
+    @Override
+    protected CgmesTapChangers<C> createExtension(C extendable) {
+        if (extendable instanceof TwoWindingsTransformer || extendable instanceof ThreeWindingsTransformer) {
+            return new CgmesTapChangersImpl<>(extendable);
+        }
+        throw new PowsyblException("CGMES Tap Changers can only be added on transformers");
+    }
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersAdderImplProvider.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersAdderImplProvider.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionAdderProvider;
+import com.powsybl.iidm.network.Connectable;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionAdderProvider.class)
+public class CgmesTapChangersAdderImplProvider<C extends Connectable<C>>
+        implements ExtensionAdderProvider<C, CgmesTapChangers<C>, CgmesTapChangersAdderImpl<C>> {
+
+    @Override
+    public String getImplementationName() {
+        return "Default";
+    }
+
+    @Override
+    public Class<? super CgmesTapChangersAdderImpl<C>> getAdderClass() {
+        return CgmesTapChangersAdderImpl.class;
+    }
+
+    @Override
+    public CgmesTapChangersAdderImpl<C> newAdder(C extendable) {
+        return new CgmesTapChangersAdderImpl<>(extendable);
+    }
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersImpl.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersImpl.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.Connectable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+class CgmesTapChangersImpl<C extends Connectable<C>> extends AbstractExtension<C> implements CgmesTapChangers<C> {
+
+    private final Map<String, CgmesTapChanger> tapChangers = new HashMap<>();
+
+    CgmesTapChangersImpl(C transformer) {
+        super(transformer);
+    }
+
+    @Override
+    public Set<CgmesTapChanger> getTapChangers() {
+        return Set.copyOf(tapChangers.values());
+    }
+
+    @Override
+    public CgmesTapChanger getTapChanger(String id) {
+        return tapChangers.get(id);
+    }
+
+    @Override
+    public CgmesTapChangerAdder newTapChanger() {
+        return new CgmesTapChangerAdderImpl(this);
+    }
+
+    void putTapChanger(CgmesTapChangerImpl tapChanger) {
+        String tapChangerId = tapChanger.getId();
+        if (tapChangers.containsKey(tapChangerId)) {
+            throw new PowsyblException(String.format("Tap changer %s has already been added", tapChangerId));
+        }
+        tapChangers.put(tapChangerId, tapChanger);
+    }
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersImpl.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersImpl.java
@@ -10,9 +10,8 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.iidm.network.Connectable;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
@@ -27,7 +26,8 @@ class CgmesTapChangersImpl<C extends Connectable<C>> extends AbstractExtension<C
 
     @Override
     public Set<CgmesTapChanger> getTapChangers() {
-        return Set.copyOf(tapChangers.values());
+        return tapChangers.values().stream().sorted(Comparator.comparing(CgmesTapChanger::getId))
+                .collect(Collectors.toCollection(LinkedHashSet::new)); // If not sorted, hard to debug in SSH files
     }
 
     @Override

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersXmlSerializer.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersXmlSerializer.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.extensions.AbstractExtensionXmlSerializer;
+import com.powsybl.commons.extensions.ExtensionXmlSerializer;
+import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlUtil;
+import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.Connectable;
+import com.powsybl.iidm.xml.NetworkXmlReaderContext;
+import com.powsybl.iidm.xml.NetworkXmlWriterContext;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionXmlSerializer.class)
+public class CgmesTapChangersXmlSerializer<C extends Connectable<C>> extends AbstractExtensionXmlSerializer<C, CgmesTapChangers<C>> {
+
+    public CgmesTapChangersXmlSerializer() {
+        super("cgmesTapChangers", "network", CgmesTapChangers.class,
+                true, "cgmesTapChangers.xsd",
+                "http://www.powsybl.org/schema/iidm/ext/cgmes_tap_changers/1_0", "ctc");
+    }
+
+    @Override
+    public void write(CgmesTapChangers<C> extension, XmlWriterContext context) throws XMLStreamException {
+        NetworkXmlWriterContext networkContext = (NetworkXmlWriterContext) context;
+        XMLStreamWriter writer = networkContext.getWriter();
+        for (CgmesTapChanger tapChanger : extension.getTapChangers()) {
+            writer.writeStartElement(getNamespaceUri(), "tapChanger");
+            writer.writeAttribute("id", tapChanger.getId());
+            if (tapChanger.getDifferentIidmId() != null) {
+                writer.writeAttribute("iidmId", tapChanger.getDifferentIidmId());
+            }
+            if (tapChanger.getType() != null) {
+                writer.writeAttribute("type", tapChanger.getType());
+            }
+            if (tapChanger.isHidden()) {
+                writer.writeAttribute("hidden", "true");
+                writer.writeAttribute("step", String.valueOf(tapChanger.getStep()
+                        .orElseThrow(() -> new PowsyblException("Step should be defined"))));
+            }
+            if (tapChanger.getControlId() != null) {
+                writer.writeAttribute("controlId", tapChanger.getControlId());
+            }
+            writer.writeEndElement();
+        }
+    }
+
+    @Override
+    public CgmesTapChangers<C> read(C extendable, XmlReaderContext context) throws XMLStreamException {
+        NetworkXmlReaderContext networkContext = (NetworkXmlReaderContext) context;
+        XMLStreamReader reader = networkContext.getReader();
+        extendable.newExtension(CgmesTapChangersAdder.class).add();
+        CgmesTapChangers<C> tapChangers = extendable.getExtension(CgmesTapChangers.class);
+        XmlUtil.readUntilEndElement(getExtensionName(), reader, () -> {
+            if (reader.getLocalName().equals("tapChanger")) {
+                CgmesTapChangerAdder adder = tapChangers.newTapChanger()
+                        .setId(reader.getAttributeValue(null, "id"))
+                        .setDifferentIidmId(reader.getAttributeValue(null, "iidmId"))
+                        .setType(reader.getAttributeValue(null, "type"))
+                        .setHiddenStatus(XmlUtil.readOptionalBoolAttribute(reader, "hidden", false))
+                        .setControlId(reader.getAttributeValue(null, "controlId"));
+                String stepStr = reader.getAttributeValue(null, "step");
+                if (stepStr != null) {
+                    adder.setStep(Integer.parseInt(stepStr));
+                }
+                adder.add();
+            } else {
+                throw new PowsyblException("Unknown element name <" + reader.getLocalName() + "> in <cgmesControlArea>");
+            }
+        });
+        return extendable.getExtension(CgmesTapChangers.class);
+    }
+}

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersXmlSerializer.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersXmlSerializer.java
@@ -40,8 +40,8 @@ public class CgmesTapChangersXmlSerializer<C extends Connectable<C>> extends Abs
         for (CgmesTapChanger tapChanger : extension.getTapChangers()) {
             writer.writeStartElement(getNamespaceUri(), "tapChanger");
             writer.writeAttribute("id", tapChanger.getId());
-            if (tapChanger.getDifferentIidmId() != null) {
-                writer.writeAttribute("iidmId", tapChanger.getDifferentIidmId());
+            if (tapChanger.getCombinedTapChangerId() != null) {
+                writer.writeAttribute("combinedTapChangerId", tapChanger.getCombinedTapChangerId());
             }
             if (tapChanger.getType() != null) {
                 writer.writeAttribute("type", tapChanger.getType());
@@ -68,7 +68,7 @@ public class CgmesTapChangersXmlSerializer<C extends Connectable<C>> extends Abs
             if (reader.getLocalName().equals("tapChanger")) {
                 CgmesTapChangerAdder adder = tapChangers.newTapChanger()
                         .setId(reader.getAttributeValue(null, "id"))
-                        .setDifferentIidmId(reader.getAttributeValue(null, "iidmId"))
+                        .setCombinedTapChangerId(reader.getAttributeValue(null, "combinedTapChangerId"))
                         .setType(reader.getAttributeValue(null, "type"))
                         .setHiddenStatus(XmlUtil.readOptionalBoolAttribute(reader, "hidden", false))
                         .setControlId(reader.getAttributeValue(null, "controlId"));
@@ -78,7 +78,7 @@ public class CgmesTapChangersXmlSerializer<C extends Connectable<C>> extends Abs
                 }
                 adder.add();
             } else {
-                throw new PowsyblException("Unknown element name <" + reader.getLocalName() + "> in <cgmesControlArea>");
+                throw new PowsyblException("Unknown element name <" + reader.getLocalName() + "> in <cgmesTapChangers>");
             }
         });
         return extendable.getExtension(CgmesTapChangers.class);

--- a/cgmes/cgmes-extensions/src/main/resources/xsd/cgmesTapChangers.xsd
+++ b/cgmes/cgmes-extensions/src/main/resources/xsd/cgmesTapChangers.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ctc="http://www.powsybl.org/schema/iidm/ext/cgmes_tap_changers/1_0"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/cgmes_tap_changers/1_0"
+           elementFormDefault="qualified">
+    <xs:simpleType name='nonEmptyString'>
+        <xs:restriction base='xs:string'>
+            <xs:minLength value='1'/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="cgmesTapChangers">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="tapChanger" minOccurs="1" maxOccurs="3">
+                    <xs:complexType>
+                        <xs:attribute name="id" use="required" type="ctc:nonEmptyString"/>
+                        <xs:attribute name="iidmId" use="optional" type="ctc:nonEmptyString"/>
+                        <xs:attribute name="type" use="optional" type="xs:string"/>
+                        <xs:attribute name="hidden" use="optional" type="xs:boolean"/>
+                        <xs:attribute name="step" use="optional" type="xs:int"/>
+                        <xs:attribute name="controlId" use="optional" type="ctc:nonEmptyString"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/cgmes/cgmes-extensions/src/main/resources/xsd/cgmesTapChangers.xsd
+++ b/cgmes/cgmes-extensions/src/main/resources/xsd/cgmesTapChangers.xsd
@@ -15,7 +15,7 @@
                 <xs:element name="tapChanger" minOccurs="1" maxOccurs="3">
                     <xs:complexType>
                         <xs:attribute name="id" use="required" type="ctc:nonEmptyString"/>
-                        <xs:attribute name="iidmId" use="optional" type="ctc:nonEmptyString"/>
+                        <xs:attribute name="combinedTapChangerId" use="optional" type="ctc:nonEmptyString"/>
                         <xs:attribute name="type" use="optional" type="xs:string"/>
                         <xs:attribute name="hidden" use="optional" type="xs:boolean"/>
                         <xs:attribute name="step" use="optional" type="xs:int"/>


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Transformers have a lot of properties that are not really user-friendly


**What is the new behavior (if this is a feature change)?**
These properties are replaced by extensions


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
Yes
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


