### PR TITLE
All CGMES models after version 3 can be considered node/breaker

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNamespace.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNamespace.java
@@ -45,6 +45,7 @@ public final class CgmesNamespace {
     private static final String CIM_16_SV_PROFILE = "http://entsoe.eu/CIM/StateVariables/4/1";
     private static final String CIM_16_SSH_PROFILE = "http://entsoe.eu/CIM/SteadyStateHypothesis/1/1";
 
+    private static final String CGMES_EQ_3_OR_GREATER_PREFIX = "http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/";
     private static final String CIM_100_EQ_PROFILE = "http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0";
     private static final String CIM_100_EQ_OPERATION_PROFILE = "http://iec.ch/TC57/ns/CIM/Operation-EU/3.0";
     private static final String CIM_100_TP_PROFILE = "http://iec.ch/TC57/ns/CIM/Topology-EU/3.0";
@@ -78,5 +79,9 @@ public final class CgmesNamespace {
             return PROFILES.get(cimVersion).get(profile);
         }
         throw new AssertionError("Unsupported CIM version " + cimVersion);
+    }
+
+    public static boolean isEqCgmes3OrGreater(String profile) {
+        return profile.startsWith(CGMES_EQ_3_OR_GREATER_PREFIX) && profile.compareTo(CIM_100_EQ_PROFILE) >= 0;
     }
 }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -163,6 +163,9 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
         if (r == null) {
             return false;
         }
+        if (allEqCgmes3OrGreater(r)) {
+            return true;
+        }
         // Only consider is node breaker if all models that have profile
         // EquipmentCore or EquipmentBoundary
         // also have EquipmentOperation or EquipmentBoundaryOperation
@@ -172,6 +175,16 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
             logNodeBreaker(consideredNodeBreaker, modelHasOperationProfile);
         }
         return consideredNodeBreaker;
+    }
+
+    private boolean allEqCgmes3OrGreater(PropertyBags modelProfiles) {
+        for (PropertyBag mp : modelProfiles) {
+            String p = mp.get(PROFILE);
+            if (p != null && isEquipmentCore(p) && !CgmesNamespace.isEqCgmes3OrGreater(p)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void logNodeBreaker(boolean consideredNodeBreaker, Map<String, Boolean> modelHasOperationProfile) {


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
CGMES 3 EQ profile enforces use of `ConnectivityNodes` even for bus/branch models, so it is safe to assume we can process any CGMES 3 or later using `ConnectivityNodes` instead of relying on `TopologicalNodes`. If model is bus/branch, internal connections between the equipment and the busbar sections associated to connectivity nodes will be created.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
