### PR TITLE
Refactor PowerFactory object reference

### DIFF
--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
@@ -10,6 +10,8 @@ import com.google.common.primitives.Ints;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.util.ContainersMapping;
 import com.powsybl.powerfactory.model.DataObject;
+import com.powsybl.powerfactory.model.DataObjectIndex;
+import com.powsybl.powerfactory.model.DataObjectRef;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -72,17 +74,17 @@ final class ContainersMappingHelper {
 
     private static final class BusesToVoltageLevelId {
 
-        private final Map<Long, DataObject> objsById;
+        private final DataObjectIndex index;
 
         private int noNameVoltageLevelCount = 0;
 
-        private BusesToVoltageLevelId(Map<Long, DataObject> objsById) {
-            this.objsById = objsById;
+        private BusesToVoltageLevelId(DataObjectIndex index) {
+            this.index = index;
         }
 
         public String getVoltageLevelId(Set<Integer> ids) {
             List<DataObject> objs = ids.stream()
-                    .map(objsById::get)
+                    .flatMap(id -> index.getDataObject(id).stream())
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
 
@@ -137,7 +139,9 @@ final class ContainersMappingHelper {
         for (DataObject elmTerm : elmTerms) {
             nodes.add(elmTerm);
             for (DataObject staCubic : elmTerm.getChildrenByClass("StaCubic")) {
-                DataObject connectedObj = staCubic.findObjectReferenceValue("obj_id").orElse(null);
+                DataObject connectedObj = staCubic.findObjectAttributeValue("obj_id")
+                        .flatMap(DataObjectRef::resolve)
+                        .orElse(null);
                 if (isBranch(connectedObj)) {
                     nodes.add(staCubic);
                     edges.add(new Edge(elmTerm, staCubic, null, false, 0, 0));
@@ -159,7 +163,7 @@ final class ContainersMappingHelper {
                         break;
                     case "ElmLne":
                         float dline = connectedObj.getFloatAttributeValue("dline");
-                        DataObject typLne = connectedObj.getObjectReferenceValue("typ_id");
+                        DataObject typLne = connectedObj.getObjectAttributeValue("typ_id").resolve().orElseThrow();
                         float rline = typLne.getFloatAttributeValue("rline");
                         float xline = typLne.getFloatAttributeValue("xline");
                         double r = rline * dline;
@@ -184,7 +188,7 @@ final class ContainersMappingHelper {
         }
     }
 
-    static ContainersMapping create(Map<Long, DataObject> objs, List<DataObject> elmTerms) {
+    static ContainersMapping create(DataObjectIndex index, List<DataObject> elmTerms) {
         List<DataObject> nodes = new ArrayList<>();
         List<Edge> edges = new ArrayList<>();
         Map<DataObject, List<DataObject>> branchesByCubicleId = new HashMap<>();
@@ -192,7 +196,7 @@ final class ContainersMappingHelper {
         createNodes(elmTerms, nodes, edges, branchesByCubicleId);
         createEdges(edges, branchesByCubicleId);
 
-        BusesToVoltageLevelId busesToVoltageLevelId = new BusesToVoltageLevelId(objs);
+        BusesToVoltageLevelId busesToVoltageLevelId = new BusesToVoltageLevelId(index);
 
         return ContainersMapping.create(nodes, edges,
             obj -> Ints.checkedCast(obj.getId()),

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
@@ -84,7 +84,7 @@ final class ContainersMappingHelper {
 
         public String getVoltageLevelId(Set<Integer> ids) {
             List<DataObject> objs = ids.stream()
-                    .flatMap(id -> index.getDataObject(id).stream())
+                    .flatMap(id -> index.getDataObjectById(id).stream())
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
 

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/PowerFactoryImporter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/PowerFactoryImporter.java
@@ -17,10 +17,7 @@ import com.powsybl.iidm.import_.Importer;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.util.ContainersMapping;
 import com.powsybl.iidm.parameters.Parameter;
-import com.powsybl.powerfactory.model.DataObject;
-import com.powsybl.powerfactory.model.PowerFactoryException;
-import com.powsybl.powerfactory.model.StudyCase;
-import com.powsybl.powerfactory.model.StudyCaseLoader;
+import com.powsybl.powerfactory.model.*;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
@@ -149,7 +146,9 @@ public class PowerFactoryImporter implements Importer {
     private Network createNetwork(StudyCase studyCase, NetworkFactory networkFactory) {
         Network network = networkFactory.createNetwork(studyCase.getName(), FORMAT);
 
-        List<DataObject> elmNets = studyCase.getElmNets();
+        List<DataObject> elmNets = studyCase.getIndex().getDataObjects().stream()
+                .filter(object -> object.getDataClassName().equals("ElmNet"))
+                .collect(Collectors.toList());
         if (elmNets.isEmpty()) {
             throw new PowsyblException("No ElmNet object found");
         }
@@ -159,19 +158,13 @@ public class PowerFactoryImporter implements Importer {
         DateTime caseDate = new Instant(studyCase.getTime().toEpochMilli()).toDateTime();
         network.setCaseDate(caseDate);
 
-        // index objects by id
-        Map<Long, DataObject> objsById = new HashMap<>();
-        for (DataObject elmNet : elmNets) {
-            elmNet.traverse(obj -> objsById.put(obj.getId(), obj));
-        }
-
-        List<DataObject> elmTerms = objsById.values().stream()
+        List<DataObject> elmTerms = studyCase.getIndex().getDataObjects().stream()
                 .filter(obj -> obj.getDataClassName().equals("ElmTerm"))
                 .collect(Collectors.toList());
 
         LOGGER.info("Creating containers...");
 
-        ContainersMapping containerMapping = ContainersMappingHelper.create(objsById, elmTerms);
+        ContainersMapping containerMapping = ContainersMappingHelper.create(studyCase.getIndex(), elmTerms);
         ImportContext importContext = new ImportContext(containerMapping);
 
         LOGGER.info("Creating topology graphs...");
@@ -190,7 +183,7 @@ public class PowerFactoryImporter implements Importer {
 
         LOGGER.info("Creating equipments...");
 
-        for (DataObject obj : objsById.values()) {
+        for (DataObject obj : studyCase.getIndex().getDataObjects()) {
             switch (obj.getDataClassName()) {
                 case "ElmCoup":
                     createSwitch(network, importContext, obj);
@@ -327,12 +320,16 @@ public class PowerFactoryImporter implements Importer {
                 .setMinP(pMinUc)
                 .setMaxP(pMaxUc)
                 .add();
-        elmSym.findObjectReferenceValue(TYP_ID).ifPresent(typSym -> createReactiveLimits(elmSym, typSym, g));
+        elmSym.findObjectAttributeValue(TYP_ID)
+                .flatMap(DataObjectRef::resolve)
+                .ifPresent(typSym -> createReactiveLimits(elmSym, typSym, g));
     }
 
     private void createReactiveLimits(DataObject elmSym, DataObject typSym, Generator g) {
         if (typSym.getDataClassName().equals("TypSym")) {
-            DataObject pQlimType = elmSym.findObjectReferenceValue("pQlimType").orElse(null);
+            DataObject pQlimType = elmSym.findObjectAttributeValue("pQlimType")
+                    .flatMap(DataObjectRef::resolve)
+                    .orElse(null);
             if (pQlimType != null) {
                 throw new PowsyblException("Reactive capability curve not supported: '" + elmSym + "'");
             } else {
@@ -366,7 +363,9 @@ public class PowerFactoryImporter implements Importer {
         NodeRef nodeRef1 = it.next();
         NodeRef nodeRef2 = it.next();
         float dline = elmLne.getFloatAttributeValue("dline");
-        DataObject typLne = elmLne.getObjectReferenceValue(TYP_ID);
+        DataObject typLne = elmLne.getObjectAttributeValue(TYP_ID)
+                .resolve()
+                .orElseThrow();
         float rline = typLne.getFloatAttributeValue("rline");
         float xline = typLne.getFloatAttributeValue("xline");
         float bline = typLne.getFloatAttributeValue("bline");
@@ -403,7 +402,9 @@ public class PowerFactoryImporter implements Importer {
         VoltageLevel vl1 = network.getVoltageLevel(nodeRef1.voltageLevelId);
         VoltageLevel vl2 = network.getVoltageLevel(nodeRef2.voltageLevelId);
         Substation s = vl1.getSubstation().orElseThrow();
-        DataObject typTr2 = elmTr2.getObjectReferenceValue(TYP_ID);
+        DataObject typTr2 = elmTr2.getObjectAttributeValue(TYP_ID)
+                .resolve()
+                .orElseThrow();
         float strn = typTr2.getFloatAttributeValue("strn");
         float utrnL = typTr2.getFloatAttributeValue("utrn_l");
         float utrnH = typTr2.getFloatAttributeValue("utrn_h");
@@ -526,7 +527,9 @@ public class PowerFactoryImporter implements Importer {
                     .add();
         }
         for (DataObject staCubic : elmTerm.getChildrenByClass("StaCubic")) {
-            DataObject connectedObj = staCubic.findObjectReferenceValue("obj_id").orElse(null);
+            DataObject connectedObj = staCubic.findObjectAttributeValue("obj_id")
+                    .flatMap(DataObjectRef::resolve)
+                    .orElse(null);
             if (connectedObj == null) {
                 importContext.cubiclesObjectNotFound.add(staCubic);
             } else {

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/PowerFactoryImporter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/PowerFactoryImporter.java
@@ -146,9 +146,7 @@ public class PowerFactoryImporter implements Importer {
     private Network createNetwork(StudyCase studyCase, NetworkFactory networkFactory) {
         Network network = networkFactory.createNetwork(studyCase.getName(), FORMAT);
 
-        List<DataObject> elmNets = studyCase.getIndex().getDataObjects().stream()
-                .filter(object -> object.getDataClassName().equals("ElmNet"))
-                .collect(Collectors.toList());
+        List<DataObject> elmNets = studyCase.getIndex().getDataObjectsByClass("ElmNet");
         if (elmNets.isEmpty()) {
             throw new PowsyblException("No ElmNet object found");
         }
@@ -158,9 +156,7 @@ public class PowerFactoryImporter implements Importer {
         DateTime caseDate = new Instant(studyCase.getTime().toEpochMilli()).toDateTime();
         network.setCaseDate(caseDate);
 
-        List<DataObject> elmTerms = studyCase.getIndex().getDataObjects().stream()
-                .filter(obj -> obj.getDataClassName().equals("ElmTerm"))
-                .collect(Collectors.toList());
+        List<DataObject> elmTerms = studyCase.getIndex().getDataObjectsByClass("ElmTerm");
 
         LOGGER.info("Creating containers...");
 

--- a/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsReader.java
+++ b/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsReader.java
@@ -19,7 +19,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -33,8 +35,6 @@ public class DgsReader {
 
     private final Map<String, DataClass> classesByName = new HashMap<>();
 
-    private final List<ToResolve> toResolveList = new ArrayList<>();
-
     private final Map<String, String> general = new HashMap<>();
 
     public static StudyCase read(Path dgsFile) {
@@ -46,21 +46,6 @@ public class DgsReader {
             return new DgsReader().read(dgsFile.getFileName().toString(), reader);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
-        }
-    }
-
-    private static final class ToResolve {
-
-        private final DataObject obj;
-
-        private final String attributeName;
-
-        private final long id;
-
-        private ToResolve(DataObject obj, String attributeName, long id) {
-            this.obj = obj;
-            this.attributeName = attributeName;
-            this.id = id;
         }
     }
 
@@ -149,7 +134,6 @@ public class DgsReader {
         @Override
         public void onObjectValue(String attributeName, long id) {
             object.setObjectAttributeValue(attributeName, id);
-            toResolveList.add(new ToResolve(object, attributeName, id));
         }
     }
 

--- a/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsReader.java
+++ b/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsReader.java
@@ -29,15 +29,13 @@ public class DgsReader {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DgsReader.class);
 
-    private final Map<Long, DataObject> objectsById = new HashMap<>();
+    private final DataObjectIndex index = new DataObjectIndex();
 
     private final Map<String, DataClass> classesByName = new HashMap<>();
 
     private final List<ToResolve> toResolveList = new ArrayList<>();
 
     private final Map<String, String> general = new HashMap<>();
-
-    private List<DataObject> elmNets = new ArrayList<>();
 
     public static StudyCase read(Path dgsFile) {
         return read(dgsFile, StandardCharsets.ISO_8859_1);
@@ -79,7 +77,7 @@ public class DgsReader {
                 type = DataAttributeType.FLOAT;
                 break;
             case 'p':
-                type = DataAttributeType.INTEGER64;
+                type = DataAttributeType.OBJECT;
                 break;
             default:
                 throw new AssertionError("Unexpected attribute type: " + attributeType);
@@ -87,17 +85,11 @@ public class DgsReader {
         return type;
     }
 
-    private void resolveLinksAndBuildObjectsTree() {
-        for (ToResolve toResolve : toResolveList) {
-            DataObject obj = objectsById.get(toResolve.id);
-            if (obj == null) {
-                throw new PowerFactoryException("Object '" + toResolve.id + "' not found");
-            }
-            if (toResolve.attributeName.equals(DataAttribute.FOLD_ID)) {
-                toResolve.obj.setParent(obj);
-            } else {
-                toResolve.obj.getReferenceValues().computeIfAbsent(toResolve.attributeName, k -> obj);
-            }
+    private void buildObjectTree() {
+        for (DataObject obj : index.getDataObjects()) {
+            obj.findObjectAttributeValue(DataAttribute.FOLD_ID)
+                    .flatMap(DataObjectRef::resolve)
+                    .ifPresent(obj::setParent);
         }
     }
 
@@ -126,24 +118,12 @@ public class DgsReader {
             }
         }
 
-        private DataObject createDataObject(long id, DataClass clazz) {
-            if (objectsById.containsKey(id)) {
-                throw new PowerFactoryException("Object '" + id + "' already exists");
-            }
-            DataObject newObj = new DataObject(id, clazz);
-            objectsById.put(id, newObj);
-            return newObj;
-        }
-
         @Override
         public void onStringValue(String attributeName, String value) {
             if (clazz != null) {
                 if ("ID".equals(attributeName)) {
                     long id = Long.parseLong(value);
-                    object = createDataObject(id, clazz);
-                    if (clazz.getName().equals("ElmNet")) {
-                        elmNets.add(object);
-                    }
+                    object = new DataObject(id, clazz, index);
                 } else {
                     object.setStringAttributeValue(attributeName, value);
                 }
@@ -168,7 +148,7 @@ public class DgsReader {
 
         @Override
         public void onObjectValue(String attributeName, long id) {
-            object.setLongAttributeValue(attributeName, id);
+            object.setObjectAttributeValue(attributeName, id);
             toResolveList.add(new ToResolve(object, attributeName, id));
         }
     }
@@ -180,20 +160,12 @@ public class DgsReader {
 
         new DgsParser().read(reader, new DgsHandlerImpl());
 
-        if (elmNets.isEmpty()) {
-            throw new PowerFactoryException("ElmNet object is missing");
-        }
-
-        // resolve object attributes links
-        resolveLinksAndBuildObjectsTree();
+        // build object tree (so resolve parents / children links)
+        buildObjectTree();
 
         stopwatch.stop();
-        LOGGER.info("DGS file read in {} ms: {} data objects", stopwatch.elapsed(TimeUnit.MILLISECONDS), objectsById.size());
+        LOGGER.info("DGS file read in {} ms: {} data objects", stopwatch.elapsed(TimeUnit.MILLISECONDS), index.getDataObjects().size());
 
-        StudyCase studyCase = new StudyCase(studyCaseName, Instant.now(), elmNets);
-        for (DataObject obj : objectsById.values()) {
-            obj.setStudyCase(studyCase);
-        }
-        return studyCase;
+        return new StudyCase(studyCaseName, Instant.now(), index);
     }
 }

--- a/powerfactory/powerfactory-dgs/src/test/java/com/powsybl/powerfactory/dgs/DgsDataTest.java
+++ b/powerfactory/powerfactory-dgs/src/test/java/com/powsybl/powerfactory/dgs/DgsDataTest.java
@@ -12,7 +12,6 @@ import com.google.common.io.Files;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.TestUtil;
 import com.powsybl.powerfactory.model.StudyCase;
-
 import org.junit.Test;
 
 import java.io.IOException;
@@ -22,7 +21,8 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -41,9 +41,7 @@ public class DgsDataTest extends AbstractConverterTest {
         String studyName = Files.getNameWithoutExtension(fileName);
         InputStream is = Objects.requireNonNull(DgsDataTest.class.getResourceAsStream(fileName));
         DgsReader dgsReader = new DgsReader();
-        StudyCase s = dgsReader.read(studyName, new InputStreamReader(is));
-
-        return s;
+        return dgsReader.read(studyName, new InputStreamReader(is));
     }
 
     private static String loadReference(String path) {

--- a/powerfactory/powerfactory-dgs/src/test/resources/TwoBuses.json
+++ b/powerfactory/powerfactory-dgs/src/test/resources/TwoBuses.json
@@ -18,7 +18,9 @@
       "uknom" : 220.0,
       "iUsage" : 0,
       "loc_name" : "Busbar-A",
-      "fold_id" : 2
+      "fold_id" : {
+        "id" : 2
+      }
     }
   }, {
     "id" : 4,
@@ -29,7 +31,9 @@
       "uknom" : 220.0,
       "iUsage" : 0,
       "loc_name" : "Busbar-B",
-      "fold_id" : 2
+      "fold_id" : {
+        "id" : 2
+      }
     }
   }, {
     "id" : 5,
@@ -37,10 +41,14 @@
       "name" : "ElmLne"
     },
     "attributeValues" : {
-      "typ_id" : 10,
+      "typ_id" : {
+        "id" : 10
+      },
       "loc_name" : "Line-A-B",
       "dline" : 1.0,
-      "fold_id" : 2
+      "fold_id" : {
+        "id" : 2
+      }
     }
   }, {
     "id" : 6,
@@ -48,10 +56,14 @@
       "name" : "StaCubic"
     },
     "attributeValues" : {
-      "obj_id" : 5,
+      "obj_id" : {
+        "id" : 5
+      },
       "obj_bus" : 0,
       "loc_name" : "Cub_1",
-      "fold_id" : 3
+      "fold_id" : {
+        "id" : 3
+      }
     }
   }, {
     "id" : 7,
@@ -59,10 +71,14 @@
       "name" : "StaCubic"
     },
     "attributeValues" : {
-      "obj_id" : 5,
+      "obj_id" : {
+        "id" : 5
+      },
       "obj_bus" : 1,
       "loc_name" : "Cub_1",
-      "fold_id" : 4
+      "fold_id" : {
+        "id" : 4
+      }
     }
   }, {
     "id" : 8,
@@ -72,7 +88,9 @@
     "attributeValues" : {
       "loc_name" : "Switch",
       "on_off" : 1,
-      "fold_id" : 6,
+      "fold_id" : {
+        "id" : 6
+      },
       "iUse" : 1
     }
   }, {
@@ -83,7 +101,9 @@
     "attributeValues" : {
       "loc_name" : "Switch",
       "on_off" : 1,
-      "fold_id" : 7,
+      "fold_id" : {
+        "id" : 7
+      },
       "iUse" : 1
     }
   }, {

--- a/powerfactory/powerfactory-dgs/src/test/resources/TwoBusesCommaAsDecimalSeparator.json
+++ b/powerfactory/powerfactory-dgs/src/test/resources/TwoBusesCommaAsDecimalSeparator.json
@@ -18,7 +18,9 @@
       "uknom" : 220.0,
       "iUsage" : 0,
       "loc_name" : "Busbar-A",
-      "fold_id" : 2
+      "fold_id" : {
+        "id" : 2
+      }
     }
   }, {
     "id" : 4,
@@ -29,7 +31,9 @@
       "uknom" : 220.0,
       "iUsage" : 0,
       "loc_name" : "Busbar-B",
-      "fold_id" : 2
+      "fold_id" : {
+        "id" : 2
+      }
     }
   }, {
     "id" : 5,
@@ -37,10 +41,14 @@
       "name" : "ElmLne"
     },
     "attributeValues" : {
-      "typ_id" : 10,
+      "typ_id" : {
+        "id" : 10
+      },
       "loc_name" : "Line-A-B",
       "dline" : 1.0,
-      "fold_id" : 2
+      "fold_id" : {
+        "id" : 2
+      }
     }
   }, {
     "id" : 6,
@@ -48,10 +56,14 @@
       "name" : "StaCubic"
     },
     "attributeValues" : {
-      "obj_id" : 5,
+      "obj_id" : {
+        "id" : 5
+      },
       "obj_bus" : 0,
       "loc_name" : "Cub_1",
-      "fold_id" : 3
+      "fold_id" : {
+        "id" : 3
+      }
     }
   }, {
     "id" : 7,
@@ -59,10 +71,14 @@
       "name" : "StaCubic"
     },
     "attributeValues" : {
-      "obj_id" : 5,
+      "obj_id" : {
+        "id" : 5
+      },
       "obj_bus" : 1,
       "loc_name" : "Cub_1",
-      "fold_id" : 4
+      "fold_id" : {
+        "id" : 4
+      }
     }
   }, {
     "id" : 8,
@@ -72,7 +88,9 @@
     "attributeValues" : {
       "loc_name" : "Switch",
       "on_off" : 1,
-      "fold_id" : 6,
+      "fold_id" : {
+        "id" : 6
+      },
       "iUse" : 1
     }
   }, {
@@ -83,7 +101,9 @@
     "attributeValues" : {
       "loc_name" : "Switch",
       "on_off" : 1,
-      "fold_id" : 7,
+      "fold_id" : {
+        "id" : 7
+      },
       "iUse" : 1
     }
   }, {

--- a/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObject.java
+++ b/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObject.java
@@ -404,14 +404,6 @@ public class DataObject {
         }
     }
 
-    public void traverseAndReference(Consumer<DataObject> handler) {
-        Objects.requireNonNull(handler);
-        handler.accept(this);
-        for (DataObject child : children) {
-            child.traverseAndReference(handler);
-        }
-    }
-
     public List<DataObject> search(String regex) {
         List<DataObject> result = new ArrayList<>();
         traverse(object -> {

--- a/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObject.java
+++ b/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObject.java
@@ -210,7 +210,10 @@ public class DataObject {
         return findObjectVectorAttributeValue(name).orElseThrow(() -> createAttributeNotFoundException("Object vector", name));
     }
 
-    public DataObject setObjectVectorAttributeValue(String name, List<DataObjectRef> value) {
+    public DataObject setObjectVectorAttributeValue(String name, List<Long> ids) {
+        List<DataObjectRef> value = Objects.requireNonNull(ids).stream()
+                .map(objId -> new DataObjectRef(objId, index))
+                .collect(Collectors.toList());
         setGenericAttributeValue(name, DataAttributeType.OBJECT_VECTOR, value);
         return this;
     }

--- a/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObjectIndex.java
+++ b/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObjectIndex.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.powerfactory.model;
+
+import java.util.*;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class DataObjectIndex {
+
+    private final Map<Long, DataObject> objectsById = new HashMap<>();
+
+    public void addDataObject(DataObject obj) {
+        Objects.requireNonNull(obj);
+        if (objectsById.containsKey(obj.getId())) {
+            throw new PowerFactoryException("Object '" + obj.getId() + "' already exists");
+        }
+        objectsById.put(obj.getId(), obj);
+    }
+
+    public Collection<DataObject> getDataObjects() {
+        return objectsById.values();
+    }
+
+    public Optional<DataObject> getDataObject(long id) {
+        return Optional.ofNullable(objectsById.get(id));
+    }
+}

--- a/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObjectIndex.java
+++ b/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObjectIndex.java
@@ -15,19 +15,28 @@ public class DataObjectIndex {
 
     private final Map<Long, DataObject> objectsById = new HashMap<>();
 
+    private final Map<String, List<DataObject>> objectsByClass = new HashMap<>();
+
     public void addDataObject(DataObject obj) {
         Objects.requireNonNull(obj);
         if (objectsById.containsKey(obj.getId())) {
             throw new PowerFactoryException("Object '" + obj.getId() + "' already exists");
         }
         objectsById.put(obj.getId(), obj);
+        objectsByClass.computeIfAbsent(obj.getDataClassName(), k -> new ArrayList<>())
+                .add(obj);
     }
 
     public Collection<DataObject> getDataObjects() {
         return objectsById.values();
     }
 
-    public Optional<DataObject> getDataObject(long id) {
+    public Optional<DataObject> getDataObjectById(long id) {
         return Optional.ofNullable(objectsById.get(id));
+    }
+
+    public List<DataObject> getDataObjectsByClass(String className) {
+        Objects.requireNonNull(className);
+        return objectsByClass.getOrDefault(className, Collections.emptyList());
     }
 }

--- a/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObjectRef.java
+++ b/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObjectRef.java
@@ -28,6 +28,6 @@ public class DataObjectRef {
     }
 
     public Optional<DataObject> resolve() {
-        return index.getDataObject(id);
+        return index.getDataObjectById(id);
     }
 }

--- a/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObjectRef.java
+++ b/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObjectRef.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.powerfactory.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class DataObjectRef {
+
+    private final long id;
+
+    private final DataObjectIndex index;
+
+    public DataObjectRef(long id, DataObjectIndex index) {
+        this.id = id;
+        this.index = Objects.requireNonNull(index);
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public Optional<DataObject> resolve() {
+        return index.getDataObject(id);
+    }
+}

--- a/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/StudyCase.java
+++ b/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/StudyCase.java
@@ -6,39 +6,30 @@
  */
 package com.powsybl.powerfactory.model;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Objects;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-
-@JsonIgnoreProperties({"time", "elmNets"})
+@JsonIgnoreProperties({"time", "index"})
 @JsonPropertyOrder({"name", "dataObjects"})
-
 public class StudyCase {
 
     private final String name;
 
     private final Instant time;
 
-    private final List<DataObject> elmNets;
+    private final DataObjectIndex index;
 
-    public StudyCase(String name, Instant time, List<DataObject> elmNets) {
+    public StudyCase(String name, Instant time, DataObjectIndex index) {
         this.name = Objects.requireNonNull(name);
         this.time = Objects.requireNonNull(time);
-        if (elmNets.isEmpty()) {
-            throw new IllegalArgumentException("Empty ElmNet list");
-        }
-        this.elmNets = Objects.requireNonNull(elmNets);
+        this.index = Objects.requireNonNull(index);
     }
 
     public String getName() {
@@ -49,21 +40,11 @@ public class StudyCase {
         return time;
     }
 
-    public List<DataObject> getElmNets() {
-        return elmNets;
+    public DataObjectIndex getIndex() {
+        return index;
     }
 
-    public List<DataObject> getDataObjects() {
-        Set<DataObject> dataObjectsSet = new HashSet<>();
-
-        for (DataObject elmNet : elmNets) {
-            elmNet.traverseAndReference(dataObjectsSet::add);
-        }
-        List<DataObject> dataObjects = new ArrayList<>();
-        dataObjects.addAll(dataObjectsSet);
-
-        Collections.sort(dataObjects, (do1, do2) -> ((Long) do1.getId()).compareTo(do2.getId()));
-
-        return dataObjects;
+    public Collection<DataObject> getDataObjects() {
+        return index.getDataObjects();
     }
 }

--- a/powerfactory/powerfactory-model/src/test/java/com/powsybl/powerfactory/model/DataObjectTest.java
+++ b/powerfactory/powerfactory-model/src/test/java/com/powsybl/powerfactory/model/DataObjectTest.java
@@ -50,8 +50,9 @@ public class DataObjectTest {
 
     @Test
     public void testObj() throws IOException {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo)
+        DataObject objFoo = new DataObject(0L, clsFoo, index)
                 .setLocName("foo");
         assertEquals(0L, objFoo.getId());
         assertSame(clsFoo, objFoo.getDataClass());
@@ -61,7 +62,7 @@ public class DataObjectTest {
         assertTrue(objFoo.getChildren().isEmpty());
 
         DataClass clsBar = DataClass.init("ElmBar");
-        DataObject objBar = new DataObject(1L, clsBar)
+        DataObject objBar = new DataObject(1L, clsBar, index)
                 .setLocName("bar");
         objFoo.setParent(objBar);
         assertEquals(1, objBar.getChildren().size());
@@ -88,8 +89,9 @@ public class DataObjectTest {
 
     @Test
     public void testStringAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findStringAttributeValue(DataAttribute.LOC_NAME).isPresent());
         objFoo.setStringAttributeValue(DataAttribute.LOC_NAME, "foo");
         assertEquals("foo", objFoo.getLocName());
@@ -106,8 +108,9 @@ public class DataObjectTest {
 
     @Test
     public void testIntAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findIntAttributeValue("i").isPresent());
         objFoo.setIntAttributeValue("i", 3);
         assertTrue(objFoo.findIntAttributeValue("i").isPresent());
@@ -119,8 +122,9 @@ public class DataObjectTest {
 
     @Test
     public void testLongAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findLongAttributeValue("l").isPresent());
         objFoo.setLongAttributeValue("l", 4L);
         assertTrue(objFoo.findLongAttributeValue("l").isPresent());
@@ -132,8 +136,9 @@ public class DataObjectTest {
 
     @Test
     public void testFloatAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findFloatAttributeValue("f").isPresent());
         objFoo.setFloatAttributeValue("f", 3.14f);
         assertTrue(objFoo.findFloatAttributeValue("f").isPresent());
@@ -145,8 +150,9 @@ public class DataObjectTest {
 
     @Test
     public void testDoubleAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findDoubleAttributeValue("d").isPresent());
         objFoo.setDoubleAttributeValue("d", 3.14d);
         assertTrue(objFoo.findDoubleAttributeValue("d").isPresent());
@@ -158,8 +164,9 @@ public class DataObjectTest {
 
     @Test
     public void testIntVectorAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findIntVectorAttributeValue("iv").isPresent());
         objFoo.setIntVectorAttributeValue("iv", List.of(3, 4));
         assertTrue(objFoo.findIntVectorAttributeValue("iv").isPresent());
@@ -171,8 +178,9 @@ public class DataObjectTest {
 
     @Test
     public void testFloatVectorAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findFloatVectorAttributeValue("fv").isPresent());
         objFoo.setFloatVectorAttributeValue("fv", List.of(3.1f, 4.1f));
         assertTrue(objFoo.findFloatVectorAttributeValue("fv").isPresent());
@@ -184,8 +192,9 @@ public class DataObjectTest {
 
     @Test
     public void testDoubleVectorAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findDoubleVectorAttributeValue("dv").isPresent());
         objFoo.setDoubleVectorAttributeValue("dv", List.of(3.2d, 4.2d));
         assertTrue(objFoo.findDoubleVectorAttributeValue("dv").isPresent());
@@ -197,8 +206,9 @@ public class DataObjectTest {
 
     @Test
     public void testMatrixVectorAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findMatrixAttributeValue("m").isPresent());
         objFoo.setMatrixAttributeValue("m", new BlockRealMatrix(2, 2));
         assertTrue(objFoo.findMatrixAttributeValue("m").isPresent());
@@ -210,8 +220,9 @@ public class DataObjectTest {
 
     @Test
     public void testInstantAttribute() {
+        DataObjectIndex index = new DataObjectIndex();
         DataClass clsFoo = createFooClass();
-        DataObject objFoo = new DataObject(0L, clsFoo);
+        DataObject objFoo = new DataObject(0L, clsFoo, index);
         assertFalse(objFoo.findInstantAttributeValue("i").isPresent());
         Instant time = Instant.parse("2021-10-30T09:35:25Z");
         objFoo.setInstantAttributeValue("i", time);

--- a/powerfactory/powerfactory-model/src/test/java/com/powsybl/powerfactory/model/StudyCaseTest.java
+++ b/powerfactory/powerfactory-model/src/test/java/com/powsybl/powerfactory/model/StudyCaseTest.java
@@ -9,6 +9,7 @@ package com.powsybl.powerfactory.model;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -25,20 +26,21 @@ public class StudyCaseTest {
                 .addAttribute(new DataAttribute("ref", DataAttributeType.INTEGER64));
         DataClass clsBar = DataClass.init("ElmBar");
 
-        DataObject objBar = new DataObject(2L, clsBar)
+        DataObjectIndex index = new DataObjectIndex();
+        DataObject objBar = new DataObject(2L, clsBar, index)
                 .setLocName("bar");
-        DataObject objFoo = new DataObject(1L, clsFoo)
+        DataObject objFoo = new DataObject(1L, clsFoo, index)
                 .setLocName("foo")
                 .setLongAttributeValue("ref", objBar.getId());
         Instant time = Instant.parse("2021-10-30T09:35:25Z");
-        DataObject elmNet = new DataObject(0L, new DataClass("ElmNet"));
-        StudyCase studyCase = new StudyCase("test", time, List.of(elmNet));
-        objBar.setStudyCase(studyCase);
-        objFoo.setStudyCase(studyCase);
+        DataClass clsNet = DataClass.init("ElmNet");
+        DataObject elmNet = new DataObject(0L, clsNet, index)
+                .setLocName("net");
+        StudyCase studyCase = new StudyCase("test", time, index);
 
         assertEquals("test", studyCase.getName());
         assertEquals(time, studyCase.getTime());
-        assertEquals(List.of(elmNet), studyCase.getElmNets());
-        assertSame(studyCase, objFoo.getStudyCase());
+        assertSame(index, objFoo.getIndex());
+        assertEquals(List.of(elmNet, objFoo, objBar), new ArrayList<>(studyCase.getIndex().getDataObjects()));
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Design fix


**What is the current behavior?** *(You can also link to an open issue here)*
When reading from DGS file, object reference are modeled by an INTEGER64 attribute, which is wrong. There are INTEGER64 attributes that are not object references and there is a dedicated type (see PF C++ API) for that.


**What is the new behavior (if this is a feature change)?**
A new `DataObjectRef`has been added to handled non resolved object references and a global data object index has also been added to allow reference resolving (and also avoid recomputing object index in converter).


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
