### PR TITLE
Matpower: create limits at both sides

### DIFF
--- a/matpower/matpower-converter/src/test/resources/ieee9_limits.xiidm
+++ b/matpower/matpower-converter/src/test/resources/ieee9_limits.xiidm
@@ -88,6 +88,10 @@
             <iidm:temporaryLimit name="RateB" acceptableDuration="1200" value="60.0"/>
             <iidm:temporaryLimit name="RateC" acceptableDuration="60" value="70.0"/>
         </iidm:apparentPowerLimits1>
+        <iidm:apparentPowerLimits2 permanentLimit="50.0">
+            <iidm:temporaryLimit name="RateB" acceptableDuration="1200" value="60.0"/>
+            <iidm:temporaryLimit name="RateC" acceptableDuration="60" value="70.0"/>
+        </iidm:apparentPowerLimits2>
     </iidm:line>
     <iidm:extension id="VL-1">
         <slt:slackTerminal id="GEN-1"/>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Apparent power limits are arbitrary created at side one.


**What is the new behavior (if this is a feature change)?**
Apparent power limits are duplicated at both sides.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
