### PR TITLE
Powerfactory voltage levels and substations

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/ContainersMapping.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/ContainersMapping.java
@@ -124,7 +124,7 @@ public class ContainersMapping {
 
     public static <N, B> ContainersMapping create(List<N> buses, List<B> branches,
         ToIntFunction<N> busToNum, ToIntFunction<B> branchToNum1, ToIntFunction<B> branchToNum2,
-        Predicate<B> branchToIsTransformer, Predicate<B> branchToIsZeroImpedance,
+        Predicate<B> branchToIsZeroImpedance, Predicate<B> branchToIsTransformer,
         ToDoubleFunction<Integer> busToNominalVoltage, Function<Set<Integer>, String> busesToVoltageLevelId,
         Function<Set<Integer>, String> busesToSubstationId) {
 

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
@@ -7,17 +7,19 @@
 package com.powsybl.powerfactory.converter;
 
 import com.google.common.primitives.Ints;
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.util.ContainersMapping;
 import com.powsybl.powerfactory.model.DataObject;
 import com.powsybl.powerfactory.model.DataObjectIndex;
 import com.powsybl.powerfactory.model.DataObjectRef;
+import com.powsybl.powerfactory.model.PowerFactoryException;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ * @author José Antonio Marqués <marquesja at aia.es>
  */
 final class ContainersMappingHelper {
 
@@ -30,21 +32,15 @@ final class ContainersMappingHelper {
 
         private final DataObject obj2;
 
-        private final DataObject obj3;
-
         private final boolean transformer;
 
-        private final double r;
+        private final boolean zeroImpedance;
 
-        private final double x;
-
-        private Edge(DataObject obj1, DataObject obj2, DataObject obj3, boolean transformer, double r, double x) {
+        private Edge(DataObject obj1, DataObject obj2, boolean transformer, boolean zeroImpedance) {
             this.obj1 = Objects.requireNonNull(obj1);
             this.obj2 = Objects.requireNonNull(obj2);
-            this.obj3 = obj3;
             this.transformer = transformer;
-            this.r = r;
-            this.x = x;
+            this.zeroImpedance = zeroImpedance;
         }
 
         private DataObject getObj1() {
@@ -55,20 +51,12 @@ final class ContainersMappingHelper {
             return obj2;
         }
 
-        public DataObject getObj3() {
-            return obj3;
-        }
-
-        public boolean isTransformer() {
+        private boolean isTransformer() {
             return transformer;
         }
 
-        public double getR() {
-            return r;
-        }
-
-        public double getX() {
-            return x;
+        private boolean isZeroImpedance() {
+            return zeroImpedance;
         }
     }
 
@@ -76,51 +64,92 @@ final class ContainersMappingHelper {
 
         private final DataObjectIndex index;
 
+        private int noNameSubstationCount = 0;
+
         private int noNameVoltageLevelCount = 0;
 
         private BusesToVoltageLevelId(DataObjectIndex index) {
             this.index = index;
         }
 
-        public String getVoltageLevelId(Set<Integer> ids) {
-            List<DataObject> objs = ids.stream()
-                    .flatMap(id -> index.getDataObjectById(id).stream())
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
+        private double getNominalVoltage(Integer id) {
+            DataObject elmTerm = index.getDataObjectById(id).orElseThrow(() -> new PowerFactoryException("One ElemTerm was expected"));
+            return NodeConverter.getNominalVoltage(elmTerm);
+        }
 
-            Set<DataObject> containers = objs.stream()
-                    .map(obj -> {
-                        String className = obj.getParent().getDataClassName();
-                        if (className.equals("ElmSubstat") || className.equals("ElmTrfstat")) {
-                            return obj.getParent();
-                        }
-                        return null;
-                    })
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toSet());
-
-            String voltageLevelId = null;
-
-            if (containers.size() == 1) {
-                float uknom = objs.stream()
-                        .map(obj -> obj.findFloatAttributeValue("uknom").orElse(null))
-                        .filter(Objects::nonNull)
-                        .findFirst()
-                        .orElseThrow();
-
-                DataObject container = containers.iterator().next();
-                float unom = container.getFloatAttributeValue("Unom");
-                if (uknom == unom) { // check terminal nominal voltage is consistent with container one
-                    voltageLevelId = container.getLocName();
-                }
-            }
-
+        private String getVoltageLevelId(Set<Integer> ids) {
+            String voltageLevelId = getPowerFactoryVoltageLevelId(ids);
             // automatic naming
             return Objects.requireNonNullElseGet(voltageLevelId, () -> "VL" + noNameVoltageLevelCount++);
         }
+
+        private String getSubstationId(Set<Integer> ids) {
+            String substationId = getPowerFactorySubstationId(ids);
+            // automatic naming
+            return Objects.requireNonNullElseGet(substationId, () -> "S" + noNameSubstationCount++);
+        }
+
+        // Find an ElmSite with same ElmSubstats as defined by the ids argument
+        private String getPowerFactorySubstationId(Set<Integer> ids) {
+
+            Set<DataObject> elmTerms = elmTermsAssociatedTo(ids);
+            Set<DataObject> elmSubstats = elmSubstatsAssociatedTo(elmTerms);
+            Set<DataObject> elmSites = elmSitesAssociatedTo(elmSubstats);
+
+            if (elmSites.size() != 1) {
+                return null;
+            }
+            DataObject elmSite = elmSites.iterator().next();
+
+            Set<DataObject> dataObjects = elmSite.getChildren().stream()
+                .filter(dataObject -> dataObject.getDataClassName().equals(DataAttributeNames.ELMSUBSTAT))
+                .collect(Collectors.toSet());
+            if (!elmSubstats.equals(dataObjects)) {
+                return null;
+            }
+            return elmSite.getLocName();
+        }
+
+        // Find an ElmSubstat with same ElmTerms (Nodes) as defined by the ids argument
+        private String getPowerFactoryVoltageLevelId(Set<Integer> ids) {
+
+            Set<DataObject> elmTerms = elmTermsAssociatedTo(ids);
+            Set<DataObject> elmSubstats = elmSubstatsAssociatedTo(elmTerms);
+
+            if (elmSubstats.size() != 1) {
+                return null;
+            }
+            DataObject elmSubstat = elmSubstats.iterator().next();
+
+            Set<DataObject> dataObjects = elmSubstat.getChildren().stream()
+                .filter(dataObject -> dataObject.getDataClassName().equals(DataAttributeNames.ELMTERM))
+                .collect(Collectors.toSet());
+            if (!elmTerms.equals(dataObjects)) {
+                return null;
+            }
+            return elmSubstat.getLocName();
+        }
+
+        private Set<DataObject> elmTermsAssociatedTo(Set<Integer> ids) {
+            return ids.stream()
+                .flatMap(id -> index.getDataObjectById(id).stream())
+                .filter(dataObject -> dataObject.getDataClassName().equals(DataAttributeNames.ELMTERM))
+                .collect(Collectors.toSet());
+        }
+
+        private Set<DataObject> elmSubstatsAssociatedTo(Set<DataObject> elmTerms) {
+            return elmTerms.stream().map(DataObject::getParent)
+                .filter(dataObject -> dataObject.getDataClassName().equals(DataAttributeNames.ELMSUBSTAT))
+                .collect(Collectors.toSet());
+        }
+
+        private Set<DataObject> elmSitesAssociatedTo(Set<DataObject> elmSubstats) {
+            return elmSubstats.stream().map(DataObject::getParent)
+                .filter(dataObject -> dataObject.getDataClassName().equals(DataAttributeNames.ELMSITE)).collect(Collectors.toSet());
+        }
     }
 
-    private static boolean isBranch(DataObject connectedObj) {
+    private static boolean isConnectedElm(DataObject connectedObj) {
         if (connectedObj == null) {
             return false;
         }
@@ -128,54 +157,54 @@ final class ContainersMappingHelper {
         return dataClassName.equals("ElmTr2")
                 || dataClassName.equals("ElmTr3")
                 || dataClassName.equals("ElmLne")
-                || dataClassName.equals("ElmCoup");
+                || dataClassName.equals("ElmCoup")
+                || dataClassName.equals("ElmZpu");
     }
 
-    private static void createNodes(List<DataObject> elmTerms, List<DataObject> nodes, List<Edge> edges,
-                                    Map<DataObject, List<DataObject>> branchesByCubicleId) {
+    private static void createNodes(List<DataObject> elmTerms, List<DataObject> nodes,
+        Map<DataObject, List<DataObject>> connectedElmByElmTermId) {
         for (DataObject elmTerm : elmTerms) {
             nodes.add(elmTerm);
             for (DataObject staCubic : elmTerm.getChildrenByClass("StaCubic")) {
-                DataObject connectedObj = staCubic.findObjectAttributeValue("obj_id")
+                DataObject connectedObj = staCubic.findObjectAttributeValue(DataAttributeNames.OBJ_ID)
                         .flatMap(DataObjectRef::resolve)
                         .orElse(null);
-                if (isBranch(connectedObj)) {
-                    nodes.add(staCubic);
-                    edges.add(new Edge(elmTerm, staCubic, null, false, 0, 0));
-                    branchesByCubicleId.computeIfAbsent(connectedObj, k -> new ArrayList<>())
-                            .add(staCubic);
+                if (isConnectedElm(connectedObj)) {
+                    connectedElmByElmTermId.computeIfAbsent(connectedObj, k -> new ArrayList<>()).add(elmTerm);
                 }
             }
         }
     }
 
-    private static void createEdges(List<Edge> edges, Map<DataObject, List<DataObject>> branchesByCubicleId) {
-        for (Map.Entry<DataObject, List<DataObject>> e : branchesByCubicleId.entrySet()) {
+    // we do not have to consider the exact orientation of the element
+    private static void createEdges(List<Edge> edges, Map<DataObject, List<DataObject>> connectedElmByElmTermId) {
+        for (Map.Entry<DataObject, List<DataObject>> e : connectedElmByElmTermId.entrySet()) {
             DataObject connectedObj = e.getKey();
-            List<DataObject> staCubics = e.getValue();
-            if (staCubics.size() == 2) {
+            List<DataObject> elmTerms = e.getValue();
+            if (elmTerms.size() == 2) {
                 switch (connectedObj.getDataClassName()) {
                     case "ElmTr2":
-                        edges.add(new Edge(staCubics.get(0), staCubics.get(1), null, true, Double.MAX_VALUE, Double.MAX_VALUE));
+                        edges.add(new Edge(elmTerms.get(0), elmTerms.get(1), true, false));
                         break;
                     case "ElmLne":
-                        // TODO. Temporary until containersMapping PR. "typ_id" is not defined in some ElmLne
-                        edges.add(new Edge(staCubics.get(0), staCubics.get(1), null, false, Double.MAX_VALUE, Double.MAX_VALUE));
+                        edges.add(new Edge(elmTerms.get(0), elmTerms.get(1), false, false));
+                        break;
+                    case "ElmZpu":
+                        edges.add(new Edge(elmTerms.get(0), elmTerms.get(1), false, false));
                         break;
                     case "ElmCoup":
-                        edges.add(new Edge(staCubics.get(0), staCubics.get(1), null, false, 0, 0));
+                        edges.add(new Edge(elmTerms.get(0), elmTerms.get(1), false, true));
                         break;
                     default:
                         throw new IllegalStateException("Unexpected object class: " + connectedObj.getDataClassName());
                 }
-            } else if (staCubics.size() == 3) {
+            } else if (elmTerms.size() == 3) {
                 if (connectedObj.getDataClassName().equals("ElmTr3")) {
-                    edges.add(new Edge(staCubics.get(0), staCubics.get(1), staCubics.get(2), true, Double.MAX_VALUE, Double.MAX_VALUE));
+                    edges.add(new Edge(elmTerms.get(0), elmTerms.get(1), true, false));
+                    edges.add(new Edge(elmTerms.get(0), elmTerms.get(2), true, false));
                 } else {
                     throw new IllegalStateException("Unexpected object class: " + connectedObj.getDataClassName());
                 }
-            } else {
-                throw new PowsyblException(connectedObj.getLocName() + " should be connected at both sides");
             }
         }
     }
@@ -183,10 +212,10 @@ final class ContainersMappingHelper {
     static ContainersMapping create(DataObjectIndex index, List<DataObject> elmTerms) {
         List<DataObject> nodes = new ArrayList<>();
         List<Edge> edges = new ArrayList<>();
-        Map<DataObject, List<DataObject>> branchesByCubicleId = new HashMap<>();
+        Map<DataObject, List<DataObject>> connectedElmByElmTermId = new HashMap<>();
 
-        createNodes(elmTerms, nodes, edges, branchesByCubicleId);
-        createEdges(edges, branchesByCubicleId);
+        createNodes(elmTerms, nodes, connectedElmByElmTermId);
+        createEdges(edges, connectedElmByElmTermId);
 
         BusesToVoltageLevelId busesToVoltageLevelId = new BusesToVoltageLevelId(index);
 
@@ -194,11 +223,10 @@ final class ContainersMappingHelper {
             obj -> Ints.checkedCast(obj.getId()),
             edge -> Ints.checkedCast(edge.getObj1().getId()),
             edge -> Ints.checkedCast(edge.getObj2().getId()),
-            edge -> edge.getObj3() != null ? Ints.checkedCast(edge.getObj3().getId()) : 0,
-            Edge::getR,
-            Edge::getX,
             Edge::isTransformer,
+            Edge::isZeroImpedance,
+            busesToVoltageLevelId::getNominalVoltage,
             busesToVoltageLevelId::getVoltageLevelId,
-            value -> "S" + value);
+            busesToVoltageLevelId::getSubstationId);
     }
 }

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
@@ -64,10 +64,6 @@ final class ContainersMappingHelper {
 
         private final DataObjectIndex index;
 
-        private int noNameSubstationCount = 0;
-
-        private int noNameVoltageLevelCount = 0;
-
         private BusesToVoltageLevelId(DataObjectIndex index) {
             this.index = index;
         }
@@ -80,13 +76,15 @@ final class ContainersMappingHelper {
         private String getVoltageLevelId(Set<Integer> ids) {
             String voltageLevelId = getPowerFactoryVoltageLevelId(ids);
             // automatic naming
-            return Objects.requireNonNullElseGet(voltageLevelId, () -> "VL" + noNameVoltageLevelCount++);
+            return Objects.requireNonNullElseGet(voltageLevelId, () -> "VL" + ids.stream().sorted().findFirst()
+                .orElseThrow(() -> new PowerFactoryException("Unexpected empty ids set")));
         }
 
         private String getSubstationId(Set<Integer> ids) {
             String substationId = getPowerFactorySubstationId(ids);
             // automatic naming
-            return Objects.requireNonNullElseGet(substationId, () -> "S" + noNameSubstationCount++);
+            return Objects.requireNonNullElseGet(substationId, () -> "S" + ids.stream().sorted().findFirst()
+                .orElseThrow(() -> new PowerFactoryException("Unexpected empty ids set")));
         }
 
         // Find an ElmSite with same ElmSubstats as defined by the ids argument

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
@@ -184,13 +184,14 @@ final class ContainersMappingHelper {
             if (elmTerms.size() == 2) {
                 switch (connectedObj.getDataClassName()) {
                     case "ElmTr2":
+                        // All transformers are considered with impedance
                         edges.add(new Edge(elmTerms.get(0), elmTerms.get(1), true, false));
                         break;
                     case "ElmLne":
-                        edges.add(new Edge(elmTerms.get(0), elmTerms.get(1), false, false));
+                        // All lines are considered with impedance, only zero impedance lines are necessary
                         break;
                     case "ElmZpu":
-                        edges.add(new Edge(elmTerms.get(0), elmTerms.get(1), false, false));
+                        // All lines are considered with impedance, only zero impedance lines are necessary
                         break;
                     case "ElmCoup":
                         edges.add(new Edge(elmTerms.get(0), elmTerms.get(1), false, true));
@@ -223,8 +224,8 @@ final class ContainersMappingHelper {
             obj -> Ints.checkedCast(obj.getId()),
             edge -> Ints.checkedCast(edge.getObj1().getId()),
             edge -> Ints.checkedCast(edge.getObj2().getId()),
-            Edge::isTransformer,
             Edge::isZeroImpedance,
+            Edge::isTransformer,
             busesToVoltageLevelId::getNominalVoltage,
             busesToVoltageLevelId::getVoltageLevelId,
             busesToVoltageLevelId::getSubstationId);

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/ContainersMappingHelper.java
@@ -102,10 +102,8 @@ final class ContainersMappingHelper {
             Set<DataObject> dataObjects = elmSite.getChildren().stream()
                 .filter(dataObject -> dataObject.getDataClassName().equals(DataAttributeNames.ELMSUBSTAT))
                 .collect(Collectors.toSet());
-            if (!elmSubstats.equals(dataObjects)) {
-                return null;
-            }
-            return elmSite.getLocName();
+
+            return elmSubstats.equals(dataObjects) ? elmSite.getLocName() : null;
         }
 
         // Find an ElmSubstat with same ElmTerms (Nodes) as defined by the ids argument
@@ -122,10 +120,8 @@ final class ContainersMappingHelper {
             Set<DataObject> dataObjects = elmSubstat.getChildren().stream()
                 .filter(dataObject -> dataObject.getDataClassName().equals(DataAttributeNames.ELMTERM))
                 .collect(Collectors.toSet());
-            if (!elmTerms.equals(dataObjects)) {
-                return null;
-            }
-            return elmSubstat.getLocName();
+
+            return elmTerms.equals(dataObjects) ? elmSubstat.getLocName() : null;
         }
 
         private Set<DataObject> elmTermsAssociatedTo(Set<Integer> ids) {
@@ -143,7 +139,8 @@ final class ContainersMappingHelper {
 
         private Set<DataObject> elmSitesAssociatedTo(Set<DataObject> elmSubstats) {
             return elmSubstats.stream().map(DataObject::getParent)
-                .filter(dataObject -> dataObject.getDataClassName().equals(DataAttributeNames.ELMSITE)).collect(Collectors.toSet());
+                .filter(dataObject -> dataObject.getDataClassName().equals(DataAttributeNames.ELMSITE))
+                .collect(Collectors.toSet());
         }
     }
 

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/DataAttributeNames.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/DataAttributeNames.java
@@ -17,4 +17,8 @@ final class DataAttributeNames {
     }
 
     static final String TYP_ID = "typ_id";
+    static final String ELMTERM = "ElmTerm";
+    static final String ELMSUBSTAT = "ElmSubstat";
+    static final String ELMSITE = "ElmSite";
+    static final String OBJ_ID = "obj_id";
 }

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/NodeConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/NodeConverter.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import org.apache.commons.lang3.mutable.MutableInt;
 
 import com.google.common.primitives.Ints;
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Substation;
 import com.powsybl.iidm.network.TopologyKind;
@@ -21,6 +20,7 @@ import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.powerfactory.converter.PowerFactoryImporter.ImportContext;
 import com.powsybl.powerfactory.model.DataObject;
 import com.powsybl.powerfactory.model.DataObjectRef;
+import com.powsybl.powerfactory.model.PowerFactoryException;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -81,7 +81,7 @@ class NodeConverter extends AbstractConverter {
             .add();
     }
 
-    private static double getNominalVoltage(DataObject elmTerm) {
+    static double getNominalVoltage(DataObject elmTerm) {
         return elmTerm.getFloatAttributeValue("uknom");
     }
 
@@ -138,7 +138,7 @@ class NodeConverter extends AbstractConverter {
             new SwitchConverter(getImportContext(), getNetwork()).createFromStaSwitch(vl, node, additionalNode, staSwitches.get(0));
             referenceNode = additionalNode;
         } else {
-            throw new PowsyblException("Only one staSwitch is allowed inside a cubicle");
+            throw new PowerFactoryException("Only one staSwitch is allowed inside a cubicle");
         }
 
         return referenceNode;

--- a/powerfactory/powerfactory-converter/src/test/java/com/powsybl/powerfactory/converter/PowerFactoryImporterTest.java
+++ b/powerfactory/powerfactory-converter/src/test/java/com/powsybl/powerfactory/converter/PowerFactoryImporterTest.java
@@ -210,6 +210,11 @@ public class PowerFactoryImporterTest extends AbstractConverterTest {
         assertTrue(importAndCompareXiidm("Tower"));
     }
 
+    @Test
+    public void voltageLevelsAndSubstations() {
+        assertTrue(importAndCompareXiidm("VoltageLevelsAndSubstations"));
+    }
+
     private boolean importAndCompareXiidm(String powerfactoryCase) {
         importAndCompareXml(powerfactoryCase);
         return true;

--- a/powerfactory/powerfactory-converter/src/test/resources/CommonImpedance.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/CommonImpedance.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="CommonImpedance" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -21,7 +21,7 @@
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S3">
+    <iidm:substation id="S2">
         <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/CommonImpedance.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/CommonImpedance.xiidm
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="CommonImpedance" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S6">
+        <iidm:voltageLevel id="VL6" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL6_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.470001220703125" voltageRegulatorOn="true" targetP="50.470001220703125" targetV="116.59999370574951" targetQ="0.0" node="2">
                 <iidm:minMaxReactiveLimits minQ="0.0" maxQ="0.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S7">
+        <iidm:voltageLevel id="VL7" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL7_2 Bus 2" node="0"/>
+                <iidm:switch id="VL7_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL7_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S2">
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="zpu_2_3_1" r="-25.51043060620626" x="165.7264362335205" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL6" node2="1" voltageLevelId2="VL7"/>
+    <iidm:line id="zpu_2_3_1" r="-25.51043060620626" x="165.7264362335205" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL7" node2="2" voltageLevelId2="VL8"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/CommonImpedanceOnlyImpedance12.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/CommonImpedanceOnlyImpedance12.xiidm
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="CommonImpedanceOnlyImpedance12" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S6">
+        <iidm:voltageLevel id="VL6" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL6_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.470001220703125" voltageRegulatorOn="true" targetP="50.470001220703125" targetV="116.59999370574951" targetQ="0.0" node="2">
                 <iidm:minMaxReactiveLimits minQ="0.0" maxQ="0.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S7">
+        <iidm:voltageLevel id="VL7" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL7_2 Bus 2" node="0"/>
+                <iidm:switch id="VL7_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL7_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S2">
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="zpu_2_3_1" r="-25.51043060620626" x="165.7264362335205" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL6" node2="1" voltageLevelId2="VL7"/>
+    <iidm:line id="zpu_2_3_1" r="-25.51043060620626" x="165.7264362335205" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL7" node2="2" voltageLevelId2="VL8"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/CommonImpedanceOnlyImpedance12.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/CommonImpedanceOnlyImpedance12.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="CommonImpedanceOnlyImpedance12" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -21,7 +21,7 @@
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S3">
+    <iidm:substation id="S2">
         <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Switches.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Switches.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Switches" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Switches.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Switches.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Switches" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S10">
+        <iidm:voltageLevel id="VL10" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="423.9999694824219" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.470001220703125" voltageRegulatorOn="true" targetP="50.470001220703125" targetV="423.9999771118164" targetQ="0.0" node="2">
@@ -13,26 +13,26 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S11">
+        <iidm:voltageLevel id="VL11" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL11_2 Bus 2" node="0"/>
+                <iidm:switch id="VL11_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL11_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="418.62994384765625" angle="-1.461245059967041" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="20.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL12" nominalV="20.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 3-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="2" node2="3"/>
-                <iidm:switch id="VL2_CB.Load" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL12_3 Bus 3-Load" node="0"/>
+                <iidm:switch id="VL12_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL12_Switch#0" kind="BREAKER" retained="false" open="false" node1="2" node2="3"/>
+                <iidm:switch id="VL12_CB.Load" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="20.805301666259766" angle="-2.0938339233398438" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="3"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0031199999227605408" x="0.09771995949237713" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="20.0" ratedS="29.760000228881836" node1="2" voltageLevelId1="VL1" node2="1" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0031199999227605408" x="0.09771995949237713" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="20.0" ratedS="29.760000228881836" node1="2" voltageLevelId1="VL11" node2="1" voltageLevelId2="VL12">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.1111111111111112"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0526315789473684"/>
@@ -42,5 +42,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL10" node2="1" voltageLevelId2="VL11"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_solved.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_solved.xiidm
@@ -1,49 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_solved" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL0" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S0">
+        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 1" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL2_1 1" node="0"/>
+                <iidm:busbarSection id="VL2_2 2" node="3"/>
+                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
                 <iidm:bus v="18.719999313354492" angle="51.73326110839844" nodes="0,1,2"/>
+                <iidm:bus v="18.719999313354492" angle="69.67826080322266" nodes="3,4,5"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:bus v="18.719999313354492" angle="69.67826080322266" nodes="0,1,2"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
+            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="4">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL3" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL3_4 4" node="0"/>
-                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL3_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL1_4 4" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
                 <iidm:bus v="493.4682312011719" angle="46.70308303833008" nodes="0,1,2,3,4"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL6" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL6_7 7" node="0"/>
-                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL0_7 7" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="15.624289512634277" angle="54.178287506103516" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL0">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="11" loadTapChangingCapabilities="false">
                 <iidm:step r="-76.82265450419209" x="-76.82265450419209" g="331.4557938400971" b="331.4557938400971" rho="0.4814285564422608"/>
                 <iidm:step r="-72.06122593003874" x="-72.06122593003874" g="257.9255115116748" b="257.9255115116748" rho="0.5285714149475098"/>
@@ -70,7 +66,7 @@
                 <iidm:step r="130.60592291890356" x="130.60592291890356" g="-56.635979365037095" b="-56.635979365037095" rho="1.518571443557739"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.23699951171875" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.998000144958496" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL1" node3="2" voltageLevelId3="VL6">
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.23699951171875" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.998000144958496" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -78,32 +74,32 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:substation id="S2">
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S1">
+        <iidm:voltageLevel id="VL4" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 3" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL4_3 3" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="18.360000610351562" angle="19.876766204833984" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL4" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL3" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL4_5 5" node="0"/>
-                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL4_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL4_Switch#2" kind="BREAKER" retained="false" open="true" node1="0" node2="4"/>
-                <iidm:switch id="VL4_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
+                <iidm:busbarSection id="VL3_5 5" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL3_Switch#2" kind="BREAKER" retained="false" open="true" node1="0" node2="4"/>
+                <iidm:switch id="VL3_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
                 <iidm:bus v="482.2877502441406" angle="14.651644706726074" nodes="0,1,2,3,5"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="3"/>
             <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="4"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL4" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL4">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="11" loadTapChangingCapabilities="false">
                 <iidm:step r="-10.201804147623294" x="-10.201804147623294" g="11.360811930336002" b="11.360811930336002" rho="0.9476190999150276"/>
                 <iidm:step r="-9.297043098613834" x="-9.297043098613834" g="10.249988992885584" b="10.249988992885584" rho="0.9523809999227525"/>
@@ -131,7 +127,7 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:substation id="S3">
+    <iidm:substation id="S2">
         <iidm:voltageLevel id="VL5" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL5_6 6" node="0"/>
@@ -146,6 +142,6 @@
             <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="2"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL4" node2="1" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="1" voltageLevelId2="VL3"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL5"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_solved.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_solved.xiidm
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_solved" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S28">
+        <iidm:voltageLevel id="VL28" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_1 1" node="0"/>
-                <iidm:busbarSection id="VL2_2 2" node="3"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:busbarSection id="VL28_1 1" node="0"/>
+                <iidm:busbarSection id="VL28_2 2" node="3"/>
+                <iidm:switch id="VL28_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL28_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL28_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL28_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
                 <iidm:bus v="18.719999313354492" angle="51.73326110839844" nodes="0,1,2"/>
                 <iidm:bus v="18.719999313354492" angle="69.67826080322266" nodes="3,4,5"/>
             </iidm:nodeBreakerTopology>
@@ -19,27 +19,27 @@
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL31" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_4 4" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL31_4 4" node="0"/>
+                <iidm:switch id="VL31_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL31_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL31_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL31_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
                 <iidm:bus v="493.4682312011719" angle="46.70308303833008" nodes="0,1,2,3,4"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL34" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_7 7" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL34_7 7" node="0"/>
+                <iidm:switch id="VL34_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL34_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="15.624289512634277" angle="54.178287506103516" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL31" node2="2" voltageLevelId2="VL28">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="11" loadTapChangingCapabilities="false">
                 <iidm:step r="-76.82265450419209" x="-76.82265450419209" g="331.4557938400971" b="331.4557938400971" rho="0.4814285564422608"/>
                 <iidm:step r="-72.06122593003874" x="-72.06122593003874" g="257.9255115116748" b="257.9255115116748" rho="0.5285714149475098"/>
@@ -66,7 +66,7 @@
                 <iidm:step r="130.60592291890356" x="130.60592291890356" g="-56.635979365037095" b="-56.635979365037095" rho="1.518571443557739"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.23699951171875" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.998000144958496" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.23699951171875" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.998000144958496" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL31" node2="5" voltageLevelId2="VL28" node3="2" voltageLevelId3="VL34">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -74,32 +74,32 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL4" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S30">
+        <iidm:voltageLevel id="VL30" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL4_3 3" node="0"/>
-                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL30_3 3" node="0"/>
+                <iidm:switch id="VL30_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL30_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="18.360000610351562" angle="19.876766204833984" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL3" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL32" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL3_5 5" node="0"/>
-                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL3_Switch#2" kind="BREAKER" retained="false" open="true" node1="0" node2="4"/>
-                <iidm:switch id="VL3_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
+                <iidm:busbarSection id="VL32_5 5" node="0"/>
+                <iidm:switch id="VL32_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL32_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL32_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL32_Switch#2" kind="BREAKER" retained="false" open="true" node1="0" node2="4"/>
+                <iidm:switch id="VL32_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
                 <iidm:bus v="482.2877502441406" angle="14.651644706726074" nodes="0,1,2,3,5"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="3"/>
             <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="4"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL4">
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL32" node2="2" voltageLevelId2="VL30">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="11" loadTapChangingCapabilities="false">
                 <iidm:step r="-10.201804147623294" x="-10.201804147623294" g="11.360811930336002" b="11.360811930336002" rho="0.9476190999150276"/>
                 <iidm:step r="-9.297043098613834" x="-9.297043098613834" g="10.249988992885584" b="10.249988992885584" rho="0.9523809999227525"/>
@@ -127,13 +127,13 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:substation id="S2">
-        <iidm:voltageLevel id="VL5" nominalV="500.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S33">
+        <iidm:voltageLevel id="VL33" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL5_6 6" node="0"/>
-                <iidm:switch id="VL5_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL5_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL5_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL33_6 6" node="0"/>
+                <iidm:switch id="VL33_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL33_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL33_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="500.0" angle="0.0" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="3">
@@ -142,6 +142,6 @@
             <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="2"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="1" voltageLevelId2="VL3"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL31" node2="1" voltageLevelId2="VL32"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL32" node2="1" voltageLevelId2="VL33"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding1" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S32">
+        <iidm:voltageLevel id="VL32" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_1 1" node="0"/>
-                <iidm:busbarSection id="VL2_2 2" node="3"/>
-                <iidm:busbarSection id="VL2_3 3" node="7"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
-                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
-                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
+                <iidm:busbarSection id="VL32_1 1" node="0"/>
+                <iidm:busbarSection id="VL32_2 2" node="3"/>
+                <iidm:busbarSection id="VL32_3 3" node="7"/>
+                <iidm:switch id="VL32_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL32_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL32_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL32_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL32_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL32_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL32_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-3.4843528270721436" nodes="0,1,2"/>
                 <iidm:bus v="18.719999313354492" angle="3.0161287784576416" nodes="3,4,5,6"/>
                 <iidm:bus v="18.360000610351562" angle="-14.952764511108398" nodes="7,8,9"/>
@@ -27,25 +27,25 @@
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL35" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_4 4" node="0"/>
-                <iidm:busbarSection id="VL1_5 5" node="5"/>
-                <iidm:busbarSection id="VL1_6 6" node="12"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
-                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
-                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
-                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
-                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
-                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
-                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
-                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
-                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
-                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
+                <iidm:busbarSection id="VL35_4 4" node="0"/>
+                <iidm:busbarSection id="VL35_5 5" node="5"/>
+                <iidm:busbarSection id="VL35_6 6" node="12"/>
+                <iidm:switch id="VL35_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL35_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL35_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL35_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL35_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL35_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL35_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL35_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL35_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL35_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL35_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL35_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL35_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL35_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="508.2210998535156" angle="-8.368151664733887" nodes="0,1,2,3,4"/>
                 <iidm:bus v="497.08197021484375" angle="-20.021961212158203" nodes="5,6,7,8,10,11"/>
                 <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
@@ -58,21 +58,21 @@
             <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
             <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL38" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_7 7" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL38_7 7" node="0"/>
+                <iidm:switch id="VL38_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL38_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL38_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.824806213378906" angle="-17.741437911987305" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL35" node2="2" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
@@ -80,6 +80,6 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL35"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL35" node2="13" voltageLevelId2="VL35"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1.xiidm
@@ -1,94 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding1" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL0" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S0">
+        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 1" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL2_1 1" node="0"/>
+                <iidm:busbarSection id="VL2_2 2" node="3"/>
+                <iidm:busbarSection id="VL2_3 3" node="7"/>
+                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-3.4843528270721436" nodes="0,1,2"/>
+                <iidm:bus v="18.719999313354492" angle="3.0161287784576416" nodes="3,4,5,6"/>
+                <iidm:bus v="18.360000610351562" angle="-14.952764511108398" nodes="7,8,9"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="18.719999313354492" angle="3.0161287784576416" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
+            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="4">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 3" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:bus v="18.360000610351562" angle="-14.952764511108398" nodes="0,1,2"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="1">
+            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="8">
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL3" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL3_4 4" node="0"/>
-                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL3_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL1_4 4" node="0"/>
+                <iidm:busbarSection id="VL1_5 5" node="5"/>
+                <iidm:busbarSection id="VL1_6 6" node="12"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="508.2210998535156" angle="-8.368151664733887" nodes="0,1,2,3,4"/>
+                <iidm:bus v="497.08197021484375" angle="-20.021961212158203" nodes="5,6,7,8,10,11"/>
+                <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL4" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL4_5 5" node="0"/>
-                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL4_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL4_Switch#2" kind="BREAKER" retained="false" open="true" node1="0" node2="4"/>
-                <iidm:switch id="VL4_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL4_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
-                <iidm:bus v="497.08197021484375" angle="-20.021961212158203" nodes="0,1,2,3,5,6"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="3"/>
-            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="4"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL5" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL5_6 6" node="0"/>
-                <iidm:switch id="VL5_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL5_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL5_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL5_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:bus v="500.0" angle="0.0" nodes="0,1,2,3,4"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="3">
+            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="15">
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
             </iidm:generator>
-            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="2"/>
+            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
+            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="8"/>
+            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
+            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL6" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL6_7 7" node="0"/>
-                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL6_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL0_7 7" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.824806213378906" angle="-17.741437911987305" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL0"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL5" node2="3" voltageLevelId2="VL1"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL4" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="6" voltageLevelId1="VL4" node2="3" voltageLevelId2="VL6"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL1" node3="2" voltageLevelId3="VL6">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
@@ -96,6 +80,6 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL4" node2="1" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding12.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding12.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding12" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S32">
+        <iidm:voltageLevel id="VL32" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_1 1" node="0"/>
-                <iidm:busbarSection id="VL2_2 2" node="3"/>
-                <iidm:busbarSection id="VL2_3 3" node="7"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
-                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
-                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
+                <iidm:busbarSection id="VL32_1 1" node="0"/>
+                <iidm:busbarSection id="VL32_2 2" node="3"/>
+                <iidm:busbarSection id="VL32_3 3" node="7"/>
+                <iidm:switch id="VL32_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL32_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL32_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL32_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL32_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL32_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL32_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-3.236793041229248" nodes="0,1,2"/>
                 <iidm:bus v="18.719999313354492" angle="2.994687080383301" nodes="3,4,5,6"/>
                 <iidm:bus v="18.360000610351562" angle="-14.669854164123535" nodes="7,8,9"/>
@@ -27,25 +27,25 @@
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL35" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_4 4" node="0"/>
-                <iidm:busbarSection id="VL1_5 5" node="5"/>
-                <iidm:busbarSection id="VL1_6 6" node="12"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
-                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
-                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
-                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
-                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
-                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
-                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
-                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
-                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
-                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
+                <iidm:busbarSection id="VL35_4 4" node="0"/>
+                <iidm:busbarSection id="VL35_5 5" node="5"/>
+                <iidm:busbarSection id="VL35_6 6" node="12"/>
+                <iidm:switch id="VL35_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL35_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL35_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL35_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL35_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL35_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL35_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL35_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL35_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL35_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL35_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL35_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL35_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL35_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="509.7851257324219" angle="-8.105572700500488" nodes="0,1,2,3,4"/>
                 <iidm:bus v="497.94464111328125" angle="-19.73024559020996" nodes="5,6,7,8,10,11"/>
                 <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
@@ -58,21 +58,21 @@
             <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
             <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL38" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_7 7" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL38_7 7" node="0"/>
+                <iidm:switch id="VL38_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL38_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL38_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.872366905212402" angle="-17.446496963500977" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL35" node2="2" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
@@ -80,6 +80,6 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL35"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL35" node2="13" voltageLevelId2="VL35"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding12.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding12.xiidm
@@ -1,94 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding12" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL0" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S0">
+        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 1" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL2_1 1" node="0"/>
+                <iidm:busbarSection id="VL2_2 2" node="3"/>
+                <iidm:busbarSection id="VL2_3 3" node="7"/>
+                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-3.236793041229248" nodes="0,1,2"/>
+                <iidm:bus v="18.719999313354492" angle="2.994687080383301" nodes="3,4,5,6"/>
+                <iidm:bus v="18.360000610351562" angle="-14.669854164123535" nodes="7,8,9"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="18.719999313354492" angle="2.994687080383301" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
+            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="4">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 3" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:bus v="18.360000610351562" angle="-14.669854164123535" nodes="0,1,2"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="1">
+            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="8">
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL3" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL3_4 4" node="0"/>
-                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL3_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL1_4 4" node="0"/>
+                <iidm:busbarSection id="VL1_5 5" node="5"/>
+                <iidm:busbarSection id="VL1_6 6" node="12"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="509.7851257324219" angle="-8.105572700500488" nodes="0,1,2,3,4"/>
+                <iidm:bus v="497.94464111328125" angle="-19.73024559020996" nodes="5,6,7,8,10,11"/>
+                <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL4" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL4_5 5" node="0"/>
-                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL4_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL4_Switch#2" kind="BREAKER" retained="false" open="true" node1="0" node2="4"/>
-                <iidm:switch id="VL4_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL4_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
-                <iidm:bus v="497.94464111328125" angle="-19.73024559020996" nodes="0,1,2,3,5,6"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="3"/>
-            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="4"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL5" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL5_6 6" node="0"/>
-                <iidm:switch id="VL5_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL5_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL5_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL5_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:bus v="500.0" angle="0.0" nodes="0,1,2,3,4"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="3">
+            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="15">
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
             </iidm:generator>
-            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="2"/>
+            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
+            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="8"/>
+            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
+            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL6" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL6_7 7" node="0"/>
-                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL6_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL0_7 7" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.872366905212402" angle="-17.446496963500977" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL0"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL5" node2="3" voltageLevelId2="VL1"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL4" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="6" voltageLevelId1="VL4" node2="3" voltageLevelId2="VL6"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL1" node3="2" voltageLevelId3="VL6">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
@@ -96,6 +80,6 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL4" node2="1" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_complete.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_complete.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding1 - Study Case" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S78">
+        <iidm:voltageLevel id="VL78" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_1 1" node="0"/>
-                <iidm:busbarSection id="VL2_2 2" node="3"/>
-                <iidm:busbarSection id="VL2_3 3" node="7"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
-                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
-                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
+                <iidm:busbarSection id="VL78_1 1" node="0"/>
+                <iidm:busbarSection id="VL78_2 2" node="3"/>
+                <iidm:busbarSection id="VL78_3 3" node="7"/>
+                <iidm:switch id="VL78_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL78_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL78_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL78_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL78_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL78_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL78_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="1560.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
@@ -24,25 +24,25 @@
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL81" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_4 4" node="0"/>
-                <iidm:busbarSection id="VL1_5 5" node="5"/>
-                <iidm:busbarSection id="VL1_6 6" node="12"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
-                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="true" node1="5" node2="7"/>
-                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
-                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="false" node1="5" node2="9"/>
-                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
-                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
-                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
-                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
-                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
-                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
+                <iidm:busbarSection id="VL81_4 4" node="0"/>
+                <iidm:busbarSection id="VL81_5 5" node="5"/>
+                <iidm:busbarSection id="VL81_6 6" node="12"/>
+                <iidm:switch id="VL81_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL81_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL81_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL81_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL81_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL81_Switch#4" kind="BREAKER" retained="false" open="true" node1="5" node2="7"/>
+                <iidm:switch id="VL81_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL81_Switch#6" kind="BREAKER" retained="false" open="false" node1="5" node2="9"/>
+                <iidm:switch id="VL81_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL81_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL81_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL81_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL81_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL81_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="20000.0" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="14">
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
@@ -52,20 +52,20 @@
             <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="7"/>
             <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="13"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL84" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_7 7" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL84_7 7" node="0"/>
+                <iidm:switch id="VL84_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL84_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL84_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="3" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL0"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799050892384979E-7" x1="1.1395910252132228E-4" g1="0.14457200622558594" b1="-0.1079031910636207" ratedU1="500.0" ratedS1="101.0" r2="2.506555016520443E-6" x2="1.9130874466647454E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.3908508670836E-7" x3="5.517908790607979E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="4" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2" node3="3" voltageLevelId3="VL0">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="3" voltageLevelId1="VL81" node2="2" voltageLevelId2="VL78"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL81" node2="5" voltageLevelId2="VL78"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL81" node2="9" voltageLevelId2="VL78"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL81" node2="2" voltageLevelId2="VL84"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799050892384979E-7" x1="1.1395910252132228E-4" g1="0.14457200622558594" b1="-0.1079031910636207" ratedU1="500.0" ratedS1="101.0" r2="2.506555016520443E-6" x2="1.9130874466647454E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.3908508670836E-7" x3="5.517908790607979E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="4" voltageLevelId1="VL81" node2="6" voltageLevelId2="VL78" node3="3" voltageLevelId3="VL84">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
@@ -73,6 +73,6 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL1" node2="8" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="9" voltageLevelId1="VL1" node2="15" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL81" node2="8" voltageLevelId2="VL81"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="9" voltageLevelId1="VL81" node2="15" voltageLevelId2="VL81"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_complete.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_complete.xiidm
@@ -1,87 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding1 - Study Case" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL0" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S0">
+        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 1" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL2_1 1" node="0"/>
+                <iidm:busbarSection id="VL2_2 2" node="3"/>
+                <iidm:busbarSection id="VL2_3 3" node="7"/>
+                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="1560.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
             </iidm:generator>
+            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1560.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="4">
+                <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
+            </iidm:generator>
+            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="890.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="8">
+                <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
+            </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="18.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 2" node="0"/>
+                <iidm:busbarSection id="VL1_4 4" node="0"/>
+                <iidm:busbarSection id="VL1_5 5" node="5"/>
+                <iidm:busbarSection id="VL1_6 6" node="12"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="true" node1="5" node2="7"/>
+                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="false" node1="5" node2="9"/>
+                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1560.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
+            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="20000.0" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="14">
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 3" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="890.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="1">
-                <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
-            </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL3" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL3_4 4" node="0"/>
-                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL3_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-            </iidm:nodeBreakerTopology>
             <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="1"/>
+            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="6"/>
+            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="7"/>
+            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="13"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL4" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL4_5 5" node="0"/>
-                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="true" node1="0" node2="2"/>
-                <iidm:switch id="VL4_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL4_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL4_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL4_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="1"/>
-            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL5" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL5_6 6" node="0"/>
-                <iidm:switch id="VL5_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL5_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL5_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL5_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="20000.0" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="2">
-                <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
-            </iidm:generator>
-            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="1"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL6" nominalV="16.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL6_7 7" node="0"/>
-                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL6_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL0_7 7" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="3" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL0"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL5" node2="2" voltageLevelId2="VL1"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL4" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="6" voltageLevelId1="VL4" node2="2" voltageLevelId2="VL6"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799050892384979E-7" x1="1.1395910252132228E-4" g1="0.14457200622558594" b1="-0.1079031910636207" ratedU1="500.0" ratedS1="101.0" r2="2.506555016520443E-6" x2="1.9130874466647454E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.3908508670836E-7" x3="5.517908790607979E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="4" voltageLevelId1="VL3" node2="3" voltageLevelId2="VL1" node3="3" voltageLevelId3="VL6">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="3" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL0"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799050892384979E-7" x1="1.1395910252132228E-4" g1="0.14457200622558594" b1="-0.1079031910636207" ratedU1="500.0" ratedS1="101.0" r2="2.506555016520443E-6" x2="1.9130874466647454E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.3908508670836E-7" x3="5.517908790607979E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="4" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2" node3="3" voltageLevelId3="VL0">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
@@ -89,6 +73,6 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL3" node2="3" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="4" voltageLevelId1="VL4" node2="3" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL1" node2="8" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="9" voltageLevelId1="VL1" node2="15" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_ratio.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_ratio.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding1_ratio" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S32">
+        <iidm:voltageLevel id="VL32" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_1 1" node="0"/>
-                <iidm:busbarSection id="VL2_2 2" node="3"/>
-                <iidm:busbarSection id="VL2_3 3" node="7"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
-                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
-                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
+                <iidm:busbarSection id="VL32_1 1" node="0"/>
+                <iidm:busbarSection id="VL32_2 2" node="3"/>
+                <iidm:busbarSection id="VL32_3 3" node="7"/>
+                <iidm:switch id="VL32_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL32_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL32_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL32_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL32_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL32_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL32_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-3.747093677520752" nodes="0,1,2"/>
                 <iidm:bus v="18.719999313354492" angle="3.0309298038482666" nodes="3,4,5,6"/>
                 <iidm:bus v="18.360000610351562" angle="-15.142807960510254" nodes="7,8,9"/>
@@ -27,25 +27,25 @@
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL35" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_4 4" node="0"/>
-                <iidm:busbarSection id="VL1_5 5" node="5"/>
-                <iidm:busbarSection id="VL1_6 6" node="12"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
-                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
-                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
-                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
-                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
-                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
-                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
-                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
-                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
-                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
+                <iidm:busbarSection id="VL35_4 4" node="0"/>
+                <iidm:busbarSection id="VL35_5 5" node="5"/>
+                <iidm:busbarSection id="VL35_6 6" node="12"/>
+                <iidm:switch id="VL35_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL35_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL35_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL35_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL35_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL35_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL35_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL35_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL35_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL35_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL35_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL35_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL35_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL35_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="510.6855773925781" angle="-8.607267379760742" nodes="0,1,2,3,4"/>
                 <iidm:bus v="496.7574462890625" angle="-20.21532440185547" nodes="5,6,7,8,10,11"/>
                 <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
@@ -58,21 +58,21 @@
             <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
             <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL38" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_7 7" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL38_7 7" node="0"/>
+                <iidm:switch id="VL38_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL38_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL38_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.776790618896484" angle="-17.9434814453125" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL35" node2="2" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
@@ -80,6 +80,6 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL35"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL35" node2="13" voltageLevelId2="VL35"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_ratio.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_ratio.xiidm
@@ -1,94 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding1_ratio" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL0" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S0">
+        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 1" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL2_1 1" node="0"/>
+                <iidm:busbarSection id="VL2_2 2" node="3"/>
+                <iidm:busbarSection id="VL2_3 3" node="7"/>
+                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-3.747093677520752" nodes="0,1,2"/>
+                <iidm:bus v="18.719999313354492" angle="3.0309298038482666" nodes="3,4,5,6"/>
+                <iidm:bus v="18.360000610351562" angle="-15.142807960510254" nodes="7,8,9"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="18.719999313354492" angle="3.0309298038482666" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
+            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="4">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 3" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:bus v="18.360000610351562" angle="-15.142807960510254" nodes="0,1,2"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="1">
+            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="8">
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL3" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL3_4 4" node="0"/>
-                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL3_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL1_4 4" node="0"/>
+                <iidm:busbarSection id="VL1_5 5" node="5"/>
+                <iidm:busbarSection id="VL1_6 6" node="12"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="510.6855773925781" angle="-8.607267379760742" nodes="0,1,2,3,4"/>
+                <iidm:bus v="496.7574462890625" angle="-20.21532440185547" nodes="5,6,7,8,10,11"/>
+                <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL4" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL4_5 5" node="0"/>
-                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL4_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL4_Switch#2" kind="BREAKER" retained="false" open="true" node1="0" node2="4"/>
-                <iidm:switch id="VL4_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL4_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
-                <iidm:bus v="496.7574462890625" angle="-20.21532440185547" nodes="0,1,2,3,5,6"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="3"/>
-            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="4"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL5" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL5_6 6" node="0"/>
-                <iidm:switch id="VL5_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL5_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL5_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL5_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:bus v="500.0" angle="0.0" nodes="0,1,2,3,4"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="3">
+            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="15">
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
             </iidm:generator>
-            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="2"/>
+            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
+            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="8"/>
+            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
+            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL6" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL6_7 7" node="0"/>
-                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL6_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL0_7 7" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.776790618896484" angle="-17.9434814453125" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL0"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL5" node2="3" voltageLevelId2="VL1"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL4" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="6" voltageLevelId1="VL4" node2="3" voltageLevelId2="VL6"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL1" node3="2" voltageLevelId3="VL6">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
             <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
@@ -96,6 +80,6 @@
             </iidm:phaseTapChanger1>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL4" node2="1" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding2.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding2.xiidm
@@ -1,94 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding2" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL0" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S0">
+        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 1" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL2_1 1" node="0"/>
+                <iidm:busbarSection id="VL2_2 2" node="3"/>
+                <iidm:busbarSection id="VL2_3 3" node="7"/>
+                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-3.463278293609619" nodes="0,1,2"/>
+                <iidm:bus v="18.719999313354492" angle="2.961235523223877" nodes="3,4,5,6"/>
+                <iidm:bus v="18.360000610351562" angle="-14.294586181640625" nodes="7,8,9"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="18.719999313354492" angle="2.961235523223877" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
+            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="4">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 3" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:bus v="18.360000610351562" angle="-14.294586181640625" nodes="0,1,2"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="1">
+            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="8">
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL3" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL3_4 4" node="0"/>
-                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL3_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL1_4 4" node="0"/>
+                <iidm:busbarSection id="VL1_5 5" node="5"/>
+                <iidm:busbarSection id="VL1_6 6" node="12"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="512.2626953125" angle="-8.308452606201172" nodes="0,1,2,3,4"/>
+                <iidm:bus v="497.5753173828125" angle="-19.35874366760254" nodes="5,6,7,8,10,11"/>
+                <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL4" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL4_5 5" node="0"/>
-                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL4_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL4_Switch#2" kind="BREAKER" retained="false" open="true" node1="0" node2="4"/>
-                <iidm:switch id="VL4_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL4_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
-                <iidm:bus v="497.5753173828125" angle="-19.35874366760254" nodes="0,1,2,3,5,6"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="3"/>
-            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="4"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL5" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL5_6 6" node="0"/>
-                <iidm:switch id="VL5_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL5_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL5_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL5_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:bus v="500.0" angle="0.0" nodes="0,1,2,3,4"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="3">
+            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="15">
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
             </iidm:generator>
-            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="2"/>
+            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
+            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="8"/>
+            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
+            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL6" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL6_7 7" node="0"/>
-                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL6_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL0_7 7" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.809114456176758" angle="-16.863136291503906" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL0"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL5" node2="3" voltageLevelId2="VL1"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL4" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="6" voltageLevelId1="VL4" node2="3" voltageLevelId2="VL6"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL1" node3="2" voltageLevelId3="VL6">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
             <iidm:phaseTapChanger2 lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -96,6 +80,6 @@
             </iidm:phaseTapChanger2>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL4" node2="1" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding2.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding2.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding2" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S32">
+        <iidm:voltageLevel id="VL32" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_1 1" node="0"/>
-                <iidm:busbarSection id="VL2_2 2" node="3"/>
-                <iidm:busbarSection id="VL2_3 3" node="7"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
-                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
-                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
+                <iidm:busbarSection id="VL32_1 1" node="0"/>
+                <iidm:busbarSection id="VL32_2 2" node="3"/>
+                <iidm:busbarSection id="VL32_3 3" node="7"/>
+                <iidm:switch id="VL32_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL32_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL32_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL32_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL32_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL32_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL32_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-3.463278293609619" nodes="0,1,2"/>
                 <iidm:bus v="18.719999313354492" angle="2.961235523223877" nodes="3,4,5,6"/>
                 <iidm:bus v="18.360000610351562" angle="-14.294586181640625" nodes="7,8,9"/>
@@ -27,25 +27,25 @@
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL35" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_4 4" node="0"/>
-                <iidm:busbarSection id="VL1_5 5" node="5"/>
-                <iidm:busbarSection id="VL1_6 6" node="12"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
-                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
-                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
-                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
-                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
-                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
-                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
-                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
-                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
-                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
+                <iidm:busbarSection id="VL35_4 4" node="0"/>
+                <iidm:busbarSection id="VL35_5 5" node="5"/>
+                <iidm:busbarSection id="VL35_6 6" node="12"/>
+                <iidm:switch id="VL35_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL35_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL35_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL35_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL35_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL35_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL35_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL35_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL35_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL35_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL35_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL35_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL35_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL35_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="512.2626953125" angle="-8.308452606201172" nodes="0,1,2,3,4"/>
                 <iidm:bus v="497.5753173828125" angle="-19.35874366760254" nodes="5,6,7,8,10,11"/>
                 <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
@@ -58,21 +58,21 @@
             <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
             <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL38" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_7 7" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL38_7 7" node="0"/>
+                <iidm:switch id="VL38_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL38_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL38_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.809114456176758" angle="-16.863136291503906" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL35" node2="2" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
             <iidm:phaseTapChanger2 lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -80,6 +80,6 @@
             </iidm:phaseTapChanger2>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL35"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL35" node2="13" voltageLevelId2="VL35"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding3.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding3.xiidm
@@ -1,94 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding3" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL0" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S0">
+        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 1" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL2_1 1" node="0"/>
+                <iidm:busbarSection id="VL2_2 2" node="3"/>
+                <iidm:busbarSection id="VL2_3 3" node="7"/>
+                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-5.3843488693237305" nodes="0,1,2"/>
+                <iidm:bus v="18.719999313354492" angle="3.17676043510437" nodes="3,4,5,6"/>
+                <iidm:bus v="18.360000610351562" angle="-16.85239601135254" nodes="7,8,9"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="18.719999313354492" angle="3.17676043510437" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
+            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="4">
                 <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
             </iidm:generator>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 3" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:bus v="18.360000610351562" angle="-16.85239601135254" nodes="0,1,2"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="1">
+            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="8">
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL3" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL3_4 4" node="0"/>
-                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL3_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL1_4 4" node="0"/>
+                <iidm:busbarSection id="VL1_5 5" node="5"/>
+                <iidm:busbarSection id="VL1_6 6" node="12"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="510.54888916015625" angle="-10.245826721191406" nodes="0,1,2,3,4"/>
+                <iidm:bus v="497.6448974609375" angle="-21.915843963623047" nodes="5,6,7,8,10,11"/>
+                <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL4" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL4_5 5" node="0"/>
-                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL4_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL4_Switch#2" kind="BREAKER" retained="false" open="true" node1="0" node2="4"/>
-                <iidm:switch id="VL4_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL4_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
-                <iidm:bus v="497.6448974609375" angle="-21.915843963623047" nodes="0,1,2,3,5,6"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="3"/>
-            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="4"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL5" nominalV="500.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL5_6 6" node="0"/>
-                <iidm:switch id="VL5_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL5_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL5_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL5_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:bus v="500.0" angle="0.0" nodes="0,1,2,3,4"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="3">
+            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="15">
                 <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
             </iidm:generator>
-            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="2"/>
+            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
+            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="8"/>
+            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
+            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL6" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL6_7 7" node="0"/>
-                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL6_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL0_7 7" node="0"/>
+                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.860923767089844" angle="-19.837989807128906" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL0"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL5" node2="3" voltageLevelId2="VL1"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="5" voltageLevelId1="VL4" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="6" voltageLevelId1="VL4" node2="3" voltageLevelId2="VL6"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="16.0" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL3" node2="2" voltageLevelId2="VL1" node3="2" voltageLevelId3="VL6">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="16.0" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
             <iidm:phaseTapChanger3 lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -96,6 +80,6 @@
             </iidm:phaseTapChanger3>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL4" node2="1" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding3.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding3.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ThreeMIB_T3W_phase_winding3" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL2" nominalV="18.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S32">
+        <iidm:voltageLevel id="VL32" nominalV="18.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_1 1" node="0"/>
-                <iidm:busbarSection id="VL2_2 2" node="3"/>
-                <iidm:busbarSection id="VL2_3 3" node="7"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL2_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
-                <iidm:switch id="VL2_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
-                <iidm:switch id="VL2_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
+                <iidm:busbarSection id="VL32_1 1" node="0"/>
+                <iidm:busbarSection id="VL32_2 2" node="3"/>
+                <iidm:busbarSection id="VL32_3 3" node="7"/>
+                <iidm:switch id="VL32_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL32_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL32_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL32_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL32_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL32_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL32_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
                 <iidm:bus v="18.719999313354492" angle="-5.3843488693237305" nodes="0,1,2"/>
                 <iidm:bus v="18.719999313354492" angle="3.17676043510437" nodes="3,4,5,6"/>
                 <iidm:bus v="18.360000610351562" angle="-16.85239601135254" nodes="7,8,9"/>
@@ -27,25 +27,25 @@
                 <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="500.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL35" nominalV="500.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_4 4" node="0"/>
-                <iidm:busbarSection id="VL1_5 5" node="5"/>
-                <iidm:busbarSection id="VL1_6 6" node="12"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
-                <iidm:switch id="VL1_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
-                <iidm:switch id="VL1_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
-                <iidm:switch id="VL1_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
-                <iidm:switch id="VL1_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
-                <iidm:switch id="VL1_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
-                <iidm:switch id="VL1_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
-                <iidm:switch id="VL1_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
-                <iidm:switch id="VL1_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
-                <iidm:switch id="VL1_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
+                <iidm:busbarSection id="VL35_4 4" node="0"/>
+                <iidm:busbarSection id="VL35_5 5" node="5"/>
+                <iidm:busbarSection id="VL35_6 6" node="12"/>
+                <iidm:switch id="VL35_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL35_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL35_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL35_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL35_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL35_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL35_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL35_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL35_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL35_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL35_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL35_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL35_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL35_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
                 <iidm:bus v="510.54888916015625" angle="-10.245826721191406" nodes="0,1,2,3,4"/>
                 <iidm:bus v="497.6448974609375" angle="-21.915843963623047" nodes="5,6,7,8,10,11"/>
                 <iidm:bus v="500.0" angle="0.0" nodes="12,13,14,15,16"/>
@@ -58,21 +58,21 @@
             <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
             <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL0" nominalV="16.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL38" nominalV="16.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_7 7" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL38_7 7" node="0"/>
+                <iidm:switch id="VL38_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL38_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL38_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="15.860923767089844" angle="-19.837989807128906" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL1" node2="9" voltageLevelId2="VL2"/>
-        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL0"/>
-        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="16.0" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL1" node2="5" voltageLevelId2="VL2" node3="2" voltageLevelId3="VL0">
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL35" node2="2" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="16.0" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
             <iidm:phaseTapChanger3 lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -80,6 +80,6 @@
             </iidm:phaseTapChanger3>
         </iidm:threeWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL1" node2="13" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL35"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL35" node2="13" voltageLevelId2="VL35"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Tower.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Tower.xiidm
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Tower" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S9">
+        <iidm:voltageLevel id="VL9" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL9_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL9_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.290000915527344" voltageRegulatorOn="true" targetP="50.290000915527344" targetV="423.9999771118164" targetQ="0.0" node="3">
                 <iidm:minMaxReactiveLimits minQ="0.0" maxQ="0.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S10">
+        <iidm:voltageLevel id="VL10" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL10_2 Bus 2" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL10_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S2">
-        <iidm:voltageLevel id="VL2" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S11">
+        <iidm:voltageLevel id="VL11" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL2_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL11_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL11_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL11_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL11_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL11_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="2"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
-    <iidm:line id="lne_2_3_1" r="2.817992478609085" x="21.60901963710785" g1="5.412337245047638E-22" b1="7.191954040527343E-5" g2="5.412337245047638E-22" b2="7.191954040527343E-5" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2"/>
-    <iidm:line id="lne_2_3_2" r="2.817992478609085" x="21.60901963710785" g1="5.412337245047638E-22" b1="7.191954040527343E-5" g2="5.412337245047638E-22" b2="7.191954040527343E-5" node1="3" voltageLevelId1="VL1" node2="4" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL9" node2="1" voltageLevelId2="VL10"/>
+    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL9" node2="1" voltageLevelId2="VL11"/>
+    <iidm:line id="lne_2_3_1" r="2.817992478609085" x="21.60901963710785" g1="5.412337245047638E-22" b1="7.191954040527343E-5" g2="5.412337245047638E-22" b2="7.191954040527343E-5" node1="2" voltageLevelId1="VL10" node2="3" voltageLevelId2="VL11"/>
+    <iidm:line id="lne_2_3_2" r="2.817992478609085" x="21.60901963710785" g1="5.412337245047638E-22" b1="7.191954040527343E-5" g2="5.412337245047638E-22" b2="7.191954040527343E-5" node1="3" voltageLevelId1="VL10" node2="4" voltageLevelId2="VL11"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Tower.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Tower.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Tower" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -23,7 +23,7 @@
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S3">
+    <iidm:substation id="S2">
         <iidm:voltageLevel id="VL2" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral-with-mTaps.xiidm
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB-Neutral-with-mTaps" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S11">
+        <iidm:voltageLevel id="VL11" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL11_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL11_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL11_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL11_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="174.89999389648438" angle="0.0" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="59.95000076293945" voltageRegulatorOn="true" targetP="59.95000076293945" targetV="174.89999055862427" targetQ="0.0" node="3">
@@ -14,22 +14,22 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S12">
+        <iidm:voltageLevel id="VL12" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:busbarSection id="VL12_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL12_3 Bus 2-Load" node="3"/>
+                <iidm:switch id="VL12_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL12_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL12_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL12_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL12_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="170.83094787597656" angle="-0.38687682151794434" nodes="0,1,2"/>
                 <iidm:bus v="170.26544189453125" angle="-0.7061053514480591" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL12" node2="6" voltageLevelId2="VL12">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.979999542236328"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -37,6 +37,6 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL11" node2="1" voltageLevelId2="VL12"/>
+    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL11" node2="4" voltageLevelId2="VL12"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral-with-mTaps.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB-Neutral-with-mTaps" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -18,22 +18,18 @@
         <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="170.83094787597656" angle="-0.38687682151794434" nodes="0,1,2"/>
+                <iidm:bus v="170.26544189453125" angle="-0.7061053514480591" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="165.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="170.26544189453125" angle="-0.7061053514480591" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.979999542236328"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -42,5 +38,5 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral.xiidm
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S11">
+        <iidm:voltageLevel id="VL11" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL11_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL11_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL11_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL11_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="174.89999389648438" angle="0.0" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="59.95000076293945" voltageRegulatorOn="true" targetP="59.95000076293945" targetV="174.89999055862427" targetQ="0.0" node="3">
@@ -14,22 +14,22 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S12">
+        <iidm:voltageLevel id="VL12" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:busbarSection id="VL12_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL12_3 Bus 2-Load" node="3"/>
+                <iidm:switch id="VL12_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL12_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL12_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL12_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL12_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="170.83094787597656" angle="-0.38687682151794434" nodes="0,1,2"/>
                 <iidm:bus v="170.26544189453125" angle="-0.7061053514480591" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL12" node2="6" voltageLevelId2="VL12">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.001999855041504"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
@@ -37,6 +37,6 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL11" node2="1" voltageLevelId2="VL12"/>
+    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL11" node2="4" voltageLevelId2="VL12"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -18,22 +18,18 @@
         <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="170.83094787597656" angle="-0.38687682151794434" nodes="0,1,2"/>
+                <iidm:bus v="170.26544189453125" angle="-0.7061053514480591" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="165.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="170.26544189453125" angle="-0.7061053514480591" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.001999855041504"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
@@ -42,5 +38,5 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-complete.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-complete.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB - Study Case" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -17,20 +17,16 @@
         <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
             </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="4"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="165.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08272846419289497" x="8.356852297791427" g="3.1227095417161836E-4" b="-0.002902681037437016" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08272846419289497" x="8.356852297791427" g="3.1227095417161836E-4" b="-0.002902681037437016" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.98"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.002"/>
@@ -39,5 +35,5 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="lne_1_2_1" r="5.276205062866211" x="16.109033584594727" g1="0.0" b1="6.355923080444336E-4" g2="0.0" b2="6.355923080444336E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276205062866211" x="16.109033584594727" g1="0.0" b1="6.355923080444336E-4" g2="0.0" b2="6.355923080444336E-4" node1="3" voltageLevelId1="VL0" node2="2" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_3_1" r="5.276205062866211" x="16.109033584594727" g1="0.0" b1="6.355923080444336E-4" g2="0.0" b2="6.355923080444336E-4" node1="3" voltageLevelId1="VL0" node2="5" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-complete.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-complete.xiidm
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB - Study Case" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S64">
+        <iidm:voltageLevel id="VL64" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL64_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL64_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL64_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL64_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="-10000.0" maxP="10000.0" voltageRegulatorOn="true" targetP="61.130001068115234" targetV="174.89999055862427" targetQ="0.0" node="1">
                 <iidm:minMaxReactiveLimits minQ="0.0" maxQ="0.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S65">
+        <iidm:voltageLevel id="VL65" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:busbarSection id="VL65_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL65_3 Bus 2-Load" node="3"/>
+                <iidm:switch id="VL65_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL65_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL65_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL65_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL65_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="4"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08272846419289497" x="8.356852297791427" g="3.1227095417161836E-4" b="-0.002902681037437016" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08272846419289497" x="8.356852297791427" g="3.1227095417161836E-4" b="-0.002902681037437016" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL65" node2="6" voltageLevelId2="VL65">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.98"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.002"/>
@@ -34,6 +34,6 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="5.276205062866211" x="16.109033584594727" g1="0.0" b1="6.355923080444336E-4" g2="0.0" b2="6.355923080444336E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276205062866211" x="16.109033584594727" g1="0.0" b1="6.355923080444336E-4" g2="0.0" b2="6.355923080444336E-4" node1="3" voltageLevelId1="VL0" node2="5" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="5.276205062866211" x="16.109033584594727" g1="0.0" b1="6.355923080444336E-4" g2="0.0" b2="6.355923080444336E-4" node1="2" voltageLevelId1="VL64" node2="1" voltageLevelId2="VL65"/>
+    <iidm:line id="lne_1_3_1" r="5.276205062866211" x="16.109033584594727" g1="0.0" b1="6.355923080444336E-4" g2="0.0" b2="6.355923080444336E-4" node1="3" voltageLevelId1="VL64" node2="5" voltageLevelId2="VL65"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-with-mTaps.xiidm
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB-with-mTaps" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S11">
+        <iidm:voltageLevel id="VL11" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL11_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL11_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL11_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL11_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="174.89999389648438" angle="0.0" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="61.130001068115234" voltageRegulatorOn="true" targetP="61.130001068115234" targetV="174.89999055862427" targetQ="0.0" node="3">
@@ -14,22 +14,22 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S12">
+        <iidm:voltageLevel id="VL12" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:busbarSection id="VL12_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL12_3 Bus 2-Load" node="3"/>
+                <iidm:switch id="VL12_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL12_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL12_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL12_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL12_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="170.28341674804688" angle="-2.38899302482605" nodes="0,1,2"/>
                 <iidm:bus v="170.47706604003906" angle="1.308721899986267" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL12" node2="6" voltageLevelId2="VL12">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.979999542236328"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.001999855041504"/>
@@ -37,6 +37,6 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL11" node2="1" voltageLevelId2="VL12"/>
+    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL11" node2="4" voltageLevelId2="VL12"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-with-mTaps.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB-with-mTaps" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -18,22 +18,18 @@
         <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="170.28341674804688" angle="-2.38899302482605" nodes="0,1,2"/>
+                <iidm:bus v="170.47706604003906" angle="1.308721899986267" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="165.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="170.47706604003906" angle="1.308721899986267" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.979999542236328"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.001999855041504"/>
@@ -42,5 +38,5 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -18,22 +18,18 @@
         <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="170.28341674804688" angle="-2.38899302482605" nodes="0,1,2"/>
+                <iidm:bus v="170.47706604003906" angle="1.308721899986267" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="165.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="170.47706604003906" angle="1.308721899986267" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.001999855041504"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
@@ -42,5 +38,5 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB.xiidm
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-GB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S11">
+        <iidm:voltageLevel id="VL11" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL11_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL11_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL11_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL11_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="174.89999389648438" angle="0.0" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="61.130001068115234" voltageRegulatorOn="true" targetP="61.130001068115234" targetV="174.89999055862427" targetQ="0.0" node="3">
@@ -14,22 +14,22 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="165.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S12">
+        <iidm:voltageLevel id="VL12" nominalV="165.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:busbarSection id="VL12_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL12_3 Bus 2-Load" node="3"/>
+                <iidm:switch id="VL12_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL12_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL12_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL12_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL12_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="170.28341674804688" angle="-2.38899302482605" nodes="0,1,2"/>
                 <iidm:bus v="170.47706604003906" angle="1.308721899986267" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL12" node2="6" voltageLevelId2="VL12">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.001999855041504"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
@@ -37,6 +37,6 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="1" voltageLevelId1="VL11" node2="1" voltageLevelId2="VL12"/>
+    <iidm:line id="lne_1_3_1" r="5.276180267333984" x="16.109027862548828" g1="0.0" b1="6.35592357635498E-4" g2="0.0" b2="6.35592357635498E-4" node1="2" voltageLevelId1="VL11" node2="4" voltageLevelId2="VL12"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral-with-mTaps.xiidm
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-Neutral-with-mTaps" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S13">
+        <iidm:voltageLevel id="VL13" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL13_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL13_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL13_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL13_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="423.9999694824219" angle="0.0" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.22999954223633" voltageRegulatorOn="true" targetP="50.22999954223633" targetV="423.9999771118164" targetQ="0.0" node="3">
@@ -14,22 +14,22 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S14">
+        <iidm:voltageLevel id="VL14" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:busbarSection id="VL14_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL14_3 Bus 2-Load" node="3"/>
+                <iidm:switch id="VL14_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL14_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL14_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL14_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL14_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="423.7755432128906" angle="-0.7948187589645386" nodes="0,1,2"/>
                 <iidm:bus v="423.5598449707031" angle="-0.851496160030365" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -37,6 +37,6 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL13" node2="1" voltageLevelId2="VL14"/>
+    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL13" node2="4" voltageLevelId2="VL14"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral-with-mTaps.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-Neutral-with-mTaps" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -18,22 +18,18 @@
         <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="423.7755432128906" angle="-0.7948187589645386" nodes="0,1,2"/>
+                <iidm:bus v="423.5598449707031" angle="-0.851496160030365" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="400.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="423.5598449707031" angle="-0.851496160030365" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
@@ -42,5 +38,5 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -18,22 +18,18 @@
         <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="423.7755432128906" angle="-0.7948187589645386" nodes="0,1,2"/>
+                <iidm:bus v="423.5598449707031" angle="-0.851496160030365" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="400.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="423.5598449707031" angle="-0.851496160030365" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.8799999952316284"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
@@ -42,5 +38,5 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral.xiidm
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S13">
+        <iidm:voltageLevel id="VL13" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL13_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL13_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL13_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL13_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="423.9999694824219" angle="0.0" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.22999954223633" voltageRegulatorOn="true" targetP="50.22999954223633" targetV="423.9999771118164" targetQ="0.0" node="3">
@@ -14,22 +14,22 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S14">
+        <iidm:voltageLevel id="VL14" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:busbarSection id="VL14_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL14_3 Bus 2-Load" node="3"/>
+                <iidm:switch id="VL14_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL14_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL14_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL14_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL14_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="423.7755432128906" angle="-0.7948187589645386" nodes="0,1,2"/>
                 <iidm:bus v="423.5598449707031" angle="-0.851496160030365" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.8799999952316284"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
@@ -37,6 +37,6 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL13" node2="1" voltageLevelId2="VL14"/>
+    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL13" node2="4" voltageLevelId2="VL14"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-with-mTaps.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-with-mTaps" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -18,22 +18,18 @@
         <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="423.7253723144531" angle="-1.219657301902771" nodes="0,1,2"/>
+                <iidm:bus v="423.58294677734375" angle="-0.4262980818748474" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="400.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="423.58294677734375" angle="-0.4262980818748474" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.8799999952316284"/>
@@ -42,5 +38,5 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-with-mTaps.xiidm
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase-with-mTaps" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S13">
+        <iidm:voltageLevel id="VL13" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL13_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL13_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL13_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL13_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="423.9999694824219" angle="0.0" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.290000915527344" voltageRegulatorOn="true" targetP="50.290000915527344" targetV="423.9999771118164" targetQ="0.0" node="3">
@@ -14,22 +14,22 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S14">
+        <iidm:voltageLevel id="VL14" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:busbarSection id="VL14_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL14_3 Bus 2-Load" node="3"/>
+                <iidm:switch id="VL14_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL14_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL14_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL14_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL14_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="423.7253723144531" angle="-1.219657301902771" nodes="0,1,2"/>
                 <iidm:bus v="423.58294677734375" angle="-0.4262980818748474" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.8799999952316284"/>
@@ -37,6 +37,6 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL13" node2="1" voltageLevelId2="VL14"/>
+    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL13" node2="4" voltageLevelId2="VL14"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -18,22 +18,18 @@
         <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
                 <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="423.7253723144531" angle="-1.219657301902771" nodes="0,1,2"/>
+                <iidm:bus v="423.58294677734375" angle="-0.4262980818748474" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="400.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:bus v="423.58294677734375" angle="-0.4262980818748474" nodes="0,1,2,3"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="2"/>
-        </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="3" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.8799999952316284"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
@@ -42,5 +38,5 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase.xiidm
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-Phase" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S13">
+        <iidm:voltageLevel id="VL13" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL13_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL13_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL13_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL13_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:bus v="423.9999694824219" angle="0.0" nodes="0,1,2,3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.290000915527344" voltageRegulatorOn="true" targetP="50.290000915527344" targetV="423.9999771118164" targetQ="0.0" node="3">
@@ -14,22 +14,22 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S14">
+        <iidm:voltageLevel id="VL14" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="3"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
-                <iidm:switch id="VL1_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="VL1_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:busbarSection id="VL14_2 Bus 2" node="0"/>
+                <iidm:busbarSection id="VL14_3 Bus 2-Load" node="3"/>
+                <iidm:switch id="VL14_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL14_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL14_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL14_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL14_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
                 <iidm:bus v="423.7253723144531" angle="-1.219657301902771" nodes="0,1,2"/>
                 <iidm:bus v="423.58294677734375" angle="-0.4262980818748474" nodes="3,4,5,6"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL1" node2="6" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
             <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.8799999952316284"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
@@ -37,6 +37,6 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL0" node2="4" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL13" node2="1" voltageLevelId2="VL14"/>
+    <iidm:line id="lne_1_3_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="2" voltageLevelId1="VL13" node2="4" voltageLevelId2="VL14"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB-Non-Neutral-proportion.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB-Non-Neutral-proportion.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl-GB-Non-Neutral-proportion" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB-Non-Neutral-proportion.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB-Non-Neutral-proportion.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl-GB-Non-Neutral-proportion" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="233.19998168945312" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.540000915527344" voltageRegulatorOn="true" targetP="50.540000915527344" targetV="233.19998741149902" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S9">
+        <iidm:voltageLevel id="VL9" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL9_2 Bus 2" node="0"/>
+                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="228.96177673339844" angle="-1.367474913597107" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL10" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="118.12033081054688" angle="-3.5520355701446533" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.20391181633482833" x="11.013560495822835" g="1.6189272651623288E-8" b="-5.644121253326473E-4" ratedU1="208.15960693359375" ratedU2="110.0" ratedS="180.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.20391181633482833" x="11.013560495822835" g="1.6189272651623288E-8" b="-5.644121253326473E-4" ratedU1="208.15960693359375" ratedU2="110.0" ratedS="180.0" node1="2" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL10">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="14" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.2197485036451494"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.2008988096135902"/>
@@ -59,5 +59,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL9"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB-Non-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB-Non-Neutral.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl-GB-Non-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB-Non-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB-Non-Neutral.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl-GB-Non-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="233.19998168945312" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.540000915527344" voltageRegulatorOn="true" targetP="50.540000915527344" targetV="233.19998741149902" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S9">
+        <iidm:voltageLevel id="VL9" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL9_2 Bus 2" node="0"/>
+                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="228.96177673339844" angle="-1.367474913597107" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL10" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="118.12033081054688" angle="-3.5520355701446533" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.20328000273527924" x="10.99647728654783" g="0.0" b="-5.652892491049017E-4" ratedU1="208.15960693359375" ratedU2="110.0" ratedS="180.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.20328000273527924" x="10.99647728654783" g="0.0" b="-5.652892491049017E-4" ratedU1="208.15960693359375" ratedU2="110.0" ratedS="180.0" node1="2" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL10">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="14" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.2197485036451494"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.2008988096135902"/>
@@ -59,5 +59,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL9"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl-GB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-GB.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl-GB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="233.19998168945312" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.54999923706055" voltageRegulatorOn="true" targetP="50.54999923706055" targetV="233.19998741149902" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S9">
+        <iidm:voltageLevel id="VL9" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL9_2 Bus 2" node="0"/>
+                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="229.03372192382812" angle="-1.3729606866836548" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL10" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="111.50525665283203" angle="-3.8185269832611084" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.20328000273527924" x="10.99647728654783" g="0.0" b="-5.652892491049017E-4" ratedU1="220.0" ratedU2="110.0" ratedS="180.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.20328000273527924" x="10.99647728654783" g="0.0" b="-5.652892491049017E-4" ratedU1="220.0" ratedU2="110.0" ratedS="180.0" node1="2" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL10">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="19" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.3009692073323427"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.2806825747343356"/>
@@ -60,5 +60,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL9"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-Non-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-Non-Neutral.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl-Non-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S10">
+        <iidm:voltageLevel id="VL10" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="423.9999694824219" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.470001220703125" voltageRegulatorOn="true" targetP="50.470001220703125" targetV="423.9999771118164" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S11">
+        <iidm:voltageLevel id="VL11" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL11_2 Bus 2" node="0"/>
+                <iidm:switch id="VL11_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL11_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="418.6197204589844" angle="-1.460877776145935" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="20.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL12" nominalV="20.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL12_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL12_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL12_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="20.19123077392578" angle="-2.1322784423828125" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0031199999227605408" x="0.09771995949237713" g="0.0" b="-0.0" ratedU1="412.0" ratedU2="20.0" ratedS="29.760000228881836" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0031199999227605408" x="0.09771995949237713" g="0.0" b="-0.0" ratedU1="412.0" ratedU2="20.0" ratedS="29.760000228881836" node1="2" voltageLevelId1="VL11" node2="2" voltageLevelId2="VL12">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="3" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.1704545549678902"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.107526887399032"/>
@@ -42,5 +42,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL10" node2="1" voltageLevelId2="VL11"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-Non-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl-Non-Neutral.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl-Non-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VhVl.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VhVl" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S10">
+        <iidm:voltageLevel id="VL10" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="423.9999694824219" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.470001220703125" voltageRegulatorOn="true" targetP="50.470001220703125" targetV="423.9999771118164" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="400.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S11">
+        <iidm:voltageLevel id="VL11" nominalV="400.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL11_2 Bus 2" node="0"/>
+                <iidm:switch id="VL11_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL11_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="418.62994384765625" angle="-1.461245059967041" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="20.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL12" nominalV="20.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL12_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL12_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL12_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="20.805301666259766" angle="-2.0938339233398438" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0031199999227605408" x="0.09771995949237713" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="20.0" ratedS="29.760000228881836" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0031199999227605408" x="0.09771995949237713" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="20.0" ratedS="29.760000228881836" node1="2" voltageLevelId1="VL11" node2="2" voltageLevelId2="VL12">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.1111111111111112"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0526315789473684"/>
@@ -41,5 +41,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VL10" node2="1" voltageLevelId2="VL11"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB-Non-Neutral-proportion.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB-Non-Neutral-proportion.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh-GB-Non-Neutral-proportion" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="233.19998168945312" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="51.5099983215332" voltageRegulatorOn="true" targetP="51.5099983215332" targetV="233.19998741149902" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S9">
+        <iidm:voltageLevel id="VL9" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL9_2 Bus 2" node="0"/>
+                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="228.9239044189453" angle="-1.4022903442382812" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL10" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="105.55027770996094" angle="-2.9006764888763428" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.12809088466190127" x="5.9334006428771575" g="9.760761348963235E-5" b="-7.759805952154142E-4" ratedU1="220.0" ratedU2="103.11399841308594" ratedS="200.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.12809088466190127" x="5.9334006428771575" g="9.760761348963235E-5" b="-7.759805952154142E-4" ratedU1="220.0" ratedU2="103.11399841308594" ratedS="200.0" node1="2" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL10">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="5" loadTapChangingCapabilities="false">
                 <iidm:step r="-17.86908215542723" x="-17.86908215542723" g="21.756827543609415" b="21.756827543609415" rho="0.9062610983848571"/>
                 <iidm:step r="-14.435857431157995" x="-14.435857431157995" g="16.87138677226081" b="16.87138677226081" rho="0.9250088787078856"/>
@@ -49,5 +49,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL9"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB-Non-Neutral-proportion.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB-Non-Neutral-proportion.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh-GB-Non-Neutral-proportion" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB-Non-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB-Non-Neutral.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh-GB-Non-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB-Non-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB-Non-Neutral.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh-GB-Non-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="233.19998168945312" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="51.5099983215332" voltageRegulatorOn="true" targetP="51.5099983215332" targetV="233.19998741149902" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S9">
+        <iidm:voltageLevel id="VL9" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL9_2 Bus 2" node="0"/>
+                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="228.9239044189453" angle="-1.4022903442382812" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL10" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="105.55027770996094" angle="-2.9006764888763428" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.1286532096916801" x="5.926544933071275" g="9.78133388988724E-5" b="-7.768645070724027E-4" ratedU1="220.0" ratedU2="103.11399841308594" ratedS="200.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.1286532096916801" x="5.926544933071275" g="9.78133388988724E-5" b="-7.768645070724027E-4" ratedU1="220.0" ratedU2="103.11399841308594" ratedS="200.0" node1="2" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL10">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="5" loadTapChangingCapabilities="false">
                 <iidm:step r="-17.86908215542723" x="-17.86908215542723" g="21.756827543609415" b="21.756827543609415" rho="0.9062610983848571"/>
                 <iidm:step r="-14.435857431157995" x="-14.435857431157995" g="16.87138677226081" b="16.87138677226081" rho="0.9250088787078856"/>
@@ -49,5 +49,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL9"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh-GB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-GB.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh-GB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="233.19998168945312" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="51.650001525878906" voltageRegulatorOn="true" targetP="51.650001525878906" targetV="233.19998741149902" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S9">
+        <iidm:voltageLevel id="VL9" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL9_2 Bus 2" node="0"/>
+                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="228.9239044189453" angle="-1.4022903442382812" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL10" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="112.5989761352539" angle="-2.9006764888763428" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.14641" x="6.744530087748594" g="8.59504132231405E-5" b="-6.826453953309849E-4" ratedU1="220.0" ratedU2="110.0" ratedS="200.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.14641" x="6.744530087748594" g="8.59504132231405E-5" b="-6.826453953309849E-4" ratedU1="220.0" ratedU2="110.0" ratedS="200.0" node1="2" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL10">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="9" loadTapChangingCapabilities="false">
                 <iidm:step r="-29.13180869345685" x="-29.13180869345685" g="41.10703004602738" b="41.10703004602738" rho="0.8418324732780457"/>
                 <iidm:step r="-26.14202221156008" x="-26.14202221156008" g="35.39498777835719" b="35.39498777835719" rho="0.8594066429138183"/>
@@ -50,5 +50,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="9.379916191101074" x="28.638273239135742" g1="0.0" b1="3.5752053070068355E-4" g2="0.0" b2="3.5752053070068355E-4" node1="1" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL9"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-Non-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-Non-Neutral.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh-Non-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="116.59999084472656" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="52.790000915527344" voltageRegulatorOn="true" targetP="52.790000915527344" targetV="116.59999370574951" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S9">
+        <iidm:voltageLevel id="VL9" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_2 Bus 2" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL9_2 Bus 2" node="0"/>
+                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="112.57804870605469" angle="-1.1524275541305542" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="35.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL10" nominalV="35.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="25.0313720703125" angle="-25.546560287475586" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.3807835064674956" x="7.818953752740731" g="0.0" b="-0.0" ratedU1="110.0" ratedU2="36.04999923706055" ratedS="20.0" node1="2" voltageLevelId1="VL2" node2="2" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.3807835064674956" x="7.818953752740731" g="0.0" b="-0.0" ratedU1="110.0" ratedU2="36.04999923706055" ratedS="20.0" node1="2" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL10">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="15" loadTapChangingCapabilities="false">
                 <iidm:step r="-31.666894487414087" x="-31.666894487414087" g="46.34195131316186" b="46.34195131316186" rho="0.8266384065151214"/>
                 <iidm:step r="-29.742772361292534" x="-29.742772361292534" g="42.33411046937763" b="42.33411046937763" rho="0.83819584608078"/>
@@ -62,5 +62,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="2.344939947128296" x="7.1595683097839355" g1="0.0" b1="0.0014300827178955079" g2="0.0" b2="0.0014300827178955079" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_2_1" r="2.344939947128296" x="7.1595683097839355" g1="0.0" b1="0.0014300827178955079" g2="0.0" b2="0.0014300827178955079" node1="1" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL9"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-Non-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh-Non-Neutral.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh-Non-Neutral" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -14,24 +14,24 @@
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="110.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL2_2 Bus 2" node="0"/>
+                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="112.57804870605469" angle="-1.1524275541305542" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="35.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL1" nominalV="35.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="25.0313720703125" angle="-25.546560287475586" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.3807835064674956" x="7.818953752740731" g="0.0" b="-0.0" ratedU1="110.0" ratedU2="36.04999923706055" ratedS="20.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.3807835064674956" x="7.818953752740731" g="0.0" b="-0.0" ratedU1="110.0" ratedU2="36.04999923706055" ratedS="20.0" node1="2" voltageLevelId1="VL2" node2="2" voltageLevelId2="VL1">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="15" loadTapChangingCapabilities="false">
                 <iidm:step r="-31.666894487414087" x="-31.666894487414087" g="46.34195131316186" b="46.34195131316186" rho="0.8266384065151214"/>
                 <iidm:step r="-29.742772361292534" x="-29.742772361292534" g="42.33411046937763" b="42.33411046937763" rho="0.83819584608078"/>
@@ -62,5 +62,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="2.344939947128296" x="7.1595683097839355" g1="0.0" b1="0.0014300827178955079" g2="0.0" b2="0.0014300827178955079" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="2.344939947128296" x="7.1595683097839355" g1="0.0" b1="0.0014300827178955079" g2="0.0" b2="0.0014300827178955079" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
@@ -14,24 +14,24 @@
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="110.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_2 Bus 2" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL2_2 Bus 2" node="0"/>
+                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="112.57804870605469" angle="-1.1524275541305542" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL2" nominalV="35.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL1" nominalV="35.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="24.30230140686035" angle="-25.546560287475586" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.3589249906539917" x="7.370114132992315" g="0.0" b="-0.0" ratedU1="110.0" ratedU2="35.0" ratedS="20.0" node1="2" voltageLevelId1="VL1" node2="2" voltageLevelId2="VL2">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.3589249906539917" x="7.370114132992315" g="0.0" b="-0.0" ratedU1="110.0" ratedU2="35.0" ratedS="20.0" node1="2" voltageLevelId1="VL2" node2="2" voltageLevelId2="VL1">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="12" loadTapChangingCapabilities="false">
                 <iidm:step r="-26.529395662837775" x="-26.529395662837775" g="36.10885727997057" b="36.10885727997057" rho="0.8571499538421631"/>
                 <iidm:step r="-24.474492894101473" x="-24.474492894101473" g="32.405598892284715" b="32.405598892284715" rho="0.8690541243553161"/>
@@ -61,5 +61,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="2.344939947128296" x="7.1595683097839355" g1="0.0" b1="0.0014300827178955079" g2="0.0" b2="0.0014300827178955079" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_1_2_1" r="2.344939947128296" x="7.1595683097839355" g1="0.0" b1="0.0014300827178955079" g2="0.0" b2="0.0014300827178955079" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-VlVh.xiidm
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="Transformer-VlVh" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S8">
+        <iidm:voltageLevel id="VL8" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1-Slack" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL8_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="116.59999084472656" angle="0.0" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="52.790000915527344" voltageRegulatorOn="true" targetP="52.790000915527344" targetV="116.59999370574951" targetQ="0.0" node="2">
@@ -13,25 +13,25 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL2" nominalV="110.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S9">
+        <iidm:voltageLevel id="VL9" nominalV="110.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_2 Bus 2" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL9_2 Bus 2" node="0"/>
+                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="112.57804870605469" angle="-1.1524275541305542" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL1" nominalV="35.0" topologyKind="NODE_BREAKER">
+        <iidm:voltageLevel id="VL10" nominalV="35.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_3 Bus 2-Load" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:bus v="24.30230140686035" angle="-25.546560287475586" nodes="0,1,2"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.3589249906539917" x="7.370114132992315" g="0.0" b="-0.0" ratedU1="110.0" ratedU2="35.0" ratedS="20.0" node1="2" voltageLevelId1="VL2" node2="2" voltageLevelId2="VL1">
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.3589249906539917" x="7.370114132992315" g="0.0" b="-0.0" ratedU1="110.0" ratedU2="35.0" ratedS="20.0" node1="2" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL10">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="12" loadTapChangingCapabilities="false">
                 <iidm:step r="-26.529395662837775" x="-26.529395662837775" g="36.10885727997057" b="36.10885727997057" rho="0.8571499538421631"/>
                 <iidm:step r="-24.474492894101473" x="-24.474492894101473" g="32.405598892284715" b="32.405598892284715" rho="0.8690541243553161"/>
@@ -61,5 +61,5 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="lne_1_2_1" r="2.344939947128296" x="7.1595683097839355" g1="0.0" b1="0.0014300827178955079" g2="0.0" b2="0.0014300827178955079" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_1_2_1" r="2.344939947128296" x="7.1595683097839355" g1="0.0" b1="0.0014300827178955079" g2="0.0" b2="0.0014300827178955079" node1="1" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL9"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGenerator" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -20,5 +20,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGenerator.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGenerator" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntC.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntC.xiidm
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorAndShuntC" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:shunt id="NE_Cap1" sectionCount="7" voltageRegulatorOn="false" node="2">
@@ -12,11 +12,11 @@
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -24,5 +24,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntC.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntC.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorAndShuntC" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntRL.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntRL.xiidm
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorAndShuntRL" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:shunt id="Shunt/Filter" sectionCount="1" voltageRegulatorOn="false" node="2">
@@ -12,11 +12,11 @@
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -24,5 +24,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntRL.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntRL.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorAndShuntRL" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntRLrxrea.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntRLrxrea.xiidm
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorAndShuntRLrxrea" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:shunt id="Shunt/Filter" sectionCount="1" voltageRegulatorOn="false" node="2">
@@ -12,11 +12,11 @@
             </iidm:shunt>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -24,5 +24,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntRLrxrea.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAndShuntRLrxrea.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorAndShuntRLrxrea" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAvmode.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAvmode.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorAvmode" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAvmode.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorAvmode.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorAvmode" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -20,5 +20,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorElmReactiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorElmReactiveLimits.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorElmReactiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorElmReactiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorElmReactiveLimits.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorElmReactiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -20,5 +20,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorIqtype.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorIqtype.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorIqtype" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorIqtype.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorIqtype.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorIqtype" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -20,5 +20,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypMvarReactiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypMvarReactiveLimits.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorTypMvarReactiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -20,5 +20,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypMvarReactiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypMvarReactiveLimits.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorTypMvarReactiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypReactiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypReactiveLimits.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorTypReactiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -20,5 +20,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypReactiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorTypReactiveLimits.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorTypReactiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutActiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutActiveLimits.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorWithoutActiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="25.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -20,5 +20,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutActiveLimits.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutActiveLimits.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorWithoutActiveLimits" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIqtype.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIqtype.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorWithoutIqtype" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIqtype.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIqtype.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorWithoutIqtype" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="true" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -20,5 +20,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIvmode.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIvmode.xiidm
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorWithoutIvmode" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:internalConnection node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_B_1" energySource="OTHER" minP="0.0" maxP="250.0" voltageRegulatorOn="false" targetP="25.0" targetV="224.399995803833" targetQ="10.0" node="2">
@@ -20,5 +20,5 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIvmode.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesGeneratorWithoutIvmode.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesGeneratorWithoutIvmode" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithB.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesLineWithB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithB.xiidm
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesLineWithB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.1272838592529294E-5" g2="0.0" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithC.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithC.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesLineWithC" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithC.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithC.xiidm
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesLineWithC" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.127279984520725E-5" g2="0.0" b2="4.127279984520725E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="0.0" b1="4.127279984520725E-5" g2="0.0" b2="4.127279984520725E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithGandB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithGandB.xiidm
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesLineWithGandB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="7.24637508392334E-6" b1="4.1272838592529294E-5" g2="7.24637508392334E-6" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="7.24637508392334E-6" b1="4.1272838592529294E-5" g2="7.24637508392334E-6" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithGandB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithGandB.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesLineWithGandB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithTandB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithTandB.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesLineWithTandB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S2">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_Busbar-A" node="0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithTandB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TwoBusesLineWithTandB.xiidm
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="TwoBusesLineWithTandB" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S3">
+        <iidm:voltageLevel id="VL3" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_Busbar-A" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL3_Busbar-A" node="0"/>
+                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="220.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S4">
+        <iidm:voltageLevel id="VL4" nominalV="220.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_Busbar-B" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:busbarSection id="VL4_Busbar-B" node="0"/>
+                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="7.246272087097168E-6" b1="4.1272838592529294E-5" g2="7.246272087097168E-6" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_A_B_1" r="3.561228036880493" x="11.731100082397461" g1="7.246272087097168E-6" b1="4.1272838592529294E-5" g2="7.246272087097168E-6" b2="4.1272838592529294E-5" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/VoltageLevelsAndSubstations.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/VoltageLevelsAndSubstations.dgs
@@ -1,0 +1,86 @@
+$$General;ID(a:40);Descr(a:40);Val(a:40)
+  1;Version;5.0
+
+
+$$ChaRef;ID(a:40);loc_name(a:40);fold_id(p)
+  2;fline;6
+  3;ratfac;13
+
+
+$$ChaVec;ID(a:40);loc_name(a:40);fold_id(p);scale(p);usage(i);approx(i);vector:SIZEROW(i);vector:0(r);vector:1(r);vector:2(r)
+  4;vec_1;;;0;0;3;100;199,98;199,98
+  5;vec_2;;;0;0;3;100;33598,7903225806;33598,7903225806
+
+
+$$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
+  6;lne_1_2_1;;8;27;52;1;0;0;1;0
+
+
+$$ElmLod;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);mode_inp(a:3);slini(r);plini(r);qlini(r);coslini(r);pf_recap(i);scale0(r);i_scale(i);outserv(i);classif(a:20)
+  7;lod_3_1;;8;28;PQ;55,9017;50;25;0,894427;0;1;0;0;
+
+
+$$ElmNet;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);frnom(r);pDiagram(p)
+  8;1 aux_1;;;60;
+
+
+$$ElmSym;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);cCategory(a);ngnum(i);i_mot(i);pgini(r);qgini(r);cosgini(r);usetp(r);pf_recap(i);q_min(r);q_max(r);outserv(i);av_mode(a);phtech(i)
+  9;sym_1_1;;8;29;Others;1;0;50,47;0;1;1,06;0;0;0;0;constv;1
+
+
+$$ElmTerm;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);systype(i);iUsage(i);uknom(r);unknom(r);iminus(i);outserv(i);GPSlat(r);GPSlon(r);vtarget(r);m:u(r);m:phiu(r)
+  10;1 Bus 1-Slack;;31;;0;0;400;230,9401;0;0;0;0;1;1,05999994277954;0
+  11;2 Bus 2;;32;;0;0;400;230,9401;0;0;0;0;1;1,04657487761001;-1,46124506647397
+  12;3 Bus 2-Load;;33;;0;0;20;11,54701;0;0;0;0;1;1,04026508640743;-2,09383399110034
+
+
+$$ElmTr2;ID(a:40);loc_name(a:40);fold_id(p);for_name(a:50);typ_id(p);ntnum(i);outserv(i);nntap(i);i_auto(i);ntrcn(i);usetp(r);usp_low(r);usp_up(r);t2ldc(i)
+  13;trf_2_3_1;8;;30;1;0;0;0;1;1;0,9;1,1;0
+
+
+$$ElmZone;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);icolor(i);curscale(r)
+  14;1_aux_1;;;1;1
+
+
+$$StaCubic;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);obj_bus(i);obj_id(p);it2p1(i);it2p2(i);it2p3(i)
+  15;lne_1_2_1;;10;0;6;0;1;2
+  16;sym_1_1;;10;0;9;0;1;2
+  17;lne_1_2_1;;11;1;6;0;1;2
+  18;trf_2_3_1;;11;0;13;0;1;2
+  19;lod_3_1;;12;0;7;0;1;2
+  20;trf_2_3_1;;12;1;13;0;1;2
+
+
+$$StaSwitch;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);on_off(i);typ_id(p);aUsage(a)
+  21;Switch;;15;1;;cbk
+  22;Switch;;16;1;;cbk
+  23;Switch;;17;1;;cbk
+  24;Switch;;18;1;;cbk
+  25;Switch;;19;1;;cbk
+  26;Switch;;20;1;;cbk
+
+
+$$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
+  27;tlne_1_2_1;;8;400;7,216878;1;0;0,596307;1,820615;999999;999999;0;80;80;0;3;0;60;Cu;4,159616;0
+
+
+$$TypLod;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);systp(i);phtech(i);aP(r);bP(r);kpu0(r);kpu1(r);kpu(r);aQ(r);bQ(r);kqu0(r);kqu1(r);kqu(r)
+  28;lodtyp_pq;;8;0;0;1;0;0;1;2;1;0;0;1;2
+
+
+$$TypSym;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);nphase(i);nslty(i);x0sy(r);r0sy(r);x2sy(r);r2sy(r);iopt_data(i);xds(r);xqs(r);xl(r);xdss(r);xqss(r);xrlq(r);tds(r);tqs(r);tdss(r);tqss(r)
+  29;tsym_1_1;;8;615;400;1;2;2;1;0;1,2;0;3;2;1;0;1;0;1;0,3;0,3;0,1;1;1;0;1;0;0,05;0,05
+
+
+$$TypTr2;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);nt2ph(i);strn(r);frnom(r);utrn_h(r);utrn_l(r);uktr(r);pcutr(r);uk0tr(r);ur0tr(r);tr2cn_h(a:2);tr2cn_l(a:2);nt2ag(r);curmg(r);pfe(r);zx0hl_n(r);itapch(i);tap_side(i);dutap(r);phitr(r);nntap0(i);ntpmn(i);ntpmx(i);manuf(a:20)
+  30;ttrf_2_3_1;;8;3;29,76;60;400;20;0,727407;6,908129;0;0;D;D;0;0;0;100;1;0;5;0;0;-2;2;
+
+$$ElmSubstat;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);sShort(a:6);sType(a:80);GPSlat(r);GPSlon(r)
+  31;VoltageLevel1-400;;34;;;49,95646302;11,45051847
+  32;VoltageLevel2-400;;35;;;49,95646302;11,45051847
+  33;VoltageLevel2-20;;35;;;49,95646302;11,45051847
+  
+$$ElmSite;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);sType(a:80);GPSlat(r);GPSlon(r)
+  34;Substation1;;8;;49,95646302;11,45051847
+  35;Substation2;;8;;50,89789337;11,01545826
+  

--- a/powerfactory/powerfactory-converter/src/test/resources/VoltageLevelsAndSubstations.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/VoltageLevelsAndSubstations.xiidm
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="VoltageLevelsAndSubstations" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="Substation1">
+        <iidm:voltageLevel id="VoltageLevel1-400" nominalV="400.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VoltageLevel1-400_1 Bus 1-Slack" node="0"/>
+                <iidm:switch id="VoltageLevel1-400_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VoltageLevel1-400_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:bus v="423.9999694824219" angle="0.0" nodes="0,1,2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="50.470001220703125" voltageRegulatorOn="true" targetP="50.470001220703125" targetV="423.9999771118164" targetQ="0.0" node="2">
+                <iidm:minMaxReactiveLimits minQ="0.0" maxQ="0.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="Substation2">
+        <iidm:voltageLevel id="VoltageLevel2-400" nominalV="400.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VoltageLevel2-400_2 Bus 2" node="0"/>
+                <iidm:switch id="VoltageLevel2-400_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VoltageLevel2-400_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:bus v="418.62994384765625" angle="-1.461245059967041" nodes="0,1,2"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VoltageLevel2-20" nominalV="20.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VoltageLevel2-20_3 Bus 2-Load" node="0"/>
+                <iidm:switch id="VoltageLevel2-20_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VoltageLevel2-20_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:bus v="20.805301666259766" angle="-2.0938339233398438" nodes="0,1,2"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="1"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0031199999227605408" x="0.09771995949237713" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="20.0" ratedS="29.760000228881836" node1="2" voltageLevelId1="VoltageLevel2-400" node2="2" voltageLevelId2="VoltageLevel2-20">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.1111111111111112"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0526315789473684"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9523809523809523"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9090909090909091"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="lne_1_2_1" r="31.007963180541992" x="94.67198181152344" g1="0.0" b1="1.0815001583099366E-4" g2="0.0" b2="1.0815001583099366E-4" node1="1" voltageLevelId1="VoltageLevel1-400" node2="1" voltageLevelId2="VoltageLevel2-400"/>
+</iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ieee14.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ieee14.xiidm
@@ -1,84 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ieee14" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S0">
-        <iidm:voltageLevel id="VL0" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S37">
+        <iidm:voltageLevel id="VL37" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL0_1 Bus 1" node="0"/>
-                <iidm:switch id="VL0_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL0_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL0_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL37_1 Bus 1" node="0"/>
+                <iidm:switch id="VL37_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL37_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL37_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_1_1" energySource="OTHER" minP="-10000.0" maxP="10000.0" voltageRegulatorOn="true" targetP="0.0" targetV="146.27999210357666" targetQ="0.0" node="3">
                 <iidm:minMaxReactiveLimits minQ="0.0" maxQ="0.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
-        <iidm:voltageLevel id="VL1" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S38">
+        <iidm:voltageLevel id="VL38" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL1_10 Bus 10" node="0"/>
-                <iidm:switch id="VL1_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL1_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL1_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL38_10 Bus 10" node="0"/>
+                <iidm:switch id="VL38_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL38_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL38_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_10_1" loadType="UNDEFINED" p0="9.0" q0="5.800000190734863" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S2">
-        <iidm:voltageLevel id="VL2" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S39">
+        <iidm:voltageLevel id="VL39" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL2_11 Bus 11" node="0"/>
-                <iidm:switch id="VL2_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL2_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL2_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL39_11 Bus 11" node="0"/>
+                <iidm:switch id="VL39_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL39_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL39_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_11_1" loadType="UNDEFINED" p0="3.5" q0="1.7999999523162842" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S3">
-        <iidm:voltageLevel id="VL3" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S40">
+        <iidm:voltageLevel id="VL40" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL3_12 Bus 12" node="0"/>
-                <iidm:switch id="VL3_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL3_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL3_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL40_12 Bus 12" node="0"/>
+                <iidm:switch id="VL40_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL40_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL40_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_12_1" loadType="UNDEFINED" p0="6.099999904632568" q0="1.600000023841858" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S4">
-        <iidm:voltageLevel id="VL4" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S41">
+        <iidm:voltageLevel id="VL41" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL4_13 Bus 13" node="0"/>
-                <iidm:switch id="VL4_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL4_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL4_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL4_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL41_13 Bus 13" node="0"/>
+                <iidm:switch id="VL41_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL41_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL41_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL41_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_13_1" loadType="UNDEFINED" p0="13.5" q0="5.800000190734863" node="4"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S5">
-        <iidm:voltageLevel id="VL5" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S42">
+        <iidm:voltageLevel id="VL42" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL5_14 Bus 14" node="0"/>
-                <iidm:switch id="VL5_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL5_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL5_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:busbarSection id="VL42_14 Bus 14" node="0"/>
+                <iidm:switch id="VL42_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL42_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL42_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_14_1" loadType="UNDEFINED" p0="14.899999618530273" q0="5.0" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S6">
-        <iidm:voltageLevel id="VL6" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S43">
+        <iidm:voltageLevel id="VL43" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL6_2 Bus 2" node="0"/>
-                <iidm:switch id="VL6_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL6_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL6_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL6_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL6_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL6_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
+                <iidm:busbarSection id="VL43_2 Bus 2" node="0"/>
+                <iidm:switch id="VL43_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL43_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL43_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL43_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL43_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
+                <iidm:switch id="VL43_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_2_1" energySource="OTHER" minP="-10000.0" maxP="10000.0" voltageRegulatorOn="true" targetP="40.0" targetV="144.2099940776825" targetQ="0.0" node="6">
                 <iidm:minMaxReactiveLimits minQ="-40.00001907348633" maxQ="49.99998092651367"/>
@@ -86,14 +86,14 @@
             <iidm:load id="lod_2_1" loadType="UNDEFINED" p0="21.700000762939453" q0="12.699999809265137" node="5"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S7">
-        <iidm:voltageLevel id="VL7" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S44">
+        <iidm:voltageLevel id="VL44" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL7_3 Bus 3" node="0"/>
-                <iidm:switch id="VL7_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL7_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL7_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL7_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:busbarSection id="VL44_3 Bus 3" node="0"/>
+                <iidm:switch id="VL44_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL44_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL44_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL44_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_3_1" energySource="OTHER" minP="-10000.0" maxP="10000.0" voltageRegulatorOn="true" targetP="0.0" targetV="139.37999868392944" targetQ="0.0" node="4">
                 <iidm:minMaxReactiveLimits minQ="0.0" maxQ="40.00001907348633"/>
@@ -101,27 +101,27 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="94.19999694824219" q0="19.0" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S8">
-        <iidm:voltageLevel id="VL8" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S45">
+        <iidm:voltageLevel id="VL45" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL8_4 Bus 4" node="0"/>
-                <iidm:busbarSection id="VL8_7 Bus 7" node="7"/>
-                <iidm:busbarSection id="VL8_9 Bus 9" node="11"/>
-                <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL8_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL8_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL8_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL8_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
-                <iidm:switch id="VL8_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
-                <iidm:switch id="VL8_Switch#6" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
-                <iidm:switch id="VL8_Switch#7" kind="BREAKER" retained="false" open="false" node1="7" node2="10"/>
-                <iidm:switch id="VL8_Switch#8" kind="BREAKER" retained="false" open="false" node1="11" node2="12"/>
-                <iidm:switch id="VL8_Switch#9" kind="BREAKER" retained="false" open="false" node1="11" node2="13"/>
-                <iidm:switch id="VL8_Switch#10" kind="BREAKER" retained="false" open="false" node1="11" node2="14"/>
-                <iidm:switch id="VL8_Switch#11" kind="BREAKER" retained="false" open="false" node1="11" node2="15"/>
-                <iidm:switch id="VL8_Switch#12" kind="BREAKER" retained="false" open="false" node1="11" node2="16"/>
-                <iidm:switch id="VL8_Switch#13" kind="BREAKER" retained="false" open="false" node1="11" node2="17"/>
+                <iidm:busbarSection id="VL45_4 Bus 4" node="0"/>
+                <iidm:busbarSection id="VL45_7 Bus 7" node="7"/>
+                <iidm:busbarSection id="VL45_9 Bus 9" node="11"/>
+                <iidm:switch id="VL45_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL45_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL45_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL45_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL45_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
+                <iidm:switch id="VL45_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
+                <iidm:switch id="VL45_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL45_Switch#6" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
+                <iidm:switch id="VL45_Switch#7" kind="BREAKER" retained="false" open="false" node1="7" node2="10"/>
+                <iidm:switch id="VL45_Switch#8" kind="BREAKER" retained="false" open="false" node1="11" node2="12"/>
+                <iidm:switch id="VL45_Switch#9" kind="BREAKER" retained="false" open="false" node1="11" node2="13"/>
+                <iidm:switch id="VL45_Switch#10" kind="BREAKER" retained="false" open="false" node1="11" node2="14"/>
+                <iidm:switch id="VL45_Switch#11" kind="BREAKER" retained="false" open="false" node1="11" node2="15"/>
+                <iidm:switch id="VL45_Switch#12" kind="BREAKER" retained="false" open="false" node1="11" node2="16"/>
+                <iidm:switch id="VL45_Switch#13" kind="BREAKER" retained="false" open="false" node1="11" node2="17"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="47.79999923706055" q0="-3.9000000953674316" node="4"/>
             <iidm:load id="lod_9_1" loadType="UNDEFINED" p0="29.5" q0="16.600000381469727" node="15"/>
@@ -129,7 +129,7 @@
                 <iidm:shuntLinearModel bPerSection="9.976895751953126E-4" gPerSection="0.0" maximumSectionCount="1"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_7_1" r="0.0" x="39.824814049530026" g="0.0" b="-0.0" ratedU1="134.96400451660156" ratedU2="138.0" ratedS="100.0" node1="5" voltageLevelId1="VL8" node2="10" voltageLevelId2="VL8">
+        <iidm:twoWindingsTransformer id="trf_4_7_1" r="0.0" x="39.824814049530026" g="0.0" b="-0.0" ratedU1="134.96400451660156" ratedU2="138.0" ratedS="100.0" node1="5" voltageLevelId1="VL45" node2="10" voltageLevelId2="VL45">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="75" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.8865664915043474"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.864526139533094"/>
@@ -293,7 +293,7 @@
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6551667851728639"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="trf_4_9_1" r="0.0" x="105.91891925811768" g="0.0" b="-0.0" ratedU1="133.7220001220703" ratedU2="138.0" ratedS="100.0" node1="6" voltageLevelId1="VL8" node2="17" voltageLevelId2="VL8">
+        <iidm:twoWindingsTransformer id="trf_4_9_1" r="0.0" x="105.91891925811768" g="0.0" b="-0.0" ratedU1="133.7220001220703" ratedU2="138.0" ratedS="100.0" node1="6" voltageLevelId1="VL45" node2="17" voltageLevelId2="VL45">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="74" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.864526139533094"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.8429948259912872"/>
@@ -458,22 +458,22 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:substation id="S9">
-        <iidm:voltageLevel id="VL9" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S46">
+        <iidm:voltageLevel id="VL46" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL9_5 Bus 5" node="0"/>
-                <iidm:busbarSection id="VL9_6 Bus 6" node="6"/>
-                <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL9_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL9_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL9_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL9_Switch#4" kind="BREAKER" retained="false" open="false" node1="6" node2="7"/>
-                <iidm:switch id="VL9_Switch#5" kind="BREAKER" retained="false" open="false" node1="6" node2="8"/>
-                <iidm:switch id="VL9_Switch#6" kind="BREAKER" retained="false" open="false" node1="6" node2="9"/>
-                <iidm:switch id="VL9_Switch#7" kind="BREAKER" retained="false" open="false" node1="6" node2="10"/>
-                <iidm:switch id="VL9_Switch#8" kind="BREAKER" retained="false" open="false" node1="6" node2="11"/>
-                <iidm:switch id="VL9_Switch#9" kind="BREAKER" retained="false" open="false" node1="6" node2="12"/>
+                <iidm:busbarSection id="VL46_5 Bus 5" node="0"/>
+                <iidm:busbarSection id="VL46_6 Bus 6" node="6"/>
+                <iidm:switch id="VL46_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL46_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL46_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL46_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL46_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
+                <iidm:switch id="VL46_Switch#4" kind="BREAKER" retained="false" open="false" node1="6" node2="7"/>
+                <iidm:switch id="VL46_Switch#5" kind="BREAKER" retained="false" open="false" node1="6" node2="8"/>
+                <iidm:switch id="VL46_Switch#6" kind="BREAKER" retained="false" open="false" node1="6" node2="9"/>
+                <iidm:switch id="VL46_Switch#7" kind="BREAKER" retained="false" open="false" node1="6" node2="10"/>
+                <iidm:switch id="VL46_Switch#8" kind="BREAKER" retained="false" open="false" node1="6" node2="11"/>
+                <iidm:switch id="VL46_Switch#9" kind="BREAKER" retained="false" open="false" node1="6" node2="12"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_6_1" energySource="OTHER" minP="-10000.0" maxP="10000.0" voltageRegulatorOn="true" targetP="0.0" targetV="147.66000723838806" targetQ="0.0" node="11">
                 <iidm:minMaxReactiveLimits minQ="-6.0" maxQ="24.0"/>
@@ -481,7 +481,7 @@
             <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="7.599999904632568" q0="1.600000023841858" node="4"/>
             <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="11.199999809265137" q0="7.5" node="10"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_5_6_1" r="0.0" x="47.99468816070557" g="0.0" b="-0.0" ratedU1="128.61599731445312" ratedU2="138.0" ratedS="100.0" node1="5" voltageLevelId1="VL9" node2="12" voltageLevelId2="VL9">
+        <iidm:twoWindingsTransformer id="trf_5_6_1" r="0.0" x="47.99468816070557" g="0.0" b="-0.0" ratedU1="128.61599731445312" ratedU2="138.0" ratedS="100.0" node1="5" voltageLevelId1="VL46" node2="12" voltageLevelId2="VL46">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="68" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.742390304643878"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.7235731866568458"/>
@@ -646,33 +646,33 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:substation id="S10">
-        <iidm:voltageLevel id="VL10" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S49">
+        <iidm:voltageLevel id="VL49" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL10_8 Bus 8" node="0"/>
-                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL49_8 Bus 8" node="0"/>
+                <iidm:switch id="VL49_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL49_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_8_1" energySource="OTHER" minP="-10000.0" maxP="10000.0" voltageRegulatorOn="true" targetP="0.0" targetV="150.42000460624695" targetQ="0.0" node="2">
                 <iidm:minMaxReactiveLimits minQ="-6.0" maxQ="24.0"/>
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="lne_10_11_1" r="15.62559986114502" x="36.57780075073242" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL1" node2="1" voltageLevelId2="VL2"/>
-    <iidm:line id="lne_12_13_1" r="42.071998596191406" x="38.065101623535156" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL3" node2="1" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_13_14_1" r="32.55189895629883" x="66.27690124511719" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL4" node2="1" voltageLevelId2="VL5"/>
-    <iidm:line id="lne_1_2_1" r="3.690730094909668" x="11.26830005645752" g1="0.0" b1="1.386264953613281E-4" g2="0.0" b2="1.386264953613281E-4" node1="1" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL6"/>
-    <iidm:line id="lne_1_5_1" r="10.28950023651123" x="42.47570037841797" g1="0.0" b1="1.2917449951171874E-4" g2="0.0" b2="1.2917449951171874E-4" node1="2" voltageLevelId1="VL0" node2="1" voltageLevelId2="VL9"/>
-    <iidm:line id="lne_2_3_1" r="8.948780059814453" x="37.70140075683594" g1="0.0" b1="1.1499700164794922E-4" g2="0.0" b2="1.1499700164794922E-4" node1="2" voltageLevelId1="VL6" node2="1" voltageLevelId2="VL7"/>
-    <iidm:line id="lne_2_4_1" r="11.066499710083008" x="33.578399658203125" g1="0.0" b1="8.926699829101562E-5" g2="0.0" b2="8.926699829101562E-5" node1="3" voltageLevelId1="VL6" node2="1" voltageLevelId2="VL8"/>
-    <iidm:line id="lne_2_5_1" r="10.845600128173828" x="33.11370086669922" g1="0.0" b1="9.084249877929687E-5" g2="0.0" b2="9.084249877929687E-5" node1="4" voltageLevelId1="VL6" node2="2" voltageLevelId2="VL9"/>
-    <iidm:line id="lne_3_4_1" r="12.76140022277832" x="32.57099914550781" g1="0.0" b1="3.360639953613281E-5" g2="0.0" b2="3.360639953613281E-5" node1="2" voltageLevelId1="VL7" node2="2" voltageLevelId2="VL8"/>
-    <iidm:line id="lne_4_5_1" r="2.542370080947876" x="8.019430160522461" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="3" voltageLevelId1="VL8" node2="3" voltageLevelId2="VL9"/>
-    <iidm:line id="lne_6_11_1" r="18.08799934387207" x="37.878501892089844" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL2"/>
-    <iidm:line id="lne_6_12_1" r="23.406999588012695" x="48.71649932861328" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="8" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL3"/>
-    <iidm:line id="lne_6_13_1" r="12.597599983215332" x="24.8085994720459" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="9" voltageLevelId1="VL9" node2="3" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_7_8_1" r="0.0" x="33.54600143432617" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="8" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL10"/>
-    <iidm:line id="lne_7_9_1" r="0.0" x="20.950300216674805" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="9" voltageLevelId1="VL8" node2="12" voltageLevelId2="VL8"/>
-    <iidm:line id="lne_9_10_1" r="6.0578999519348145" x="16.092199325561523" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="13" voltageLevelId1="VL8" node2="2" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_9_14_1" r="24.20680046081543" x="51.4911994934082" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="14" voltageLevelId1="VL8" node2="2" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_10_11_1" r="15.62559986114502" x="36.57780075073242" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL38" node2="1" voltageLevelId2="VL39"/>
+    <iidm:line id="lne_12_13_1" r="42.071998596191406" x="38.065101623535156" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL40" node2="1" voltageLevelId2="VL41"/>
+    <iidm:line id="lne_13_14_1" r="32.55189895629883" x="66.27690124511719" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL41" node2="1" voltageLevelId2="VL42"/>
+    <iidm:line id="lne_1_2_1" r="3.690730094909668" x="11.26830005645752" g1="0.0" b1="1.386264953613281E-4" g2="0.0" b2="1.386264953613281E-4" node1="1" voltageLevelId1="VL37" node2="1" voltageLevelId2="VL43"/>
+    <iidm:line id="lne_1_5_1" r="10.28950023651123" x="42.47570037841797" g1="0.0" b1="1.2917449951171874E-4" g2="0.0" b2="1.2917449951171874E-4" node1="2" voltageLevelId1="VL37" node2="1" voltageLevelId2="VL46"/>
+    <iidm:line id="lne_2_3_1" r="8.948780059814453" x="37.70140075683594" g1="0.0" b1="1.1499700164794922E-4" g2="0.0" b2="1.1499700164794922E-4" node1="2" voltageLevelId1="VL43" node2="1" voltageLevelId2="VL44"/>
+    <iidm:line id="lne_2_4_1" r="11.066499710083008" x="33.578399658203125" g1="0.0" b1="8.926699829101562E-5" g2="0.0" b2="8.926699829101562E-5" node1="3" voltageLevelId1="VL43" node2="1" voltageLevelId2="VL45"/>
+    <iidm:line id="lne_2_5_1" r="10.845600128173828" x="33.11370086669922" g1="0.0" b1="9.084249877929687E-5" g2="0.0" b2="9.084249877929687E-5" node1="4" voltageLevelId1="VL43" node2="2" voltageLevelId2="VL46"/>
+    <iidm:line id="lne_3_4_1" r="12.76140022277832" x="32.57099914550781" g1="0.0" b1="3.360639953613281E-5" g2="0.0" b2="3.360639953613281E-5" node1="2" voltageLevelId1="VL44" node2="2" voltageLevelId2="VL45"/>
+    <iidm:line id="lne_4_5_1" r="2.542370080947876" x="8.019430160522461" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="3" voltageLevelId1="VL45" node2="3" voltageLevelId2="VL46"/>
+    <iidm:line id="lne_6_11_1" r="18.08799934387207" x="37.878501892089844" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL46" node2="2" voltageLevelId2="VL39"/>
+    <iidm:line id="lne_6_12_1" r="23.406999588012695" x="48.71649932861328" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="8" voltageLevelId1="VL46" node2="2" voltageLevelId2="VL40"/>
+    <iidm:line id="lne_6_13_1" r="12.597599983215332" x="24.8085994720459" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="9" voltageLevelId1="VL46" node2="3" voltageLevelId2="VL41"/>
+    <iidm:line id="lne_7_8_1" r="0.0" x="33.54600143432617" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="8" voltageLevelId1="VL45" node2="1" voltageLevelId2="VL49"/>
+    <iidm:line id="lne_7_9_1" r="0.0" x="20.950300216674805" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="9" voltageLevelId1="VL45" node2="12" voltageLevelId2="VL45"/>
+    <iidm:line id="lne_9_10_1" r="6.0578999519348145" x="16.092199325561523" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="13" voltageLevelId1="VL45" node2="2" voltageLevelId2="VL38"/>
+    <iidm:line id="lne_9_14_1" r="24.20680046081543" x="51.4911994934082" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="14" voltageLevelId1="VL45" node2="2" voltageLevelId2="VL42"/>
 </iidm:network>

--- a/powerfactory/powerfactory-converter/src/test/resources/ieee14.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ieee14.xiidm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="ieee14" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S6">
+    <iidm:substation id="S0">
         <iidm:voltageLevel id="VL0" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL0_1 Bus 1" node="0"/>
@@ -13,7 +13,7 @@
             </iidm:generator>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S5">
+    <iidm:substation id="S1">
         <iidm:voltageLevel id="VL1" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL1_10 Bus 10" node="0"/>
@@ -24,7 +24,7 @@
             <iidm:load id="lod_10_1" loadType="UNDEFINED" p0="9.0" q0="5.800000190734863" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S8">
+    <iidm:substation id="S2">
         <iidm:voltageLevel id="VL2" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL2_11 Bus 11" node="0"/>
@@ -35,7 +35,7 @@
             <iidm:load id="lod_11_1" loadType="UNDEFINED" p0="3.5" q0="1.7999999523162842" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S7">
+    <iidm:substation id="S3">
         <iidm:voltageLevel id="VL3" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL3_12 Bus 12" node="0"/>
@@ -46,7 +46,7 @@
             <iidm:load id="lod_12_1" loadType="UNDEFINED" p0="6.099999904632568" q0="1.600000023841858" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S10">
+    <iidm:substation id="S4">
         <iidm:voltageLevel id="VL4" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL4_13 Bus 13" node="0"/>
@@ -58,7 +58,7 @@
             <iidm:load id="lod_13_1" loadType="UNDEFINED" p0="13.5" q0="5.800000190734863" node="4"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S9">
+    <iidm:substation id="S5">
         <iidm:voltageLevel id="VL5" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL5_14 Bus 14" node="0"/>
@@ -69,7 +69,7 @@
             <iidm:load id="lod_14_1" loadType="UNDEFINED" p0="14.899999618530273" q0="5.0" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S2">
+    <iidm:substation id="S6">
         <iidm:voltageLevel id="VL6" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL6_2 Bus 2" node="0"/>
@@ -86,7 +86,7 @@
             <iidm:load id="lod_2_1" loadType="UNDEFINED" p0="21.700000762939453" q0="12.699999809265137" node="5"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S1">
+    <iidm:substation id="S7">
         <iidm:voltageLevel id="VL7" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL7_3 Bus 3" node="0"/>
@@ -101,43 +101,35 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="94.19999694824219" q0="19.0" node="3"/>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:substation id="S4">
+    <iidm:substation id="S8">
         <iidm:voltageLevel id="VL8" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL8_4 Bus 4" node="0"/>
+                <iidm:busbarSection id="VL8_7 Bus 7" node="7"/>
+                <iidm:busbarSection id="VL8_9 Bus 9" node="11"/>
                 <iidm:switch id="VL8_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL8_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:switch id="VL8_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:switch id="VL8_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
                 <iidm:switch id="VL8_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
                 <iidm:switch id="VL8_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
+                <iidm:switch id="VL8_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL8_Switch#6" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
+                <iidm:switch id="VL8_Switch#7" kind="BREAKER" retained="false" open="false" node1="7" node2="10"/>
+                <iidm:switch id="VL8_Switch#8" kind="BREAKER" retained="false" open="false" node1="11" node2="12"/>
+                <iidm:switch id="VL8_Switch#9" kind="BREAKER" retained="false" open="false" node1="11" node2="13"/>
+                <iidm:switch id="VL8_Switch#10" kind="BREAKER" retained="false" open="false" node1="11" node2="14"/>
+                <iidm:switch id="VL8_Switch#11" kind="BREAKER" retained="false" open="false" node1="11" node2="15"/>
+                <iidm:switch id="VL8_Switch#12" kind="BREAKER" retained="false" open="false" node1="11" node2="16"/>
+                <iidm:switch id="VL8_Switch#13" kind="BREAKER" retained="false" open="false" node1="11" node2="17"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="47.79999923706055" q0="-3.9000000953674316" node="4"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL11" nominalV="138.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL11_7 Bus 7" node="0"/>
-                <iidm:switch id="VL11_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL11_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL11_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-            </iidm:nodeBreakerTopology>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL13" nominalV="138.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL13_9 Bus 9" node="0"/>
-                <iidm:switch id="VL13_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL13_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL13_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL13_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL13_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL13_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_9_1" loadType="UNDEFINED" p0="29.5" q0="16.600000381469727" node="4"/>
-            <iidm:shunt id="shntfix_9_ 1" sectionCount="1" voltageRegulatorOn="false" node="5">
+            <iidm:load id="lod_9_1" loadType="UNDEFINED" p0="29.5" q0="16.600000381469727" node="15"/>
+            <iidm:shunt id="shntfix_9_ 1" sectionCount="1" voltageRegulatorOn="false" node="16">
                 <iidm:shuntLinearModel bPerSection="9.976895751953126E-4" gPerSection="0.0" maximumSectionCount="1"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_4_7_1" r="0.0" x="39.824814049530026" g="0.0" b="-0.0" ratedU1="134.96400451660156" ratedU2="138.0" ratedS="100.0" node1="5" voltageLevelId1="VL8" node2="3" voltageLevelId2="VL11">
+        <iidm:twoWindingsTransformer id="trf_4_7_1" r="0.0" x="39.824814049530026" g="0.0" b="-0.0" ratedU1="134.96400451660156" ratedU2="138.0" ratedS="100.0" node1="5" voltageLevelId1="VL8" node2="10" voltageLevelId2="VL8">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="75" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.8865664915043474"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.864526139533094"/>
@@ -301,7 +293,7 @@
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.6551667851728639"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="trf_4_9_1" r="0.0" x="105.91891925811768" g="0.0" b="-0.0" ratedU1="133.7220001220703" ratedU2="138.0" ratedS="100.0" node1="6" voltageLevelId1="VL8" node2="6" voltageLevelId2="VL13">
+        <iidm:twoWindingsTransformer id="trf_4_9_1" r="0.0" x="105.91891925811768" g="0.0" b="-0.0" ratedU1="133.7220001220703" ratedU2="138.0" ratedS="100.0" node1="6" voltageLevelId1="VL8" node2="17" voltageLevelId2="VL8">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="74" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.864526139533094"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.8429948259912872"/>
@@ -466,34 +458,30 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:substation id="S3">
+    <iidm:substation id="S9">
         <iidm:voltageLevel id="VL9" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
                 <iidm:busbarSection id="VL9_5 Bus 5" node="0"/>
+                <iidm:busbarSection id="VL9_6 Bus 6" node="6"/>
                 <iidm:switch id="VL9_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
                 <iidm:switch id="VL9_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
                 <iidm:switch id="VL9_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
                 <iidm:switch id="VL9_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
                 <iidm:switch id="VL9_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
+                <iidm:switch id="VL9_Switch#4" kind="BREAKER" retained="false" open="false" node1="6" node2="7"/>
+                <iidm:switch id="VL9_Switch#5" kind="BREAKER" retained="false" open="false" node1="6" node2="8"/>
+                <iidm:switch id="VL9_Switch#6" kind="BREAKER" retained="false" open="false" node1="6" node2="9"/>
+                <iidm:switch id="VL9_Switch#7" kind="BREAKER" retained="false" open="false" node1="6" node2="10"/>
+                <iidm:switch id="VL9_Switch#8" kind="BREAKER" retained="false" open="false" node1="6" node2="11"/>
+                <iidm:switch id="VL9_Switch#9" kind="BREAKER" retained="false" open="false" node1="6" node2="12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="7.599999904632568" q0="1.600000023841858" node="4"/>
-        </iidm:voltageLevel>
-        <iidm:voltageLevel id="VL10" nominalV="138.0" topologyKind="NODE_BREAKER">
-            <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL10_6 Bus 6" node="0"/>
-                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
-                <iidm:switch id="VL10_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
-                <iidm:switch id="VL10_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
-                <iidm:switch id="VL10_Switch#3" kind="BREAKER" retained="false" open="false" node1="0" node2="5"/>
-                <iidm:switch id="VL10_Switch#4" kind="BREAKER" retained="false" open="false" node1="0" node2="6"/>
-            </iidm:nodeBreakerTopology>
-            <iidm:generator id="sym_6_1" energySource="OTHER" minP="-10000.0" maxP="10000.0" voltageRegulatorOn="true" targetP="0.0" targetV="147.66000723838806" targetQ="0.0" node="5">
+            <iidm:generator id="sym_6_1" energySource="OTHER" minP="-10000.0" maxP="10000.0" voltageRegulatorOn="true" targetP="0.0" targetV="147.66000723838806" targetQ="0.0" node="11">
                 <iidm:minMaxReactiveLimits minQ="-6.0" maxQ="24.0"/>
             </iidm:generator>
-            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="11.199999809265137" q0="7.5" node="4"/>
+            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="7.599999904632568" q0="1.600000023841858" node="4"/>
+            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="11.199999809265137" q0="7.5" node="10"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="trf_5_6_1" r="0.0" x="47.99468816070557" g="0.0" b="-0.0" ratedU1="128.61599731445312" ratedU2="138.0" ratedS="100.0" node1="5" voltageLevelId1="VL9" node2="6" voltageLevelId2="VL10">
+        <iidm:twoWindingsTransformer id="trf_5_6_1" r="0.0" x="47.99468816070557" g="0.0" b="-0.0" ratedU1="128.61599731445312" ratedU2="138.0" ratedS="100.0" node1="5" voltageLevelId1="VL9" node2="12" voltageLevelId2="VL9">
             <iidm:ratioTapChanger lowTapPosition="0" tapPosition="68" loadTapChangingCapabilities="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.742390304643878"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.7235731866568458"/>
@@ -658,12 +646,12 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:substation id="S11">
-        <iidm:voltageLevel id="VL12" nominalV="138.0" topologyKind="NODE_BREAKER">
+    <iidm:substation id="S10">
+        <iidm:voltageLevel id="VL10" nominalV="138.0" topologyKind="NODE_BREAKER">
             <iidm:nodeBreakerTopology>
-                <iidm:busbarSection id="VL12_8 Bus 8" node="0"/>
-                <iidm:switch id="VL12_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
-                <iidm:switch id="VL12_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:busbarSection id="VL10_8 Bus 8" node="0"/>
+                <iidm:switch id="VL10_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL10_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="sym_8_1" energySource="OTHER" minP="-10000.0" maxP="10000.0" voltageRegulatorOn="true" targetP="0.0" targetV="150.42000460624695" targetQ="0.0" node="2">
                 <iidm:minMaxReactiveLimits minQ="-6.0" maxQ="24.0"/>
@@ -680,11 +668,11 @@
     <iidm:line id="lne_2_5_1" r="10.845600128173828" x="33.11370086669922" g1="0.0" b1="9.084249877929687E-5" g2="0.0" b2="9.084249877929687E-5" node1="4" voltageLevelId1="VL6" node2="2" voltageLevelId2="VL9"/>
     <iidm:line id="lne_3_4_1" r="12.76140022277832" x="32.57099914550781" g1="0.0" b1="3.360639953613281E-5" g2="0.0" b2="3.360639953613281E-5" node1="2" voltageLevelId1="VL7" node2="2" voltageLevelId2="VL8"/>
     <iidm:line id="lne_4_5_1" r="2.542370080947876" x="8.019430160522461" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="3" voltageLevelId1="VL8" node2="3" voltageLevelId2="VL9"/>
-    <iidm:line id="lne_6_11_1" r="18.08799934387207" x="37.878501892089844" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL10" node2="2" voltageLevelId2="VL2"/>
-    <iidm:line id="lne_6_12_1" r="23.406999588012695" x="48.71649932861328" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL10" node2="2" voltageLevelId2="VL3"/>
-    <iidm:line id="lne_6_13_1" r="12.597599983215332" x="24.8085994720459" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="3" voltageLevelId1="VL10" node2="3" voltageLevelId2="VL4"/>
-    <iidm:line id="lne_7_8_1" r="0.0" x="33.54600143432617" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL11" node2="1" voltageLevelId2="VL12"/>
-    <iidm:line id="lne_7_9_1" r="0.0" x="20.950300216674805" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL11" node2="1" voltageLevelId2="VL13"/>
-    <iidm:line id="lne_9_10_1" r="6.0578999519348145" x="16.092199325561523" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL13" node2="2" voltageLevelId2="VL1"/>
-    <iidm:line id="lne_9_14_1" r="24.20680046081543" x="51.4911994934082" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="3" voltageLevelId1="VL13" node2="2" voltageLevelId2="VL5"/>
+    <iidm:line id="lne_6_11_1" r="18.08799934387207" x="37.878501892089844" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL2"/>
+    <iidm:line id="lne_6_12_1" r="23.406999588012695" x="48.71649932861328" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="8" voltageLevelId1="VL9" node2="2" voltageLevelId2="VL3"/>
+    <iidm:line id="lne_6_13_1" r="12.597599983215332" x="24.8085994720459" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="9" voltageLevelId1="VL9" node2="3" voltageLevelId2="VL4"/>
+    <iidm:line id="lne_7_8_1" r="0.0" x="33.54600143432617" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="8" voltageLevelId1="VL8" node2="1" voltageLevelId2="VL10"/>
+    <iidm:line id="lne_7_9_1" r="0.0" x="20.950300216674805" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="9" voltageLevelId1="VL8" node2="12" voltageLevelId2="VL8"/>
+    <iidm:line id="lne_9_10_1" r="6.0578999519348145" x="16.092199325561523" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="13" voltageLevelId1="VL8" node2="2" voltageLevelId2="VL1"/>
+    <iidm:line id="lne_9_14_1" r="24.20680046081543" x="51.4911994934082" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="14" voltageLevelId1="VL8" node2="2" voltageLevelId2="VL5"/>
 </iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
`VoltageLevels` are generated by joining buses connected with zero impedance lines and then  `substations `by joining `voltage Levels` connected with transformers.  Different voltageLevels are created for buses with same nominal voltage if they are only connected with transformers through the primary voltage. 


**What is the new behavior (if this is a feature change)?**
`Substations` are generated by joining buses connected with zero impedance lines and transformers, then each substation  is split into `voltageLevels` by joining buses connected with zero impedance lines. Finally, `VoltageLevels` (inside the substation) with same nominal voltage are merged.  

Powerfactory uses `ElmSite `objects to define substations and `ElmSubstat `to define the voltageLevels. Both objects are optional and  they are used to obtain the substation and voltageLevel `ids`.

Automatic naming has been modified to be invariant of the algorithm used.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
