### PR TITLE
Use intermediary objects to copy limits for modification AttachNewLin…

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AttachNewLineOnLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AttachNewLineOnLine.java
@@ -215,14 +215,16 @@ public class AttachNewLineOnLine implements NetworkModification {
         LineAdder adder2 = createLineAdder(100 - percent, line2Id, line2Name, fictitiousVlId, line.getTerminal2().getVoltageLevel().getId(), network, line);
         attachLine(line.getTerminal1(), adder1, (bus, adder) -> adder.setConnectableBus1(bus.getId()), (bus, adder) -> adder.setBus1(bus.getId()), (node, adder) -> adder.setNode1(node));
         attachLine(line.getTerminal2(), adder2, (bus, adder) -> adder.setConnectableBus2(bus.getId()), (bus, adder) -> adder.setBus2(bus.getId()), (node, adder) -> adder.setNode2(node));
+        LoadingLimitsBags limits1 = new LoadingLimitsBags(line::getActivePowerLimits1, line::getApparentPowerLimits1, line::getCurrentLimits1);
+        LoadingLimitsBags limits2 = new LoadingLimitsBags(line::getActivePowerLimits2, line::getApparentPowerLimits2, line::getCurrentLimits2);
 
         // Remove the existing line
         line.remove();
 
         Line line1 = adder1.setNode2(0).add();
         Line line2 = adder2.setNode1(2).add();
-        addLoadingLimits(line1, line, Branch.Side.ONE);
-        addLoadingLimits(line2, line, Branch.Side.TWO);
+        addLoadingLimits(line1, limits1, Branch.Side.ONE);
+        addLoadingLimits(line2, limits2, Branch.Side.TWO);
 
         // Create the topology inside the fictitious voltage level
         fictitiousVl.getNodeBreakerView()

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AttachVoltageLevelOnLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AttachVoltageLevelOnLine.java
@@ -124,6 +124,8 @@ public class AttachVoltageLevelOnLine implements NetworkModification {
         LineAdder adder2 = createLineAdder(100 - percent, line2Id, line2Name, voltageLevelId, line.getTerminal2().getVoltageLevel().getId(), network, line);
         attachLine(line.getTerminal1(), adder1, (bus, adder) -> adder.setConnectableBus1(bus.getId()), (bus, adder) -> adder.setBus1(bus.getId()), (node, adder) -> adder.setNode1(node));
         attachLine(line.getTerminal2(), adder2, (bus, adder) -> adder.setConnectableBus2(bus.getId()), (bus, adder) -> adder.setBus2(bus.getId()), (node, adder) -> adder.setNode2(node));
+        LoadingLimitsBags limits1 = new LoadingLimitsBags(line::getActivePowerLimits1, line::getApparentPowerLimits1, line::getCurrentLimits1);
+        LoadingLimitsBags limits2 = new LoadingLimitsBags(line::getActivePowerLimits2, line::getApparentPowerLimits2, line::getCurrentLimits2);
 
         // Create the topology inside the existing voltage level
         TopologyKind topologyKind = voltageLevel.getTopologyKind();
@@ -164,8 +166,8 @@ public class AttachVoltageLevelOnLine implements NetworkModification {
         // Create the two lines
         Line line1 = adder1.add();
         Line line2 = adder2.add();
-        addLoadingLimits(line1, line, Branch.Side.ONE);
-        addLoadingLimits(line2, line, Branch.Side.TWO);
+        addLoadingLimits(line1, limits1, Branch.Side.ONE);
+        addLoadingLimits(line2, limits2, Branch.Side.TWO);
     }
 
     @Override


### PR DESCRIPTION
…eOnLine and AttachVoltageLevelOnLine

Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Clean code: use intermediary objects to store and copy limits during topology modifications rather than accessing a removed line.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
