### PR TITLE
Fix file leak when reading DGS file

### DIFF
--- a/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsStudyCaseLoader.java
+++ b/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsStudyCaseLoader.java
@@ -11,8 +11,7 @@ import com.google.common.io.Files;
 import com.powsybl.powerfactory.model.StudyCase;
 import com.powsybl.powerfactory.model.StudyCaseLoader;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -27,12 +26,21 @@ public class DgsStudyCaseLoader implements StudyCaseLoader {
 
     @Override
     public boolean test(InputStream is) {
+        try {
+            is.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         return true;
     }
 
     @Override
     public StudyCase doLoad(String fileName, InputStream is) {
         String studyCaseName = Files.getNameWithoutExtension(fileName);
-        return new DgsReader().read(studyCaseName, new InputStreamReader(is));
+        try (Reader reader = new InputStreamReader(is)) {
+            return new DgsReader().read(studyCaseName, reader);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsStudyCaseLoader.java
+++ b/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsStudyCaseLoader.java
@@ -11,7 +11,8 @@ import com.google.common.io.Files;
 import com.powsybl.powerfactory.model.StudyCase;
 import com.powsybl.powerfactory.model.StudyCaseLoader;
 
-import java.io.*;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -26,21 +27,12 @@ public class DgsStudyCaseLoader implements StudyCaseLoader {
 
     @Override
     public boolean test(InputStream is) {
-        try {
-            is.close();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
         return true;
     }
 
     @Override
     public StudyCase doLoad(String fileName, InputStream is) {
         String studyCaseName = Files.getNameWithoutExtension(fileName);
-        try (Reader reader = new InputStreamReader(is)) {
-            return new DgsReader().read(studyCaseName, reader);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return new DgsReader().read(studyCaseName, new InputStreamReader(is));
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When reading a DGS file, 2 ÌnputStream`are created but never closed.


**What is the new behavior (if this is a feature change)?**
All ÌnputStream` are correctly closed.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
