### PR TITLE
Fix sensitivity factor model reader for BUS_VOLTAGE factor

### DIFF
--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFactorModelReader.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFactorModelReader.java
@@ -34,7 +34,7 @@ public class SensitivityFactorModelReader implements SensitivityFactorReader {
         for (SensitivityFactor factor : factors) {
             String functionId = factor.getFunctionId();
             if (factor.getFunctionType() == SensitivityFunctionType.BUS_VOLTAGE) {
-                Bus bus = new IdBasedBusRef(factor.getFunctionId()).resolve(network, TopologyLevel.BUS_BRANCH)
+                Bus bus = new IdBasedBusRef(factor.getFunctionId()).resolve(network, TopologyLevel.BUS_BREAKER)
                     .orElseThrow(() -> new PowsyblException("The bus ref for '" + factor.getFunctionId() + "' cannot be resolved."));
                 functionId = bus.getId();
             }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

Yes, issue #2226.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

It resolves the id based bus ref at bus/breaker topology and not longer at bus/branch topology.

**What is the current behavior?** *(You can also link to an open issue here)*

It is resolves at bus/branch topology, and it forces the implementation to be based on bus view. 

**What is the new behavior (if this is a feature change)?**

It is up to the implementation to choose if the bus voltage function is based on the bus/breaker view or on the bus view. 

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
