### PR TITLE
fix getBaseName in DataSourceUtil so we can read files with multiple dots in their name

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -15,7 +15,6 @@ import com.powsybl.cgmes.model.CgmesModelFactory;
 import com.powsybl.cgmes.model.CgmesOnDataSource;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.datasource.DataSource;
-import com.powsybl.commons.datasource.DataSourceUtil;
 import com.powsybl.commons.datasource.GenericReadOnlyDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.util.ServiceLoaderCache;
@@ -129,7 +128,7 @@ public class CgmesImport implements Importer {
                         boundaryLocationParameter,
                         defaultValueConfig));
         // Check that the Data Source has valid CGMES names
-        ReadOnlyDataSource ds = new GenericReadOnlyDataSource(loc, DataSourceUtil.getBaseName(loc));
+        ReadOnlyDataSource ds = new GenericReadOnlyDataSource(loc, loc.getFileName().toString());
         if ((new CgmesOnDataSource(ds)).names().isEmpty()) {
             return null;
         }

--- a/commons/src/main/java/com/powsybl/commons/datasource/Bzip2FileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/Bzip2FileDataSource.java
@@ -17,12 +17,12 @@ import java.nio.file.Path;
  */
 public class Bzip2FileDataSource extends FileDataSource {
 
-    public Bzip2FileDataSource(Path directory, String baseName, DataSourceObserver observer) {
-        super(directory, baseName, observer);
+    public Bzip2FileDataSource(Path directory, String fileName, DataSourceObserver observer) {
+        super(directory, fileName, observer);
     }
 
-    public Bzip2FileDataSource(Path directory, String baseName) {
-        super(directory, baseName);
+    public Bzip2FileDataSource(Path directory, String fileName) {
+        super(directory, fileName);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/datasource/DataSourceUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/DataSourceUtil.java
@@ -34,7 +34,7 @@ public interface DataSourceUtil {
 
     static String getBaseName(String fileName) {
         Objects.requireNonNull(fileName);
-        int pos = fileName.indexOf('.'); // find first dot in case of double extension (.xml.gz)
+        int pos = fileName.lastIndexOf('.'); // find last dot
         return pos == -1 ? fileName : fileName.substring(0, pos);
     }
 
@@ -63,11 +63,11 @@ public interface DataSourceUtil {
         Objects.requireNonNull(fileNameOrBaseName);
 
         if (fileNameOrBaseName.endsWith(".zip")) {
-            return new ZipFileDataSource(directory, getBaseName(fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 4)), observer);
+            return new ZipFileDataSource(directory, getBaseName(fileNameOrBaseName), observer);
         } else if (fileNameOrBaseName.endsWith(".gz")) {
-            return new GzFileDataSource(directory, getBaseName(fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 3)), observer);
+            return new GzFileDataSource(directory, getBaseName(fileNameOrBaseName), observer);
         } else if (fileNameOrBaseName.endsWith(".bz2")) {
-            return new Bzip2FileDataSource(directory, getBaseName(fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 4)), observer);
+            return new Bzip2FileDataSource(directory, getBaseName(fileNameOrBaseName), observer);
         } else {
             return new FileDataSource(directory, getBaseName(fileNameOrBaseName), observer);
         }

--- a/commons/src/main/java/com/powsybl/commons/datasource/DataSourceUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/DataSourceUtil.java
@@ -47,29 +47,29 @@ public interface DataSourceUtil {
         } else {
             switch (compressionExtension) {
                 case GZIP:
-                    return new GzFileDataSource(directory, basename, observer);
+                    return new GzFileDataSource(directory, basename + ".gz", observer);
                 case BZIP2:
-                    return new Bzip2FileDataSource(directory, basename, observer);
+                    return new Bzip2FileDataSource(directory, basename + ".bz2", observer);
                 case ZIP:
-                    return new ZipFileDataSource(directory, basename, observer);
+                    return new ZipFileDataSource(directory, basename + ".zip", observer);
                 default:
                     throw new AssertionError("Unexpected CompressionFormat value: " + compressionExtension);
             }
         }
     }
 
-    static DataSource createDataSource(Path directory, String fileNameOrBaseName, DataSourceObserver observer) {
+    static DataSource createDataSource(Path directory, String fileName, DataSourceObserver observer) {
         Objects.requireNonNull(directory);
-        Objects.requireNonNull(fileNameOrBaseName);
+        Objects.requireNonNull(fileName);
 
-        if (fileNameOrBaseName.endsWith(".zip")) {
-            return new ZipFileDataSource(directory, getBaseName(fileNameOrBaseName), observer);
-        } else if (fileNameOrBaseName.endsWith(".gz")) {
-            return new GzFileDataSource(directory, getBaseName(fileNameOrBaseName), observer);
-        } else if (fileNameOrBaseName.endsWith(".bz2")) {
-            return new Bzip2FileDataSource(directory, getBaseName(fileNameOrBaseName), observer);
+        if (fileName.endsWith(".zip")) {
+            return new ZipFileDataSource(directory, fileName, observer);
+        } else if (fileName.endsWith(".gz")) {
+            return new GzFileDataSource(directory, fileName, observer);
+        } else if (fileName.endsWith(".bz2")) {
+            return new Bzip2FileDataSource(directory, fileName, observer);
         } else {
-            return new FileDataSource(directory, getBaseName(fileNameOrBaseName), observer);
+            return new FileDataSource(directory, fileName, observer);
         }
     }
 }

--- a/commons/src/main/java/com/powsybl/commons/datasource/FileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/FileDataSource.java
@@ -26,23 +26,23 @@ public class FileDataSource implements DataSource {
 
     private final Path directory;
 
-    private final String baseName;
+    private final String fileName;
 
     private final DataSourceObserver observer;
 
-    public FileDataSource(Path directory, String baseName) {
-        this(directory, baseName, null);
+    public FileDataSource(Path directory, String fileName) {
+        this(directory, fileName, null);
     }
 
-    public FileDataSource(Path directory, String baseName, DataSourceObserver observer) {
+    public FileDataSource(Path directory, String fileName, DataSourceObserver observer) {
         this.directory = Objects.requireNonNull(directory);
-        this.baseName = Objects.requireNonNull(baseName);
+        this.fileName = Objects.requireNonNull(fileName);
         this.observer = observer;
     }
 
     @Override
     public String getBaseName() {
-        return baseName;
+        return DataSourceUtil.getBaseName(fileName);
     }
 
     protected String getCompressionExt() {
@@ -59,12 +59,12 @@ public class FileDataSource implements DataSource {
 
     private Path getPath(String fileName) {
         Objects.requireNonNull(fileName);
-        return directory.resolve(fileName + getCompressionExt());
+        return directory.resolve(fileName);
     }
 
     @Override
     public OutputStream newOutputStream(String suffix, String ext, boolean append) throws IOException {
-        return newOutputStream(DataSourceUtil.getFileName(baseName, suffix, ext), append);
+        return newOutputStream(DataSourceUtil.getFileName(DataSourceUtil.getBaseName(fileName), suffix, ext), append);
     }
 
     @Override
@@ -76,7 +76,7 @@ public class FileDataSource implements DataSource {
 
     @Override
     public boolean exists(String suffix, String ext) throws IOException {
-        return exists(DataSourceUtil.getFileName(baseName, suffix, ext));
+        return fileName.endsWith((suffix == null ? "" : suffix) + "." + ext + getCompressionExt()) && Files.isRegularFile(directory.resolve(fileName));
     }
 
     @Override
@@ -87,7 +87,7 @@ public class FileDataSource implements DataSource {
 
     @Override
     public InputStream newInputStream(String suffix, String ext) throws IOException {
-        return newInputStream(DataSourceUtil.getFileName(baseName, suffix, ext));
+        return newInputStream(fileName);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/datasource/GenericReadOnlyDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/GenericReadOnlyDataSource.java
@@ -20,13 +20,13 @@ public class GenericReadOnlyDataSource implements ReadOnlyDataSource {
 
     private final ReadOnlyDataSource[] dataSources;
 
-    public GenericReadOnlyDataSource(Path directory, String baseName, DataSourceObserver observer) {
+    public GenericReadOnlyDataSource(Path directory, String fileName, DataSourceObserver observer) {
         dataSources = new DataSource[] {
-            new FileDataSource(directory, baseName, observer),
+            new FileDataSource(directory, fileName, observer),
             new ZipFileDataSource(directory),
-            new ZipFileDataSource(directory, baseName + ".zip", baseName, observer),
-            new GzFileDataSource(directory, baseName, observer),
-            new Bzip2FileDataSource(directory, baseName, observer)
+            new ZipFileDataSource(directory, fileName, observer),
+            new GzFileDataSource(directory, fileName, observer),
+            new Bzip2FileDataSource(directory, fileName, observer)
         };
     }
 

--- a/commons/src/main/java/com/powsybl/commons/datasource/GzFileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/GzFileDataSource.java
@@ -18,12 +18,12 @@ import java.util.zip.GZIPOutputStream;
  */
 public class GzFileDataSource extends FileDataSource {
 
-    public GzFileDataSource(Path directory, String baseName, DataSourceObserver observer) {
-        super(directory, baseName, observer);
+    public GzFileDataSource(Path directory, String fileName, DataSourceObserver observer) {
+        super(directory, fileName, observer);
     }
 
-    public GzFileDataSource(Path directory, String baseName) {
-        super(directory, baseName);
+    public GzFileDataSource(Path directory, String fileName) {
+        super(directory, fileName);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/datasource/ZipFileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/ZipFileDataSource.java
@@ -35,36 +35,25 @@ public class ZipFileDataSource implements DataSource {
 
     private final String zipFileName;
 
-    private final String baseName;
-
     private final DataSourceObserver observer;
 
-    public ZipFileDataSource(Path directory, String zipFileName, String baseName, DataSourceObserver observer) {
+    public ZipFileDataSource(Path directory, String zipFileName, DataSourceObserver observer) {
         this.directory = Objects.requireNonNull(directory);
         this.zipFileName = Objects.requireNonNull(zipFileName);
-        this.baseName = Objects.requireNonNull(baseName);
         this.observer = observer;
     }
 
-    public ZipFileDataSource(Path directory, String zipFileName, String baseName) {
-        this(directory, zipFileName, baseName, null);
-    }
-
-    public ZipFileDataSource(Path directory, String baseName) {
-        this(directory, baseName + ".zip", baseName, null);
-    }
-
-    public ZipFileDataSource(Path directory, String baseName, DataSourceObserver observer) {
-        this(directory, baseName + ".zip", baseName, observer);
+    public ZipFileDataSource(Path directory, String zipFileName) {
+        this(directory, zipFileName, null);
     }
 
     public ZipFileDataSource(Path zipFile) {
-        this(zipFile.getParent(), com.google.common.io.Files.getNameWithoutExtension(zipFile.getFileName().toString()));
+        this(zipFile.getParent(), zipFile.getFileName().toString());
     }
 
     @Override
     public String getBaseName() {
-        return baseName;
+        return DataSourceUtil.getBaseName(zipFileName);
     }
 
     private Path getZipFilePath() {
@@ -73,7 +62,7 @@ public class ZipFileDataSource implements DataSource {
 
     @Override
     public boolean exists(String suffix, String ext) throws IOException {
-        return exists(DataSourceUtil.getFileName(baseName, suffix, ext));
+        return zipFileName.endsWith((suffix == null ? "" : suffix) + "." + ext + ".zip") && exists(DataSourceUtil.getBaseName(zipFileName));
     }
 
     private static boolean entryExists(Path zipFilePath, String fileName) {
@@ -96,7 +85,7 @@ public class ZipFileDataSource implements DataSource {
 
     @Override
     public InputStream newInputStream(String suffix, String ext) throws IOException {
-        return newInputStream(DataSourceUtil.getFileName(baseName, suffix, ext));
+        return newInputStream(DataSourceUtil.getBaseName(zipFileName));
     }
 
     private static final class ZipEntryInputStream extends ForwardingInputStream<InputStream> {
@@ -197,7 +186,7 @@ public class ZipFileDataSource implements DataSource {
 
     @Override
     public OutputStream newOutputStream(String suffix, String ext, boolean append) throws IOException {
-        return newOutputStream(DataSourceUtil.getFileName(baseName, suffix, ext), append);
+        return newOutputStream(DataSourceUtil.getFileName(DataSourceUtil.getBaseName(zipFileName), suffix, ext), append);
     }
 
     @Override

--- a/commons/src/test/java/com/powsybl/commons/datasource/DataSourceUtilTest.java
+++ b/commons/src/test/java/com/powsybl/commons/datasource/DataSourceUtilTest.java
@@ -17,7 +17,7 @@ public class DataSourceUtilTest {
 
     @Test
     public void testGetBaseName() {
-        assertEquals("dummy", DataSourceUtil.getBaseName("dummy.xml.gz"));
+        assertEquals("dummy.xml", DataSourceUtil.getBaseName("dummy.xml.gz"));
         assertEquals("dummy", DataSourceUtil.getBaseName("dummy.gz"));
         assertEquals("dummy", DataSourceUtil.getBaseName("dummy"));
     }

--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/export/Exporters.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/export/Exporters.java
@@ -70,8 +70,8 @@ public final class Exporters {
         return getExporter(LOADER.get(), format);
     }
 
-    public static DataSource createDataSource(Path directory, String fileNameOrBaseName, DataSourceObserver observer) {
-        return DataSourceUtil.createDataSource(directory, fileNameOrBaseName, observer);
+    public static DataSource createDataSource(Path directory, String fileName, DataSourceObserver observer) {
+        return DataSourceUtil.createDataSource(directory, fileName, observer);
     }
 
     public static DataSource createDataSource(Path file, DataSourceObserver observer) {

--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importers.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importers.java
@@ -326,8 +326,7 @@ public final class Importers {
 
     private static void addDataSource(Path dir, Path file, Importer importer, List<ReadOnlyDataSource> dataSources) {
         Objects.requireNonNull(importer);
-        String caseBaseName = DataSourceUtil.getBaseName(file);
-        ReadOnlyDataSource ds = new GenericReadOnlyDataSource(dir, caseBaseName);
+        ReadOnlyDataSource ds = new GenericReadOnlyDataSource(dir, file.toString());
         if (importer.exists(ds)) {
             dataSources.add(ds);
         }
@@ -428,8 +427,8 @@ public final class Importers {
         return createDataSource(absFile.getParent(), absFile.getFileName().toString());
     }
 
-    public static DataSource createDataSource(Path directory, String fileNameOrBaseName) {
-        return DataSourceUtil.createDataSource(directory, fileNameOrBaseName, null);
+    public static DataSource createDataSource(Path directory, String fileName) {
+        return DataSourceUtil.createDataSource(directory, fileName, null);
     }
 
     public static Importer findImporter(ReadOnlyDataSource dataSource, ImportersLoader loader, ComputationManager computationManager, ImportConfig config) {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/XMLImporter.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/XMLImporter.java
@@ -157,9 +157,14 @@ public class XMLImporter implements Importer {
                 ByteStreams.copy(is, os);
             }
             // and also anonymization file if exists
-            if (fromDataSource.exists(SUFFIX_MAPPING, "csv")) {
-                try (InputStream is = fromDataSource.newInputStream(SUFFIX_MAPPING, "csv");
-                     OutputStream os = toDataSource.newOutputStream(SUFFIX_MAPPING, "csv", false)) {
+            //
+            // Using the basename here feels a bit off to me. I think
+            // using the full filename with a "_mapping.csv" suffix
+            // seems more predictable and easier to explain to people.
+            String mappingFileName = fromDataSource.getBaseName() + SUFFIX_MAPPING + ".csv";
+            if (fromDataSource.exists(mappingFileName)) {
+                try (InputStream is = fromDataSource.newInputStream(mappingFileName);
+                     OutputStream os = toDataSource.newOutputStream(mappingFileName, false)) {
                     ByteStreams.copy(is, os);
                 }
             }
@@ -196,4 +201,3 @@ public class XMLImporter implements Importer {
                 .setExtensions(ConversionParameters.readStringListParameter(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig) != null ? new HashSet<>(ConversionParameters.readStringListParameter(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig)) : null);
     }
 }
-


### PR DESCRIPTION
Signed-off-by: Lucas Leblow <lucasleblow@mailbox.org>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Fixes #1934 

It looks like there is an issue with DataSourceUtil.getBaseName where if you
pass it a filename with multiple dots, it returns a truncated base name. For
example, if passing `test_1.0.xml` as a file name, it would return `test_1` as a
basename. This leads to some errors in the CGMES importer and the iTools
network-convert command, for example:

```
$ distribution-core/target/powsybl/bin/itools convert-network --input-file cgmes/cgmes-conversion/src/test/resources/RealGrid-Merged_v3.0.zip --output-file test.zip --output-format AMPL
com.powsybl.cgmes.model.CgmesModelException: Listing CGMES names in data source com.powsybl.commons.datasource.ZipFileDataSource@23348b5d
        at com.powsybl.cgmes.model.CgmesOnDataSource.names(CgmesOnDataSource.java:73)
        at com.powsybl.cgmes.model.CgmesOnDataSource.namespaces(CgmesOnDataSource.java:96)
        at com.powsybl.cgmes.model.CgmesOnDataSource.exists(CgmesOnDataSource.java:38)
        at com.powsybl.cgmes.conversion.CgmesImport.exists(CgmesImport.java:84)
        at com.powsybl.iidm.import_.Importers.findImporter(Importers.java:437)
        at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:461)
        at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:483)
        at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:497)
        at com.powsybl.iidm.tools.ConversionTool.run(ConversionTool.java:111)
        at com.powsybl.tools.CommandLineTools.run(CommandLineTools.java:164)
        at com.powsybl.tools.Main.main(Main.java:29)
Caused by: java.nio.file.NoSuchFileException: /home/lucas/src/powsybl/powsybl-core/cgmes/cgmes-conversion/src/test/resources/RealGrid-Merged_v3.zip
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
        at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
        at java.base/java.nio.file.Files.newByteChannel(Files.java:373)
        at java.base/java.nio.file.Files.newByteChannel(Files.java:424)
        at com.powsybl.commons.datasource.ZipFileDataSource.listNames(ZipFileDataSource.java:209)
        at com.powsybl.cgmes.model.CgmesOnDataSource.names(CgmesOnDataSource.java:69)
        ... 10 more
```

This PR fixes the issue by using the whole filename up to the last dot as the
base name. In the case of files ending with `.xml.gz`, `.xml` is part of the
basename and `.gz` is the extension.

Here is the same command above with the fix:
```
distribution-core/target/powsybl/bin/itools convert-network --input-file cgmes/cgmes-conversion/src/test/resources/RealGrid-Merged_v3.0.zip --output-file test.zip --output-format AMPL
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_buses.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_tct.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_rtc.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_ptc.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_branches.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_limits.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_generators.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_batteries.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_loads.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_shunts.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_static_var_compensators.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_substations.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_vsc_converter_stations.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_lcc_converter_stations.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.zip:test_network_hvdc.txt...
```

also tested multiple dots in the `ouput-file`:
```
distribution-core/target/powsybl/bin/itools convert-network --input-file cgmes/cgmes-conversion/src/test/resources/RealGrid-Merged_v3.0.zip --output-file test.3.0.zip --output-format AMPL
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_buses.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_tct.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_rtc.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_ptc.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_branches.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_limits.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_generators.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_batteries.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_loads.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_shunts.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_static_var_compensators.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_substations.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_vsc_converter_stations.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_lcc_converter_stations.txt...
Generating file /home/lucas/src/powsybl/powsybl-core/test.3.0.zip:test.3.0_network_hvdc.txt...
```

getBaseName is used in another place (https://github.com/powsybl/powsybl-core/blob/c6d7506d190c38dac3d2ce14aae3e87bd30f8959/action/action-simulator/src/main/java/com/powsybl/action/simulator/tools/ActionSimulatorTool.java#L251), which is also causing an error:
```
distribution-core/target/powsybl/bin/itools action-simulator --case-file test.3.0.xiidm --dsl-file dsl.groovy
Loading network 'test.3.0.xiidm'
com.powsybl.commons.PowsyblException: Unsupported file format or invalid file.
        at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:472)
        at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:486)
        at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:500)
        at com.powsybl.action.simulator.tools.ActionSimulatorTool.run(ActionSimulatorTool.java:259)
        at com.powsybl.tools.CommandLineTools.run(CommandLineTools.java:164)
        at com.powsybl.tools.Main.main(Main.java:29)
```

and is fixed with this change:
```
distribution-core/target/powsybl/bin/itools action-simulator --case-file test.3.0.xiidm --dsl-file dsl.groovy
Loading network 'test.3.0.xiidm'
Loading DSL 'file:/home/lucas/src/powsybl/powsybl-core/dsl.groovy'
Using 'loadflow' rules engine
Starting pre-contingency analysis
    Round 0
2022-01-17_16:22:54.408 [ForkJoinPool.commonPool-worker-3] ERROR c.p.o.n.impl.LfNetworkLoaderImpl - Discard network {CC0 SC0} because there is no equipment to control voltage
    Load flow diverged
Final result
Pre-contingency violations:
+--------+---------------+-----+---------+--------------+----------------+----------------+-------+-------+------------------+----------------+
| Action | Equipment (0) | End | Country | Base voltage | Violation type | Violation name | Value | Limit | abs(value-limit) | Loading rate % |
+--------+---------------+-----+---------+--------------+----------------+----------------+-------+-------+------------------+----------------+
```
