### PR TITLE
CGMES export to specific CIM version

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
@@ -52,9 +52,9 @@ public class CgmesExport implements Exporter {
         CgmesExportContext context = new CgmesExportContext(network)
                 .setExportBoundaryPowerFlows(ConversionParameters.readBooleanParameter(getFormat(), params, EXPORT_BOUNDARY_POWER_FLOWS_PARAMETER))
                 .setExportFlowsForSwitches(ConversionParameters.readBooleanParameter(getFormat(), params, EXPORT_POWER_FLOWS_FOR_SWITCHES_PARAMETER));
-        int cimVersionParam = (int) ConversionParameters.readDoubleParameter(getFormat(), params, CIM_VERSION_PARAMETER);
-        if (cimVersionParam > 0) {
-            context.setCimVersion(cimVersionParam);
+        String cimVersionParam = ConversionParameters.readStringParameter(getFormat(), params, CIM_VERSION_PARAMETER);
+        if (cimVersionParam != null) {
+            context.setCimVersion(Integer.parseInt(cimVersionParam));
         }
         try {
             List<String> profiles = ConversionParameters.readStringListParameter(getFormat(), params, PROFILES_PARAMETER);
@@ -93,7 +93,7 @@ public class CgmesExport implements Exporter {
         String baseName = ConversionParameters.readStringParameter(getFormat(), params, BASE_NAME_PARAMETER);
         if (baseName != null) {
             return baseName;
-        } else if (ds.getBaseName() != null) {
+        } else if (ds.getBaseName() != null && !ds.getBaseName().isEmpty()) {
             return ds.getBaseName();
         }
         return network.getNameOrId();
@@ -137,9 +137,9 @@ public class CgmesExport implements Exporter {
             List.of("EQ", "TP", "SSH", "SV"));
     private static final Parameter CIM_VERSION_PARAMETER = new Parameter(
             CIM_VERSION,
-            ParameterType.DOUBLE,
+            ParameterType.STRING,
             "CIM version to export",
-            -1.0);
+            null);
 
     private static final List<Parameter> STATIC_PARAMETERS = List.of(
             BASE_NAME_PARAMETER,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -59,7 +59,7 @@ public final class CgmesExportUtil {
     }
 
     public static String getUniqueId() {
-        return UUID.randomUUID().toString();
+        return "_" + UUID.randomUUID();
     }
 
     public static void writeRdfRoot(int cimVersion, XMLStreamWriter writer) throws XMLStreamException {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportToCimVersionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportToCimVersionTest.java
@@ -11,13 +11,16 @@ import com.powsybl.cgmes.conversion.CgmesImport;
 import com.powsybl.cgmes.extensions.CimCharacteristics;
 import com.powsybl.cgmes.model.test.cim14.Cim14SmallCasesCatalog;
 import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ZipFileDataSource;
 import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.NetworkFactory;
+import com.powsybl.iidm.network.test.NetworkTest1Factory;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -28,13 +31,25 @@ import static org.junit.Assert.assertEquals;
 public class ExportToCimVersionTest extends AbstractConverterTest {
 
     @Test
+    public void testExportDataSourceEmptyBaseName() throws IOException {
+        MemDataSource ds = new MemDataSource();
+        Network n = NetworkTest1Factory.create();
+        // The export is not given baseName as parameter, and the data source has an empty basename
+        new CgmesExport().export(n, null, ds);
+        String nameEQ = ds.listNames(".*EQ.*xml").iterator().next();
+        String baseName = nameEQ.replace("_EQ.xml", "");
+        // The baseName of the output files should be taken from the network name or id
+        assertEquals(n.getNameOrId(), baseName);
+    }
+
+    @Test
     public void testExportIEEE14Cim14ToCim16() {
         ReadOnlyDataSource dataSource = Cim14SmallCasesCatalog.ieee14().dataSource();
         Network networkCim14 = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), null);
         CimCharacteristics cim14 = networkCim14.getExtension(CimCharacteristics.class);
 
         Properties params = new Properties();
-        params.put(CgmesExport.CIM_VERSION, 16);
+        params.put(CgmesExport.CIM_VERSION, "16");
         ZipFileDataSource zipIEEE14Cim16 = new ZipFileDataSource(tmpDir.resolve("."), "IEEE14");
         new CgmesExport().export(networkCim14, params, zipIEEE14Cim16);
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportToCimVersionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportToCimVersionTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.test.export;
+
+import com.powsybl.cgmes.conversion.CgmesExport;
+import com.powsybl.cgmes.conversion.CgmesImport;
+import com.powsybl.cgmes.extensions.CimCharacteristics;
+import com.powsybl.cgmes.model.test.cim14.Cim14SmallCasesCatalog;
+import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.commons.datasource.ReadOnlyDataSource;
+import com.powsybl.commons.datasource.ZipFileDataSource;
+import com.powsybl.iidm.import_.Importers;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.NetworkFactory;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Luma <zamarrenolm at aia.es>
+ */
+public class ExportToCimVersionTest extends AbstractConverterTest {
+
+    @Test
+    public void testExportIEEE14Cim14ToCim16() {
+        ReadOnlyDataSource dataSource = Cim14SmallCasesCatalog.ieee14().dataSource();
+        Network networkCim14 = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), null);
+        CimCharacteristics cim14 = networkCim14.getExtension(CimCharacteristics.class);
+
+        Properties params = new Properties();
+        params.put(CgmesExport.CIM_VERSION, 16);
+        ZipFileDataSource zipIEEE14Cim16 = new ZipFileDataSource(tmpDir.resolve("."), "IEEE14");
+        new CgmesExport().export(networkCim14, params, zipIEEE14Cim16);
+
+        Network networkCim16 = Importers.loadNetwork(tmpDir.resolve("IEEE14.zip"));
+        CimCharacteristics cim16 = networkCim16.getExtension(CimCharacteristics.class);
+
+        assertEquals(14, cim14.getCimVersion());
+        assertEquals(16, cim16.getCimVersion());
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
The ability to export Network to a specific CIM version when exporting to CGMES format.

**What is the current behavior?** *(You can also link to an open issue here)*
Code in `CgmesExport` wrote in the output the CIM headers corresponding to the CIM version stored in the extension `CimCharacteristics`. If the extension was not available (if the Network was not imported from CGMES data), CIM version 16 was used by default.

**What is the new behavior (if this is a feature change)?**
The user can specify the output CIM version to use using a conversion parameter. A test unit demonstrating its use has been added: `ExportToCimVersionTest:testExportIEEE14Cim14ToCim16`.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
In addition:

- Unique identifiers created during export have been fixed (they can not start with a digit).
- Basename for export is read: first from parameter, then from data source, last from network name or id. 