### PR TITLE
Make CIM namespace detection more specific in order not to select an incorrect namespace

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNamespace.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNamespace.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.cgmes.model;
 
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -33,6 +34,8 @@ public final class CgmesNamespace {
     public static final String EQ_OPERATION_PROFILE = "http://entsoe.eu/CIM/EquipmentOperation/3/1";
     public static final String SV_PROFILE = "http://entsoe.eu/CIM/StateVariables/4/1";
     public static final String SSH_PROFILE = "http://entsoe.eu/CIM/SteadyStateHypothesis/1/1";
+
+    public static final Set<String> CIM_NAMESPACES = Set.of(CIM_14_NAMESPACE, CIM_16_NAMESPACE, CIM_100_NAMESPACE);
 
     public static String getCimNamespace(int cimVersion) {
         if (cimVersion == 14) {

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -77,7 +77,7 @@ public class CgmesOnDataSource {
     private static boolean isCimNamespace(String ns) {
         // Until CIM16 the CIM namespace contained the string "CIM-schema-cim<versionNumber>#"
         // Since CIM100 the namespace seems to follow the pattern "/CIM<versionNumber>#"
-        return ns.contains("CIM-schema-cim") || CIM_100_PLUS_NAMESPACE_PATTERN.matcher(ns).matches();
+        return CIM_NAMESPACES.contains(ns) || CIM_100_PLUS_NAMESPACE_PATTERN.matcher(ns).matches();
     }
 
     private boolean containsValidNamespace(String name) {


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Select as CIM namespace any namespace containing `CIM-schema-cim` which may not be a correct CIM schema.


**What is the new behavior (if this is a feature change)?**
Strictly select from known CIM namespaces


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
