### PR TITLE
New HVDC AC emulation LoadFlow parameter

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -63,7 +63,8 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
     // VERSION = 1.4 dc, distributedSlack, balanceType
     // VERSION = 1.5 dcUseTransformerRatio, countriesToBalance, computedConnectedComponentScope
     // VERSION = 1.6 shuntCompensatorVoltageControlOn instead of simulShunt
-    public static final String VERSION = "1.6";
+    // VERSION = 1.7 hvdcAcEmulation
+    public static final String VERSION = "1.7";
 
     public static final VoltageInitMode DEFAULT_VOLTAGE_INIT_MODE = VoltageInitMode.UNIFORM_VALUES;
     public static final boolean DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON = false;
@@ -79,6 +80,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
     public static final boolean DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT = true;
     public static final Set<Country> DEFAULT_COUNTRIES_TO_BALANCE = EnumSet.noneOf(Country.class);
     public static final ConnectedComponentMode DEFAULT_CONNECTED_COMPONENT_MODE = ConnectedComponentMode.MAIN;
+    public static final boolean DEFAULT_HVDC_AC_EMULATION_ON = true;
 
     private static final Supplier<ExtensionProviders<ConfigLoader>> SUPPLIER =
             Suppliers.memoize(() -> ExtensionProviders.createProvider(ConfigLoader.class, "loadflow-parameters"));
@@ -128,6 +130,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
                 parameters.setDcUseTransformerRatio(config.getBooleanProperty("dcUseTransformerRatio", DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT));
                 parameters.setCountriesToBalance(config.getEnumSetProperty("countriesToBalance", Country.class, DEFAULT_COUNTRIES_TO_BALANCE));
                 parameters.setConnectedComponentMode(config.getEnumProperty("connectedComponentMode", ConnectedComponentMode.class, DEFAULT_CONNECTED_COMPONENT_MODE));
+                parameters.setHvdcAcEmulation(config.getBooleanProperty("hvdcAcEmulation", DEFAULT_HVDC_AC_EMULATION_ON));
             });
     }
 
@@ -159,11 +162,13 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
 
     private ConnectedComponentMode connectedComponentMode;
 
+    private boolean hvdcAcEmulation;
+
     public LoadFlowParameters(VoltageInitMode voltageInitMode, boolean transformerVoltageControlOn,
                               boolean noGeneratorReactiveLimits, boolean phaseShifterRegulationOn,
                               boolean twtSplitShuntAdmittance, boolean shuntCompensatorVoltageControlOn, boolean readSlackBus, boolean writeSlackBus,
                               boolean dc, boolean distributedSlack, BalanceType balanceType, boolean dcUseTransformerRatio,
-                              Set<Country> countriesToBalance, ConnectedComponentMode connectedComponentMode) {
+                              Set<Country> countriesToBalance, ConnectedComponentMode connectedComponentMode, boolean hvdcAcEmulation) {
         this.voltageInitMode = voltageInitMode;
         this.transformerVoltageControlOn = transformerVoltageControlOn;
         this.noGeneratorReactiveLimits = noGeneratorReactiveLimits;
@@ -178,13 +183,14 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
         this.dcUseTransformerRatio = dcUseTransformerRatio;
         this.countriesToBalance = countriesToBalance;
         this.connectedComponentMode = connectedComponentMode;
+        this.hvdcAcEmulation = hvdcAcEmulation;
     }
 
     public LoadFlowParameters(VoltageInitMode voltageInitMode, boolean transformerVoltageControlOn,
         boolean noGeneratorReactiveLimits, boolean phaseShifterRegulationOn,
         boolean twtSplitShuntAdmittance) {
         this(voltageInitMode, transformerVoltageControlOn, noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance, DEFAULT_SHUNT_COMPENSATOR_VOLTAGE_CONTROL_ON, DEFAULT_READ_SLACK_BUS, DEFAULT_WRITE_SLACK_BUS,
-                DEFAULT_DC, DEFAULT_DISTRIBUTED_SLACK, DEFAULT_BALANCE_TYPE, DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT, DEFAULT_COUNTRIES_TO_BALANCE, DEFAULT_CONNECTED_COMPONENT_MODE);
+                DEFAULT_DC, DEFAULT_DISTRIBUTED_SLACK, DEFAULT_BALANCE_TYPE, DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT, DEFAULT_COUNTRIES_TO_BALANCE, DEFAULT_CONNECTED_COMPONENT_MODE, DEFAULT_HVDC_AC_EMULATION_ON);
     }
 
     public LoadFlowParameters(VoltageInitMode voltageInitMode, boolean transformerVoltageControlOn) {
@@ -215,6 +221,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
         dcUseTransformerRatio = other.dcUseTransformerRatio;
         countriesToBalance = other.countriesToBalance;
         connectedComponentMode = other.connectedComponentMode;
+        hvdcAcEmulation = other.hvdcAcEmulation;
     }
 
     public VoltageInitMode getVoltageInitMode() {
@@ -380,7 +387,8 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
                 .put("balanceType", balanceType)
                 .put("dcUseTransformerRatio", dcUseTransformerRatio)
                 .put("countriesToBalance", countriesToBalance)
-                .put("computedConnectedComponentScope", connectedComponentMode);
+                .put("computedConnectedComponentScope", connectedComponentMode)
+                .put("hvdcAcEmulation", hvdcAcEmulation);
         return immutableMapBuilder.build();
     }
 
@@ -408,6 +416,15 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
 
     public LoadFlowParameters setConnectedComponentMode(ConnectedComponentMode connectedComponentMode) {
         this.connectedComponentMode = connectedComponentMode;
+        return this;
+    }
+
+    public boolean isHvdcAcEmulation() {
+        return hvdcAcEmulation;
+    }
+
+    public LoadFlowParameters setHvdcAcEmulation(boolean hvdcAcEmulation) {
+        this.hvdcAcEmulation = hvdcAcEmulation;
         return this;
     }
 

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersDeserializer.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersDeserializer.java
@@ -151,6 +151,12 @@ public class LoadFlowParametersDeserializer extends StdDeserializer<LoadFlowPara
                     parameters.setConnectedComponentMode(parser.readValueAs(LoadFlowParameters.ConnectedComponentMode.class));
                     break;
 
+                case "hvdcAcEmulation":
+                    JsonUtil.assertGreaterOrEqualThanReferenceVersion(CONTEXT_NAME, "Tag: hvdcAcEmulation" + parser.getCurrentName(), version, "1.7");
+                    parser.nextToken();
+                    parameters.setHvdcAcEmulation(parser.readValueAs(Boolean.class));
+                    break;
+
                 case "extensions":
                     parser.nextToken();
                     extensions = JsonUtil.updateExtensions(parser, deserializationContext, JsonLoadFlowParameters.getExtensionSerializers(), parameters);

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersSerializer.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowParametersSerializer.java
@@ -48,6 +48,7 @@ public class LoadFlowParametersSerializer extends StdSerializer<LoadFlowParamete
         }
         jsonGenerator.writeEndArray();
         jsonGenerator.writeStringField("connectedComponentMode", parameters.getConnectedComponentMode().name());
+        jsonGenerator.writeBooleanField("hvdcAcEmulation", parameters.isHvdcAcEmulation());
 
         JsonUtil.writeExtensions(parameters, jsonGenerator, serializerProvider, JsonLoadFlowParameters.getExtensionSerializers());
 

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
@@ -62,7 +62,8 @@ public class LoadFlowParametersTest {
                              boolean simulShunt, boolean readSlackBus, boolean writeSlackBus,
                              boolean dc, boolean distributedSlack, LoadFlowParameters.BalanceType balanceType,
                              boolean dcUseTransformerRatio, Set<Country> countriesToBalance,
-                             LoadFlowParameters.ConnectedComponentMode computedConnectedComponent) {
+                             LoadFlowParameters.ConnectedComponentMode computedConnectedComponent,
+                             boolean hvdcAcEmulation) {
         assertEquals(parameters.getVoltageInitMode(), voltageInitMode);
         assertEquals(parameters.isTransformerVoltageControlOn(), transformerVoltageControlOn);
         assertEquals(parameters.isPhaseShifterRegulationOn(), phaseShifterRegulationOn);
@@ -77,6 +78,7 @@ public class LoadFlowParametersTest {
         assertEquals(parameters.isDcUseTransformerRatio(), dcUseTransformerRatio);
         assertEquals(parameters.getCountriesToBalance(), countriesToBalance);
         assertEquals(parameters.getConnectedComponentMode(), computedConnectedComponent);
+        assertEquals(parameters.isHvdcAcEmulation(), hvdcAcEmulation);
     }
 
     @Test
@@ -96,7 +98,8 @@ public class LoadFlowParametersTest {
                 LoadFlowParameters.DEFAULT_BALANCE_TYPE,
                 LoadFlowParameters.DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT,
                 LoadFlowParameters.DEFAULT_COUNTRIES_TO_BALANCE,
-                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE);
+                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE,
+                LoadFlowParameters.DEFAULT_HVDC_AC_EMULATION_ON);
     }
 
     @Test
@@ -116,6 +119,7 @@ public class LoadFlowParametersTest {
         boolean dcUseTransformerRatio = true;
         Set<Country> countriesToBalance = new HashSet<>();
         LoadFlowParameters.ConnectedComponentMode computedConnectedComponent = LoadFlowParameters.ConnectedComponentMode.MAIN;
+        boolean hvdcAcEmulation = true;
 
         MapModuleConfig moduleConfig = platformConfig.createModuleConfig("load-flow-default-parameters");
         moduleConfig.setStringProperty("voltageInitMode", "UNIFORM_VALUES");
@@ -133,12 +137,13 @@ public class LoadFlowParametersTest {
         moduleConfig.setStringProperty("dcUseTransformerRatio", Boolean.toString(dc));
         moduleConfig.setStringListProperty("countriesToBalance", countriesToBalance.stream().map(e -> e.name()).collect(Collectors.toList()));
         moduleConfig.setStringProperty("computedConnectedComponent", computedConnectedComponent.name());
+        moduleConfig.setStringProperty("hvdcAcEmulation", Boolean.toString(hvdcAcEmulation));
 
         LoadFlowParameters parameters = new LoadFlowParameters();
         LoadFlowParameters.load(parameters, platformConfig);
         checkValues(parameters, voltageInitMode, transformerVoltageControlOn,
                     noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance, simulShunt, readSlackBus, writeSlackBus,
-                    dc, distributedSlack, balanceType, dcUseTransformerRatio, countriesToBalance, computedConnectedComponent);
+                    dc, distributedSlack, balanceType, dcUseTransformerRatio, countriesToBalance, computedConnectedComponent, hvdcAcEmulation);
     }
 
     @Test
@@ -154,7 +159,7 @@ public class LoadFlowParametersTest {
                 LoadFlowParameters.DEFAULT_SHUNT_COMPENSATOR_VOLTAGE_CONTROL_ON, LoadFlowParameters.DEFAULT_READ_SLACK_BUS, LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS,
                 LoadFlowParameters.DEFAULT_DC, LoadFlowParameters.DEFAULT_DISTRIBUTED_SLACK, LoadFlowParameters.DEFAULT_BALANCE_TYPE,
                 LoadFlowParameters.DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT, LoadFlowParameters.DEFAULT_COUNTRIES_TO_BALANCE,
-                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE);
+                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE, LoadFlowParameters.DEFAULT_HVDC_AC_EMULATION_ON);
     }
 
     @Test
@@ -167,7 +172,7 @@ public class LoadFlowParametersTest {
                 LoadFlowParameters.DEFAULT_SHUNT_COMPENSATOR_VOLTAGE_CONTROL_ON, LoadFlowParameters.DEFAULT_READ_SLACK_BUS, LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS,
                 LoadFlowParameters.DEFAULT_DC, LoadFlowParameters.DEFAULT_DISTRIBUTED_SLACK, LoadFlowParameters.DEFAULT_BALANCE_TYPE,
                 LoadFlowParameters.DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT, LoadFlowParameters.DEFAULT_COUNTRIES_TO_BALANCE,
-                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE);
+                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE, LoadFlowParameters.DEFAULT_HVDC_AC_EMULATION_ON);
     }
 
     @Test
@@ -180,7 +185,7 @@ public class LoadFlowParametersTest {
                 LoadFlowParameters.DEFAULT_SHUNT_COMPENSATOR_VOLTAGE_CONTROL_ON, LoadFlowParameters.DEFAULT_READ_SLACK_BUS, LoadFlowParameters.DEFAULT_WRITE_SLACK_BUS,
                 LoadFlowParameters.DEFAULT_DC, LoadFlowParameters.DEFAULT_DISTRIBUTED_SLACK, LoadFlowParameters.DEFAULT_BALANCE_TYPE,
                 LoadFlowParameters.DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT, LoadFlowParameters.DEFAULT_COUNTRIES_TO_BALANCE,
-                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE);
+                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE, LoadFlowParameters.DEFAULT_HVDC_AC_EMULATION_ON);
     }
 
     @Test
@@ -199,7 +204,8 @@ public class LoadFlowParametersTest {
                 LoadFlowParameters.DEFAULT_BALANCE_TYPE,
                 LoadFlowParameters.DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT,
                 LoadFlowParameters.DEFAULT_COUNTRIES_TO_BALANCE,
-                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE);
+                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE,
+                LoadFlowParameters.DEFAULT_HVDC_AC_EMULATION_ON);
     }
 
     @Test
@@ -218,7 +224,8 @@ public class LoadFlowParametersTest {
                 LoadFlowParameters.DEFAULT_BALANCE_TYPE,
                 LoadFlowParameters.DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT,
                 LoadFlowParameters.DEFAULT_COUNTRIES_TO_BALANCE,
-                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE);
+                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE,
+                LoadFlowParameters.DEFAULT_HVDC_AC_EMULATION_ON);
 
         LoadFlowParameters parameters1 = new LoadFlowParameters(parameters);
         parameters1.setDc(true);
@@ -237,7 +244,8 @@ public class LoadFlowParametersTest {
                 LoadFlowParameters.BalanceType.PROPORTIONAL_TO_LOAD,
                 LoadFlowParameters.DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT,
                 LoadFlowParameters.DEFAULT_COUNTRIES_TO_BALANCE,
-                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE);
+                LoadFlowParameters.DEFAULT_CONNECTED_COMPONENT_MODE,
+                LoadFlowParameters.DEFAULT_HVDC_AC_EMULATION_ON);
     }
 
     @Test
@@ -256,6 +264,7 @@ public class LoadFlowParametersTest {
         boolean dcUseTransformerRatio = true;
         Set<Country> countriesToBalance = new HashSet<>();
         LoadFlowParameters.ConnectedComponentMode computedConnectedComponent = LoadFlowParameters.ConnectedComponentMode.MAIN;
+        boolean hvdcAcEmulation = false;
 
         LoadFlowParameters parameters = new LoadFlowParameters();
         LoadFlowParameters.load(parameters, platformConfig);
@@ -269,11 +278,12 @@ public class LoadFlowParametersTest {
                 .setWriteSlackBus(writeSlackBus)
                 .setDc(dc)
                 .setDistributedSlack(distributedSlack)
-                .setBalanceType(balanceType);
+                .setBalanceType(balanceType)
+                .setHvdcAcEmulation(hvdcAcEmulation);
 
         checkValues(parameters, voltageInitMode, transformerVoltageControlOn, noGeneratorReactiveLimits,
                     phaseShifterRegulationOn, twtSplitShuntAdmittance, simulShunt, readSlackBus, writeSlackBus,
-                    dc, distributedSlack, balanceType, dcUseTransformerRatio, countriesToBalance, computedConnectedComponent);
+                    dc, distributedSlack, balanceType, dcUseTransformerRatio, countriesToBalance, computedConnectedComponent, hvdcAcEmulation);
     }
 
     @Test
@@ -292,15 +302,16 @@ public class LoadFlowParametersTest {
         boolean dcUseTransformerRatio = true;
         Set<Country> countriesToBalance = new HashSet<>();
         LoadFlowParameters.ConnectedComponentMode computedConnectedComponent = LoadFlowParameters.ConnectedComponentMode.MAIN;
+        boolean hvdcAcEmulation = true;
         LoadFlowParameters parameters = new LoadFlowParameters(voltageInitMode, transformerVoltageControlOn,
                                                                noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance, simulShunt, readSlackBus, writeSlackBus,
-                                                               dc, distributedSlack, balanceType, dcUseTransformerRatio, countriesToBalance, computedConnectedComponent);
+                                                               dc, distributedSlack, balanceType, dcUseTransformerRatio, countriesToBalance, computedConnectedComponent, hvdcAcEmulation);
         LoadFlowParameters parametersCloned = parameters.copy();
         checkValues(parametersCloned, parameters.getVoltageInitMode(), parameters.isTransformerVoltageControlOn(),
                 parameters.isNoGeneratorReactiveLimits(), parameters.isPhaseShifterRegulationOn(), parameters.isTwtSplitShuntAdmittance(),
                 parameters.isShuntCompensatorVoltageControlOn(), parameters.isReadSlackBus(), parameters.isWriteSlackBus(),
                 parameters.isDc(), parameters.isDistributedSlack(), parameters.getBalanceType(), parameters.isDcUseTransformerRatio(),
-                parameters.getCountriesToBalance(), parameters.getConnectedComponentMode());
+                parameters.getCountriesToBalance(), parameters.getConnectedComponentMode(), parameters.isHvdcAcEmulation());
     }
 
     @Test

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
@@ -124,6 +124,13 @@ public class JsonLoadFlowParametersTest extends AbstractConverterTest {
     }
 
     @Test
+    public void readJsonVersion17() {
+        LoadFlowParameters parameters = JsonLoadFlowParameters
+                .read(getClass().getResourceAsStream("/LoadFlowParametersVersion17.json"));
+        assertTrue(parameters.isHvdcAcEmulation());
+    }
+
+    @Test
     public void readJsonVersion10Exception() {
         InputStream inputStream = getClass().getResourceAsStream("/LoadFlowParametersVersion10Exception.json");
         assertThrows("LoadFlowParameters. Tag: t2wtSplitShuntAdmittance is not valid for version 1.0. Version should be > 1.0",

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion17.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion17.json
@@ -6,13 +6,13 @@
   "noGeneratorReactiveLimits" : true,
   "twtSplitShuntAdmittance" : false,
   "shuntCompensatorVoltageControlOn" : false,
-  "readSlackBus" : true,
+  "readSlackBus" : false,
   "writeSlackBus" : false,
   "dc" : false,
   "distributedSlack" : true,
   "balanceType" : "PROPORTIONAL_TO_GENERATION_P_MAX",
   "dcUseTransformerRatio" : true,
-  "countriesToBalance" : [ ],
+  "countriesToBalance" : [ "FR" , "KI" ],
   "connectedComponentMode" : "MAIN",
   "hvdcAcEmulation" : true
 }

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowParametersWithExtension.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowParametersWithExtension.json
@@ -1,5 +1,5 @@
 {
-  "version" : "1.6",
+  "version" : "1.7",
   "voltageInitMode" : "UNIFORM_VALUES",
   "transformerVoltageControlOn" : false,
   "phaseShifterRegulationOn" : false,
@@ -14,6 +14,7 @@
   "dcUseTransformerRatio" : true,
   "countriesToBalance" : [ ],
   "connectedComponentMode" : "MAIN",
+  "hvdcAcEmulation" : true,
   "extensions" : {
     "dummy-extension" : { }
   }

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParametersV1.1.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParametersV1.1.json
@@ -8,7 +8,7 @@
     "high-voltage-absolute-threshold" : 0.0
   },
   "load-flow-parameters" : {
-    "version" : "1.6",
+    "version" : "1.7",
     "voltageInitMode" : "UNIFORM_VALUES",
     "transformerVoltageControlOn" : false,
     "phaseShifterRegulationOn" : false,
@@ -22,6 +22,7 @@
     "balanceType" : "PROPORTIONAL_TO_GENERATION_P_MAX",
     "dcUseTransformerRatio" : true,
     "countriesToBalance" : [ ],
-    "connectedComponentMode" : "MAIN"
+    "connectedComponentMode" : "MAIN",
+    "hvdcAcEmulation" : true
   }
 }

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParametersWithExtension.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisParametersWithExtension.json
@@ -8,7 +8,7 @@
     "high-voltage-absolute-threshold" : 0.0
   },
   "load-flow-parameters" : {
-    "version" : "1.6",
+    "version" : "1.7",
     "voltageInitMode" : "UNIFORM_VALUES",
     "transformerVoltageControlOn" : false,
     "phaseShifterRegulationOn" : false,
@@ -22,7 +22,8 @@
     "balanceType" : "PROPORTIONAL_TO_GENERATION_P_MAX",
     "dcUseTransformerRatio" : true,
     "countriesToBalance" : [ ],
-    "connectedComponentMode" : "MAIN"
+    "connectedComponentMode" : "MAIN",
+    "hvdcAcEmulation" : true
   },
   "extensions" : {
     "dummy-extension" : { }

--- a/sensitivity-analysis-api/src/test/resources/SensitivityAnalysisParameters.json
+++ b/sensitivity-analysis-api/src/test/resources/SensitivityAnalysisParameters.json
@@ -1,7 +1,7 @@
 {
   "version" : "1.0",
   "load-flow-parameters" : {
-    "version" : "1.6",
+    "version" : "1.7",
     "voltageInitMode" : "UNIFORM_VALUES",
     "transformerVoltageControlOn" : false,
     "phaseShifterRegulationOn" : false,
@@ -15,6 +15,7 @@
     "balanceType" : "PROPORTIONAL_TO_GENERATION_P_MAX",
     "dcUseTransformerRatio" : true,
     "countriesToBalance" : [ ],
-    "connectedComponentMode" : "MAIN"
+    "connectedComponentMode" : "MAIN",
+    "hvdcAcEmulation" : true
   }
 }

--- a/sensitivity-analysis-api/src/test/resources/SensitivityAnalysisParametersWithExtension.json
+++ b/sensitivity-analysis-api/src/test/resources/SensitivityAnalysisParametersWithExtension.json
@@ -1,7 +1,7 @@
 {
   "version" : "1.0",
   "load-flow-parameters" : {
-    "version" : "1.6",
+    "version" : "1.7",
     "voltageInitMode" : "UNIFORM_VALUES",
     "transformerVoltageControlOn" : false,
     "phaseShifterRegulationOn" : false,
@@ -15,7 +15,8 @@
     "balanceType" : "PROPORTIONAL_TO_GENERATION_P_MAX",
     "dcUseTransformerRatio" : true,
     "countriesToBalance" : [ ],
-    "connectedComponentMode" : "MAIN"
+    "connectedComponentMode" : "MAIN",
+    "hvdcAcEmulation" : true
   },
   "extensions" : {
     "dummy-extension" : { }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

We introduce a parameter in the `LoadFlowParameters` in order to active or not the HVDC AC emulation. Even if the HVDC line has the extension `HvdcAngleDroopActivePowerControl` is present and enabled, we have the possibility to deactivate the HVDC AC emulation for this HVDC and modelling it through its `activePowerSetpoint`. The default value is `true`.

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
