### PR TITLE
Triplestore: remove prefix using indexOf instead of replaceAll

### DIFF
--- a/triple-store/triple-store-api/src/main/java/com/powsybl/triplestore/api/PropertyBag.java
+++ b/triple-store/triple-store-api/src/main/java/com/powsybl/triplestore/api/PropertyBag.java
@@ -33,6 +33,12 @@ public class PropertyBag extends HashMap<String, String> {
         return propertyNames;
     }
 
+    public void putNonNull(String key, String value) {
+        if (key != null && value != null) {
+            put(key, value);
+        }
+    }
+
     public String getLocal(String property) {
         String value = get(property);
         if (value == null) {

--- a/triple-store/triple-store-api/src/main/java/com/powsybl/triplestore/api/PropertyBag.java
+++ b/triple-store/triple-store-api/src/main/java/com/powsybl/triplestore/api/PropertyBag.java
@@ -33,18 +33,12 @@ public class PropertyBag extends HashMap<String, String> {
         return propertyNames;
     }
 
-    public void putNonNull(String key, String value) {
-        if (key != null && value != null) {
-            put(key, value);
-        }
-    }
-
     public String getLocal(String property) {
         String value = get(property);
         if (value == null) {
             return null;
         }
-        return value.replaceAll("^.*#", "");
+        return removePrefix(value, false);
     }
 
     public String getId(String property) {
@@ -52,17 +46,11 @@ public class PropertyBag extends HashMap<String, String> {
         if (value == null) {
             return null;
         }
-        // rdf:ID is the mRID plus an underscore added at the beginning of the string
-        // We may decide if we want to preserve or not the underscore
-        if (removeInitialUnderscoreForIdentifiers) {
-            return value.replaceAll("^.*#_?", "");
-        } else {
-            return value.replaceAll("^.*#", "");
-        }
+        return removePrefix(value, true);
     }
 
     public String getId0(String property) {
-        // Return the first part of the Id (before he first hyphen)
+        // Return the first part of the Identifier (before the first hyphen)
         String id = getId(property);
         if (id == null) {
             return null;
@@ -144,9 +132,18 @@ public class PropertyBag extends HashMap<String, String> {
         return "";
     }
 
-    private static String padr(String s, int size) {
-        String format = String.format("%%-%ds", size);
-        return String.format(format, s);
+    private String removePrefix(String s, boolean isIdentifier) {
+        String s1 = s;
+        int iHash = s.indexOf('#');
+        if (iHash >= 0) {
+            s1 = s.substring(iHash + 1);
+        }
+        // rdf:ID is the mRID plus an underscore added at the beginning of the string
+        // We may decide if we want to preserve or not the underscore
+        if (isIdentifier && removeInitialUnderscoreForIdentifiers && s1.charAt(0) == '_') {
+            s1 = s1.substring(1);
+        }
+        return s1;
     }
 
     @Override
@@ -170,7 +167,6 @@ public class PropertyBag extends HashMap<String, String> {
     }
 
     public boolean isResource(String name) {
-        // TODO do not rely on property name, use metadata or answer based on value?
         return RESOURCE_NAMES.contains(name) || resourceNames.contains(name);
     }
 


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
minor optimization

**What is the current behavior?** *(You can also link to an open issue here)*
IRI prefixes of RDF names are removed using `String::replaceAll` with a regular expression.


**What is the new behavior (if this is a feature change)?**
IRI prefixes of RDF names are removed using `String::indexOf`.

**Other information**:
Removed unused private method `padr`.