### PR TITLE
Small fix in CgmesDiscretePostProcessor: when SwitchPosition, type is SWITCH_POSITION, not OTHER

### DIFF
--- a/cgmes/cgmes-measurements/src/main/java/com/powsybl/cgmes/measurements/CgmesDiscretePostProcessor.java
+++ b/cgmes/cgmes-measurements/src/main/java/com/powsybl/cgmes/measurements/CgmesDiscretePostProcessor.java
@@ -69,8 +69,6 @@ public final class CgmesDiscretePostProcessor {
                 .setType(type);
         if (type == TAP_POSITION) {
             setTapChanger(adder, identifiable);
-        } else {
-            adder.setType(OTHER);
         }
         DiscreteMeasurement measurement = adder.add();
         measurement.putProperty("cgmesType", measurementType);


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix


**What is the current behavior?** *(You can also link to an open issue here)*
type is OTHER when not TAP_POSITION


**What is the new behavior (if this is a feature change)?**
type can be SWITCH_POSITION

