### PR TITLE
redundant attribute in ObservabilityQuality is a boolean and not a Boolean anymore + some code improvements

### DIFF
--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/BranchObservability.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/BranchObservability.java
@@ -27,7 +27,7 @@ public interface BranchObservability<B extends Branch<B>> extends Extension<B>, 
      */
     ObservabilityQuality<B> getQualityP1();
 
-    BranchObservability<B> setQualityP1(double standardDeviation, Boolean redundant);
+    BranchObservability<B> setQualityP1(double standardDeviation, boolean redundant);
 
     BranchObservability<B> setQualityP1(double standardDeviation);
 
@@ -37,7 +37,7 @@ public interface BranchObservability<B extends Branch<B>> extends Extension<B>, 
      */
     ObservabilityQuality<B> getQualityP2();
 
-    BranchObservability<B> setQualityP2(double standardDeviation, Boolean redundant);
+    BranchObservability<B> setQualityP2(double standardDeviation, boolean redundant);
 
     BranchObservability<B> setQualityP2(double standardDeviation);
 
@@ -47,7 +47,7 @@ public interface BranchObservability<B extends Branch<B>> extends Extension<B>, 
      */
     ObservabilityQuality<B> getQualityQ1();
 
-    BranchObservability<B> setQualityQ1(double standardDeviation, Boolean redundant);
+    BranchObservability<B> setQualityQ1(double standardDeviation, boolean redundant);
 
     BranchObservability<B> setQualityQ1(double standardDeviation);
 
@@ -57,7 +57,7 @@ public interface BranchObservability<B extends Branch<B>> extends Extension<B>, 
      */
     ObservabilityQuality<B> getQualityQ2();
 
-    BranchObservability<B> setQualityQ2(double standardDeviation, Boolean redundant);
+    BranchObservability<B> setQualityQ2(double standardDeviation, boolean redundant);
 
     BranchObservability<B> setQualityQ2(double standardDeviation);
 }

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/InjectionObservability.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/InjectionObservability.java
@@ -27,7 +27,7 @@ public interface InjectionObservability<I extends Injection<I>> extends Extensio
      */
     ObservabilityQuality<I> getQualityP();
 
-    InjectionObservability<I> setQualityP(double standardDeviation, Boolean redundant);
+    InjectionObservability<I> setQualityP(double standardDeviation, boolean redundant);
 
     InjectionObservability<I> setQualityP(double standardDeviation);
 
@@ -37,7 +37,7 @@ public interface InjectionObservability<I extends Injection<I>> extends Extensio
      */
     ObservabilityQuality<I> getQualityQ();
 
-    InjectionObservability<I> setQualityQ(double standardDeviation, Boolean redundant);
+    InjectionObservability<I> setQualityQ(double standardDeviation, boolean redundant);
 
     InjectionObservability<I> setQualityQ(double standardDeviation);
 
@@ -47,7 +47,7 @@ public interface InjectionObservability<I extends Injection<I>> extends Extensio
      */
     ObservabilityQuality<I> getQualityV();
 
-    InjectionObservability<I> setQualityV(double standardDeviation, Boolean redundant);
+    InjectionObservability<I> setQualityV(double standardDeviation, boolean redundant);
 
     InjectionObservability<I> setQualityV(double standardDeviation);
 }

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ObservabilityQuality.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ObservabilityQuality.java
@@ -6,8 +6,6 @@
  */
 package com.powsybl.iidm.network.extensions;
 
-import java.util.Optional;
-
 /**
  * Quality information.
  *
@@ -26,7 +24,7 @@ public interface ObservabilityQuality<T> {
     /**
      * Value optional. Can be empty.
      */
-    Optional<Boolean> isRedundant();
+    boolean isRedundant();
 
-    ObservabilityQuality<T> setRedundant(Boolean redundant);
+    ObservabilityQuality<T> setRedundant(boolean redundant);
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/BranchObservabilityAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/BranchObservabilityAdderImpl.java
@@ -20,21 +20,21 @@ public class BranchObservabilityAdderImpl<B extends Branch<B>>
 
     private boolean observable;
 
-    private Double standardDeviationP1 = null;
+    private double standardDeviationP1 = Double.NaN;
 
-    private Double standardDeviationP2 = null;
+    private double standardDeviationP2 = Double.NaN;
 
-    private Double standardDeviationQ1 = null;
+    private double standardDeviationQ1 = Double.NaN;
 
-    private Double standardDeviationQ2 = null;
+    private double standardDeviationQ2 = Double.NaN;
 
-    private Boolean redundantP1 = null;
+    private boolean redundantP1 = false;
 
-    private Boolean redundantP2 = null;
+    private boolean redundantP2 = false;
 
-    private Boolean redundantQ1 = null;
+    private boolean redundantQ1 = false;
 
-    private Boolean redundantQ2 = null;
+    private boolean redundantQ2 = false;
 
     public BranchObservabilityAdderImpl(B extendable) {
         super(extendable);
@@ -43,16 +43,16 @@ public class BranchObservabilityAdderImpl<B extends Branch<B>>
     @Override
     protected BranchObservability<B> createExtension(B extendable) {
         BranchObservabilityImpl<B> extension = new BranchObservabilityImpl<>(extendable, observable);
-        if (standardDeviationP1 != null) {
+        if (!Double.isNaN(standardDeviationP1)) {
             extension.setQualityP1(standardDeviationP1, redundantP1);
         }
-        if (standardDeviationP2 != null) {
+        if (!Double.isNaN(standardDeviationP2)) {
             extension.setQualityP2(standardDeviationP2, redundantP2);
         }
-        if (standardDeviationQ1 != null) {
+        if (!Double.isNaN(standardDeviationQ1)) {
             extension.setQualityQ1(standardDeviationQ1, redundantQ1);
         }
-        if (standardDeviationQ2 != null) {
+        if (!Double.isNaN(standardDeviationQ2)) {
             extension.setQualityQ2(standardDeviationQ2, redundantQ2);
         }
         return extension;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/BranchObservabilityImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/BranchObservabilityImpl.java
@@ -33,10 +33,10 @@ public class BranchObservabilityImpl<B extends Branch<B>> extends AbstractExtens
     }
 
     public BranchObservabilityImpl(B component, boolean observable,
-                                   double standardDeviationP1, Boolean redundantP1,
-                                   double standardDeviationP2, Boolean redundantP2,
-                                   double standardDeviationQ1, Boolean redundantQ1,
-                                   double standardDeviationQ2, Boolean redundantQ2) {
+                                   double standardDeviationP1, boolean redundantP1,
+                                   double standardDeviationP2, boolean redundantP2,
+                                   double standardDeviationQ1, boolean redundantQ1,
+                                   double standardDeviationQ2, boolean redundantQ2) {
         this(component, observable);
         this.qualityP1 = new ObservabilityQualityImpl<>(standardDeviationP1, redundantP1);
         this.qualityP2 = new ObservabilityQualityImpl<>(standardDeviationP2, redundantP2);
@@ -60,7 +60,7 @@ public class BranchObservabilityImpl<B extends Branch<B>> extends AbstractExtens
     }
 
     @Override
-    public BranchObservability<B> setQualityP1(double standardDeviation, Boolean redundant) {
+    public BranchObservability<B> setQualityP1(double standardDeviation, boolean redundant) {
         if (qualityP1 == null) {
             qualityP1 = new ObservabilityQualityImpl<>(standardDeviation, redundant);
         } else {
@@ -86,7 +86,7 @@ public class BranchObservabilityImpl<B extends Branch<B>> extends AbstractExtens
     }
 
     @Override
-    public BranchObservability<B> setQualityP2(double standardDeviation, Boolean redundant) {
+    public BranchObservability<B> setQualityP2(double standardDeviation, boolean redundant) {
         if (qualityP2 == null) {
             qualityP2 = new ObservabilityQualityImpl<>(standardDeviation, redundant);
         } else {
@@ -112,7 +112,7 @@ public class BranchObservabilityImpl<B extends Branch<B>> extends AbstractExtens
     }
 
     @Override
-    public BranchObservability<B> setQualityQ1(double standardDeviation, Boolean redundant) {
+    public BranchObservability<B> setQualityQ1(double standardDeviation, boolean redundant) {
         if (qualityQ1 == null) {
             qualityQ1 = new ObservabilityQualityImpl<>(standardDeviation, redundant);
         } else {
@@ -138,7 +138,7 @@ public class BranchObservabilityImpl<B extends Branch<B>> extends AbstractExtens
     }
 
     @Override
-    public BranchObservability<B> setQualityQ2(double standardDeviation, Boolean redundant) {
+    public BranchObservability<B> setQualityQ2(double standardDeviation, boolean redundant) {
         if (qualityQ2 == null) {
             qualityQ2 = new ObservabilityQualityImpl<>(standardDeviation, redundant);
         } else {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/InjectionObservabilityAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/InjectionObservabilityAdderImpl.java
@@ -20,17 +20,17 @@ public class InjectionObservabilityAdderImpl<I extends Injection<I>>
 
     private boolean observable;
 
-    private Double standardDeviationP = null;
+    private double standardDeviationP = Double.NaN;
 
-    private Double standardDeviationQ = null;
+    private double standardDeviationQ = Double.NaN;
 
-    private Double standardDeviationV = null;
+    private double standardDeviationV = Double.NaN;
 
-    private Boolean redundantP = null;
+    private boolean redundantP = false;
 
-    private Boolean redundantQ = null;
+    private boolean redundantQ = false;
 
-    private Boolean redundantV = null;
+    private boolean redundantV = false;
 
     public InjectionObservabilityAdderImpl(I extendable) {
         super(extendable);
@@ -39,13 +39,13 @@ public class InjectionObservabilityAdderImpl<I extends Injection<I>>
     @Override
     protected InjectionObservability<I> createExtension(I extendable) {
         InjectionObservabilityImpl<I> extension = new InjectionObservabilityImpl<>(extendable, observable);
-        if (standardDeviationP != null) {
+        if (!Double.isNaN(standardDeviationP)) {
             extension.setQualityP(standardDeviationP, redundantP);
         }
-        if (standardDeviationQ != null) {
+        if (!Double.isNaN(standardDeviationQ)) {
             extension.setQualityQ(standardDeviationQ, redundantQ);
         }
-        if (standardDeviationV != null) {
+        if (!Double.isNaN(standardDeviationV)) {
             extension.setQualityV(standardDeviationV, redundantV);
         }
         return extension;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/InjectionObservabilityImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/InjectionObservabilityImpl.java
@@ -31,9 +31,9 @@ public class InjectionObservabilityImpl<T extends Injection<T>> extends Abstract
     }
 
     public InjectionObservabilityImpl(T component, boolean observable,
-                                      double standardDeviationP, Boolean redundantP,
-                                      double standardDeviationQ, Boolean redundantQ,
-                                      double standardDeviationV, Boolean redundantV) {
+                                      double standardDeviationP, boolean redundantP,
+                                      double standardDeviationQ, boolean redundantQ,
+                                      double standardDeviationV, boolean redundantV) {
         this(component, observable);
         this.qualityP = new ObservabilityQualityImpl<>(standardDeviationP, redundantP);
         this.qualityQ = new ObservabilityQualityImpl<>(standardDeviationQ, redundantQ);
@@ -56,7 +56,7 @@ public class InjectionObservabilityImpl<T extends Injection<T>> extends Abstract
     }
 
     @Override
-    public InjectionObservability<T> setQualityP(double standardDeviation, Boolean redundant) {
+    public InjectionObservability<T> setQualityP(double standardDeviation, boolean redundant) {
         if (qualityP == null) {
             qualityP = new ObservabilityQualityImpl<>(standardDeviation, redundant);
         } else {
@@ -82,7 +82,7 @@ public class InjectionObservabilityImpl<T extends Injection<T>> extends Abstract
     }
 
     @Override
-    public InjectionObservability<T> setQualityQ(double standardDeviation, Boolean redundant) {
+    public InjectionObservability<T> setQualityQ(double standardDeviation, boolean redundant) {
         if (qualityQ == null) {
             qualityQ = new ObservabilityQualityImpl<>(standardDeviation, redundant);
         } else {
@@ -108,7 +108,7 @@ public class InjectionObservabilityImpl<T extends Injection<T>> extends Abstract
     }
 
     @Override
-    public InjectionObservability<T> setQualityV(double standardDeviation, Boolean redundant) {
+    public InjectionObservability<T> setQualityV(double standardDeviation, boolean redundant) {
         if (qualityV == null) {
             qualityV = new ObservabilityQualityImpl<>(standardDeviation, redundant);
         } else {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ObservabilityQualityImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ObservabilityQualityImpl.java
@@ -8,8 +8,6 @@ package com.powsybl.iidm.network.impl.extensions;
 
 import com.powsybl.iidm.network.extensions.ObservabilityQuality;
 
-import java.util.Optional;
-
 /**
  * @author Thomas Adam <tadam at silicom.fr>
  */
@@ -17,7 +15,7 @@ public class ObservabilityQualityImpl<T> implements ObservabilityQuality<T> {
 
     private double standardDeviation;
 
-    private Boolean redundant;
+    private boolean redundant = false;
 
     public ObservabilityQualityImpl(double standardDeviation, Boolean redundant) {
         this.standardDeviation = standardDeviation;
@@ -26,7 +24,6 @@ public class ObservabilityQualityImpl<T> implements ObservabilityQuality<T> {
 
     public ObservabilityQualityImpl(double standardDeviation) {
         this.standardDeviation = standardDeviation;
-        redundant = null;
     }
 
     @Override
@@ -41,12 +38,12 @@ public class ObservabilityQualityImpl<T> implements ObservabilityQuality<T> {
     }
 
     @Override
-    public Optional<Boolean> isRedundant() {
-        return Optional.ofNullable(redundant);
+    public boolean isRedundant() {
+        return redundant;
     }
 
     @Override
-    public ObservabilityQuality<T> setRedundant(Boolean redundant) {
+    public ObservabilityQuality<T> setRedundant(boolean redundant) {
         this.redundant = redundant;
         return this;
     }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractBranchObservabilityTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractBranchObservabilityTest.java
@@ -52,12 +52,12 @@ public abstract class AbstractBranchObservabilityTest {
         branchObservability.getQualityP2().setStandardDeviation(0.08d);
         assertEquals(0.08d, branchObservability.getQualityP2().getStandardDeviation(), 0d);
 
-        assertTrue(branchObservability.getQualityP1().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(branchObservability.getQualityP1().isRedundant());
         branchObservability.getQualityP1().setRedundant(false);
-        assertFalse(branchObservability.getQualityP1().isRedundant().orElseThrow(AssertionError::new));
-        assertFalse(branchObservability.getQualityP2().isRedundant().orElseThrow(AssertionError::new));
+        assertFalse(branchObservability.getQualityP1().isRedundant());
+        assertFalse(branchObservability.getQualityP2().isRedundant());
         branchObservability.getQualityP2().setRedundant(true);
-        assertTrue(branchObservability.getQualityP2().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(branchObservability.getQualityP2().isRedundant());
 
         // Q
         assertEquals(0.5d, branchObservability.getQualityQ1().getStandardDeviation(), 0d);
@@ -67,12 +67,12 @@ public abstract class AbstractBranchObservabilityTest {
         branchObservability.getQualityQ2().setStandardDeviation(1.01d);
         assertEquals(1.01d, branchObservability.getQualityQ2().getStandardDeviation(), 0d);
 
-        assertTrue(branchObservability.getQualityQ1().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(branchObservability.getQualityQ1().isRedundant());
         branchObservability.getQualityQ1().setRedundant(false);
-        assertFalse(branchObservability.getQualityQ1().isRedundant().orElseThrow(AssertionError::new));
-        assertFalse(branchObservability.getQualityQ2().isRedundant().orElseThrow(AssertionError::new));
+        assertFalse(branchObservability.getQualityQ1().isRedundant());
+        assertFalse(branchObservability.getQualityQ2().isRedundant());
         branchObservability.getQualityQ2().setRedundant(true);
-        assertTrue(branchObservability.getQualityQ2().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(branchObservability.getQualityQ2().isRedundant());
     }
 
     @Test
@@ -97,9 +97,9 @@ public abstract class AbstractBranchObservabilityTest {
         assertSame(branchObservability, branchObservability.setQualityP1(0.04d));
         assertEquals(0.04d, branchObservability.getQualityP1().getStandardDeviation(), 0d);
 
-        assertTrue(branchObservability.getQualityP1().isRedundant().isEmpty());
+        assertFalse(branchObservability.getQualityP1().isRedundant());
         branchObservability.getQualityP1().setRedundant(true);
-        assertTrue(branchObservability.getQualityP1().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(branchObservability.getQualityP1().isRedundant());
 
         // P2
         assertSame(branchObservability, branchObservability.setQualityP2(0.031d));
@@ -107,9 +107,9 @@ public abstract class AbstractBranchObservabilityTest {
         assertSame(branchObservability, branchObservability.setQualityP2(0.041d));
         assertEquals(0.041d, branchObservability.getQualityP2().getStandardDeviation(), 0d);
 
-        assertTrue(branchObservability.getQualityP2().isRedundant().isEmpty());
+        assertFalse(branchObservability.getQualityP2().isRedundant());
         branchObservability.getQualityP2().setRedundant(true);
-        assertTrue(branchObservability.getQualityP2().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(branchObservability.getQualityP2().isRedundant());
 
         // Q1
         assertSame(branchObservability, branchObservability.setQualityQ1(0.6d));
@@ -117,9 +117,9 @@ public abstract class AbstractBranchObservabilityTest {
         assertSame(branchObservability, branchObservability.setQualityQ1(0.61d));
         assertEquals(0.61d, branchObservability.getQualityQ1().getStandardDeviation(), 0d);
 
-        assertTrue(branchObservability.getQualityQ1().isRedundant().isEmpty());
+        assertFalse(branchObservability.getQualityQ1().isRedundant());
         branchObservability.getQualityQ1().setRedundant(true);
-        assertTrue(branchObservability.getQualityQ1().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(branchObservability.getQualityQ1().isRedundant());
 
         // Q2
         assertSame(branchObservability, branchObservability.setQualityQ2(0.6d));
@@ -127,8 +127,8 @@ public abstract class AbstractBranchObservabilityTest {
         assertSame(branchObservability, branchObservability.setQualityQ2(0.61d));
         assertEquals(0.61d, branchObservability.getQualityQ2().getStandardDeviation(), 0d);
 
-        assertTrue(branchObservability.getQualityQ2().isRedundant().isEmpty());
+        assertFalse(branchObservability.getQualityQ2().isRedundant());
         branchObservability.getQualityQ2().setRedundant(true);
-        assertTrue(branchObservability.getQualityQ2().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(branchObservability.getQualityQ2().isRedundant());
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractInjectionObservabilityTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractInjectionObservabilityTest.java
@@ -46,25 +46,25 @@ public abstract class AbstractInjectionObservabilityTest {
         injectionObservability.getQualityP().setStandardDeviation(0.03d);
         assertEquals(0.03d, injectionObservability.getQualityP().getStandardDeviation(), 0d);
 
-        assertTrue(injectionObservability.getQualityP().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(injectionObservability.getQualityP().isRedundant());
         injectionObservability.getQualityP().setRedundant(false);
-        assertFalse(injectionObservability.getQualityP().isRedundant().orElseThrow(AssertionError::new));
+        assertFalse(injectionObservability.getQualityP().isRedundant());
 
         assertEquals(0.5d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
         injectionObservability.getQualityQ().setStandardDeviation(0.6d);
         assertEquals(0.6d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
 
-        assertTrue(injectionObservability.getQualityQ().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(injectionObservability.getQualityQ().isRedundant());
         injectionObservability.getQualityQ().setRedundant(false);
-        assertFalse(injectionObservability.getQualityQ().isRedundant().orElseThrow(AssertionError::new));
+        assertFalse(injectionObservability.getQualityQ().isRedundant());
 
         assertEquals(0.0d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
         injectionObservability.getQualityV().setStandardDeviation(0.01d);
         assertEquals(0.01d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
 
-        assertTrue(injectionObservability.getQualityV().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(injectionObservability.getQualityV().isRedundant());
         injectionObservability.getQualityV().setRedundant(false);
-        assertFalse(injectionObservability.getQualityV().isRedundant().orElseThrow(AssertionError::new));
+        assertFalse(injectionObservability.getQualityV().isRedundant());
     }
 
     @Test
@@ -87,26 +87,26 @@ public abstract class AbstractInjectionObservabilityTest {
         assertSame(injectionObservability, injectionObservability.setQualityP(0.04d));
         assertEquals(0.04d, injectionObservability.getQualityP().getStandardDeviation(), 0d);
 
-        assertTrue(injectionObservability.getQualityP().isRedundant().isEmpty());
+        assertFalse(injectionObservability.getQualityP().isRedundant());
         injectionObservability.getQualityP().setRedundant(true);
-        assertTrue(injectionObservability.getQualityP().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(injectionObservability.getQualityP().isRedundant());
 
         assertSame(injectionObservability, injectionObservability.setQualityQ(0.6d));
         assertEquals(0.6d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
         assertSame(injectionObservability, injectionObservability.setQualityQ(0.61d));
         assertEquals(0.61d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
 
-        assertTrue(injectionObservability.getQualityQ().isRedundant().isEmpty());
+        assertFalse(injectionObservability.getQualityQ().isRedundant());
         injectionObservability.getQualityQ().setRedundant(true);
-        assertTrue(injectionObservability.getQualityQ().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(injectionObservability.getQualityQ().isRedundant());
 
         assertSame(injectionObservability, injectionObservability.setQualityV(0.01d));
         assertEquals(0.01d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
         assertSame(injectionObservability, injectionObservability.setQualityV(0.02d));
         assertEquals(0.02d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
 
-        assertTrue(injectionObservability.getQualityV().isRedundant().isEmpty());
+        assertFalse(injectionObservability.getQualityV().isRedundant());
         injectionObservability.getQualityV().setRedundant(true);
-        assertTrue(injectionObservability.getQualityV().isRedundant().orElseThrow(AssertionError::new));
+        assertTrue(injectionObservability.getQualityV().isRedundant());
     }
 }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/BranchObservabilityXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/BranchObservabilityXmlSerializer.java
@@ -8,7 +8,6 @@ package com.powsybl.iidm.xml.extensions;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.commons.extensions.AbstractExtensionXmlSerializer;
 import com.powsybl.commons.extensions.ExtensionXmlSerializer;
 import com.powsybl.commons.xml.XmlReaderContext;
@@ -17,6 +16,7 @@ import com.powsybl.commons.xml.XmlWriterContext;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.extensions.BranchObservability;
 import com.powsybl.iidm.network.extensions.BranchObservabilityAdder;
+import com.powsybl.iidm.network.extensions.ObservabilityQuality;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -45,48 +45,30 @@ public class BranchObservabilityXmlSerializer<T extends Branch<T>> extends Abstr
         // qualityP1
         context.getWriter().writeEmptyElement(getNamespaceUri(), QUALITY_P);
         context.getWriter().writeAttribute(SIDE, Branch.Side.ONE.name());
-        XmlUtil.writeDouble(STANDARD_DEVIATION, branchObservability.getQualityP1().getStandardDeviation(), context.getWriter());
-        branchObservability.getQualityP1().isRedundant().ifPresent(redundant -> {
-            try {
-                context.getWriter().writeAttribute(REDUNDANT, Boolean.toString(redundant));
-            } catch (XMLStreamException e) {
-                throw new UncheckedXmlStreamException(e);
-            }
-        });
+        ObservabilityQuality<T> qualityP1 = branchObservability.getQualityP1();
+        XmlUtil.writeDouble(STANDARD_DEVIATION, qualityP1.getStandardDeviation(), context.getWriter());
+        XmlUtil.writeOptionalBoolean(REDUNDANT, qualityP1.isRedundant(), false, context.getWriter());
+
         // qualityP2
         context.getWriter().writeEmptyElement(getNamespaceUri(), QUALITY_P);
         context.getWriter().writeAttribute(SIDE, Branch.Side.TWO.name());
-        XmlUtil.writeDouble(STANDARD_DEVIATION, branchObservability.getQualityP2().getStandardDeviation(), context.getWriter());
-        branchObservability.getQualityP2().isRedundant().ifPresent(redundant -> {
-            try {
-                context.getWriter().writeAttribute(REDUNDANT, Boolean.toString(redundant));
-            } catch (XMLStreamException e) {
-                throw new UncheckedXmlStreamException(e);
-            }
-        });
+        ObservabilityQuality<T> qualityP2 = branchObservability.getQualityP2();
+        XmlUtil.writeDouble(STANDARD_DEVIATION, qualityP2.getStandardDeviation(), context.getWriter());
+        XmlUtil.writeOptionalBoolean(REDUNDANT, qualityP2.isRedundant(), false, context.getWriter());
 
         // qualityQ1
         context.getWriter().writeEmptyElement(getNamespaceUri(), QUALITY_Q);
         context.getWriter().writeAttribute(SIDE, Branch.Side.ONE.name());
-        XmlUtil.writeDouble(STANDARD_DEVIATION, branchObservability.getQualityQ1().getStandardDeviation(), context.getWriter());
-        branchObservability.getQualityQ1().isRedundant().ifPresent(redundant -> {
-            try {
-                context.getWriter().writeAttribute(REDUNDANT, Boolean.toString(redundant));
-            } catch (XMLStreamException e) {
-                throw new UncheckedXmlStreamException(e);
-            }
-        });
+        ObservabilityQuality<T> qualityQ1 = branchObservability.getQualityQ1();
+        XmlUtil.writeDouble(STANDARD_DEVIATION, qualityQ1.getStandardDeviation(), context.getWriter());
+        XmlUtil.writeOptionalBoolean(REDUNDANT, qualityQ1.isRedundant(), false, context.getWriter());
+
         // qualityQ2
         context.getWriter().writeEmptyElement(getNamespaceUri(), QUALITY_Q);
         context.getWriter().writeAttribute(SIDE, Branch.Side.TWO.name());
-        XmlUtil.writeDouble(STANDARD_DEVIATION, branchObservability.getQualityQ2().getStandardDeviation(), context.getWriter());
-        branchObservability.getQualityQ2().isRedundant().ifPresent(redundant -> {
-            try {
-                context.getWriter().writeAttribute(REDUNDANT, Boolean.toString(redundant));
-            } catch (XMLStreamException e) {
-                throw new UncheckedXmlStreamException(e);
-            }
-        });
+        ObservabilityQuality<T> qualityQ2 = branchObservability.getQualityQ2();
+        XmlUtil.writeDouble(STANDARD_DEVIATION, qualityQ2.getStandardDeviation(), context.getWriter());
+        XmlUtil.writeOptionalBoolean(REDUNDANT, qualityQ2.isRedundant(), false, context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlSerializer.java
@@ -8,7 +8,6 @@ package com.powsybl.iidm.xml.extensions;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.commons.exceptions.UncheckedXmlStreamException;
 import com.powsybl.commons.extensions.AbstractExtensionXmlSerializer;
 import com.powsybl.commons.extensions.ExtensionXmlSerializer;
 import com.powsybl.commons.xml.XmlReaderContext;
@@ -52,13 +51,7 @@ public class InjectionObservabilityXmlSerializer<T extends Injection<T>> extends
         if (quality != null) {
             writer.writeEmptyElement(getNamespaceUri(), elementName);
             XmlUtil.writeDouble(STANDARD_DEVIATION, quality.getStandardDeviation(), writer);
-            quality.isRedundant().ifPresent(redundant -> {
-                try {
-                    writer.writeAttribute(REDUNDANT, Boolean.toString(redundant));
-                } catch (XMLStreamException e) {
-                    throw new UncheckedXmlStreamException(e);
-                }
-            });
+            XmlUtil.writeOptionalBoolean(REDUNDANT, quality.isRedundant(), false, writer);
         }
     }
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/BranchObservabilityXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/BranchObservabilityXmlTest.java
@@ -57,7 +57,7 @@ public class BranchObservabilityXmlTest extends AbstractConverterTest {
 
         Network network2 = roundTripXmlTest(network,
                 NetworkXml::writeAndValidate,
-                NetworkXml::read,
+                NetworkXml::validateAndRead,
                 getVersionedNetworkPath("/branchObservabilityRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
 
         line1 = network2.getLine("NHV1_NHV2_1");
@@ -67,14 +67,14 @@ public class BranchObservabilityXmlTest extends AbstractConverterTest {
 
         assertEquals(line1BranchObservability.isObservable(), line1BranchObservability2.isObservable());
         assertEquals(line1BranchObservability.getQualityP1().getStandardDeviation(), line1BranchObservability2.getQualityP1().getStandardDeviation(), 0.0d);
-        assertEquals(line1BranchObservability.getQualityP1().isRedundant().orElse(null), line1BranchObservability2.getQualityP1().isRedundant().orElse(null));
+        assertEquals(line1BranchObservability.getQualityP1().isRedundant(), line1BranchObservability2.getQualityP1().isRedundant());
         assertEquals(line1BranchObservability.getQualityP2().getStandardDeviation(), line1BranchObservability2.getQualityP2().getStandardDeviation(), 0.0d);
-        assertEquals(line1BranchObservability.getQualityP2().isRedundant().orElse(null), line1BranchObservability2.getQualityP2().isRedundant().orElse(null));
+        assertEquals(line1BranchObservability.getQualityP2().isRedundant(), line1BranchObservability2.getQualityP2().isRedundant());
 
         assertEquals(line1BranchObservability.getQualityQ1().getStandardDeviation(), line1BranchObservability2.getQualityQ1().getStandardDeviation(), 0.0d);
-        assertEquals(line1BranchObservability.getQualityQ1().isRedundant().orElse(null), line1BranchObservability2.getQualityQ1().isRedundant().orElse(null));
+        assertEquals(line1BranchObservability.getQualityQ1().isRedundant(), line1BranchObservability2.getQualityQ1().isRedundant());
         assertEquals(line1BranchObservability.getQualityQ2().getStandardDeviation(), line1BranchObservability2.getQualityQ2().getStandardDeviation(), 0.0d);
-        assertEquals(line1BranchObservability.getQualityQ2().isRedundant().orElse(null), line1BranchObservability2.getQualityQ2().isRedundant().orElse(null));
+        assertEquals(line1BranchObservability.getQualityQ2().isRedundant(), line1BranchObservability2.getQualityQ2().isRedundant());
 
         assertEquals(line1BranchObservability.getName(), line1BranchObservability2.getName());
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlTest.java
@@ -48,9 +48,9 @@ public class InjectionObservabilityXmlTest extends AbstractConverterTest {
         Generator generator = network.getGenerator("GEN");
         generator.addExtension(InjectionObservability.class, new InjectionObservabilityImpl<>(generator, false, 0.02d, true, 0.5d, true, 0.0d, true));
 
-        Network network2 = roundTripTest(network,
+        Network network2 = roundTripXmlTest(network,
                 NetworkXml::writeAndValidate,
-                NetworkXml::read,
+                NetworkXml::validateAndRead,
                 getVersionedNetworkPath("/injectionObservabilityRoundTripRef.xml", CURRENT_IIDM_XML_VERSION));
 
         Battery bat2 = network2.getBattery("BAT");
@@ -61,8 +61,8 @@ public class InjectionObservabilityXmlTest extends AbstractConverterTest {
         assertEquals(injectionObservability.isObservable(), injectionObservability2.isObservable());
         assertEquals(injectionObservability.getQualityP().getStandardDeviation(), injectionObservability2.getQualityP().getStandardDeviation(), 0.0d);
         assertEquals(injectionObservability.getQualityQ().getStandardDeviation(), injectionObservability2.getQualityQ().getStandardDeviation(), 0.0d);
-        assertEquals(injectionObservability.getQualityP().isRedundant().orElse(null), injectionObservability2.getQualityP().isRedundant().orElse(null));
-        assertEquals(injectionObservability.getQualityQ().isRedundant().orElse(null), injectionObservability2.getQualityQ().isRedundant().orElse(null));
+        assertEquals(injectionObservability.getQualityP().isRedundant(), injectionObservability2.getQualityP().isRedundant());
+        assertEquals(injectionObservability.getQualityQ().isRedundant(), injectionObservability2.getQualityQ().isRedundant());
         assertEquals(injectionObservability.getQualityV(), injectionObservability2.getQualityV());
 
         assertEquals(injectionObservability.getName(), injectionObservability2.getName());

--- a/iidm/iidm-xml-converter/src/test/resources/V1_6/branchObservabilityRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_6/branchObservabilityRoundTripRef.xml
@@ -34,14 +34,14 @@
             <bo:qualityP side="ONE" standardDeviation="0.1" redundant="true"/>
             <bo:qualityP side="TWO" standardDeviation="0.2" redundant="true"/>
             <bo:qualityQ side="ONE" standardDeviation="0.3" redundant="true"/>
-            <bo:qualityQ side="TWO" standardDeviation="0.4" redundant="false"/>
+            <bo:qualityQ side="TWO" standardDeviation="0.4"/>
         </bo:branchObservability>
     </iidm:extension>
     <iidm:extension id="NHV1_NHV2_1">
         <bo:branchObservability observable="true">
-            <bo:qualityP side="ONE" standardDeviation="0.03" redundant="false"/>
-            <bo:qualityP side="TWO" standardDeviation="0.6" redundant="false"/>
-            <bo:qualityQ side="ONE" standardDeviation="0.1" redundant="false"/>
+            <bo:qualityP side="ONE" standardDeviation="0.03"/>
+            <bo:qualityP side="TWO" standardDeviation="0.6"/>
+            <bo:qualityQ side="ONE" standardDeviation="0.1"/>
             <bo:qualityQ side="TWO" standardDeviation="0.04" redundant="true"/>
         </bo:branchObservability>
     </iidm:extension>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_6/injectionObservabilityRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_6/injectionObservabilityRoundTripRef.xml
@@ -38,8 +38,8 @@
     </iidm:extension>
     <iidm:extension id="BAT">
         <io:injectionObservability observable="true">
-            <io:qualityP standardDeviation="0.03" redundant="false"/>
-            <io:qualityQ standardDeviation="0.6" redundant="false"/>
+            <io:qualityP standardDeviation="0.03"/>
+            <io:qualityQ standardDeviation="0.6"/>
         </io:injectionObservability>
     </iidm:extension>
 </iidm:network>


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Code simplification: there is no functional difference to consider the redundant attribute in ObservabilityQuality as undefined or false.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
Yes
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

