### PR TITLE
Fix: does not crash during CGMES export when a terminal is disconnected

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -387,7 +387,7 @@ public class CgmesExportContext {
                 boundaryId = CgmesExportUtil.getUniqueId();
                 c.addAlias(boundaryId, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + TERMINAL_BOUNDARY);
             }
-        } else if (c instanceof Load && ((Load) c).isFictitious()) {
+        } else if (c instanceof Load && c.isFictitious()) {
             // An fictitious load do not need an alias
         } else {
             int sequenceNumber = CgmesExportUtil.getTerminalSide(t, c);
@@ -600,6 +600,11 @@ public class CgmesExportContext {
 
     public Set<CgmesIidmMapping.CgmesTopologicalNode> getTopologicalNodesByBusViewBus(String busId) {
         return topologicalNodeByBusViewBusMapping.get(busId);
+    }
+
+    public CgmesExportContext putTopologicalNode(String iidmBusId, String cgmesId) {
+        topologicalNodeByBusViewBusMapping.computeIfAbsent(iidmBusId, k -> new HashSet<>()).add(new CgmesIidmMapping.CgmesTopologicalNode(cgmesId, cgmesId, Source.IGM));
+        return this;
     }
 
     public Set<CgmesIidmMapping.CgmesTopologicalNode> getUnmappedTopologicalNodes() {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -704,7 +704,7 @@ public final class EquipmentExport {
         if (terminal.getVoltageLevel().getTopologyKind().equals(TopologyKind.NODE_BREAKER)) {
             key = terminal.getVoltageLevel().getId() + terminal.getNodeBreakerView().getNode();
         } else {
-            key = terminal.getBusBreakerView().getBus().getId();
+            key = terminal.getBusBreakerView().getConnectableBus().getId();
         }
         return exportedNodes.get(key);
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
@@ -219,13 +219,17 @@ public final class TopologyExport {
     private static void writeHvdcTopologicalNodes(Network network, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
         for (HvdcLine line : network.getHvdcLines()) {
             Bus b1 = line.getConverterStation1().getTerminal().getBusView().getBus();
-            for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : context.getTopologicalNodesByBusViewBus(b1.getId())) {
-                writeDCTopologicalNode(topologicalNode.getCgmesId() + "DC", line.getNameOrId() + 1, cimNamespace, writer);
+            if (b1 != null) {
+                for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : context.getTopologicalNodesByBusViewBus(b1.getId())) {
+                    writeDCTopologicalNode(topologicalNode.getCgmesId() + "DC", line.getNameOrId() + 1, cimNamespace, writer);
+                }
             }
 
             Bus b2 = line.getConverterStation2().getTerminal().getBusView().getBus();
-            for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : context.getTopologicalNodesByBusViewBus(b2.getId())) {
-                writeDCTopologicalNode(topologicalNode.getCgmesId() + "DC", line.getNameOrId() + 2, cimNamespace, writer);
+            if (b2 != null) {
+                for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : context.getTopologicalNodesByBusViewBus(b2.getId())) {
+                    writeDCTopologicalNode(topologicalNode.getCgmesId() + "DC", line.getNameOrId() + 2, cimNamespace, writer);
+                }
             }
         }
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
@@ -129,7 +129,13 @@ public final class TopologyExport {
     }
 
     private static void writeHvdcBusTerminals(HvdcLine line, Bus bus, int side, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
-        for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : context.getTopologicalNodesByBusViewBus(bus.getId())) {
+        String iidmId;
+        if (bus == null) {
+            iidmId = line.getId() + side;
+        } else {
+            iidmId = bus.getId();
+        }
+        for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : context.getTopologicalNodesByBusViewBus(iidmId)) {
             String dcTopologicalNode = topologicalNode.getCgmesId() + "DC";
             String dcNode = line.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "DCNode" + side).orElseThrow(PowsyblException::new);
             writeDCNode(dcNode, dcTopologicalNode, cimNamespace, writer);
@@ -223,6 +229,10 @@ public final class TopologyExport {
                 for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : context.getTopologicalNodesByBusViewBus(b1.getId())) {
                     writeDCTopologicalNode(topologicalNode.getCgmesId() + "DC", line.getNameOrId() + 1, cimNamespace, writer);
                 }
+            } else {
+                String topologicalNode = CgmesExportUtil.getUniqueId();
+                context.putTopologicalNode(line.getId() + 1, topologicalNode);
+                writeDCTopologicalNode(topologicalNode + "DC", line.getNameOrId() + 1, cimNamespace, writer);
             }
 
             Bus b2 = line.getConverterStation2().getTerminal().getBusView().getBus();
@@ -230,7 +240,12 @@ public final class TopologyExport {
                 for (CgmesIidmMapping.CgmesTopologicalNode topologicalNode : context.getTopologicalNodesByBusViewBus(b2.getId())) {
                     writeDCTopologicalNode(topologicalNode.getCgmesId() + "DC", line.getNameOrId() + 2, cimNamespace, writer);
                 }
+            } else {
+                String topologicalNode = CgmesExportUtil.getUniqueId();
+                context.putTopologicalNode(line.getId() + 2, topologicalNode);
+                writeDCTopologicalNode(topologicalNode + "DC", line.getNameOrId() + 2, cimNamespace, writer);
             }
+
         }
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
@@ -92,8 +92,8 @@ public final class TopologyExport {
             Bus bus1;
             Bus bus2;
             if (vl.getTopologyKind() == TopologyKind.NODE_BREAKER) {
-                bus1 = Networks.getEquivalentTerminal(vl, vl.getNodeBreakerView().getNode1(sw.getId())).getBusView().getBus();
-                bus2 = Networks.getEquivalentTerminal(vl, vl.getNodeBreakerView().getNode2(sw.getId())).getBusView().getBus();
+                bus1 = Optional.ofNullable(Networks.getEquivalentTerminal(vl, vl.getNodeBreakerView().getNode1(sw.getId()))).map(t -> t.getBusView().getBus()).orElse(null);
+                bus2 = Optional.ofNullable(Networks.getEquivalentTerminal(vl, vl.getNodeBreakerView().getNode2(sw.getId()))).map(t -> t.getBusView().getBus()).orElse(null);
             } else {
                 bus1 = vl.getBusView().getMergedBus(vl.getBusBreakerView().getBus1(sw.getId()).getId());
                 bus2 = vl.getBusView().getMergedBus(vl.getBusBreakerView().getBus2(sw.getId()).getId());

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
@@ -11,9 +11,7 @@ import com.google.common.jimfs.Jimfs;
 import com.powsybl.commons.datasource.GenericReadOnlyDataSource;
 import com.powsybl.iidm.export.Exporters;
 import com.powsybl.iidm.import_.Importers;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.SwitchKind;
-import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
 import com.powsybl.iidm.network.util.Networks;
 import org.junit.Test;
@@ -31,20 +29,54 @@ import static org.junit.Assert.assertNull;
 public class CgmesExportTest {
 
     @Test
-    public void testFromIidm() throws IOException { // Test from IIDM with configuration that does not exist in CGMES (disconnected node)
+    public void testFromIidm() throws IOException {
+        // Test from IIDM with configuration that does not exist in CGMES (disconnected node on switch and HVDC line)
+
         Network network = FictitiousSwitchFactory.create();
-        network.getVoltageLevel("C").getNodeBreakerView().newSwitch().setId("TEST_SW")
+        VoltageLevel vl = network.getVoltageLevel("C");
+
+        // Add disconnected node on switch (side 2)
+        vl.getNodeBreakerView().newSwitch().setId("TEST_SW")
                 .setKind(SwitchKind.DISCONNECTOR)
                 .setOpen(true)
                 .setNode1(0)
                 .setNode2(6)
                 .add();
+
+        // Add disconnected node on DC converter station (side 2)
+        vl.newVscConverterStation()
+                .setId("C1")
+                .setNode(5)
+                .setLossFactor(1.1f)
+                .setVoltageSetpoint(405.0)
+                .setVoltageRegulatorOn(true)
+                .add();
+        vl.getNodeBreakerView().newInternalConnection().setNode1(0).setNode2(5).add();
+        vl.newVscConverterStation()
+                .setId("C2")
+                .setNode(6)
+                .setLossFactor(1.1f)
+                .setReactivePowerSetpoint(123)
+                .setVoltageRegulatorOn(false)
+                .add();
+        network.newHvdcLine()
+                .setId("hvdc_line")
+                .setR(5.0)
+                .setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)
+                .setNominalV(440.0)
+                .setMaxP(50.0)
+                .setActivePowerSetpoint(20.0)
+                .setConverterStationId1("C1")
+                .setConverterStationId2("C2")
+                .add();
+
         try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
             Path tmpDir = Files.createDirectory(fs.getPath("/cgmes"));
             Exporters.export("CGMES", network, null, tmpDir.resolve("tmp"));
             Network n2 = Importers.loadNetwork(new GenericReadOnlyDataSource(tmpDir, "tmp"));
             VoltageLevel c = n2.getVoltageLevel("C");
             assertNull(Networks.getEquivalentTerminal(c, c.getNodeBreakerView().getNode2("TEST_SW")));
+            assertNull(n2.getVscConverterStation("C2").getTerminal().getBusView().getBus());
         }
     }
 }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertNull;
 public class CgmesExportTest {
 
     @Test
-    public void testFromIidm() throws IOException {
+    public void testFromIidm() throws IOException { // Test from IIDM with configuration that does not exist in CGMES (disconnected node)
         Network network = FictitiousSwitchFactory.create();
         network.getVoltageLevel("C").getNodeBreakerView().newSwitch().setId("TEST_SW")
                 .setKind(SwitchKind.DISCONNECTOR)

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.test.export;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.datasource.GenericReadOnlyDataSource;
+import com.powsybl.iidm.export.Exporters;
+import com.powsybl.iidm.import_.Importers;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
+import com.powsybl.iidm.network.util.Networks;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+public class CgmesExportTest {
+
+    @Test
+    public void testFromIidm() throws IOException {
+        Network network = FictitiousSwitchFactory.create();
+        network.getVoltageLevel("C").getNodeBreakerView().newSwitch().setId("TEST_SW")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setOpen(true)
+                .setNode1(0)
+                .setNode2(6)
+                .add();
+        try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
+            Path tmpDir = Files.createDirectory(fs.getPath("/cgmes"));
+            Exporters.export("CGMES", network, null, tmpDir.resolve("tmp"));
+            Network n2 = Importers.loadNetwork(new GenericReadOnlyDataSource(tmpDir, "tmp"));
+            VoltageLevel c = n2.getVoltageLevel("C");
+            assertNull(Networks.getEquivalentTerminal(c, c.getNodeBreakerView().getNode2("TEST_SW")));
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix


**What is the current behavior?** *(You can also link to an open issue here)*
An exception is thrown when there is no bus of the bus view at both ends of a switch.


**What is the new behavior (if this is a feature change)?**
A fictitious topological node is created.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
