### PR TITLE
Add new overload for loadNetwork and improve code in Importers

### DIFF
--- a/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importers.java
+++ b/iidm/iidm-converter-api/src/main/java/com/powsybl/iidm/import_/Importers.java
@@ -50,6 +50,8 @@ public final class Importers {
 
     private static final Supplier<ImportConfig> CONFIG = Suppliers.memoize(ImportConfig::load);
 
+    private static final String UNSUPPORTED_FILE_FORMAT_OR_INVALID_FILE = "Unsupported file format or invalid file.";
+
     private Importers() {
     }
 
@@ -469,7 +471,7 @@ public final class Importers {
         if (importer != null) {
             return importer.importData(dataSource, NetworkFactory.findDefault(), parameters, reporter);
         }
-        throw new PowsyblException("Unsupported file format or invalid file.");
+        throw new PowsyblException(UNSUPPORTED_FILE_FORMAT_OR_INVALID_FILE);
     }
 
     /**
@@ -545,7 +547,7 @@ public final class Importers {
         if (importer != null) {
             return importer.importData(dataSource, NetworkFactory.findDefault(), parameters, reporter);
         }
-        throw new PowsyblException("Unsupported file format or invalid file.");
+        throw new PowsyblException(UNSUPPORTED_FILE_FORMAT_OR_INVALID_FILE);
     }
 
     /**
@@ -644,7 +646,7 @@ public final class Importers {
         if (importer != null) {
             return importer.importData(dataSource, NetworkFactory.findDefault(), properties, reporter);
         }
-        throw new PowsyblException("Unsupported file format or invalid file.");
+        throw new PowsyblException(UNSUPPORTED_FILE_FORMAT_OR_INVALID_FILE);
     }
 
     public static void loadNetworks(Path dir, boolean parallel, ImportersLoader loader, ComputationManager computationManager, ImportConfig config, Properties parameters, Consumer<Network> consumer, Consumer<ReadOnlyDataSource> listener, Reporter reporter) throws IOException, InterruptedException, ExecutionException {

--- a/iidm/iidm-converter-api/src/test/java/com/powsybl/iidm/import_/ImportersTest.java
+++ b/iidm/iidm-converter-api/src/test/java/com/powsybl/iidm/import_/ImportersTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.import_;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.TestUtil;
 import com.powsybl.commons.datasource.DataSource;
+import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.reporter.ReporterModel;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.AbstractConvertersTest;
@@ -145,8 +146,8 @@ public class ImportersTest extends AbstractConvertersTest {
     }
 
     @Test
-    public void importData() {
-        Network network = Importers.importData(loader, TEST_FORMAT, null, null, computationManager, importConfigMock);
+    public void importData() throws IOException {
+        Network network = Importers.loadNetwork((ReadOnlyDataSource) null);
         assertNotNull(network);
         assertNotNull(network.getLoad("LOAD"));
     }


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature : Add some overload of `Importers.loadNetwork` which allows `ReadOnlyDataSource` as parameter
+ some code improvements


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
