### PR TITLE
Fix serializer of HvdcOperatorActivePowerRange: its attributes are optional

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/HvdcOperatorActivePowerRangeXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/HvdcOperatorActivePowerRangeXmlSerializer.java
@@ -42,8 +42,8 @@ public class HvdcOperatorActivePowerRangeXmlSerializer extends AbstractExtension
 
     @Override
     public HvdcOperatorActivePowerRange read(HvdcLine hvdcLine, XmlReaderContext context) {
-        float oprFromCS1toCS2 = XmlUtil.readFloatAttribute(context.getReader(), "fromCS1toCS2");
-        float oprFromCS2toCS1 = XmlUtil.readFloatAttribute(context.getReader(), "fromCS2toCS1");
+        float oprFromCS1toCS2 = XmlUtil.readOptionalFloatAttribute(context.getReader(), "fromCS1toCS2");
+        float oprFromCS2toCS1 = XmlUtil.readOptionalFloatAttribute(context.getReader(), "fromCS2toCS1");
         hvdcLine.newExtension(HvdcOperatorActivePowerRangeAdder.class)
                 .withOprFromCS1toCS2(oprFromCS1toCS2)
                 .withOprFromCS2toCS1(oprFromCS2toCS1)


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix: HvdcOperatorActivePowerRange's attributes are optional but the deserializer does not consider them as optional. It will do so now.
