### PR TITLE
TransformerEnd persistence

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
@@ -16,6 +16,7 @@ import com.powsybl.cgmes.extensions.CgmesTapChangers;
 import com.powsybl.cgmes.extensions.CgmesTapChangersAdder;
 import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.iidm.network.*;
+import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
 
 import java.util.List;
@@ -109,6 +110,11 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
     @Override
     protected void addAliasesAndProperties(Identifiable<?> identifiable) {
         super.addAliasesAndProperties(identifiable);
+        int end = 1;
+        for (PropertyBag p : ps) {
+            identifiable.addAlias(p.getId("TransformerEnd"), Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + end);
+            end++;
+        }
         List<String> ptcs = context.cgmes().phaseTapChangerListForPowerTransformer(identifiable.getId());
         if (ptcs != null) {
             for (int i = 0; i < ptcs.size(); i++) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -355,16 +355,29 @@ public class CgmesExportContext {
 
     private void addIidmMappingsTapChangers(Network network) {
         for (TwoWindingsTransformer twt : network.getTwoWindingsTransformers()) {
+            addIidmTransformerEnd(twt, 1);
+            addIidmTransformerEnd(twt, 2);
             addIidmPhaseTapChanger(twt, twt.getPhaseTapChanger());
             addIidmRatioTapChanger(twt, twt.getRatioTapChanger());
         }
         for (ThreeWindingsTransformer twt : network.getThreeWindingsTransformers()) {
+            addIidmTransformerEnd(twt, 1);
+            addIidmTransformerEnd(twt, 2);
+            addIidmTransformerEnd(twt, 3);
             addIidmPhaseTapChanger(twt, twt.getLeg1().getPhaseTapChanger(), 1);
             addIidmRatioTapChanger(twt, twt.getLeg1().getRatioTapChanger(), 1);
             addIidmPhaseTapChanger(twt, twt.getLeg2().getPhaseTapChanger(), 2);
             addIidmRatioTapChanger(twt, twt.getLeg2().getRatioTapChanger(), 2);
             addIidmPhaseTapChanger(twt, twt.getLeg3().getPhaseTapChanger(), 3);
             addIidmRatioTapChanger(twt, twt.getLeg3().getRatioTapChanger(), 3);
+        }
+    }
+
+    private void addIidmTransformerEnd(Identifiable<?> eq, int end) {
+        String endId = eq.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + end).orElse(null);
+        if (endId == null) {
+            endId = CgmesExportUtil.getUniqueId();
+            eq.addAlias(endId, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + end);
         }
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -341,7 +341,7 @@ public final class EquipmentExport {
     private static void writeTwoWindingsTransformers(Network network, Map<Terminal, String> exportedTerminals, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {
         for (TwoWindingsTransformer twt : network.getTwoWindingsTransformers()) {
             PowerTransformerEq.write(twt.getId(), twt.getNameOrId(), cimNamespace, writer);
-            String end1Id = CgmesExportUtil.getUniqueId();
+            String end1Id = twt.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + 1).orElseThrow(PowsyblException::new);
             // structural ratio at end1
             double a0 = twt.getRatedU1() / twt.getRatedU2();
             // move structural ratio from end1 to end2
@@ -351,7 +351,8 @@ public final class EquipmentExport {
             double g = twt.getG() / a02;
             double b = twt.getB() / a02;
             PowerTransformerEq.writeEnd(end1Id, twt.getNameOrId() + "_1", twt.getId(), 1, r, x, g, b, twt.getRatedU1(), exportedTerminalId(exportedTerminals, twt.getTerminal1()), cimNamespace, writer);
-            PowerTransformerEq.writeEnd(CgmesExportUtil.getUniqueId(), twt.getNameOrId() + "_2", twt.getId(), 2, 0.0, 0.0, 0.0, 0.0, twt.getRatedU2(), exportedTerminalId(exportedTerminals, twt.getTerminal2()), cimNamespace, writer);
+            String end2Id = twt.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + 2).orElseThrow(PowsyblException::new);
+            PowerTransformerEq.writeEnd(end2Id, twt.getNameOrId() + "_2", twt.getId(), 2, 0.0, 0.0, 0.0, 0.0, twt.getRatedU2(), exportedTerminalId(exportedTerminals, twt.getTerminal2()), cimNamespace, writer);
             writePhaseTapChanger(twt, twt.getPhaseTapChanger(), twt.getNameOrId(), end1Id, twt.getTerminal1().getVoltageLevel().getNominalV(), cimNamespace, writer);
             writeRatioTapChanger(twt, twt.getRatioTapChanger(), twt.getNameOrId(), end1Id, cimNamespace, writer);
             writeBranchLimits(twt, exportedTerminalId(exportedTerminals, twt.getTerminal1()), exportedTerminalId(exportedTerminals, twt.getTerminal2()), cimNamespace, writer);
@@ -362,9 +363,12 @@ public final class EquipmentExport {
         for (ThreeWindingsTransformer twt : network.getThreeWindingsTransformers()) {
             PowerTransformerEq.write(twt.getId(), twt.getNameOrId(), cimNamespace, writer);
             double ratedU0 = twt.getLeg1().getRatedU();
-            writeThreeWindingsTransformerEnd(twt, twt.getId(), twt.getNameOrId() + "_1", CgmesExportUtil.getUniqueId(), 1, twt.getLeg1(), ratedU0, exportedTerminalId(exportedTerminals, twt.getLeg1().getTerminal()), cimNamespace, writer);
-            writeThreeWindingsTransformerEnd(twt, twt.getId(), twt.getNameOrId() + "_2", CgmesExportUtil.getUniqueId(), 2, twt.getLeg2(), ratedU0, exportedTerminalId(exportedTerminals, twt.getLeg2().getTerminal()), cimNamespace, writer);
-            writeThreeWindingsTransformerEnd(twt, twt.getId(), twt.getNameOrId() + "_3", CgmesExportUtil.getUniqueId(), 3, twt.getLeg3(), ratedU0, exportedTerminalId(exportedTerminals, twt.getLeg3().getTerminal()), cimNamespace, writer);
+            String end1Id = twt.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + 1).orElseThrow(PowsyblException::new);
+            writeThreeWindingsTransformerEnd(twt, twt.getId(), twt.getNameOrId() + "_1", end1Id, 1, twt.getLeg1(), ratedU0, exportedTerminalId(exportedTerminals, twt.getLeg1().getTerminal()), cimNamespace, writer);
+            String end2Id = twt.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + 2).orElseThrow(PowsyblException::new);
+            writeThreeWindingsTransformerEnd(twt, twt.getId(), twt.getNameOrId() + "_2", end2Id, 2, twt.getLeg2(), ratedU0, exportedTerminalId(exportedTerminals, twt.getLeg2().getTerminal()), cimNamespace, writer);
+            String end3Id = twt.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + 3).orElseThrow(PowsyblException::new);
+            writeThreeWindingsTransformerEnd(twt, twt.getId(), twt.getNameOrId() + "_3", end3Id, 3, twt.getLeg3(), ratedU0, exportedTerminalId(exportedTerminals, twt.getLeg3().getTerminal()), cimNamespace, writer);
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The original Id of the TransformerEnds is not preserved in the export to CGMES.


**What is the new behavior (if this is a feature change)?**
Keep the Id of the TransformerEnd if it exists, or create a new Id to use for all network exports.

