### PR TITLE
Remove feeder result from short circuit analysis result

### DIFF
--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/ShortCircuitAnalysisResult.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/ShortCircuitAnalysisResult.java
@@ -30,16 +30,9 @@ public class ShortCircuitAnalysisResult extends AbstractExtendable<ShortCircuitA
 
     private final List<LimitViolation> limitViolations = new ArrayList<>();
 
-    private List<FeederResult> feederResults = new ArrayList<>();
-
-    public ShortCircuitAnalysisResult(List<FaultResult> faultResults, List<LimitViolation> limitViolations, List<FeederResult> feederResults) {
+    public ShortCircuitAnalysisResult(List<FaultResult> faultResults, List<LimitViolation> limitViolations) {
         this.faultResults.addAll(Objects.requireNonNull(faultResults));
         this.limitViolations.addAll(Objects.requireNonNull(limitViolations));
-        this.feederResults.addAll(feederResults);
-    }
-
-    public ShortCircuitAnalysisResult(List<FaultResult> faultResults, List<LimitViolation> limitViolations) {
-        this(faultResults, limitViolations, Collections.emptyList());
     }
 
     /**
@@ -65,10 +58,6 @@ public class ShortCircuitAnalysisResult extends AbstractExtendable<ShortCircuitA
     public ShortCircuitAnalysisResult setNetworkMetadata(NetworkMetadata networkMetadata) {
         this.networkMetadata = networkMetadata;
         return this;
-    }
-
-    public List<FeederResult> getFeederResults() {
-        return Collections.unmodifiableList(feederResults);
     }
 
 }

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisMock.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisMock.java
@@ -62,6 +62,6 @@ public class ShortCircuitAnalysisMock implements ShortCircuitAnalysisProvider {
         FeederResult feederResult = new FeederResult("GEN", 5);
         FaultResult faultResult = new FaultResult("VLGEN", 10, Collections.singletonList(feederResult));
         LimitViolation limitViolation = new LimitViolation("VLGEN", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, 0, 0, 0);
-        return new ShortCircuitAnalysisResult(Collections.singletonList(faultResult), Collections.singletonList(limitViolation), Collections.singletonList(feederResult));
+        return new ShortCircuitAnalysisResult(Collections.singletonList(faultResult), Collections.singletonList(limitViolation));
     }
 }

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisTest.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisTest.java
@@ -65,7 +65,6 @@ public class ShortCircuitAnalysisTest {
 
         assertEquals(0, res.getFaultResults().size());
         assertEquals(0, res.getLimitViolations().size());
-        assertEquals(0, res.getFeederResults().size());
     }
 
     private static final String DEFAULT_PROVIDER_NAME = "ShortCircuitAnalysisMock";


### PR DESCRIPTION
Signed-off-by: Coline PILOQUET <coline.piloquet@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Remove the feederResult from ShortCircuitAnalysisResult as it is not useful there
