### PR TITLE
Move shortcircuit serializers/deserializers into json package

### DIFF
--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/Fault.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/Fault.java
@@ -8,7 +8,7 @@ package com.powsybl.shortcircuit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.json.JsonUtil;
-import com.powsybl.shortcircuit.converter.ShortCircuitAnalysisJsonModule;
+import com.powsybl.shortcircuit.json.ShortCircuitAnalysisJsonModule;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FaultParameters.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FaultParameters.java
@@ -8,7 +8,7 @@ package com.powsybl.shortcircuit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.json.JsonUtil;
-import com.powsybl.shortcircuit.converter.ShortCircuitAnalysisJsonModule;
+import com.powsybl.shortcircuit.json.ShortCircuitAnalysisJsonModule;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/converter/JsonShortCircuitAnalysisResultExporter.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/converter/JsonShortCircuitAnalysisResultExporter.java
@@ -12,6 +12,7 @@ import com.google.auto.service.AutoService;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.shortcircuit.ShortCircuitAnalysisResult;
+import com.powsybl.shortcircuit.json.ShortCircuitAnalysisJsonModule;
 
 import java.io.IOException;
 import java.io.Writer;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultDeserializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultDeserializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultParametersDeserializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultParametersDeserializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultParametersSerializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultParametersSerializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultDeserializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultDeserializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultSerializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultSerializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultSerializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultSerializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FeederResultDeserializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FeederResultDeserializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -17,39 +17,33 @@ import java.io.IOException;
 /**
  * @author Thomas Adam <tadam at silicom.fr>
  */
-class ShortCircuitBusResultsDeserializer extends StdDeserializer<ShortCircuitBusResults> {
+class FeederResultDeserializer extends StdDeserializer<FeederResult> {
 
-    ShortCircuitBusResultsDeserializer() {
-        super(ShortCircuitBusResults.class);
+    FeederResultDeserializer() {
+        super(FeederResult.class);
     }
 
     @Override
-    public ShortCircuitBusResults deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
-        String voltageLevelId = null;
-        String busId = null;
-        FortescueValue voltage = null;
+    public FeederResult deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
+        String connectableId = null;
+        FortescueValue current = null;
 
         while (parser.nextToken() != JsonToken.END_OBJECT) {
             switch (parser.getCurrentName()) {
-                case "voltageLevelId":
+                case "connectableId":
                     parser.nextToken();
-                    voltageLevelId = parser.readValueAs(String.class);
+                    connectableId = parser.readValueAs(String.class);
                     break;
 
-                case "busId":
+                case "current":
                     parser.nextToken();
-                    busId = parser.readValueAs(String.class);
-                    break;
-
-                case "voltage":
-                    parser.nextToken();
-                    voltage = parser.readValueAs(FortescueValue.class);
+                    current = parser.readValueAs(FortescueValue.class);
                     break;
 
                 default:
                     throw new AssertionError("Unexpected field: " + parser.getCurrentName());
             }
         }
-        return new ShortCircuitBusResults(voltageLevelId, busId, voltage);
+        return new FeederResult(connectableId, current);
     }
 }

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FeederResultSerializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FeederResultSerializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FortescueValuesDeserializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FortescueValuesDeserializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FortescueValuesSerializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FortescueValuesSerializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/JsonShortCircuitParameters.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/JsonShortCircuitParameters.java
@@ -14,7 +14,6 @@ import com.powsybl.commons.extensions.ExtensionJsonSerializer;
 import com.powsybl.commons.extensions.ExtensionProviders;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.shortcircuit.ShortCircuitParameters;
-import com.powsybl.shortcircuit.converter.ShortCircuitAnalysisJsonModule;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitAnalysisJsonModule.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitAnalysisJsonModule.java
@@ -4,15 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.powsybl.security.LimitViolation;
 import com.powsybl.security.json.LimitViolationDeserializer;
 import com.powsybl.security.json.LimitViolationSerializer;
 import com.powsybl.shortcircuit.*;
-import com.powsybl.shortcircuit.json.ShortCircuitParametersDeserializer;
-import com.powsybl.shortcircuit.json.ShortCircuitParametersSerializer;
 import com.powsybl.shortcircuit.FaultParameters;
 
 /**

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitAnalysisResultDeserializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitAnalysisResultDeserializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitAnalysisResultSerializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitAnalysisResultSerializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitBusResultsDeserializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitBusResultsDeserializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -17,33 +17,39 @@ import java.io.IOException;
 /**
  * @author Thomas Adam <tadam at silicom.fr>
  */
-class FeederResultDeserializer extends StdDeserializer<FeederResult> {
+class ShortCircuitBusResultsDeserializer extends StdDeserializer<ShortCircuitBusResults> {
 
-    FeederResultDeserializer() {
-        super(FeederResult.class);
+    ShortCircuitBusResultsDeserializer() {
+        super(ShortCircuitBusResults.class);
     }
 
     @Override
-    public FeederResult deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
-        String connectableId = null;
-        FortescueValue current = null;
+    public ShortCircuitBusResults deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
+        String voltageLevelId = null;
+        String busId = null;
+        FortescueValue voltage = null;
 
         while (parser.nextToken() != JsonToken.END_OBJECT) {
             switch (parser.getCurrentName()) {
-                case "connectableId":
+                case "voltageLevelId":
                     parser.nextToken();
-                    connectableId = parser.readValueAs(String.class);
+                    voltageLevelId = parser.readValueAs(String.class);
                     break;
 
-                case "current":
+                case "busId":
                     parser.nextToken();
-                    current = parser.readValueAs(FortescueValue.class);
+                    busId = parser.readValueAs(String.class);
+                    break;
+
+                case "voltage":
+                    parser.nextToken();
+                    voltage = parser.readValueAs(FortescueValue.class);
                     break;
 
                 default:
                     throw new AssertionError("Unexpected field: " + parser.getCurrentName());
             }
         }
-        return new FeederResult(connectableId, current);
+        return new ShortCircuitBusResults(voltageLevelId, busId, voltage);
     }
 }

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitBusResultsSerializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/ShortCircuitBusResultsSerializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.shortcircuit.converter;
+package com.powsybl.shortcircuit.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/converter/ShortCircuitAnalysisResultExportersTest.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/converter/ShortCircuitAnalysisResultExportersTest.java
@@ -13,6 +13,7 @@ import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.security.LimitViolation;
 import com.powsybl.security.LimitViolationType;
 import com.powsybl.shortcircuit.*;
+import com.powsybl.shortcircuit.json.ShortCircuitAnalysisResultDeserializer;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/json/JsonFortescueValueTest.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/json/JsonFortescueValueTest.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.shortcircuit.FortescueValue;
-import com.powsybl.shortcircuit.converter.ShortCircuitAnalysisJsonModule;
 import org.junit.Test;
 
 import java.io.IOException;


### PR DESCRIPTION
Signed-off-by: Coline PILOQUET <coline.piloquet@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Moves serializers and deserializers of the shortcircuit API into the right package.


**What is the current behavior?** *(You can also link to an open issue here)*
Serializers/deserializers are into the converter package.