### PR TITLE
First step towards reproducible itools-packager builds: setTime in the zip

### DIFF
--- a/itools-packager/src/main/java/com/powsybl/itools/ItoolsPackagerMojo.java
+++ b/itools-packager/src/main/java/com/powsybl/itools/ItoolsPackagerMojo.java
@@ -24,9 +24,12 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
+import java.time.OffsetDateTime;
+import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -50,6 +53,9 @@ public class ItoolsPackagerMojo extends AbstractMojo {
     @Parameter(defaultValue = "config")
     private String configName;
 
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
+
     public static class CopyTo {
 
         private File[] files;
@@ -72,7 +78,8 @@ public class ItoolsPackagerMojo extends AbstractMojo {
     @Parameter
     private CopyTo copyToEtc;
 
-    private static void zip(Path dir, Path baseDir, Path zipFilePath) throws IOException {
+    private static void zip(Path dir, Path baseDir, Path zipFilePath, FileTime reproducibleFileTime)
+            throws IOException {
         try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(Files.newOutputStream(zipFilePath))) {
             Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
                 @Override
@@ -83,6 +90,9 @@ public class ItoolsPackagerMojo extends AbstractMojo {
                     } else {
                         entry.setUnixMode(0100660);
                     }
+                    if (reproducibleFileTime != null) {
+                        entry.setTime(reproducibleFileTime);
+                    }
                     zos.putArchiveEntry(entry);
                     Files.copy(file, zos);
                     zos.closeArchiveEntry();
@@ -91,7 +101,11 @@ public class ItoolsPackagerMojo extends AbstractMojo {
 
                 @Override
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                    zos.putArchiveEntry(new ZipArchiveEntry(baseDir.relativize(dir).toString() + "/"));
+                    ZipArchiveEntry entry = new ZipArchiveEntry(baseDir.relativize(dir).toString() + "/");
+                    if (reproducibleFileTime != null) {
+                        entry.setTime(reproducibleFileTime);
+                    }
+                    zos.putArchiveEntry(entry);
                     zos.closeArchiveEntry();
                     return FileVisitResult.CONTINUE;
                 }
@@ -180,9 +194,30 @@ public class ItoolsPackagerMojo extends AbstractMojo {
 
             getLog().info("Zip package");
             String archiveNameNotNull = archiveName != null ? archiveName : packageNameNotNull;
-            zip(packageDir, targetDir, targetDir.resolve(archiveNameNotNull + ".zip"));
+            // non null if reproducible build
+            FileTime reproducibleFileTime = parseOutputTimestamp();
+            zip(packageDir, targetDir, targetDir.resolve(archiveNameNotNull + ".zip"), reproducibleFileTime);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
+
+    //lifted from spring-boot-maven-plugin RepackageMojo.java (apache license)
+    private FileTime parseOutputTimestamp() {
+        // Maven ignores a single-character timestamp as it is "useful to override a full
+        // value during pom inheritance"
+        if (this.outputTimestamp == null || this.outputTimestamp.length() < 2) {
+            return null;
+        }
+        return FileTime.from(getOutputTimestampEpochSeconds(), TimeUnit.SECONDS);
+    }
+
+    private long getOutputTimestampEpochSeconds() {
+        try {
+            return Long.parseLong(this.outputTimestamp);
+        } catch (NumberFormatException ex) {
+            return OffsetDateTime.parse(this.outputTimestamp).toInstant().getEpochSecond();
+        }
+    }
+
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
the zip changes at every build


**What is the new behavior (if this is a feature change)?**
the zip is byte for byte identical between two consecutives build


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO


**Other information**:
This is called reproducible builds