### PR TITLE
CGMES conversion: non-impedant equivalent branches and series compensators mapped to fictitious switches, consistent with ac line segments

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
@@ -97,49 +97,9 @@ public class ACLineSegmentConversion extends AbstractBranchConversion implements
     private void convertLine() {
         double r = p.asDouble("r");
         double x = p.asDouble("x");
-        double bch = p.asDouble("bch");
         double gch = p.asDouble("gch", 0.0);
-        if (isZeroImpedanceInsideVoltageLevel(r, x, bch, gch)) {
-            // Convert to switch
-            Switch sw;
-            boolean open = !(terminalConnected(1) && terminalConnected(2));
-            if (context.nodeBreaker()) {
-                VoltageLevel.NodeBreakerView.SwitchAdder adder;
-                adder = voltageLevel().getNodeBreakerView().newSwitch()
-                        .setKind(SwitchKind.BREAKER)
-                        .setRetained(true)
-                        .setFictitious(true);
-                identify(adder);
-                connect(adder, open);
-                sw = adder.add();
-            } else {
-                VoltageLevel.BusBreakerView.SwitchAdder adder;
-                adder = voltageLevel().getBusBreakerView().newSwitch()
-                        .setFictitious(true);
-                identify(adder);
-                connect(adder, open);
-                sw = adder.add();
-            }
-            addAliasesAndProperties(sw);
-        } else {
-            final LineAdder adder = context.network().newLine()
-                    .setEnsureIdUnicity(context.config().isEnsureIdAliasUnicity())
-                    .setR(r)
-                    .setX(x)
-                    .setG1(gch / 2)
-                    .setG2(gch / 2)
-                    .setB1(bch / 2)
-                    .setB2(bch / 2);
-            identify(adder);
-            connect(adder);
-            final Line l = adder.add();
-            addAliasesAndProperties(l);
-            convertedTerminals(l.getTerminal1(), l.getTerminal2());
-        }
-    }
-
-    private boolean isZeroImpedanceInsideVoltageLevel(double r, double x, double bch, double gch) {
-        return r == 0.0 && x == 0.0 && voltageLevel(1) == voltageLevel(2);
+        double bch = p.asDouble("bch");
+        convertBranch(r, x, gch, bch);
     }
 
     private void convertLineAtBoundary(int boundarySide) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SeriesCompensatorConversion.java
@@ -9,8 +9,6 @@ package com.powsybl.cgmes.conversion.elements;
 
 import com.powsybl.cgmes.conversion.Context;
 import com.powsybl.cgmes.model.CgmesNames;
-import com.powsybl.iidm.network.Line;
-import com.powsybl.iidm.network.LineAdder;
 import com.powsybl.triplestore.api.PropertyBag;
 
 /**
@@ -26,17 +24,8 @@ public class SeriesCompensatorConversion extends AbstractBranchConversion {
     public void convert() {
         double r = p.asDouble("r");
         double x = p.asDouble("x");
-        final LineAdder adder = context.network().newLine()
-                .setR(r)
-                .setX(x)
-                .setG1(0)
-                .setG2(0)
-                .setB1(0)
-                .setB2(0);
-        identify(adder);
-        connect(adder);
-        final Line l = adder.add();
-        addAliasesAndProperties(l);
-        convertedTerminals(l.getTerminal1(), l.getTerminal2());
+        double gch = 0;
+        double bch = 0;
+        convertBranch(r, x, gch, bch);
     }
 }


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
conversion improvement.

**What is the current behavior?** *(You can also link to an open issue here)*
CGMES Non-impedant (z0) equivalent branches and series compensators contained in a voltage level are mapped to IIDM Line objects with r = x = 0. But CGMES z0 ac line segments with both ends in a voltage level are converted to IIDM fictitious switches. 

**What is the new behavior (if this is a feature change)?**
CGMES z0 equivalent branches, series compensators and AC line segments contained in a voltage level (both ends in the same voltage level) are converted in a consistent way. All these non-impedant branches are replaced in the IIDM model by a fictitious switch.

**Other information**:
If a CGMES case containing  z0 equivalent branches or series compensators was exported back to CGMES, they were exported as z0 ac line segments. Comparing the IIDM networks from original CGMES files and reimported files failed because different kind of objects were used to represent the same links.