### PR TITLE
Propagate Cancel to CompletableFutureTask (kill external process of localcomputationmanager)

### DIFF
--- a/computation/src/main/java/com/powsybl/computation/CompletableFutureTask.java
+++ b/computation/src/main/java/com/powsybl/computation/CompletableFutureTask.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.computation;
 
+import java.util.Objects;
 import java.util.concurrent.*;
 
 /**
@@ -96,10 +97,10 @@ public class CompletableFutureTask<R> extends CompletableFuture<R> implements Ru
      * @author Jon Harper <jon.harper at rte-france.com>
      */
     static class SourceCancelingCompletableFuture<T> extends CompletableFuture<T> {
-        CompletableFuture<?> source;
+        private final CompletableFuture<?> source;
 
         public SourceCancelingCompletableFuture(CompletableFuture<?> source) {
-            this.source = source;
+            this.source = Objects.requireNonNull(source);
         }
 
         @Override

--- a/computation/src/main/java/com/powsybl/computation/CompletableFutureTask.java
+++ b/computation/src/main/java/com/powsybl/computation/CompletableFutureTask.java
@@ -88,4 +88,17 @@ public class CompletableFutureTask<R> extends CompletableFuture<R> implements Ru
         return super.cancel(mayInterruptIfRunning) && future.cancel(mayInterruptIfRunning);
     }
 
+    /**
+     * Helps propagate back cancellation from one future to another,
+     * typically from a future exposed to the user, to an inner future which is
+     * actually linked to an actual task.
+     */
+    public static <T> CompletableFuture<T> propagateCancel(CompletableFuture<T> from, CompletableFuture<?> to) {
+        from.whenComplete((res, exc) -> {
+            if (exc instanceof CancellationException) {
+                to.cancel(true);
+            }
+        });
+        return from;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
BugFix / Feature


**What is the current behavior?** *(You can also link to an open issue here)*
calling cancel(true) on the CompletableFuture returned by the SecurityAnalysis API (probably other APIs too) do not kill the external process (when using an implementation based on LocalComputationManager)


**What is the new behavior (if this is a feature change)?**
kills the external process.
Calling cancel() multiple times now returns true only for the one time that cause a cancel. (it was already the case in some paths of the code, just not all of them)

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No
