### PR TITLE
topological nodes set can not be null

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -126,20 +126,12 @@ public final class StateVariablesExport {
             LOG.info(log.get());
             return;
         }
-        Set<CgmesIidmMapping.CgmesTopologicalNode> topologicalNodes = context.getTopologicalNodesByBusViewBus(busId);
-        if (topologicalNodes == null) {
-            return;
-        }
-        CgmesIidmMapping.CgmesTopologicalNode topologicalNode = topologicalNodes.iterator().next();
+        CgmesIidmMapping.CgmesTopologicalNode topologicalNode = context.getTopologicalNodesByBusViewBus(busId).iterator().next();
         angleRefs.put(componentNum, topologicalNode.getCgmesId());
     }
 
     private static void buildAngleRefs(String busId, Map<String, String> angleRefs, CgmesExportContext context) {
-        Set<CgmesIidmMapping.CgmesTopologicalNode> topologicalNodes = context.getTopologicalNodesByBusViewBus(busId);
-        if (topologicalNodes == null) {
-            return;
-        }
-        CgmesIidmMapping.CgmesTopologicalNode topologicalNode = topologicalNodes.iterator().next();
+        CgmesIidmMapping.CgmesTopologicalNode topologicalNode = context.getTopologicalNodesByBusViewBus(busId).iterator().next();
         angleRefs.put(topologicalNode.getCgmesId(),
                 topologicalNode.getCgmesId());
     }
@@ -149,12 +141,8 @@ public final class StateVariablesExport {
         for (Bus b : network.getBusView().getBuses()) {
             if (b.getSynchronousComponent() != null) {
                 int num = b.getSynchronousComponent().getNum();
-                Set<CgmesIidmMapping.CgmesTopologicalNode> topologicalNodes = context.getTopologicalNodesByBusViewBus(b.getId());
-                if (topologicalNodes == null) {
-                    continue;
-                }
                 islands.computeIfAbsent(String.valueOf(num), i -> new ArrayList<>());
-                islands.get(String.valueOf(num)).addAll(topologicalNodes.stream().map(CgmesIidmMapping.CgmesTopologicalNode::getCgmesId).collect(Collectors.toSet()));
+                islands.get(String.valueOf(num)).addAll(context.getTopologicalNodesByBusViewBus(b.getId()).stream().map(CgmesIidmMapping.CgmesTopologicalNode::getCgmesId).collect(Collectors.toSet()));
             } else {
                 islands.put(b.getId(), Collections.singletonList(b.getId()));
             }
@@ -164,11 +152,7 @@ public final class StateVariablesExport {
 
     private static void writeVoltagesForTopologicalNodes(Network network, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
         for (Bus b : network.getBusView().getBuses()) {
-            Set<CgmesIidmMapping.CgmesTopologicalNode> topologicalNodes = context.getTopologicalNodesByBusViewBus(b.getId());
-            if (topologicalNodes == null) {
-                continue;
-            }
-            for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : topologicalNodes) {
+            for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : context.getTopologicalNodesByBusViewBus(b.getId())) {
                 writeVoltage(topologicalNode.getCgmesId(), b.getV(), b.getAngle(), cimNamespace, writer);
             }
         }
@@ -329,14 +313,9 @@ public final class StateVariablesExport {
         if (bus == null) {
             LOG.warn("Fictitious load does not have a BusView bus. No SvInjection is written");
         } else {
-            Set<CgmesIidmMapping.CgmesTopologicalNode> topologicalNodes = context.getTopologicalNodesByBusViewBus(bus.getId());
-            if (topologicalNodes.isEmpty()) {
-                LOG.warn("Fictitious load does not have a corresponding Topological Node. No SvInjection is written");
-            } else {
-                // SvInjection will be assigned to the first of the TNs mapped to the bus
-                CgmesIidmMapping.CgmesTopologicalNode topologicalNode = topologicalNodes.iterator().next();
-                writeSvInjection(svInjection, topologicalNode.getCgmesId(), cimNamespace, writer);
-            }
+            // SvInjection will be assigned to the first of the TNs mapped to the bus
+            CgmesIidmMapping.CgmesTopologicalNode topologicalNode = context.getTopologicalNodesByBusViewBus(bus.getId()).iterator().next();
+            writeSvInjection(svInjection, topologicalNode.getCgmesId(), cimNamespace, writer);
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
When obtaining the list of topological nodes of a bus, it is verified that it is not null.


**What is the new behavior (if this is a feature change)?**
Currently this list cannot be null, so the check is unnecessary.
