### PR TITLE
Fix NPE: no NPE thrown when equipment added and validation level has been invalidated

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -1188,7 +1188,9 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
     }
 
     void setValidationLevelIfGreaterThan(ValidationLevel validationLevel) {
-        this.validationLevel = ValidationLevel.min(this.validationLevel, validationLevel);
+        if (this.validationLevel != null) {
+            this.validationLevel = ValidationLevel.min(this.validationLevel, validationLevel);
+        }
     }
 
     void invalidateValidationLevel() {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -223,6 +223,7 @@ public abstract class AbstractNetworkTest {
         network.runValidationChecks();
         network.setMinimumAcceptableValidationLevel(ValidationLevel.EQUIPMENT);
         assertEquals(ValidationLevel.STEADY_STATE_HYPOTHESIS, network.getValidationLevel());
+        network.getLoad("load1").setP0(0.0);
         voltageLevel1.newLoad()
                 .setId("unchecked")
                 .setP0(1.0)


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
A NPE is thrown when a network component is added and the validation level has been invalidated



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
