### PR TITLE
Fix IIDM bus/breaker switch anonymizer

### DIFF
--- a/iidm/iidm-xml-converter/pom.xml
+++ b/iidm/iidm-xml-converter/pom.xml
@@ -88,6 +88,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -133,8 +133,8 @@ class VoltageLevelXml extends AbstractIdentifiableXml<VoltageLevel, VoltageLevel
             BusXml.INSTANCE.write(b, null, context);
         }
         for (Switch sw : IidmXmlUtil.sorted(vl.getBusBreakerView().getSwitches(), context.getOptions())) {
-            Bus b1 = vl.getBusBreakerView().getBus1(context.getAnonymizer().anonymizeString(sw.getId()));
-            Bus b2 = vl.getBusBreakerView().getBus2(context.getAnonymizer().anonymizeString(sw.getId()));
+            Bus b1 = vl.getBusBreakerView().getBus1(sw.getId());
+            Bus b2 = vl.getBusBreakerView().getBus2(sw.getId());
             if (!context.getFilter().test(b1) || !context.getFilter().test(b2)) {
                 continue;
             }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/BusBreakerAnonymiserBugTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/BusBreakerAnonymiserBugTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.xml;
+
+import com.powsybl.commons.config.InMemoryPlatformConfig;
+import com.powsybl.commons.config.PlatformConfig;
+import com.powsybl.commons.datasource.MemDataSource;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VoltageLevel;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class BusBreakerAnonymiserBugTest extends AbstractXmlConverterTest {
+
+    @Test
+    public void test() throws IOException {
+        Network network = NetworkXmlTest.createEurostagTutorialExample1();
+        // add a switch
+        VoltageLevel vlgen = network.getVoltageLevel("VLGEN");
+        vlgen.getBusBreakerView().newBus()
+                .setId("NEW_BUS")
+                .add();
+        vlgen.getBusBreakerView().newSwitch()
+                .setId("NEW_SWITCH")
+                .setBus1("NGEN")
+                .setBus2("NEW_BUS")
+                .add();
+
+        PlatformConfig platformConfig = new InMemoryPlatformConfig(fileSystem);
+        Properties properties = new Properties();
+        properties.put(XMLExporter.ANONYMISED, "true");
+        MemDataSource dataSource = new MemDataSource();
+
+        // check we have no more exception
+        var exporter = new XMLExporter(platformConfig);
+        Assertions.assertThatCode(() -> exporter.export(network, properties, dataSource))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
We have an exception when we try to export anonymized IIDM with a switch in a bus/breaker voltage level.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
