### PR TITLE
Fix: exists() method for CGMES should not rely on profiles identifiers in file name

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -13,11 +13,8 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.powsybl.cgmes.model.CgmesNamespace.*;
 

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -112,19 +112,11 @@ public class CgmesOnDataSource {
     }
 
     private final ReadOnlyDataSource dataSource;
-
-    private static final String REGEX_VALID_NAME_IDS = Stream.of(
-        Stream.of("ME"),
-        Arrays.stream(CgmesSubset.values()).map(CgmesSubset::getIdentifier))
-        .flatMap(s -> s)
-        .collect(Collectors.joining("|", "(", ")"));
     private static final String REGEX_VALID_NAME = ""
         // Ignore case
         + "(?i)"
         // Any number of characters from the start
         + "^.*"
-        // Contains one of the valid subset ids
-        + REGEX_VALID_NAME_IDS
-        // Any number of characters and ending with extension .xml
-        + ".*\\.XML$";
+        // Ending with extension .xml
+        + "\\.XML$";
 }


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix


**What is the current behavior?** *(You can also link to an open issue here)*
exists() in CgmesImport returns false if files does not contain EQ, TP, SSH.... etc


**What is the new behavior (if this is a feature change)?**
exists() does not take the file name into account

