### PR TITLE
CGMES export: refactor profile writers to use context

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/AbstractCgmesProfileWriter.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/AbstractCgmesProfileWriter.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.export;
+
+import com.powsybl.commons.PowsyblException;
+
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+public abstract class AbstractCgmesProfileWriter {
+    protected final CgmesExportContext context;
+    protected XMLStreamWriter xmlWriter;
+
+    protected AbstractCgmesProfileWriter(CgmesExportContext context) {
+        this.context = context;
+    }
+
+    public static AbstractCgmesProfileWriter create(String profile, CgmesExportContext context) {
+        if ("EQ".equals(profile)) {
+            return new EquipmentExport(context);
+        } else if ("TP".equals(profile)) {
+            return new TopologyExport(context);
+        } else if ("SSH".equals(profile)) {
+            return new SteadyStateHypothesisExport(context);
+        } else if ("SV".equals(profile)) {
+            return new StateVariablesExport(context);
+        }
+        throw new PowsyblException("No CGMES profile writer for profile " + profile);
+    }
+
+    public abstract String getProfile();
+
+    public abstract void write();
+
+    public void setXmlWriter(XMLStreamWriter xmlWriter) {
+        this.xmlWriter = xmlWriter;
+    }
+
+    public String getFileName(String baseName) {
+        return baseName + "_" + getProfile() + ".xml";
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -39,6 +39,7 @@ public class CgmesExportContext {
     private CgmesTopologyKind topologyKind = CgmesTopologyKind.BUS_BRANCH;
     private DateTime scenarioTime = DateTime.now();
 
+    private final Network network;
     private final ModelDescription eqModelDescription = new ModelDescription("EQ Model", cim.getProfile("EQ"));
     private final ModelDescription tpModelDescription = new ModelDescription("TP Model", cim.getProfile("TP"));
     private final ModelDescription svModelDescription = new ModelDescription("SV Model", cim.getProfile("SV"));
@@ -82,6 +83,10 @@ public class CgmesExportContext {
                 getSvModelDescription().addDependency(sshModelId);
             }
         }
+    }
+
+    public Network getNetwork() {
+        return this.network;
     }
 
     public static final class ModelDescription {
@@ -169,6 +174,8 @@ public class CgmesExportContext {
     }
 
     public CgmesExportContext() {
+        // FIXME(Luma) review how this is used, no default constructor should be allowed
+        this.network = null;
     }
 
     public CgmesExportContext(Network network) {
@@ -180,6 +187,7 @@ public class CgmesExportContext {
     }
 
     public CgmesExportContext(Network network, boolean withTopologicalMapping, NamingStrategy namingStrategy) {
+        this.network = network;
         this.namingStrategy = namingStrategy;
         CimCharacteristics cimCharacteristics = network.getExtension(CimCharacteristics.class);
         if (cimCharacteristics != null) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -24,7 +24,7 @@ import java.util.*;
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>
  */
-public final class EquipmentExport {
+public final class EquipmentExport extends AbstractCgmesProfileWriter {
 
     private static final String ACDCCONVERTERDCTERMINAL = "ACDCConverterDCTerminal";
     private static final String CONNECTIVITY_NODE_SUFFIX = "CN";
@@ -32,11 +32,19 @@ public final class EquipmentExport {
     private static final String PHASE_TAP_CHANGER_REGULATION_MODE_CURRENT_FLOW = "currentFlow";
     private static final String PHASE_TAP_CHANGER_REGULATION_MODE_VOLTAGE = "voltage";
 
-    public static void write(Network network, XMLStreamWriter writer) {
-        write(network, writer, new CgmesExportContext(network));
+    EquipmentExport(CgmesExportContext context) {
+        super(context);
     }
 
-    public static void write(Network network, XMLStreamWriter writer, CgmesExportContext context) {
+    public String getProfile() {
+        return "EQ";
+    }
+
+    public void write() {
+        write(context.getNetwork(), xmlWriter, context);
+    }
+
+    private static void write(Network network, XMLStreamWriter writer, CgmesExportContext context) {
         try {
             String cimNamespace = context.getCim().getNamespace();
             String euNamespace = context.getCim().getEuNamespace();
@@ -894,8 +902,5 @@ public final class EquipmentExport {
         Map<Integer, List<Integer>> get() {
             return adjacency;
         }
-    }
-
-    private EquipmentExport() {
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
  */
-public final class StateVariablesExport {
+public final class StateVariablesExport extends AbstractCgmesProfileWriter {
 
     private static final String SV_VOLTAGE_ANGLE = "SvVoltage.angle";
     private static final String SV_VOLTAGE_V = "SvVoltage.v";
@@ -36,11 +36,19 @@ public final class StateVariablesExport {
 
     private static final Logger LOG = LoggerFactory.getLogger(StateVariablesExport.class);
 
-    public static void write(Network network, XMLStreamWriter writer) {
-        write(network, writer, new CgmesExportContext(network));
+    StateVariablesExport(CgmesExportContext context) {
+        super(context);
     }
 
-    public static void write(Network network, XMLStreamWriter writer, CgmesExportContext context) {
+    public String getProfile() {
+        return "SV";
+    }
+
+    public void write() {
+        write(context.getNetwork(), xmlWriter, context);
+    }
+
+    private static void write(Network network, XMLStreamWriter writer, CgmesExportContext context) {
         try {
             String cimNamespace = context.getCim().getNamespace();
             CgmesExportUtil.writeRdfRoot(cimNamespace, context.getCim().getEuPrefix(), context.getCim().getEuNamespace(), writer);
@@ -480,8 +488,5 @@ public final class StateVariablesExport {
             poleLoss = pDCInverter * converterStation.getLossFactor() / 100;
         }
         return poleLoss;
-    }
-
-    private StateVariablesExport() {
     }
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
@@ -28,16 +28,25 @@ import static com.powsybl.cgmes.model.CgmesNamespace.RDF_NAMESPACE;
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  */
-public final class SteadyStateHypothesisExport {
+public final class SteadyStateHypothesisExport extends AbstractCgmesProfileWriter {
 
     private static final Logger LOG = LoggerFactory.getLogger(SteadyStateHypothesisExport.class);
     private static final String REGULATING_CONTROL_PROPERTY = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "RegulatingControl";
     private static final String GENERATING_UNIT_PROPERTY = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "GeneratingUnit";
 
-    private SteadyStateHypothesisExport() {
+    SteadyStateHypothesisExport(CgmesExportContext context) {
+        super(context);
     }
 
-    public static void write(Network network, XMLStreamWriter writer, CgmesExportContext context) {
+    public String getProfile() {
+        return "SSH";
+    }
+
+    public void write() {
+        write(context.getNetwork(), xmlWriter, context);
+    }
+
+    private static void write(Network network, XMLStreamWriter writer, CgmesExportContext context) {
         final Map<String, List<RegulatingControlView>> regulatingControlViews = new HashMap<>();
         String cimNamespace = context.getCim().getNamespace();
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
@@ -24,16 +24,24 @@ import java.util.Set;
 /**
  * @author Marcos de Miguel <demiguelm at aia.es>
  */
-public final class TopologyExport {
+public final class TopologyExport extends AbstractCgmesProfileWriter {
 
     private static final String TOPOLOGICAL_NODE_CONNECTIVITY_NODE_CONTAINER = "TopologicalNode.ConnectivityNodeContainer";
     private static final String TOPOLOGICAL_NODE_BASE_VOLTAGE = "TopologicalNode.BaseVoltage";
 
-    public static void write(Network network, XMLStreamWriter writer) {
-        write(network, writer, new CgmesExportContext(network));
+    TopologyExport(CgmesExportContext context) {
+        super(context);
     }
 
-    public static void write(Network network, XMLStreamWriter writer, CgmesExportContext context) {
+    public String getProfile() {
+        return "TP";
+    }
+
+    public void write() {
+        write(context.getNetwork(), xmlWriter, context);
+    }
+
+    private static void write(Network network, XMLStreamWriter writer, CgmesExportContext context) {
         try {
             String cimNamespace = context.getCim().getNamespace();
             CgmesExportUtil.writeRdfRoot(cimNamespace, context.getCim().getEuPrefix(), context.getCim().getEuNamespace(), writer);
@@ -259,8 +267,5 @@ public final class TopologyExport {
         CgmesExportUtil.writeReference(TOPOLOGICAL_NODE_CONNECTIVITY_NODE_CONTAINER, connectivityNodeContainerId, cimNamespace, writer);
         CgmesExportUtil.writeReference(TOPOLOGICAL_NODE_BASE_VOLTAGE, baseVoltageId, cimNamespace, writer);
         writer.writeEndElement();
-    }
-
-    private TopologyExport() {
     }
 }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
@@ -11,8 +11,8 @@ import com.powsybl.cgmes.conformity.CgmesConformity1ModifiedCatalog;
 import com.powsybl.cgmes.conversion.CgmesImport;
 import com.powsybl.cgmes.conversion.CgmesModelExtension;
 import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.cgmes.conversion.export.AbstractCgmesProfileWriter;
 import com.powsybl.cgmes.conversion.export.CgmesExportContext;
-import com.powsybl.cgmes.conversion.export.EquipmentExport;
 import com.powsybl.cgmes.extensions.CgmesSshMetadata;
 import com.powsybl.cgmes.extensions.CgmesSvMetadata;
 import com.powsybl.cgmes.extensions.CimCharacteristics;
@@ -365,8 +365,9 @@ public class EquipmentExportTest extends AbstractConverterTest {
         Path exportedEq = tmpDir.resolve("exportedEq.xml");
         try (OutputStream os = new BufferedOutputStream(Files.newOutputStream(exportedEq))) {
             XMLStreamWriter writer = XmlUtil.initializeWriter(true, "    ", os);
-            CgmesExportContext context = new CgmesExportContext(network);
-            EquipmentExport.write(network, writer, context);
+            AbstractCgmesProfileWriter eqWriter = AbstractCgmesProfileWriter.create("EQ", new CgmesExportContext(network));
+            eqWriter.setXmlWriter(writer);
+            eqWriter.write();
         }
 
         return exportedEq;

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
@@ -10,8 +10,8 @@ import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1ModifiedCatalog;
 import com.powsybl.cgmes.conversion.CgmesImport;
 import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.cgmes.conversion.export.AbstractCgmesProfileWriter;
 import com.powsybl.cgmes.conversion.export.CgmesExportContext;
-import com.powsybl.cgmes.conversion.export.StateVariablesExport;
 import com.powsybl.cgmes.extensions.CgmesIidmMapping;
 import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.commons.AbstractConverterTest;
@@ -148,7 +148,9 @@ public class StateVariablesExportTest extends AbstractConverterTest {
         XMLStreamWriter writer = XmlUtil.initializeWriter(true, "    ", stringWriter);
         context.getSvModelDescription().setVersion(svVersion);
         context.setExportBoundaryPowerFlows(true);
-        StateVariablesExport.write(network, writer, context);
+        AbstractCgmesProfileWriter svWriter = AbstractCgmesProfileWriter.create("SV", context);
+        svWriter.setXmlWriter(writer);
+        svWriter.write();
 
         return stringWriter.toString();
     }
@@ -211,7 +213,9 @@ public class StateVariablesExportTest extends AbstractConverterTest {
             context.getSvModelDescription().setVersion(svVersion);
             context.setExportBoundaryPowerFlows(true);
             context.setExportFlowsForSwitches(exportFlowsForSwitches);
-            StateVariablesExport.write(expected, writer, context);
+            AbstractCgmesProfileWriter svWriter = AbstractCgmesProfileWriter.create("SV", context);
+            svWriter.setXmlWriter(writer);
+            svWriter.write();
         }
 
         // Zip with new SV

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/SteadyStateHypothesisExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/SteadyStateHypothesisExportTest.java
@@ -9,8 +9,8 @@ package com.powsybl.cgmes.conversion.test.export;
 import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1ModifiedCatalog;
 import com.powsybl.cgmes.conversion.CgmesImport;
+import com.powsybl.cgmes.conversion.export.AbstractCgmesProfileWriter;
 import com.powsybl.cgmes.conversion.export.CgmesExportContext;
-import com.powsybl.cgmes.conversion.export.SteadyStateHypothesisExport;
 import com.powsybl.cgmes.extensions.CgmesControlAreas;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
@@ -113,7 +113,9 @@ public class SteadyStateHypothesisExportTest extends AbstractConverterTest {
             XMLStreamWriter writer = XmlUtil.initializeWriter(true, "    ", os);
             CgmesExportContext context = new CgmesExportContext(expected);
             context.getSshModelDescription().setVersion(version);
-            SteadyStateHypothesisExport.write(expected, writer, context);
+            AbstractCgmesProfileWriter sshWriter = AbstractCgmesProfileWriter.create("SSH", context);
+            sshWriter.setXmlWriter(writer);
+            sshWriter.write();
         }
 
         // Compare the exported SSH with the original one

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/TopologyExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/TopologyExportTest.java
@@ -8,8 +8,8 @@ package com.powsybl.cgmes.conversion.test.export;
 
 import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conversion.CgmesImport;
+import com.powsybl.cgmes.conversion.export.AbstractCgmesProfileWriter;
 import com.powsybl.cgmes.conversion.export.CgmesExportContext;
-import com.powsybl.cgmes.conversion.export.TopologyExport;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.xml.XmlUtil;
@@ -60,7 +60,9 @@ public class TopologyExportTest extends AbstractConverterTest {
         try (OutputStream os = Files.newOutputStream(exportedTp)) {
             XMLStreamWriter writer = XmlUtil.initializeWriter(true, "    ", os);
             CgmesExportContext context = new CgmesExportContext(expected, true);
-            TopologyExport.write(expected, writer, context);
+            AbstractCgmesProfileWriter tpWriter = AbstractCgmesProfileWriter.create("TP", context);
+            tpWriter.setXmlWriter(writer);
+            tpWriter.write();
         }
 
         // Zip with new TP


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
code refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
The classes that write the profiles have static methods with too many parameters.


**What is the new behavior (if this is a feature change)?**
Refactor writers of CGMES instance files to remove Sonar code smells and issues.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [X] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
