### PR TITLE
Fix remove dangling switches TCK tests to be more generic

### DIFF
--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/util/AbstractRemoveDanglingSwitchesTopologyTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/util/AbstractRemoveDanglingSwitchesTopologyTest.java
@@ -11,8 +11,7 @@ import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import org.junit.After;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.*;
 
@@ -21,7 +20,7 @@ import static org.junit.Assert.*;
  */
 public abstract class AbstractRemoveDanglingSwitchesTopologyTest {
 
-    private final List<String> removedObjects = new ArrayList<>();
+    private final Set<String> removedObjects = new HashSet<>();
 
     @After
     public void tearDown() {
@@ -43,7 +42,7 @@ public abstract class AbstractRemoveDanglingSwitchesTopologyTest {
         addListener(network);
         Load ld1 = network.getLoad("LD1");
         ld1.remove();
-        assertEquals(List.of("LD1"), removedObjects);
+        assertEquals(Set.of("LD1"), removedObjects);
     }
 
     @Test
@@ -52,7 +51,7 @@ public abstract class AbstractRemoveDanglingSwitchesTopologyTest {
         addListener(network);
         Load ld1 = network.getLoad("LD1");
         ld1.remove(true);
-        assertEquals(List.of("S1VL1_LD1_BREAKER", "S1VL1_BBS_LD1_DISCONNECTOR", "LD1"), removedObjects);
+        assertEquals(Set.of("S1VL1_LD1_BREAKER", "S1VL1_BBS_LD1_DISCONNECTOR", "LD1"), removedObjects);
     }
 
     /**
@@ -116,7 +115,7 @@ public abstract class AbstractRemoveDanglingSwitchesTopologyTest {
         addListener(network);
         Load ld = network.getLoad("LD");
         ld.remove(true);
-        assertEquals(List.of("B1", "LD"), removedObjects);
+        assertEquals(Set.of("B1", "LD"), removedObjects);
         assertNull(network.getLoad("LD"));
         assertNull(network.getSwitch("B1"));
         assertNotNull(network.getGenerator("G"));


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Removed equipments list check is too restrictive as it also check order.


**What is the new behavior (if this is a feature change)?**
We don't check order anymore


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
