### PR TITLE
Reduce CGMES and Triplestore tests logs by default to ERROR level

### DIFF
--- a/cgmes/cgmes-conformity/src/test/resources/logback-test.xml
+++ b/cgmes/cgmes-conformity/src/test/resources/logback-test.xml
@@ -14,17 +14,17 @@
             <pattern>%-5p %-20C{1} | %m%n</pattern>
         </encoder>
     </appender>
-    <root level="info">
+    <root level="error">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="com.bigdata" level="warn" additivity="false">
+    <logger name="com.bigdata" level="error" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
     <!-- To see the query text in the log, set level to debug -->
-    <logger name="com.powsybl.triplestore.TripleStore" level="info" />
+    <logger name="com.powsybl.triplestore.TripleStore" level="error" />
     <!-- To see how much time each query costs, set level to debug -->
     <logger name="com.powsybl.cgmes.triplestore.CgmesModelTripleStore"
-        level="info" />
+        level="error" />
     <!-- To watch the properties of every object converted, level to debug -->
-    <logger name="com.powsybl.cgmes.conversion.Conversion" level="info" />
+    <logger name="com.powsybl.cgmes.conversion.Conversion" level="error" />
 </configuration>

--- a/cgmes/cgmes-model-alternatives/src/test/resources/logback-test.xml
+++ b/cgmes/cgmes-model-alternatives/src/test/resources/logback-test.xml
@@ -13,10 +13,10 @@
             <pattern>%-5p %d{HH:mm:ss.SSS} %-20C{1} | %m%n</pattern>
         </encoder>
     </appender>
-    <root level="info">
+    <root level="error">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="com.bigdata" level="warn" additivity="false">
+    <logger name="com.bigdata" level="error" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 </configuration>

--- a/cgmes/cgmes-model/src/test/resources/logback-test.xml
+++ b/cgmes/cgmes-model/src/test/resources/logback-test.xml
@@ -13,10 +13,10 @@
             <pattern>%-5p %d{HH:mm:ss.SSS} %-20C{1} | %m%n</pattern>
         </encoder>
     </appender>
-    <root level="info">
+    <root level="error">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="com.bigdata" level="warn" additivity="false">
+    <logger name="com.bigdata" level="error" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 </configuration>

--- a/triple-store/triple-store-test/src/test/resources/logback-test.xml
+++ b/triple-store/triple-store-test/src/test/resources/logback-test.xml
@@ -13,10 +13,10 @@
             <pattern>%-5p %d{HH:mm:ss.SSS} %-20C{1} | %m%n</pattern>
         </encoder>
     </appender>
-    <root level="info">
+    <root level="error">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="com.bigdata" level="warn" additivity="false">
+    <logger name="com.bigdata" level="error" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 </configuration>


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Reduce compilation time by reducing log verbosity in CGMES tests and Triplestore tests

