### PR TITLE
Improve loadflow results completion

### DIFF
--- a/ieee-cdf/ieee-cdf-converter/src/test/java/com/powsybl/ieeecdf/converter/IeeeCdfImporterTest.java
+++ b/ieee-cdf/ieee-cdf-converter/src/test/java/com/powsybl/ieeecdf/converter/IeeeCdfImporterTest.java
@@ -21,8 +21,6 @@ import com.powsybl.commons.datasource.FileDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
 import com.powsybl.commons.datasource.ResourceSet;
 import com.powsybl.iidm.import_.Importer;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.xml.NetworkXml;
 import com.powsybl.loadflow.LoadFlowParameters;
@@ -86,16 +84,7 @@ public class IeeeCdfImporterTest extends AbstractConverterTest {
     }
 
     public static void computeMissingFlows(Network network, LoadFlowParameters lfparams) {
-        for (Load l : network.getLoads()) {
-            l.getTerminal().setP(l.getP0());
-            l.getTerminal().setQ(l.getQ0());
-        }
-        for (Generator g : network.getGenerators()) {
-            g.getTerminal().setP(-g.getTargetP());
-            if (Double.isNaN(g.getTerminal().getQ())) {
-                g.getTerminal().setQ(-g.getTargetQ());
-            }
-        }
+
         LoadFlowResultsCompletionParameters p = new LoadFlowResultsCompletionParameters(
             LoadFlowResultsCompletionParameters.EPSILON_X_DEFAULT,
             LoadFlowResultsCompletionParameters.APPLY_REACTANCE_CORRECTION_DEFAULT,

--- a/matpower/matpower-converter/src/test/java/com/powsybl/matpower/converter/MatpowerImporterTest.java
+++ b/matpower/matpower-converter/src/test/java/com/powsybl/matpower/converter/MatpowerImporterTest.java
@@ -9,8 +9,6 @@ package com.powsybl.matpower.converter;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.FileDataSource;
 import com.powsybl.iidm.import_.Importer;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.NetworkFactory;
 import com.powsybl.iidm.xml.NetworkXml;
@@ -180,22 +178,7 @@ public class MatpowerImporterTest extends AbstractConverterTest {
     }
 
     private static void computeMissingFlows(Network network, LoadFlowParameters lfparams) {
-        for (Load l : network.getLoads()) {
-            if (Double.isNaN(l.getTerminal().getP())) {
-                l.getTerminal().setP(l.getP0());
-            }
-            if (Double.isNaN(l.getTerminal().getQ())) {
-                l.getTerminal().setQ(l.getQ0());
-            }
-        }
-        for (Generator g : network.getGenerators()) {
-            if (Double.isNaN(g.getTerminal().getP())) {
-                g.getTerminal().setP(-g.getTargetP());
-            }
-            if (Double.isNaN(g.getTerminal().getQ())) {
-                g.getTerminal().setQ(-g.getTargetQ());
-            }
-        }
+
         LoadFlowResultsCompletionParameters p = new LoadFlowResultsCompletionParameters(
             LoadFlowResultsCompletionParameters.EPSILON_X_DEFAULT,
             LoadFlowResultsCompletionParameters.APPLY_REACTANCE_CORRECTION_DEFAULT,


### PR DESCRIPTION
Signed-off-by: José Antonio Marqués <marquesja@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
To calculate the balance of a bus the active and reactive power values of the terminals are used. 
Before balance, it is necessary to complete the terminal flows of lines and transformers using the `LoadFlowResultsCompletion.run` method and the active and reactive power of the terminals associated to loads and generators by implementing the right code in each balance test.


**What is the new behavior (if this is a feature change)?**

The setting of the active and reactive power of the terminals associated to loads and generators has also been included in the `LoadFlowResultsCompletion.run`  method so no external code will be necessary.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
