### PR TITLE
Fix NPE in busbar section adder

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusbarSectionAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusbarSectionAdderImpl.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.iidm.network.BusbarSection;
 import com.powsybl.iidm.network.BusbarSectionAdder;
+import com.powsybl.iidm.network.ValidationException;
 
 /**
  *
@@ -42,6 +43,9 @@ class BusbarSectionAdderImpl extends AbstractIdentifiableAdder<BusbarSectionAdde
     @Override
     public BusbarSection add() {
         String id = checkAndGetUniqueId();
+        if (node == null) {
+            throw new ValidationException(this, "node is not set");
+        }
         TerminalExt terminal = new NodeTerminal(getNetwork().getRef(), node);
         BusbarSectionImpl section = new BusbarSectionImpl(getNetwork().getRef(), id, getName(), isFictitious());
         section.addTerminal(terminal);

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/NpeInBusbarSectionAdderTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/NpeInBusbarSectionAdderTest.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.impl.tck;
+
+import com.powsybl.iidm.network.tck.AbstractNpeInBusbarSectionAdderTest;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class NpeInBusbarSectionAdderTest extends AbstractNpeInBusbarSectionAdderTest {
+}

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNpeInBusbarSectionAdderTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNpeInBusbarSectionAdderTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.tck;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.iidm.network.ValidationException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public abstract class AbstractNpeInBusbarSectionAdderTest {
+
+    @Test
+    public void test() {
+        Network network = Network.create("test", "code");
+        var s = network.newSubstation()
+                .setId("S")
+                .add();
+        var vl = s.newVoltageLevel()
+                .setId("VL")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        var bbsAdder = vl.getNodeBreakerView().newBusbarSection()
+                .setId("BBS");
+        ValidationException exception = assertThrows(ValidationException.class, bbsAdder::add);
+        assertEquals("Busbar section 'BBS': node is not set", exception.getMessage());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If node is not set in busbar section adder, we have a NPE


**What is the new behavior (if this is a feature change)?**
A proper exception is thrown with a clear message


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
