### PR TITLE
fix lineConnectionAction deserializer

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ActionDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ActionDeserializer.java
@@ -89,7 +89,7 @@ public class ActionDeserializer extends StdDeserializer<Action> {
                 }
                 return new SwitchAction(context.id, context.switchId, context.open);
             case LineConnectionAction.NAME:
-                if (context.openSide1 == null && context.openSide2 == null) {
+                if (context.openSide1 == null || context.openSide2 == null) {
                     throw JsonMappingException.from(parser, "for line action openSide1 and openSide2 fields can't be null");
                 }
                 return new LineConnectionAction(context.id, context.lineId, context.openSide1, context.openSide2);


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
when deserializing action json, boolean of lineConnectionAction can be null


**What is the new behavior (if this is a feature change)?**

they can not be null now
