### PR TITLE
Bug fix: When looking for boundaries, all files inside the boundary location directory are considered

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -15,7 +15,6 @@ import com.powsybl.cgmes.model.CgmesModelFactory;
 import com.powsybl.cgmes.model.CgmesOnDataSource;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.datasource.DataSource;
-import com.powsybl.commons.datasource.DataSourceUtil;
 import com.powsybl.commons.datasource.GenericReadOnlyDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.util.ServiceLoaderCache;
@@ -129,7 +128,7 @@ public class CgmesImport implements Importer {
                         boundaryLocationParameter,
                         defaultValueConfig));
         // Check that the Data Source has valid CGMES names
-        ReadOnlyDataSource ds = new GenericReadOnlyDataSource(loc, DataSourceUtil.getBaseName(loc));
+        ReadOnlyDataSource ds = new GenericReadOnlyDataSource(loc);
         if ((new CgmesOnDataSource(ds)).names().isEmpty()) {
             return null;
         }

--- a/commons/src/main/java/com/powsybl/commons/datasource/GenericReadOnlyDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/GenericReadOnlyDataSource.java
@@ -30,6 +30,13 @@ public class GenericReadOnlyDataSource implements ReadOnlyDataSource {
         };
     }
 
+    /**
+     * The data source contains all files inside the given directory.
+     */
+    public GenericReadOnlyDataSource(Path directory) {
+        this(directory, "");
+    }
+
     public GenericReadOnlyDataSource(Path directory, String baseName) {
         this(directory, baseName, null);
     }


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix, following #1992 


**What is the current behavior?** *(You can also link to an open issue here)*
Boundaries files must have base name corresponding to their directory to be considered


**What is the new behavior (if this is a feature change)?**
All files inside boundary directory are considered for boundaries


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
