### PR TITLE
Loading limits bug when exporting to XIIDM 1.5

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
@@ -41,14 +41,14 @@ public abstract class AbstractConnectableXml<T extends Connectable, A extends Id
     }
 
     protected static boolean hasValidOperationalLimits(Branch<?> branch, NetworkXmlWriterContext context) {
-        if (context.getVersion().compareTo(IidmXmlVersion.V_1_5) > 0) {
+        if (context.getVersion().compareTo(IidmXmlVersion.V_1_5) >= 0) {
             return !branch.getOperationalLimits1().isEmpty() || !branch.getOperationalLimits2().isEmpty();
         }
         return branch.getCurrentLimits1() != null || branch.getCurrentLimits2() != null;
     }
 
     protected static boolean hasValidOperationalLimits(FlowsLimitsHolder limitsHolder, NetworkXmlWriterContext context) {
-        if (context.getVersion().compareTo(IidmXmlVersion.V_1_5) > 0) {
+        if (context.getVersion().compareTo(IidmXmlVersion.V_1_5) >= 0) {
             return !limitsHolder.getOperationalLimits().isEmpty();
         }
         return limitsHolder.getCurrentLimits() != null;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsBugTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsBugTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.iidm.xml;
 
 import com.powsybl.commons.AbstractConverterTest;
@@ -8,6 +14,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
 public class LoadingLimitsBugTest extends AbstractConverterTest {
 
     @Test

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsBugTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsBugTest.java
@@ -50,6 +50,6 @@ public class LoadingLimitsBugTest extends AbstractConverterTest {
         // these new limits should not be in the XIIDM.
         ExportOptions options = new ExportOptions()
                 .setVersion(IidmXmlVersion.V_1_5.toString("."));
-        roundTripTest(network, (n, path) -> NetworkXml.write(n, options, path), NetworkXml::read, "/loading-limits-bug.xml");
+        roundTripXmlTest(network, (n, path) -> NetworkXml.writeAndValidate(n, options, path), NetworkXml::validateAndRead, "/loading-limits-bug.xml");
     }
 }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsBugTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsBugTest.java
@@ -44,10 +44,7 @@ public class LoadingLimitsBugTest extends AbstractConverterTest {
         twt.newApparentPowerLimits1()
                 .setPermanentLimit(100)
                 .add();
-        // export in 1.5 version, in 1.5 there is only current limits suppported
-        // new limits (apparent power and active power) have been added from 1.6 and so
-        // event if present in the network model, when asking for a <= 1.5 version export
-        // these new limits should not be in the XIIDM.
+        // check that XIIDM 1.5 is not ill-formed
         ExportOptions options = new ExportOptions()
                 .setVersion(IidmXmlVersion.V_1_5.toString("."));
         roundTripXmlTest(network, (n, path) -> NetworkXml.writeAndValidate(n, options, path), NetworkXml::validateAndRead, "/loading-limits-bug.xml");

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsBugTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsBugTest.java
@@ -1,0 +1,46 @@
+package com.powsybl.iidm.xml;
+
+import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.iidm.export.ExportOptions;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class LoadingLimitsBugTest extends AbstractConverterTest {
+
+    @Test
+    public void test() throws IOException {
+        var network = EurostagTutorialExample1Factory.create();
+        network.setCaseDate(DateTime.parse("2020-07-16T10:08:48.321+02:00"));
+        // to reproduce the bug we need a 2 windings transformer without any data
+        // that could create a sub element in the XML except apparent and active power limits
+        // (tap changer, properties, current limits)
+        var twt = network.getSubstation("P1").newTwoWindingsTransformer()
+                .setId("TWT")
+                .setVoltageLevel1("VLGEN")
+                .setBus1("NGEN")
+                .setConnectableBus1("NGEN")
+                .setRatedU1(24.0)
+                .setVoltageLevel2("VLHV1")
+                .setBus2("NHV1")
+                .setConnectableBus2("NHV1")
+                .setRatedU2(400.0)
+                .setR(1)
+                .setX(1)
+                .setG(0.0)
+                .setB(0.0)
+                .add();
+        twt.newApparentPowerLimits1()
+                .setPermanentLimit(100)
+                .add();
+        // export in 1.5 version, in 1.5 there is only current limits suppported
+        // new limits (apparent power and active power) have been added from 1.6 and so
+        // event if present in the network model, when asking for a <= 1.5 version export
+        // these new limits should not be in the XIIDM.
+        ExportOptions options = new ExportOptions()
+                .setVersion(IidmXmlVersion.V_1_5.toString("."));
+        roundTripTest(network, (n, path) -> NetworkXml.write(n, options, path), NetworkXml::read, "/loading-limits-bug.xml");
+    }
+}

--- a/iidm/iidm-xml-converter/src/test/resources/loading-limits-bug.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/loading-limits-bug.xml
@@ -15,8 +15,9 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
-        <iidm:twoWindingsTransformer id="TWT" r="1.0" x="1.0" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
-        <iidm:apparentPowerLimits1 permanentLimit="100.0"/>
+        <iidm:twoWindingsTransformer id="TWT" r="1.0" x="1.0" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1">
+            <iidm:apparentPowerLimits1 permanentLimit="100.0"/>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
         <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">

--- a/iidm/iidm-xml-converter/src/test/resources/loading-limits-bug.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/loading-limits-bug.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_5" id="sim1" caseDate="2020-07-16T10:08:48.321+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+        <iidm:twoWindingsTransformer id="TWT" r="1.0" x="1.0" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+        <iidm:apparentPowerLimits1 permanentLimit="100.0"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+</iidm:network>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If we have a network with a transformer with apparent or active power limit and if we export to a <= 1.5 XIIDM version,
the resulting XML is ill formed.


**What is the new behavior (if this is a feature change)?**
Apparent or active power limit, should not be exported if XIIDM version <= 1.5 and XML should be well formed.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
