### PR TITLE
PowerFactory: GeneratorConverter

### DIFF
--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/AbstractConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/AbstractConverter.java
@@ -21,6 +21,8 @@ import java.util.Objects;
  */
 public abstract class AbstractConverter {
 
+    static final String TYP_ID = "typ_id";
+
     private final ImportContext importContext;
 
     private final Network network;

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/AbstractConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/AbstractConverter.java
@@ -21,8 +21,6 @@ import java.util.Objects;
  */
 public abstract class AbstractConverter {
 
-    static final String TYP_ID = "typ_id";
-
     private final ImportContext importContext;
 
     private final Network network;

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
@@ -115,11 +115,8 @@ final class ContainersMappingHelper {
                 }
             }
 
-            if (voltageLevelId == null) { // automatic naming
-                return "VL" + noNameVoltageLevelCount++;
-            }
-
-            return voltageLevelId;
+            // automatic naming
+            return Objects.requireNonNullElseGet(voltageLevelId, () -> "VL" + noNameVoltageLevelCount++);
         }
     }
 

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/DataAttributeNames.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/DataAttributeNames.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.powerfactory.converter;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author José Antonio Marqués <marquesja at aia.es>
+ */
+
+final class DataAttributeNames {
+
+    private DataAttributeNames() {
+    }
+
+    static final String TYP_ID = "typ_id";
+}

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.powerfactory.converter;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.powerfactory.converter.PowerFactoryImporter.ImportContext;
+import com.powsybl.powerfactory.converter.PowerFactoryImporter.NodeRef;
+import com.powsybl.powerfactory.model.DataObject;
+import com.powsybl.powerfactory.model.DataObjectRef;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author José Antonio Marqués <marquesja at aia.es>
+ */
+
+class GeneratorConverter extends AbstractConverter {
+
+    GeneratorConverter(ImportContext importContext, Network network) {
+        super(importContext, network);
+    }
+
+    void create(DataObject elmSym) {
+        NodeRef nodeRef = checkNodes(elmSym, 1).get(0);
+        GeneratorModel generatorModel = GeneratorModel.create(elmSym);
+
+        VoltageLevel vl = getNetwork().getVoltageLevel(nodeRef.voltageLevelId);
+        Generator g = vl.newGenerator()
+            .setId(elmSym.getLocName())
+            .setEnsureIdUnicity(true)
+            .setNode(nodeRef.node)
+            .setTargetP(generatorModel.targetP)
+            .setTargetQ(generatorModel.targetQ)
+            .setTargetV(generatorModel.targetVpu * vl.getNominalV())
+            .setVoltageRegulatorOn(generatorModel.voltageRegulatorOn)
+            .setMinP(generatorModel.minP)
+            .setMaxP(generatorModel.maxP)
+            .add();
+        if (generatorModel.isDisconnected) {
+            g.getTerminal().disconnect();
+        }
+        Optional<ReactiveLimits> reactiveLimits = ReactiveLimits.create(elmSym);
+        if (reactiveLimits.isPresent()) {
+            g.newMinMaxReactiveLimits()
+                .setMinQ(reactiveLimits.get().minQ)
+                .setMaxQ(reactiveLimits.get().maxQ)
+                .add();
+        }
+    }
+
+    static class GeneratorModel {
+        private final boolean isDisconnected;
+        private final double targetP;
+        private final double targetQ;
+        private final double targetVpu;
+        private final boolean voltageRegulatorOn;
+        private final double minP;
+        private final double maxP;
+
+        GeneratorModel(boolean isDisconnected, double targetP, double targetQ, double targetVpu, boolean voltageRegulatorOn, double minP, double maxP) {
+            this.isDisconnected = isDisconnected;
+            this.targetP = targetP;
+            this.targetQ = targetQ;
+            this.targetVpu = targetVpu;
+            this.voltageRegulatorOn = voltageRegulatorOn;
+            this.minP = minP;
+            this.maxP = maxP;
+        }
+
+        static GeneratorModel create(DataObject elmSym) {
+            boolean isDisconnected = disconnected(elmSym);
+            boolean voltageRegulatorOn = voltageRegulatorOn(elmSym);
+
+            float pgini = elmSym.getFloatAttributeValue("pgini");
+            float qgini = elmSym.getFloatAttributeValue("qgini");
+            double usetp = elmSym.getFloatAttributeValue("usetp");
+            double pMinUc = minP(elmSym, pgini);
+            double pMaxUc = maxP(elmSym, pgini);
+
+            return new GeneratorModel(isDisconnected, pgini, qgini, usetp, voltageRegulatorOn, pMinUc, pMaxUc);
+        }
+
+        private static boolean disconnected(DataObject elmSym) {
+            OptionalInt outserv = elmSym.findIntAttributeValue("outserv");
+            if (outserv.isPresent()) {
+                return outserv.getAsInt() == 1;
+            }
+            return false;
+        }
+
+        private static boolean voltageRegulatorOn(DataObject elmSym) {
+            OptionalInt ivMode = elmSym.findIntAttributeValue("iv_mode");
+            if (ivMode.isPresent()) {
+                return ivMode.getAsInt() == 1;
+            }
+            Optional<String> avMode = elmSym.findStringAttributeValue("av_mode");
+            if (avMode.isPresent()) {
+                return avMode.get().equals("constv");
+            }
+            return false;
+        }
+
+        private static double minP(DataObject elmSym, double p) {
+            Optional<Float> pMinUc = elmSym.findFloatAttributeValue("Pmin_uc");
+            if (pMinUc.isPresent()) {
+                return pMinUc.get();
+            }
+            if (p < 0.0) {
+                return p;
+            }
+            return 0.0;
+        }
+
+        private static double maxP(DataObject elmSym, double p) {
+            Optional<Float> pMaxUc = elmSym.findFloatAttributeValue("Pmax_uc");
+            if (pMaxUc.isPresent()) {
+                return pMaxUc.get();
+            }
+            if (p > 0.0) {
+                return p;
+            }
+            return 0.0;
+        }
+    }
+
+    static class ReactiveLimits {
+        private final double minQ;
+        private final double maxQ;
+
+        ReactiveLimits(double minQ, double maxQ) {
+            this.minQ = minQ;
+            this.maxQ = maxQ;
+        }
+
+        static Optional<ReactiveLimits> create(DataObject elmSym) {
+            Optional<DataObject> pQlimType = elmSym.findObjectAttributeValue("pQlimType").flatMap(DataObjectRef::resolve);
+            if (pQlimType.isPresent()) {
+                throw new PowsyblException("Reactive capability curve not supported: '" + elmSym + "'");
+            }
+            Optional<DataObject> typSym = elmSym.findObjectAttributeValue(TYP_ID).flatMap(DataObjectRef::resolve);
+            if (typSym.isPresent()) {
+                return create(elmSym, typSym.get());
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        private static Optional<ReactiveLimits> create(DataObject elmSym, DataObject typSym) {
+
+            OptionalInt iqtype = elmSym.findIntAttributeValue("iqtype");
+            Optional<Float> qMinPuElm = elmSym.findFloatAttributeValue("q_min");
+            Optional<Float> qMaxPuElm = elmSym.findFloatAttributeValue("q_max");
+            Optional<Float> qMinPuTyp = typSym.findFloatAttributeValue("q_min");
+            Optional<Float> qMaxPuTyp = typSym.findFloatAttributeValue("q_max");
+            Optional<Float> sgn = typSym.findFloatAttributeValue("sgn");
+            Optional<Float> qMinMvar = typSym.findFloatAttributeValue("Q_min");
+            Optional<Float> qMaxMvar = typSym.findFloatAttributeValue("Q_max");
+
+            // Reactive limits form Elm
+            double qMinElm = Double.NaN;
+            double qMaxElm = Double.NaN;
+            if (qMinPuElm.isPresent() && qMaxPuElm.isPresent() && sgn.isPresent()) {
+                qMinElm = qMinPuElm.get() * sgn.get();
+                qMaxElm = qMaxPuElm.get() * sgn.get();
+            }
+            // Reactive limits from Typ
+            double qMinTyp = Double.NaN;
+            double qMaxTyp = Double.NaN;
+            if (qMinMvar.isPresent() && qMaxMvar.isPresent()) {
+                qMinTyp = qMinMvar.get();
+                qMaxTyp = qMaxMvar.get();
+            } else if (qMinPuTyp.isPresent() && qMaxPuTyp.isPresent() && sgn.isPresent()) {
+                qMinTyp = qMinPuTyp.get() * sgn.get();
+                qMaxTyp = qMaxPuTyp.get() * sgn.get();
+            }
+
+            if (iqtype.isPresent() && iqtype.getAsInt() == 0 && !Double.isNaN(qMinElm) && !Double.isNaN(qMaxElm)) {
+                return Optional.of(new ReactiveLimits(qMinElm, qMaxElm));
+            }
+            if (iqtype.isPresent() && iqtype.getAsInt() != 0 && !Double.isNaN(qMinTyp) && !Double.isNaN(qMaxTyp)) {
+                return Optional.of(new ReactiveLimits(qMinTyp, qMaxTyp));
+            }
+            if (!Double.isNaN(qMinElm) && !Double.isNaN(qMaxElm)) {
+                return Optional.of(new ReactiveLimits(qMinElm, qMaxElm));
+            }
+            if (!Double.isNaN(qMinTyp) && !Double.isNaN(qMaxTyp)) {
+                return Optional.of(new ReactiveLimits(qMinTyp, qMaxTyp));
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
@@ -45,9 +45,6 @@ class GeneratorConverter extends AbstractConverter {
             .setMinP(generatorModel.minP)
             .setMaxP(generatorModel.maxP)
             .add();
-        if (generatorModel.isDisconnected) {
-            g.getTerminal().disconnect();
-        }
         Optional<ReactiveLimits> reactiveLimits = ReactiveLimits.create(elmSym);
         if (reactiveLimits.isPresent()) {
             g.newMinMaxReactiveLimits()
@@ -58,7 +55,6 @@ class GeneratorConverter extends AbstractConverter {
     }
 
     static class GeneratorModel {
-        private final boolean isDisconnected;
         private final double targetP;
         private final double targetQ;
         private final double targetVpu;
@@ -66,8 +62,7 @@ class GeneratorConverter extends AbstractConverter {
         private final double minP;
         private final double maxP;
 
-        GeneratorModel(boolean isDisconnected, double targetP, double targetQ, double targetVpu, boolean voltageRegulatorOn, double minP, double maxP) {
-            this.isDisconnected = isDisconnected;
+        GeneratorModel(double targetP, double targetQ, double targetVpu, boolean voltageRegulatorOn, double minP, double maxP) {
             this.targetP = targetP;
             this.targetQ = targetQ;
             this.targetVpu = targetVpu;
@@ -77,7 +72,6 @@ class GeneratorConverter extends AbstractConverter {
         }
 
         static GeneratorModel create(DataObject elmSym) {
-            boolean isDisconnected = disconnected(elmSym);
             boolean voltageRegulatorOn = voltageRegulatorOn(elmSym);
 
             float pgini = elmSym.getFloatAttributeValue("pgini");
@@ -86,15 +80,7 @@ class GeneratorConverter extends AbstractConverter {
             double pMinUc = minP(elmSym, pgini);
             double pMaxUc = maxP(elmSym, pgini);
 
-            return new GeneratorModel(isDisconnected, pgini, qgini, usetp, voltageRegulatorOn, pMinUc, pMaxUc);
-        }
-
-        private static boolean disconnected(DataObject elmSym) {
-            OptionalInt outserv = elmSym.findIntAttributeValue("outserv");
-            if (outserv.isPresent()) {
-                return outserv.getAsInt() == 1;
-            }
-            return false;
+            return new GeneratorModel(pgini, qgini, usetp, voltageRegulatorOn, pMinUc, pMaxUc);
         }
 
         private static boolean voltageRegulatorOn(DataObject elmSym) {

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
@@ -132,7 +132,7 @@ class GeneratorConverter extends AbstractConverter {
             if (pQlimType.isPresent()) {
                 throw new PowsyblException("Reactive capability curve not supported: '" + elmSym + "'");
             }
-            Optional<DataObject> typSym = elmSym.findObjectAttributeValue(TYP_ID).flatMap(DataObjectRef::resolve);
+            Optional<DataObject> typSym = elmSym.findObjectAttributeValue(DataAttributeNames.TYP_ID).flatMap(DataObjectRef::resolve);
             if (typSym.isPresent()) {
                 return create(elmSym, typSym.get());
             } else {

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/LineConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/LineConverter.java
@@ -69,7 +69,7 @@ class LineConverter extends AbstractConverter {
         }
 
         static Optional<LineModel> createFromTypLne(DataObject elmLne) {
-            return elmLne.findObjectAttributeValue(TYP_ID).flatMap(DataObjectRef::resolve).map(typLne -> typeLneModel(elmLne, typLne));
+            return elmLne.findObjectAttributeValue(DataAttributeNames.TYP_ID).flatMap(DataObjectRef::resolve).map(typLne -> typeLneModel(elmLne, typLne));
         }
 
         private static LineModel typeLneModel(DataObject elmLne, DataObject typLne) {

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/LineConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/LineConverter.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.powerfactory.converter.PowerFactoryImporter.ImportContext;
 import com.powsybl.powerfactory.converter.PowerFactoryImporter.NodeRef;
 import com.powsybl.powerfactory.model.DataObject;
+import com.powsybl.powerfactory.model.DataObjectRef;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,13 +22,11 @@ import java.util.Optional;
 
 class LineConverter extends AbstractConverter {
 
-    private static final String TYP_ID = "typ_id";
-
     LineConverter(ImportContext importContext, Network network) {
         super(importContext, network);
     }
 
-    void createFromElmLne(DataObject elmLne) {
+    void create(DataObject elmLne) {
         List<NodeRef> nodeRefs = checkNodes(elmLne, 2);
         Optional<LineModel> lineModel = LineModel.createFromTypLne(elmLne);
         if (lineModel.isEmpty()) {
@@ -70,7 +69,7 @@ class LineConverter extends AbstractConverter {
         }
 
         static Optional<LineModel> createFromTypLne(DataObject elmLne) {
-            return elmLne.getObjectAttributeValue(TYP_ID).resolve().map(typLne -> typeLneModel(elmLne, typLne));
+            return elmLne.findObjectAttributeValue(TYP_ID).flatMap(DataObjectRef::resolve).map(typLne -> typeLneModel(elmLne, typLne));
         }
 
         private static LineModel typeLneModel(DataObject elmLne, DataObject typLne) {

--- a/powerfactory/powerfactory-converter/src/test/java/com/powsybl/powerfactory/converter/PowerFactoryImporterTest.java
+++ b/powerfactory/powerfactory-converter/src/test/java/com/powsybl/powerfactory/converter/PowerFactoryImporterTest.java
@@ -131,4 +131,19 @@ public class PowerFactoryImporterTest extends AbstractConverterTest {
     public void twoBusesGeneratorWithoutIqtypeTest() {
         assertTrue(importAndCompareXml("TwoBusesGeneratorWithoutIqtype"));
     }
+
+    @Test
+    public void twoBusesGeneratorElmReactiveLimits() {
+        assertTrue(importAndCompareXml("TwoBusesGeneratorElmReactiveLimits"));
+    }
+
+    @Test
+    public void twoBusesGeneratorTypReactiveLimits() {
+        assertTrue(importAndCompareXml("TwoBusesGeneratorTypReactiveLimits"));
+    }
+
+    @Test
+    public void twoBusesGeneratorTypMvarReactiveLimits() {
+        assertTrue(importAndCompareXml("TwoBusesGeneratorTypMvarReactiveLimits"));
+    }
 }

--- a/powerfactory/powerfactory-converter/src/test/java/com/powsybl/powerfactory/converter/PowerFactoryImporterTest.java
+++ b/powerfactory/powerfactory-converter/src/test/java/com/powsybl/powerfactory/converter/PowerFactoryImporterTest.java
@@ -101,4 +101,34 @@ public class PowerFactoryImporterTest extends AbstractConverterTest {
     public void twoBusesLineWithCTest() {
         assertTrue(importAndCompareXml("TwoBusesLineWithC"));
     }
+
+    @Test
+    public void twoBusesGeneratorTest() {
+        assertTrue(importAndCompareXml("TwoBusesGenerator"));
+    }
+
+    @Test
+    public void twoBusesGeneratorWithoutIvmodeTest() {
+        assertTrue(importAndCompareXml("TwoBusesGeneratorWithoutIvmode"));
+    }
+
+    @Test
+    public void twoBusesGeneratorAvmodeTest() {
+        assertTrue(importAndCompareXml("TwoBusesGeneratorAvmode"));
+    }
+
+    @Test
+    public void twoBusesGeneratorWithoutActiveLimitsTest() {
+        assertTrue(importAndCompareXml("TwoBusesGeneratorWithoutActiveLimits"));
+    }
+
+    @Test
+    public void twoBusesGeneratorIqtypeTest() {
+        assertTrue(importAndCompareXml("TwoBusesGeneratorIqtype"));
+    }
+
+    @Test
+    public void twoBusesGeneratorWithoutIqtypeTest() {
+        assertTrue(importAndCompareXml("TwoBusesGeneratorWithoutIqtype"));
+    }
 }

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.dgs
@@ -9,16 +9,22 @@ $$ElmTerm;ID(a:40);loc_name(a:40);fold_id(p);iUsage(i);uknom(r)
  4;Busbar-B;2;0;220
 
 $$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
-  5;lne_A_B_1;;2;10;1;1;0;0;1;0
+  5;lne_A_B_1;;2;12;1;1;0;0;1;0
+
+$$ElmSym;ID(a:40);loc_name(a:40);fold_id(p);typ_id(p);ngnum(i);i_mot(i);chr_name(a:20);outserv(i);pgini(r);qgini(r);usetp(r);iv_mode(i);q_min(r);q_max(r);Pmin_uc(r);Pmax_uc(r);iqtype(i)
+  6;sym_B_1;2;13;1;0;;0;25;10;1,02;1;-1,1;1,2;0;250;0
 
 $$StaCubic;ID(a:40);loc_name(a:40);fold_id(p);chr_name(a:20);obj_id(p);obj_bus(i)
- 6;Cub_1;3;;5;0
- 7;Cub_1;4;;5;1
+ 7;Cub_1;3;;5;0
+ 8;Cub_1;4;;5;1
+ 9;Cub_2;4;;6;0
 
 $$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
- 8;Switch;6;1;1
- 9;Switch;7;1;1
+ 10;Switch;7;1;1
+ 11;Switch;8;1;1
 
 $$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
-  10;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
+  12;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
 
+$$TypSym;ID(a:40);loc_name(a:40);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);Q_min(r);Q_max(r);q_min(r);q_max(r)
+  13;tsym_B_1;220;100;2;1;2;2;1;0;1,2;0;-100;100;-1;1

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.xiidm
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorActiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S2">
+        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:internalConnection node1="0" node2="2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="-110.0" maxQ="120.00000762939453"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.xiidm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorActiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGenerator" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="S2">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAvmode.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAvmode.dgs
@@ -9,16 +9,22 @@ $$ElmTerm;ID(a:40);loc_name(a:40);fold_id(p);iUsage(i);uknom(r)
  4;Busbar-B;2;0;220
 
 $$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
-  5;lne_A_B_1;;2;10;1;1;0;0;1;0
+  5;lne_A_B_1;;2;12;1;1;0;0;1;0
+
+$$ElmSym;ID(a:40);loc_name(a:40);fold_id(p);typ_id(p);ngnum(i);i_mot(i);chr_name(a:20);outserv(i);pgini(r);qgini(r);usetp(r);av_mode(a);q_min(r);q_max(r);Pmin_uc(r);Pmax_uc(r);iqtype(i)
+  6;sym_B_1;2;13;1;0;;0;25;10;1,02;constv;-1,1;1,2;0;250;0
 
 $$StaCubic;ID(a:40);loc_name(a:40);fold_id(p);chr_name(a:20);obj_id(p);obj_bus(i)
- 6;Cub_1;3;;5;0
- 7;Cub_1;4;;5;1
+ 7;Cub_1;3;;5;0
+ 8;Cub_1;4;;5;1
+ 9;Cub_2;4;;6;0
 
 $$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
- 8;Switch;6;1;1
- 9;Switch;7;1;1
+ 10;Switch;7;1;1
+ 11;Switch;8;1;1
 
 $$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
-  10;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
+  12;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
 
+$$TypSym;ID(a:40);loc_name(a:40);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);Q_min(r);Q_max(r);q_min(r);q_max(r)
+  13;tsym_B_1;220;100;2;1;2;2;1;0;1,2;0;-100;100;-1;1

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAvmode.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAvmode.xiidm
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorAvmode" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S2">
+        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:internalConnection node1="0" node2="2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="-110.0" maxQ="120.00000762939453"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorElmReactiveLimits.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorElmReactiveLimits.dgs
@@ -1,0 +1,30 @@
+$$General;ID(a:40);Descr(a:40);Val(a:40)
+ 1;Version;5.0
+
+$$ElmNet;ID(a:40);loc_name(a:40);fold_id(p);frnom(r)
+ 2;MS;;50
+
+$$ElmTerm;ID(a:40);loc_name(a:40);fold_id(p);iUsage(i);uknom(r)
+ 3;Busbar-A;2;0;220
+ 4;Busbar-B;2;0;220
+
+$$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
+  5;lne_A_B_1;;2;12;1;1;0;0;1;0
+
+$$ElmSym;ID(a:40);loc_name(a:40);fold_id(p);typ_id(p);ngnum(i);i_mot(i);chr_name(a:20);outserv(i);pgini(r);qgini(r);usetp(r);iv_mode(i);q_min(r);q_max(r);Pmin_uc(r);Pmax_uc(r)
+  6;sym_B_1;2;13;1;0;;0;25;10;1,02;1;-1,1;1,2;0;250
+
+$$StaCubic;ID(a:40);loc_name(a:40);fold_id(p);chr_name(a:20);obj_id(p);obj_bus(i)
+ 7;Cub_1;3;;5;0
+ 8;Cub_1;4;;5;1
+ 9;Cub_2;4;;6;0
+
+$$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
+ 10;Switch;7;1;1
+ 11;Switch;8;1;1
+
+$$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
+  12;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
+
+$$TypSym;ID(a:40);loc_name(a:40);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i)
+  13;tsym_B_1;220;100;2;1;2;2;1;0;1,2;0

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorElmReactiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorElmReactiveLimits.xiidm
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorElmReactiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S2">
+        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:internalConnection node1="0" node2="2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="-110.0" maxQ="120.00000762939453"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorIqtype.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorIqtype.dgs
@@ -9,16 +9,22 @@ $$ElmTerm;ID(a:40);loc_name(a:40);fold_id(p);iUsage(i);uknom(r)
  4;Busbar-B;2;0;220
 
 $$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
-  5;lne_A_B_1;;2;10;1;1;0;0;1;0
+  5;lne_A_B_1;;2;12;1;1;0;0;1;0
+
+$$ElmSym;ID(a:40);loc_name(a:40);fold_id(p);typ_id(p);ngnum(i);i_mot(i);chr_name(a:20);outserv(i);pgini(r);qgini(r);usetp(r);iv_mode(i);q_min(r);q_max(r);Pmin_uc(r);Pmax_uc(r);iqtype(i)
+  6;sym_B_1;2;13;1;0;;0;25;10;1,02;1;-1,1;1,2;0;250;1
 
 $$StaCubic;ID(a:40);loc_name(a:40);fold_id(p);chr_name(a:20);obj_id(p);obj_bus(i)
- 6;Cub_1;3;;5;0
- 7;Cub_1;4;;5;1
+ 7;Cub_1;3;;5;0
+ 8;Cub_1;4;;5;1
+ 9;Cub_2;4;;6;0
 
 $$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
- 8;Switch;6;1;1
- 9;Switch;7;1;1
+ 10;Switch;7;1;1
+ 11;Switch;8;1;1
 
 $$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
-  10;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
+  12;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
 
+$$TypSym;ID(a:40);loc_name(a:40);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);Q_min(r);Q_max(r);q_min(r);q_max(r)
+  13;tsym_B_1;220;100;2;1;2;2;1;0;1,2;0;-100;100;-1;1

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorIqtype.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorIqtype.xiidm
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorIqtype" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S2">
+        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:internalConnection node1="0" node2="2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="-100.0" maxQ="100.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypMvarReactiveLimits.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypMvarReactiveLimits.dgs
@@ -1,0 +1,30 @@
+$$General;ID(a:40);Descr(a:40);Val(a:40)
+ 1;Version;5.0
+
+$$ElmNet;ID(a:40);loc_name(a:40);fold_id(p);frnom(r)
+ 2;MS;;50
+
+$$ElmTerm;ID(a:40);loc_name(a:40);fold_id(p);iUsage(i);uknom(r)
+ 3;Busbar-A;2;0;220
+ 4;Busbar-B;2;0;220
+
+$$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
+  5;lne_A_B_1;;2;12;1;1;0;0;1;0
+
+$$ElmSym;ID(a:40);loc_name(a:40);fold_id(p);typ_id(p);ngnum(i);i_mot(i);chr_name(a:20);outserv(i);pgini(r);qgini(r);usetp(r);iv_mode(i);Pmin_uc(r);Pmax_uc(r)
+  6;sym_B_1;2;13;1;0;;0;25;10;1,02;1;0;250
+
+$$StaCubic;ID(a:40);loc_name(a:40);fold_id(p);chr_name(a:20);obj_id(p);obj_bus(i)
+ 7;Cub_1;3;;5;0
+ 8;Cub_1;4;;5;1
+ 9;Cub_2;4;;6;0
+
+$$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
+ 10;Switch;7;1;1
+ 11;Switch;8;1;1
+
+$$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
+  12;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
+
+$$TypSym;ID(a:40);loc_name(a:40);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);Q_min(r);Q_max(r)
+  13;tsym_B_1;220;100;2;1;2;2;1;0;1,2;0;-100;100

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypMvarReactiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypMvarReactiveLimits.xiidm
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorTypMvarReactiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S2">
+        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:internalConnection node1="0" node2="2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="-100.0" maxQ="100.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypReactiveLimits.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypReactiveLimits.dgs
@@ -1,0 +1,30 @@
+$$General;ID(a:40);Descr(a:40);Val(a:40)
+ 1;Version;5.0
+
+$$ElmNet;ID(a:40);loc_name(a:40);fold_id(p);frnom(r)
+ 2;MS;;50
+
+$$ElmTerm;ID(a:40);loc_name(a:40);fold_id(p);iUsage(i);uknom(r)
+ 3;Busbar-A;2;0;220
+ 4;Busbar-B;2;0;220
+
+$$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
+  5;lne_A_B_1;;2;12;1;1;0;0;1;0
+
+$$ElmSym;ID(a:40);loc_name(a:40);fold_id(p);typ_id(p);ngnum(i);i_mot(i);chr_name(a:20);outserv(i);pgini(r);qgini(r);usetp(r);iv_mode(i);Pmin_uc(r);Pmax_uc(r)
+  6;sym_B_1;2;13;1;0;;0;25;10;1,02;1;0;250
+
+$$StaCubic;ID(a:40);loc_name(a:40);fold_id(p);chr_name(a:20);obj_id(p);obj_bus(i)
+ 7;Cub_1;3;;5;0
+ 8;Cub_1;4;;5;1
+ 9;Cub_2;4;;6;0
+
+$$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
+ 10;Switch;7;1;1
+ 11;Switch;8;1;1
+
+$$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
+  12;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
+
+$$TypSym;ID(a:40);loc_name(a:40);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);q_min(r);q_max(r)
+  13;tsym_B_1;220;100;2;1;2;2;1;0;1,2;0;-1;1

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypReactiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypReactiveLimits.xiidm
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorTypReactiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S2">
+        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:internalConnection node1="0" node2="2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="-100.0" maxQ="100.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutActiveLimits.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutActiveLimits.dgs
@@ -9,16 +9,22 @@ $$ElmTerm;ID(a:40);loc_name(a:40);fold_id(p);iUsage(i);uknom(r)
  4;Busbar-B;2;0;220
 
 $$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
-  5;lne_A_B_1;;2;10;1;1;0;0;1;0
+  5;lne_A_B_1;;2;12;1;1;0;0;1;0
+
+$$ElmSym;ID(a:40);loc_name(a:40);fold_id(p);typ_id(p);ngnum(i);i_mot(i);chr_name(a:20);outserv(i);pgini(r);qgini(r);usetp(r);iv_mode(i);q_min(r);q_max(r);iqtype(i)
+  6;sym_B_1;2;13;1;0;;0;25;10;1,02;1;-1,1;1,2;0
 
 $$StaCubic;ID(a:40);loc_name(a:40);fold_id(p);chr_name(a:20);obj_id(p);obj_bus(i)
- 6;Cub_1;3;;5;0
- 7;Cub_1;4;;5;1
+ 7;Cub_1;3;;5;0
+ 8;Cub_1;4;;5;1
+ 9;Cub_2;4;;6;0
 
 $$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
- 8;Switch;6;1;1
- 9;Switch;7;1;1
+ 10;Switch;7;1;1
+ 11;Switch;8;1;1
 
 $$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
-  10;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
+  12;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
 
+$$TypSym;ID(a:40);loc_name(a:40);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);Q_min(r);Q_max(r);q_min(r);q_max(r)
+  13;tsym_B_1;220;100;2;1;2;2;1;0;1,2;0;-100;100;-1;1

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutActiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutActiveLimits.xiidm
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorWithoutActiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S2">
+        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:internalConnection node1="0" node2="2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="25.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="-110.0" maxQ="120.00000762939453"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIqtype.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIqtype.dgs
@@ -9,16 +9,22 @@ $$ElmTerm;ID(a:40);loc_name(a:40);fold_id(p);iUsage(i);uknom(r)
  4;Busbar-B;2;0;220
 
 $$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
-  5;lne_A_B_1;;2;10;1;1;0;0;1;0
+  5;lne_A_B_1;;2;12;1;1;0;0;1;0
+
+$$ElmSym;ID(a:40);loc_name(a:40);fold_id(p);typ_id(p);ngnum(i);i_mot(i);chr_name(a:20);outserv(i);pgini(r);qgini(r);usetp(r);iv_mode(i);q_min(r);q_max(r);Pmin_uc(r);Pmax_uc(r)
+  6;sym_B_1;2;13;1;0;;0;25;10;1,02;1;-1,1;1,2;0;250
 
 $$StaCubic;ID(a:40);loc_name(a:40);fold_id(p);chr_name(a:20);obj_id(p);obj_bus(i)
- 6;Cub_1;3;;5;0
- 7;Cub_1;4;;5;1
+ 7;Cub_1;3;;5;0
+ 8;Cub_1;4;;5;1
+ 9;Cub_2;4;;6;0
 
 $$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
- 8;Switch;6;1;1
- 9;Switch;7;1;1
+ 10;Switch;7;1;1
+ 11;Switch;8;1;1
 
 $$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
-  10;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
+  12;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
 
+$$TypSym;ID(a:40);loc_name(a:40);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);Q_min(r);Q_max(r);q_min(r);q_max(r)
+  13;tsym_B_1;220;100;2;1;2;2;1;0;1,2;0;-100;100;-1;1

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIqtype.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIqtype.xiidm
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorWithoutIqtype" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S2">
+        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:internalConnection node1="0" node2="2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="-110.0" maxQ="120.00000762939453"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIvmode.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIvmode.dgs
@@ -9,16 +9,22 @@ $$ElmTerm;ID(a:40);loc_name(a:40);fold_id(p);iUsage(i);uknom(r)
  4;Busbar-B;2;0;220
 
 $$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
-  5;lne_A_B_1;;2;10;1;1;0;0;1;0
+  5;lne_A_B_1;;2;12;1;1;0;0;1;0
+
+$$ElmSym;ID(a:40);loc_name(a:40);fold_id(p);typ_id(p);ngnum(i);i_mot(i);chr_name(a:20);outserv(i);pgini(r);qgini(r);usetp(r);q_min(r);q_max(r);Pmin_uc(r);Pmax_uc(r);iqtype(i)
+  6;sym_B_1;2;13;1;0;;1;25;10;1,02;-1,1;1,2;0;250;0
 
 $$StaCubic;ID(a:40);loc_name(a:40);fold_id(p);chr_name(a:20);obj_id(p);obj_bus(i)
- 6;Cub_1;3;;5;0
- 7;Cub_1;4;;5;1
+ 7;Cub_1;3;;5;0
+ 8;Cub_1;4;;5;1
+ 9;Cub_2;4;;6;0
 
 $$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
- 8;Switch;6;1;1
- 9;Switch;7;1;1
+ 10;Switch;7;1;1
+ 11;Switch;8;1;1
 
 $$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
-  10;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
+  12;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;82,54568;0
 
+$$TypSym;ID(a:40);loc_name(a:40);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);Q_min(r);Q_max(r);q_min(r);q_max(r)
+  13;tsym_B_1;220;100;2;1;2;2;1;0;1,2;0;-100;100;-1;1

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIvmode.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIvmode.xiidm
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="TwoBusesGeneratorWithoutIvmode" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S2">
+        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:internalConnection node1="0" node2="2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="false" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="-110.0" maxQ="120.00000762939453"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithC.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithC.dgs
@@ -20,5 +20,5 @@ $$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
  9;Switch;7;1;1
 
 $$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);cline(r)
-  10;tlne_A_B_1;;5;138;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;0,218959
+  10;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;0,218959
 

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithGandB.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithGandB.dgs
@@ -20,5 +20,5 @@ $$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
  9;Switch;7;1;1
 
 $$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);gline(r);bline(r)
-  10;tlne_A_B_1;;5;138;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;14,49275;82,54568
+  10;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;14,49275;82,54568
 

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithTandB.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithTandB.dgs
@@ -20,5 +20,5 @@ $$StaSwitch;ID(a:40);loc_name(a:40);fold_id(p);iUse(i);on_off(i)
  9;Switch;7;1;1
 
 $$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);tline(r);bline(r)
-  10;tlne_A_B_1;;5;138;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;0,17557;82,54568
+  10;tlne_A_B_1;;5;220;99999;1;0;3,561228;11,7311;999999;999999;0;80;80;0;3;0;60;Cu;0,17557;82,54568
 


### PR DESCRIPTION
Signed-off-by: José Antonio Marqués <marquesja@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Only `iv_mode` is considered to define `voltageRegulatorOn`
`Q_min` and `Q_max` are used to convert per unit reactive limits to Mvar reactive limits

**What is the new behavior (if this is a feature change)?**
Use `iv_mode` and `av_mode` to define `voltageRegulatorOn`
Use targetP as default active power limit.
Use `sgn` to convert per unit reactive limits to Mvar reactive limits
Interpret `Q_min` and `Q_max` as Mvar reactive limits


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
