### PR TITLE
Fix bug: switches were not removed from index when all edges were removed

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -353,7 +353,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
             }
 
             @Override
-            public void allEdgesRemoved() {
+            public void allEdgesRemoved(Collection<SwitchImpl> obj) {
                 invalidateCache();
             }
         });

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -528,18 +528,14 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             }
 
             @Override
-            public void allEdgesRemoved() {
-                List<String> removedSwitchesIds = new ArrayList<>(graph.getEdgeCount());
+            public void allEdgesRemoved(Collection<SwitchImpl> aSwitches) {
                 NetworkImpl network = getNetwork();
-                for (SwitchImpl s : graph.getEdgesObject()) {
-                    if (s != null) {
-                        network.getListeners().notifyBeforeRemoval(s);
-                        removedSwitchesIds.add(s.getId());
-                        network.getIndex().remove(s);
-                    }
-                }
+                aSwitches.forEach(ss -> {
+                    network.getListeners().notifyBeforeRemoval(ss);
+                    network.getIndex().remove(ss);
+                });
                 switches.clear();
-                removedSwitchesIds.forEach(id -> network.getListeners().notifyAfterRemoval(id));
+                aSwitches.forEach(ss -> network.getListeners().notifyAfterRemoval(ss.getId()));
             }
         });
     }

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.reducer;
 
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
 import com.powsybl.iidm.network.test.HvdcTestNetwork;
 import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
 import org.junit.Rule;
@@ -304,5 +305,25 @@ public class DefaultNetworkReducerTest {
                 .withReductionOptions(new ReductionOptions())
                 .build();
         reducer.reduce(network);
+    }
+
+    @Test
+    public void testNodeBreaker() {
+        Network network = FictitiousSwitchFactory.create();
+
+        NetworkReducer reducer = NetworkReducer.builder()
+                .withNetworkPredicate(IdentifierNetworkPredicate.of("C"))
+                .build();
+        reducer.reduce(network);
+
+        assertEquals(1, network.getSubstationCount());
+        assertEquals(1, network.getVoltageLevelCount());
+        assertEquals(0, network.getTwoWindingsTransformerCount());
+        assertEquals(0, network.getLineCount());
+        assertEquals(0, network.getGeneratorCount());
+        assertEquals(2, network.getLoadCount());
+        assertEquals(0, network.getDanglingLineCount());
+        assertEquals(4, network.getSwitchCount());
+        assertEquals(1, network.getBusbarSectionCount());
     }
 }

--- a/math/src/main/java/com/powsybl/math/graph/DefaultUndirectedGraphListener.java
+++ b/math/src/main/java/com/powsybl/math/graph/DefaultUndirectedGraphListener.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.math.graph;
 
+import java.util.Collection;
+
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -43,7 +45,7 @@ public class DefaultUndirectedGraphListener<V, E> implements UndirectedGraphList
     }
 
     @Override
-    public void allEdgesRemoved() {
+    public void allEdgesRemoved(Collection<E> obj) {
         // nothing to do
     }
 }

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraphImpl.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraphImpl.java
@@ -266,10 +266,11 @@ public class UndirectedGraphImpl<V, E> implements UndirectedGraph<V, E> {
 
     @Override
     public void removeAllEdges() {
+        Collection<E> allEdges = edges.stream().map(Edge::getObject).filter(Objects::nonNull).collect(Collectors.toList());
         edges.clear();
         removedEdges.clear();
         invalidateAdjacencyList();
-        notifyAllEdgesRemoved();
+        notifyAllEdgesRemoved(allEdges);
     }
 
     @Override
@@ -642,9 +643,9 @@ public class UndirectedGraphImpl<V, E> implements UndirectedGraph<V, E> {
         }
     }
 
-    private void notifyAllEdgesRemoved() {
+    private void notifyAllEdgesRemoved(Collection<E> obj) {
         for (UndirectedGraphListener<V, E> l : listeners) {
-            l.allEdgesRemoved();
+            l.allEdgesRemoved(obj);
         }
     }
 

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraphListener.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraphListener.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.math.graph;
 
+import java.util.Collection;
+
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -24,5 +26,5 @@ public interface UndirectedGraphListener<V, E> {
 
     void edgeRemoved(int e, E obj);
 
-    void allEdgesRemoved();
+    void allEdgesRemoved(Collection<E> obj);
 }


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Switches are not removed from index and still appear (for example in `getSwitchesCount()`) after all edges removed. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
Yes
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

