### PR TITLE
CGMES import: ensure path exists before trying to load boundaries

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -135,6 +135,7 @@ public class CgmesImport implements Importer {
         }
         Path ploc = Path.of(loc);
         if (!Files.exists(ploc)) {
+            LOGGER.warn("Location of boundaries does not exist {}. No attempt to load boundaries will be made", loc);
             return null;
         }
         // Check that the Data Source has valid CGMES names

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -32,8 +32,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -132,8 +132,12 @@ public class CgmesImport implements Importer {
         if (loc == null) {
             return null;
         }
+        Path ploc = Path.of(loc);
+        if (!Files.exists(ploc)) {
+            return null;
+        }
         // Check that the Data Source has valid CGMES names
-        ReadOnlyDataSource ds = new GenericReadOnlyDataSource(Paths.get(loc));
+        ReadOnlyDataSource ds = new GenericReadOnlyDataSource(ploc);
         if ((new CgmesOnDataSource(ds)).names().isEmpty()) {
             return null;
         }


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Path for boundary is not verified before attempting to import files.


**What is the new behavior (if this is a feature change)?**
If path does not exists, import of boundary files is not attempted.


