### PR TITLE
PowerFactory: add phase angle clock from transformer connection type

### DIFF
--- a/powerfactory/powerfactory-converter/pom.xml
+++ b/powerfactory/powerfactory-converter/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-extensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-powerfactory-model</artifactId>
         </dependency>
 

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/TransformerConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/TransformerConverter.java
@@ -8,6 +8,7 @@ package com.powsybl.powerfactory.converter;
 
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.ThreeWindingsTransformer.Leg;
+import com.powsybl.iidm.network.extensions.TwoWindingsTransformerPhaseAngleClockAdder;
 import com.powsybl.powerfactory.converter.PowerFactoryImporter.ImportContext;
 import com.powsybl.powerfactory.model.DataObject;
 import com.powsybl.powerfactory.model.PowerFactoryException;
@@ -78,6 +79,13 @@ class TransformerConverter extends AbstractConverter {
             .add();
 
         tc.ifPresent(t -> tapChangerToIidm(t, t2wt));
+
+        typTr2.findFloatAttributeValue("nt2ag").ifPresent(phaseAngleClock -> {
+            if (phaseAngleClock > 0) {
+                int pac = (int) phaseAngleClock.floatValue();
+                t2wt.newExtension(TwoWindingsTransformerPhaseAngleClockAdder.class).withPhaseAngleClock(pac).add();
+            }
+        });
     }
 
     void createThreeWindings(DataObject elmTr3) {

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/TransformerConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/TransformerConverter.java
@@ -8,6 +8,7 @@ package com.powsybl.powerfactory.converter;
 
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.ThreeWindingsTransformer.Leg;
+import com.powsybl.iidm.network.extensions.ThreeWindingsTransformerPhaseAngleClockAdder;
 import com.powsybl.iidm.network.extensions.TwoWindingsTransformerPhaseAngleClockAdder;
 import com.powsybl.powerfactory.converter.PowerFactoryImporter.ImportContext;
 import com.powsybl.powerfactory.model.DataObject;
@@ -80,12 +81,9 @@ class TransformerConverter extends AbstractConverter {
 
         tc.ifPresent(t -> tapChangerToIidm(t, t2wt));
 
-        typTr2.findFloatAttributeValue("nt2ag").ifPresent(phaseAngleClock -> {
-            if (phaseAngleClock > 0) {
-                int pac = (int) phaseAngleClock.floatValue();
-                t2wt.newExtension(TwoWindingsTransformerPhaseAngleClockAdder.class).withPhaseAngleClock(pac).add();
-            }
-        });
+        Optional<PhaseAngleClockModel> pacModel = PhaseAngleClockModel.create(typTr2);
+        pacModel.ifPresent(phaseAngleClockModel -> t2wt.newExtension(TwoWindingsTransformerPhaseAngleClockAdder.class)
+            .withPhaseAngleClock(phaseAngleClockModel.pac).add());
     }
 
     void createThreeWindings(DataObject elmTr3) {
@@ -173,6 +171,15 @@ class TransformerConverter extends AbstractConverter {
         tc1.ifPresent(tc -> tapChangerToIidm(tc, t3wt.getLeg1()));
         tc2.ifPresent(tc -> tapChangerToIidm(tc, t3wt.getLeg2()));
         tc3.ifPresent(tc -> tapChangerToIidm(tc, t3wt.getLeg3()));
+
+        PhaseAngleClock3WModel pac3WModel = PhaseAngleClock3WModel.create(typTr3);
+        Optional<PhaseAngleClockModel> pac2 = pac3WModel.getEnd(windingTypeEnds.get(1));
+        Optional<PhaseAngleClockModel> pac3 = pac3WModel.getEnd(windingTypeEnds.get(2));
+        if (pac2.isPresent() || pac3.isPresent()) {
+            t3wt.newExtension(ThreeWindingsTransformerPhaseAngleClockAdder.class)
+                .withPhaseAngleClockLeg2(pac2.isPresent() ? pac2.get().pac : 0)
+                .withPhaseAngleClockLeg3(pac3.isPresent() ? pac3.get().pac : 0).add();
+        }
     }
 
     private static boolean highVoltageAtEnd1(VoltageLevel vl1, VoltageLevel vl2) {
@@ -466,6 +473,43 @@ class TransformerConverter extends AbstractConverter {
             rated3WModel.ratedModels.put(WindingType.MEDIUM, new RatedModel(utrnM, ratedU0, strnM));
             rated3WModel.ratedModels.put(WindingType.LOW, new RatedModel(utrnL, ratedU0, strnL));
             return rated3WModel;
+        }
+    }
+
+    private static final class PhaseAngleClockModel {
+        private final int pac;
+
+        private PhaseAngleClockModel(int pac) {
+            this.pac = pac;
+        }
+
+        private static Optional<PhaseAngleClockModel> create(DataObject typTr2) {
+            float nt2ag = typTr2.findFloatAttributeValue("nt2ag").orElse(0f);
+            if (nt2ag > 0) {
+                return Optional.of(new PhaseAngleClockModel((int) nt2ag));
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
+    private static final class PhaseAngleClock3WModel {
+        private final Map<WindingType, Optional<PhaseAngleClockModel>> phaseAngleClockModels = new EnumMap<>(WindingType.class);
+
+        private Optional<PhaseAngleClockModel> getEnd(WindingType windingType) {
+            return phaseAngleClockModels.get(windingType);
+        }
+
+        private static PhaseAngleClock3WModel create(DataObject typTr3) {
+            float nt3agL = typTr3.findFloatAttributeValue("nt3ag_l").orElse(0f);
+            float nt3agM = typTr3.findFloatAttributeValue("nt3ag_m").orElse(0f);
+            float nt3agH = typTr3.findFloatAttributeValue("nt3ag_h").orElse(0f);
+
+            PhaseAngleClock3WModel phaseAngleClockModel = new PhaseAngleClock3WModel();
+            phaseAngleClockModel.phaseAngleClockModels.put(WindingType.LOW, nt3agL > 0 ? Optional.of(new PhaseAngleClockModel((int) nt3agL)) : Optional.empty());
+            phaseAngleClockModel.phaseAngleClockModels.put(WindingType.MEDIUM, nt3agM > 0 ? Optional.of(new PhaseAngleClockModel((int) nt3agM)) : Optional.empty());
+            phaseAngleClockModel.phaseAngleClockModels.put(WindingType.HIGH, nt3agH > 0 ? Optional.of(new PhaseAngleClockModel((int) nt3agH)) : Optional.empty());
+            return phaseAngleClockModel;
         }
     }
 

--- a/powerfactory/powerfactory-converter/src/test/java/com/powsybl/powerfactory/converter/PowerFactoryImporterTest.java
+++ b/powerfactory/powerfactory-converter/src/test/java/com/powsybl/powerfactory/converter/PowerFactoryImporterTest.java
@@ -247,6 +247,11 @@ public class PowerFactoryImporterTest extends AbstractConverterTest {
     }
 
     @Test
+    public void transformersWithPhaseAngleClock() {
+        assertTrue(importAndCompareXiidm("TransformersWithPhaseAngleClock"));
+    }
+
+    @Test
     public void threeWindingsTransformerWinding1Ratio() {
         assertTrue(importAndCompareXiidm("ThreeWindingsTransformerWinding1Ratio"));
     }

--- a/powerfactory/powerfactory-converter/src/test/resources/TransformersWithPhaseAngleClock.dgs
+++ b/powerfactory/powerfactory-converter/src/test/resources/TransformersWithPhaseAngleClock.dgs
@@ -1,0 +1,156 @@
+$$General;ID(a:40);Descr(a:40);Val(a:40)
+  1;Version;5.0
+
+
+$$ChaRef;ID(a:40);loc_name(a:40);fold_id(p)
+  2;fline;20
+  3;fline;21
+  4;ratfac_h;43
+  5;ratfac_l;43
+  6;ratfac_m;43
+  7;ratfac;39
+  8;ratfac;40
+  9;ratfac;41
+  10;ratfac;42
+
+
+$$ChaVec;ID(a:40);loc_name(a:40);fold_id(p);scale(p);usage(i);approx(i);vector:SIZEROW(i);vector:0(r);vector:1(r);vector:2(r)
+  11;vec_1;;;0;0;3;100;100,009568462348;100,019136924696
+  12;vec_2;;;0;0;3;100;100,009468800303;100,018937600606
+  13;vec_3;;;0;0;3;10140;10141;10142
+  14;vec_4;;;0;0;3;10000;99999;99999
+  15;vec_5;;;0;0;3;10000;99999;99999
+  16;vec_6;;;0;0;3;10000;99999;99999
+  17;vec_7;;;0;0;3;100;100,990099009901;101,980198019802
+  18;vec_8;;;0;0;3;100;100,497512437811;100,995024875622
+  19;vec_9;;;0;0;3;100;100,332225913621;100,664451827243
+
+
+$$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);nlnum(i);inAir(i)
+  20;lne_4_5_1;;27;93;1;1;0;0;1;0
+  21;lne_5_6_1;;27;94;1;1;0;0;1;0
+
+
+$$ElmLod;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);mode_inp(a:3);slini(r);plini(r);qlini(r);coslini(r);pf_recap(i);scale0(r);i_scale(i);outserv(i);classif(a:20)
+  22;lod_4_1;;27;95;PQ;1403,567;1400;100;0,997458;0;1;0;0;
+  23;lod_5_1;;27;95;PQ;2002,498;2000;100;0,998752;0;1;0;0;
+  24;lod_5_2;;27;95;PQ;50;0;50;0;0;1;0;1;
+  25;lod_6_1;;27;95;PQ;10198,04;10000;2000;0,980580;0;1;0;0;
+  26;lod_7_1;;27;95;PQ;1,414214;1;1;0,707106;0;1;0;0;
+
+
+$$ElmNet;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);frnom(r);pDiagram(p)
+  27;1 1;;;60;
+
+
+$$ElmSym;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);cCategory(a);ngnum(i);i_mot(i);pgini(r);qgini(r);cosgini(r);usetp(r);pf_recap(i);q_min(r);q_max(r);outserv(i);av_mode(a);phtech(i)
+  28;sym_1_1;;27;96;Others;1;0;1404;0;1;1,04;0;-6,346154;6,346154;0;constv;1
+  29;sym_2_1;;27;97;Others;1;0;1404;0;1;1,04;0;-6,346154;6,346154;0;constv;1
+  30;sym_3_1;;27;98;Others;1;0;800;0;1;1,02;0;-11,1236;11,1236;0;constv;1
+  31;sym_6_1;;27;99;Others;1;0;9796,685;0;1;1;0;-0,099;0,099;0;constv;1
+
+
+$$ElmTerm;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);systype(i);iUsage(i);uknom(r);unknom(r);iminus(i);outserv(i);GPSlat(r);GPSlon(r);vtarget(r)
+  32;1 1;;27;;0;0;18;10,3923;0;0;0;0;1
+  33;2 2;;27;;0;0;18;10,3923;0;0;0;0;1
+  34;3 3;;27;;0;0;18;10,3923;0;0;0;0;1
+  35;4 4;;27;;0;0;500;288,6751;0;0;0;0;1
+  36;5 5;;27;;0;0;500;288,6751;0;0;0;0;1
+  37;6 6;;27;;0;0;500;288,6751;0;0;0;0;1
+  38;7 7;;27;;0;0;16;9,237604;0;0;0;0;1
+
+
+$$ElmTr2;ID(a:40);loc_name(a:40);fold_id(p);for_name(a:50);typ_id(p);ntnum(i);outserv(i);nntap(i);i_auto(i);ntrcn(i);usetp(r);usp_low(r);usp_up(r);t2ldc(i);mTaps:SIZEROW(i);mTaps:SIZECOL(i)
+  39;trf_4_1_1;27;;100;1;0;0;0;0;1,005;0,51;1,5;0;1;0
+  40;trf_5_3_1;27;;101;1;0;0;0;0;1,025;0,95;1,1;0;1;0
+  41;trf_5_7_1;27;;102;1;0;0;0;0;1,025;0,95;1,1;0;1;0
+  42;trf_6_2_1;27;;103;1;0;0;0;0;1,025;0,95;1,1;0;1;0
+
+
+$$ElmTr3;ID(a:40);loc_name(a:40);fold_id(p);for_name(a:50);nt3nm(i);typ_id(p);outserv(i);n3tap_h(i);n3tap_m(i);n3tap_l(i);i_auto_hl(i);ictrlside(i);ntrcn(i);t3ldc(i);usetp(r);usp_low(r);usp_up(r);iMeasTap(i)
+  43;tr3_4_2_7_1;27;;1;104;0;8;0;0;0;0;1;0;0;0;0;0
+
+
+$$ElmZone;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);icolor(i);curscale(r)
+  44;1_1;;;1;1
+
+
+$$StaCubic;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);obj_bus(i);obj_id(p);it2p1(i);it2p2(i);it2p3(i)
+  45;sym_1_1;;32;0;28;0;1;2
+  46;trf_4_1_1;;32;1;39;0;1;2
+  47;sym_2_1;;33;0;29;0;1;2
+  48;tr3_4_2_7_1;;33;1;43;0;1;2
+  49;trf_6_2_1;;33;1;42;0;1;2
+  50;sym_3_1;;34;0;30;0;1;2
+  51;trf_5_3_1;;34;1;40;0;1;2
+  52;lne_4_5_1;;35;0;20;0;1;2
+  53;lod_4_1;;35;0;22;0;1;2
+  54;tr3_4_2_7_1;;35;0;43;0;1;2
+  55;trf_4_1_1;;35;0;39;0;1;2
+  56;lne_4_5_1;;36;1;20;0;1;2
+  57;lne_5_6_1;;36;0;21;0;1;2
+  58;lod_5_1;;36;0;23;0;1;2
+  59;lod_5_2;;36;0;24;0;1;2
+  60;trf_5_3_1;;36;0;40;0;1;2
+  61;trf_5_7_1;;36;0;41;0;1;2
+  62;lne_5_6_1;;37;1;21;0;1;2
+  63;lod_6_1;;37;0;25;0;1;2
+  64;sym_6_1;;37;0;31;0;1;2
+  65;trf_6_2_1;;37;0;42;0;1;2
+  66;lod_7_1;;38;0;26;0;1;2
+  67;tr3_4_2_7_1;;38;2;43;0;1;2
+  68;trf_5_7_1;;38;1;41;0;1;2
+
+
+$$StaSwitch;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);on_off(i);typ_id(p);aUsage(a)
+  69;Switch;;45;1;;cbk
+  70;Switch;;46;1;;cbk
+  71;Switch;;47;1;;cbk
+  72;Switch;;48;1;;cbk
+  73;Switch;;49;1;;cbk
+  74;Switch;;50;1;;cbk
+  75;Switch;;51;1;;cbk
+  76;Switch;;52;1;;cbk
+  77;Switch;;53;1;;cbk
+  78;Switch;;54;1;;cbk
+  79;Switch;;55;1;;cbk
+  80;Switch;;56;1;;cbk
+  81;Switch;;57;1;;cbk
+  82;Switch;;58;1;;cbk
+  83;Switch;;59;0;;cbk
+  84;Switch;;60;1;;cbk
+  85;Switch;;61;1;;cbk
+  86;Switch;;62;1;;cbk
+  87;Switch;;63;1;;cbk
+  88;Switch;;64;1;;cbk
+  89;Switch;;65;1;;cbk
+  90;Switch;;66;1;;cbk
+  91;Switch;;67;1;;cbk
+  92;Switch;;68;1;;cbk
+
+
+$$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
+  93;tlne_4_5_1;;27;500;12,06778;1;0;0;90;999999;999999;0;80;80;0;3;0;60;Cu;0;0
+  94;tlne_5_6_1;;27;500;12,19479;1;0;0;300;999999;999999;0;80;80;0;3;0;60;Cu;0;0
+
+
+$$TypLod;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);systp(i);phtech(i);aP(r);bP(r);kpu0(r);kpu1(r);kpu(r);aQ(r);bQ(r);kqu0(r);kqu1(r);kqu(r)
+  95;lodtyp_pq;;27;0;0;1;0;0;1;2;1;0;0;1;2
+
+
+$$TypSym;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);nphase(i);nslty(i);x0sy(r);r0sy(r);x2sy(r);r2sy(r);iopt_data(i);xds(r);xqs(r);xl(r);xdss(r);xqss(r);xrlq(r);tds(r);tqs(r);tdss(r);tqss(r)
+  96;tsym_1_1;;27;1560;18;1;2;2;0,29;0,0019;1,2;0;3;2;0,29;0,0019;0,29;0,0019;1;0,3;0,3;0,145;0,29;0,29;0;1;0;0,05;0,05
+  97;tsym_2_1;;27;1560;18;1;2;2;0,29;0,0019;1,2;0;3;2;0,29;0,0019;0,29;0,0019;1;0,3;0,3;0,145;0,29;0,29;0;1;0;0,05;0,05
+  98;tsym_3_1;;27;890;18;1;2;2;0,337;0;1,2;0;3;2;0,337;0;0,337;0;1;0,3;0,3;0,1685;0,337;0,337;0;1;0;0,05;0,05
+  99;tsym_6_1;;27;100000;500;1;2;2;0,2;0;1,2;0;3;2;0,2;0;0,2;0;1;0,3;0,3;0,1;0,2;0,2;0;1;0;0,05;0,05
+
+
+$$TypTr2;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);nt2ph(i);strn(r);frnom(r);utrn_h(r);utrn_l(r);uktr(r);pcutr(r);uk0tr(r);ur0tr(r);tr2cn_h(a:2);tr2cn_l(a:2);nt2ag(r);curmg(r);pfe(r);zx0hl_n(r);itapch(i);tap_side(i);dutap(r);phitr(r);nntap0(i);ntpmn(i);ntpmx(i);manuf(a:20)
+  100;ttrf_4_1_1;;27;3;100;60;500;18;0,641;0;0;0;D;D;0;0;0;100;1;0;-99;0;0;0;0;
+  101;ttrf_5_3_1;;27;3;100;60;500;18;1,12;0;0;0;D;D;0;0;0;100;1;0;-10;0;0;0;0;
+  102;ttrf_5_7_1;;27;3;100;60;500;16;1,12;0;0;0;D;D;0;0;0;100;1;0;-10;0;0;0;0;
+  103;ttrf_6_2_1;;27;3;100;60;500;18;1,12;0;0;0;D;D;1;0;0;100;1;0;-10;0;0;0;0;
+
+
+$$TypTr3;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);strn3_h(r);strn3_m(r);strn3_l(r);utrn3_h(r);utrn3_m(r);utrn3_l(r);uktr3_h(r);uktr3_m(r);uktr3_l(r);pcut3_h(r);pcut3_m(r);pcut3_l(r);uk0hm(r);uk0ml(r);uk0hl(r);ur0hm(r);ur0ml(r);ur0hl(r);tr3cn_h(a:2);tr3cn_m(a:2);tr3cn_l(a:2);nt3ag_h(r);nt3ag_m(r);nt3ag_l(r);curm3(r);pfe(r);du3tp_h(r);ph3tr_h(r);n3tp0_h(i);n3tmn_h(i);n3tmx_h(i);du3tp_m(r);ph3tr_m(r);n3tp0_m(i);n3tmn_m(i);n3tmx_m(i);du3tp_l(r);ph3tr_l(r);n3tp0_l(i);n3tmn_l(i);n3tmx_l(i);itapos(i);i3loc(i)
+  104;ttr3_4_2_7_1;;27;101;201;301;515;18,36;15,68;3,083255;14,93645;6,724075;17,61356;135,1672;0,603695;0;0;0;0;0;0;YN;YN;YN;-0;1;1;0,178613;144,572;1,875;0;0;-5;7;0;0;0;0;0;0;0;0;0;0;1;0

--- a/powerfactory/powerfactory-converter/src/test/resources/TransformersWithPhaseAngleClock.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/TransformersWithPhaseAngleClock.xiidm
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" xmlns:twowtpac="http://www.powsybl.org/schema/iidm/ext/two_windings_transformer_phase_angle_clock/1_0" xmlns:threewtpac="http://www.powsybl.org/schema/iidm/ext/three_windings_transformer_phase_angle_clock/1_0" id="TransformersWithPhaseAngleClock" caseDate="2021-01-01T10:00:00.000+02:00" forecastDistance="0" sourceFormat="POWER-FACTORY" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S32">
+        <iidm:voltageLevel id="VL32" nominalV="18.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL32_1 1" node="0"/>
+                <iidm:busbarSection id="VL32_2 2" node="3"/>
+                <iidm:busbarSection id="VL32_3 3" node="7"/>
+                <iidm:switch id="VL32_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL32_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL32_Switch#1" kind="BREAKER" retained="false" open="false" node1="3" node2="4"/>
+                <iidm:switch id="VL32_Switch#2" kind="BREAKER" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="VL32_Switch#3" kind="BREAKER" retained="false" open="false" node1="3" node2="6"/>
+                <iidm:switch id="VL32_Switch#4" kind="BREAKER" retained="false" open="false" node1="7" node2="8"/>
+                <iidm:switch id="VL32_Switch#5" kind="BREAKER" retained="false" open="false" node1="7" node2="9"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_1_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="1">
+                <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
+            </iidm:generator>
+            <iidm:generator id="sym_2_1" energySource="OTHER" minP="0.0" maxP="1404.0" voltageRegulatorOn="true" targetP="1404.0" targetV="18.719999313354492" targetQ="0.0" node="4">
+                <iidm:minMaxReactiveLimits minQ="-9900.0009765625" maxQ="9900.0009765625"/>
+            </iidm:generator>
+            <iidm:generator id="sym_3_1" energySource="OTHER" minP="0.0" maxP="800.0" voltageRegulatorOn="true" targetP="800.0" targetV="18.359999656677246" targetQ="0.0" node="8">
+                <iidm:minMaxReactiveLimits minQ="-9900.00390625" maxQ="9900.00390625"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL35" nominalV="500.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL35_4 4" node="0"/>
+                <iidm:busbarSection id="VL35_5 5" node="5"/>
+                <iidm:busbarSection id="VL35_6 6" node="12"/>
+                <iidm:switch id="VL35_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL35_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL35_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="VL35_Switch#2" kind="BREAKER" retained="false" open="false" node1="0" node2="4"/>
+                <iidm:switch id="VL35_Switch#3" kind="BREAKER" retained="false" open="false" node1="5" node2="6"/>
+                <iidm:switch id="VL35_Switch#4" kind="BREAKER" retained="false" open="false" node1="5" node2="7"/>
+                <iidm:switch id="VL35_Switch#5" kind="BREAKER" retained="false" open="false" node1="5" node2="8"/>
+                <iidm:switch id="VL35_Switch#6" kind="BREAKER" retained="false" open="true" node1="5" node2="9"/>
+                <iidm:switch id="VL35_Switch#7" kind="BREAKER" retained="false" open="false" node1="5" node2="10"/>
+                <iidm:switch id="VL35_Switch#8" kind="BREAKER" retained="false" open="false" node1="5" node2="11"/>
+                <iidm:switch id="VL35_Switch#9" kind="BREAKER" retained="false" open="false" node1="12" node2="13"/>
+                <iidm:switch id="VL35_Switch#10" kind="BREAKER" retained="false" open="false" node1="12" node2="14"/>
+                <iidm:switch id="VL35_Switch#11" kind="BREAKER" retained="false" open="false" node1="12" node2="15"/>
+                <iidm:switch id="VL35_Switch#12" kind="BREAKER" retained="false" open="false" node1="12" node2="16"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="sym_6_1" energySource="OTHER" minP="0.0" maxP="9796.6845703125" voltageRegulatorOn="true" targetP="9796.6845703125" targetV="500.0" targetQ="0.0" node="15">
+                <iidm:minMaxReactiveLimits minQ="-9900.0" maxQ="9900.0"/>
+            </iidm:generator>
+            <iidm:load id="lod_4_1" loadType="UNDEFINED" p0="1400.0" q0="100.0" node="2"/>
+            <iidm:load id="lod_5_1" loadType="UNDEFINED" p0="2000.0" q0="100.0" node="8"/>
+            <iidm:load id="lod_5_2" loadType="UNDEFINED" p0="0.0" q0="50.0" node="9"/>
+            <iidm:load id="lod_6_1" loadType="UNDEFINED" p0="10000.0" q0="2000.0" node="14"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL38" nominalV="16.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="VL38_7 7" node="0"/>
+                <iidm:switch id="VL38_Switch" kind="BREAKER" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="VL38_Switch#0" kind="BREAKER" retained="false" open="false" node1="0" node2="2"/>
+                <iidm:switch id="VL38_Switch#1" kind="BREAKER" retained="false" open="false" node1="0" node2="3"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:load id="lod_7_1" loadType="UNDEFINED" p0="1.0" q0="1.0" node="1"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="trf_4_1_1" r="0.0" x="0.020768399119377133" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="4" voltageLevelId1="VL35" node2="2" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_6_2_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="16" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
+        <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
+        <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
+            <iidm:ratioTapChanger1 lowTapPosition="0" tapPosition="12" loadTapChangingCapabilities="false">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.103448275862069"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.081081081081081"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0596026490066226"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0389610389610389"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.019108280254777"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9815950920245399"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9638554216867469"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9467455621301776"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9302325581395349"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9142857142857143"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.898876404494382"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8839779005524862"/>
+            </iidm:ratioTapChanger1>
+        </iidm:threeWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="lne_4_5_1" r="0.0" x="90.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="1" voltageLevelId1="VL35" node2="6" voltageLevelId2="VL35"/>
+    <iidm:line id="lne_5_6_1" r="0.0" x="300.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="7" voltageLevelId1="VL35" node2="13" voltageLevelId2="VL35"/>
+    <iidm:extension id="trf_6_2_1">
+        <twowtpac:twoWindingsTransformerPhaseAngleClock phaseAngleClock="1"/>
+    </iidm:extension>
+    <iidm:extension id="tr3_4_2_7_1">
+        <threewtpac:threeWindingsTransformerPhaseAngleClock phaseAngleClockLeg2="1" phaseAngleClockLeg3="1"/>
+    </iidm:extension>
+</iidm:network>


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Connection type of transformers is not read.


**What is the new behavior (if this is a feature change)?**
PowerFactory expresses the winding configurations of three-phase transformers using the notation of vector group defined by the International Electrotechnical Commission (IEC) in the attribute `vecgrp`. 
In the vector group value (the _connection symbol_) the digits following the letter codes indicate the difference in phase angle between the windings, with HV winding is taken as a reference. The number is in units of 30 degrees.
This number is also provided in the PowerFactory attribute `nt2ag`.
If an difference in phase is found it is stored in the IIDM extension for "phase angle clock".

