### PR TITLE
Fix network corruption when second node already used

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -953,6 +953,14 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                     "voltage level " + NodeBreakerVoltageLevel.this.id + " has a node/breaker topology"
                             + ", a node connection should be specified instead of a bus connection");
         }
+        int node = ((NodeTerminal) terminal).getNode();
+        graph.addVertexIfNotPresent(node);
+        if (graph.getVertexObject(node) != null) {
+            throw new ValidationException(terminal.getConnectable(),
+                    "an equipment (" + graph.getVertexObject(node).getConnectable().getId()
+                            + ") is already connected to node " + node + " of voltage level "
+                            + NodeBreakerVoltageLevel.this.id);
+        }
     }
 
     @Override
@@ -962,13 +970,6 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             return;
         }
         int node = ((NodeTerminal) terminal).getNode();
-        graph.addVertexIfNotPresent(node);
-        if (graph.getVertexObject(node) != null) {
-            throw new ValidationException(terminal.getConnectable(),
-                    "an equipment (" + graph.getVertexObject(node).getConnectable().getId()
-                            + ") is already connected to node " + node + " of voltage level "
-                            + NodeBreakerVoltageLevel.this.id);
-        }
 
         // create the link terminal <-> voltage level
         terminal.setVoltageLevel(NodeBreakerVoltageLevel.this);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/CorruptedNetworkWhenSecondNodeAlreadyUsed.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/CorruptedNetworkWhenSecondNodeAlreadyUsed.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.impl.tck;
+
+import com.powsybl.iidm.network.tck.AbstractCorruptedNetworkWhenSecondNodeAlreadyUsed;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class CorruptedNetworkWhenSecondNodeAlreadyUsed extends AbstractCorruptedNetworkWhenSecondNodeAlreadyUsed {
+}

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractCorruptedNetworkWhenSecondNodeAlreadyUsed.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractCorruptedNetworkWhenSecondNodeAlreadyUsed.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.tck;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.*;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public abstract class AbstractCorruptedNetworkWhenSecondNodeAlreadyUsed {
+
+    @Test
+    public void shouldNotInsertTheTransformer() {
+        Network network = Network.create("test", "");
+        Substation s = network.newSubstation()
+                .setId("S1")
+                .add();
+        s.newVoltageLevel()
+                .setId("VL1")
+                .setNominalV(1)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        VoltageLevel vl2 = s.newVoltageLevel()
+                .setId("VL2")
+                .setNominalV(1)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        vl2.getNodeBreakerView().newBusbarSection()
+                .setId("BBS")
+                .setNode(0)
+                .add();
+        try {
+            s.newTwoWindingsTransformer()
+                    .setId("TR")
+                    .setVoltageLevel1("VL1")
+                    .setNode1(0)
+                    .setVoltageLevel2("VL2")
+                    .setNode2(0) // already taken by BBS
+                    .setR(0)
+                    .setX(1)
+                    .setB(1)
+                    .setG(0)
+                    .setRatedU1(1)
+                    .setRatedU2(1)
+                    .add();
+        } catch (PowsyblException ignored) {
+        }
+
+        TwoWindingsTransformer twt = network.getTwoWindingsTransformer("TR");
+        assertNull(twt);
+        assertEquals(0, s.getTwoWindingsTransformerCount());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When creation a line or a transformer and setting a second node already taken by another element, an exception is thrown (normal...) but the transformer is still reachable from the substation and partially connected. So when exporting network  or running a LF we endup with a NPE.


**What is the new behavior (if this is a feature change)?**
node 1 and 2 availability is checked before beginning to insert the transformer.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
