### PR TITLE
Replace protected by public for GraalVM native image

### DIFF
--- a/psse/psse-model/src/main/java/com/powsybl/psse/model/pf/PsseTwoTerminalDcTransmissionLine.java
+++ b/psse/psse-model/src/main/java/com/powsybl/psse/model/pf/PsseTwoTerminalDcTransmissionLine.java
@@ -181,7 +181,7 @@ public class PsseTwoTerminalDcTransmissionLine extends PsseVersioned {
         return inverter;
     }
 
-    protected static class ConverterHeaderTransformer extends HeaderTransformer {
+    public static class ConverterHeaderTransformer extends HeaderTransformer {
         private final String converterChar;
 
         public ConverterHeaderTransformer(String... args) {

--- a/psse/psse-model/src/main/java/com/powsybl/psse/model/pf/PsseVoltageSourceConverterDcTransmissionLine.java
+++ b/psse/psse-model/src/main/java/com/powsybl/psse/model/pf/PsseVoltageSourceConverterDcTransmissionLine.java
@@ -90,7 +90,7 @@ public class PsseVoltageSourceConverterDcTransmissionLine extends PsseVersioned 
         return converter2;
     }
 
-    protected static class ConverterHeaderTransformer extends HeaderTransformer {
+    public static class ConverterHeaderTransformer extends HeaderTransformer {
         private final String converterChar;
 
         public ConverterHeaderTransformer(String... args) {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When using GraalVM native image, HeaderTransformer have to be public to be instanciated otherwise we have following exception: 
```bash
5:44:15.039 [main] DEBUG com.powsybl.python.PyPowsyblApiLib - Unexpected error instantiating custom HeaderTransformer class 'ConverterHeaderTransformer' (com.powsybl.psse.model.pf.PsseTwoTerminalDcTransmissionLine$ConverterHeaderTransformer)
com.univocity.parsers.common.DataProcessingException: Unexpected error instantiating custom HeaderTransformer class 'ConverterHeaderTransformer' (com.powsybl.psse.model.pf.PsseTwoTerminalDcTransmissionLine$ConverterHeaderTransformer)
	at com.univocity.parsers.annotations.helpers.AnnotationHelper.newInstance(AnnotationHelper.java:326)
	at com.univocity.parsers.annotations.helpers.AnnotationHelper.processAnnotations(AnnotationHelper.java:747)
	at com.univocity.parsers.annotations.helpers.AnnotationHelper.getFieldSequence(AnnotationHelper.java:807)
	at com.univocity.parsers.annotations.helpers.AnnotationHelper.getFieldSequence(AnnotationHelper.java:772)
	at com.univocity.parsers.annotations.helpers.AnnotationHelper.allFieldsIndexOrNameBased(AnnotationHelper.java:513)
	at com.univocity.parsers.annotations.helpers.AnnotationHelper.allFieldsIndexBasedForParsing(AnnotationHelper.java:545)
	at com.univocity.parsers.common.CommonParserSettings.configureFromAnnotations(CommonParserSettings.java:427)
	at com.univocity.parsers.common.CommonParserSettings.runAutomaticConfiguration(CommonParserSettings.java:411)
	at com.univocity.parsers.common.CommonSettings.autoConfigure(CommonSettings.java:554)
	at com.univocity.parsers.common.AbstractParser.<init>(AbstractParser.java:84)
	at com.univocity.parsers.csv.CsvParser.<init>(CsvParser.java:69)
	at com.powsybl.psse.model.io.AbstractRecordGroup.parseRecords(AbstractRecordGroup.java:165)
	at com.powsybl.psse.model.io.AbstractRecordGroup.readFromStrings(AbstractRecordGroup.java:149)
	at com.powsybl.psse.model.pf.io.TwoTerminalDcTransmissionLineData$IOLegacyText.read(TwoTerminalDcTransmissionLineData.java:71)
	at com.powsybl.psse.model.io.AbstractRecordGroup.read(AbstractRecordGroup.java:132)
	at com.powsybl.psse.model.pf.io.PowerFlowRawData32.read(PowerFlowRawData32.java:48)
	at com.powsybl.psse.converter.PsseImporter.importData(PsseImporter.java:137)
	at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:464)
	at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:483)
	at com.powsybl.iidm.import_.Importers.loadNetwork(Importers.java:497)
	at com.powsybl.python.PyPowsyblNetworkApiLib.lambda$loadNetwork$3(PyPowsyblNetworkApiLib.java:174)
	at com.powsybl.python.Util.doCatch(Util.java:76)
	at com.powsybl.python.PyPowsyblNetworkApiLib.loadNetwork(PyPowsyblNetworkApiLib.java:171)
Caused by: java.lang.IllegalAccessException: class com.univocity.parsers.annotations.helpers.AnnotationHelper cannot access a member of class com.powsybl.psse.model.pf.PsseTwoTerminalDcTransmissionLine$ConverterHeaderTransformer with modifiers "public transient"
	at jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:361)
	at java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:591)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:481)
	at com.univocity.parsers.annotations.helpers.AnnotationHelper.newInstance(AnnotationHelper.java:315)
	... 22 common frames omitted
```

**What is the new behavior (if this is a feature change)?**
protected has been replace by public


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
