### PR TITLE
[Network modifications] range fix in utility method

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/TopologyModificationUtils.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/TopologyModificationUtils.java
@@ -404,7 +404,7 @@ public final class TopologyModificationUtils {
         Optional<Integer> nextSliceMin = getMinOrderUsedAfter(allOrders, sectionIndex);
         Optional<Integer> sliceMax = allOrders.get(sectionIndex).stream().max(Comparator.naturalOrder());
         int min = sliceMax.map(o -> o + 1).orElse(
-                getMaxOrderUsedBefore(allOrders, sectionIndex).map(o -> o + 1).orElse(Integer.MAX_VALUE));
+                getMaxOrderUsedBefore(allOrders, sectionIndex).map(o -> o + 1).orElse(Integer.MIN_VALUE));
         int max = nextSliceMin.map(o -> o - 1).orElse(Integer.MAX_VALUE);
         return Optional.ofNullable(min <= max ? Range.between(min, max) : null);
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/TopologyModificationUtils.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/TopologyModificationUtils.java
@@ -315,7 +315,7 @@ public final class TopologyModificationUtils {
         TreeMap<Integer, List<Integer>> ordersBySectionIndex = new TreeMap<>();
         connectablesBySectionIndex.forEach((sectionIndex, connectables) -> {
             List<Integer> orders = new ArrayList<>();
-            connectables.forEach(connectable -> addOrder(connectable, voltageLevel, orders));
+            connectables.forEach(connectable -> addOrderPositions(connectable, voltageLevel, orders));
             ordersBySectionIndex.put(sectionIndex, orders);
         });
 
@@ -444,7 +444,7 @@ public final class TopologyModificationUtils {
      */
     public static Set<Integer> getFeederPositions(VoltageLevel voltageLevel) {
         Set<Integer> feederPositionsOrders = new HashSet<>();
-        voltageLevel.getConnectables().forEach(connectable -> addOrder(connectable, voltageLevel, feederPositionsOrders));
+        voltageLevel.getConnectables().forEach(connectable -> addOrderPositions(connectable, voltageLevel, feederPositionsOrders));
         return feederPositionsOrders;
     }
 
@@ -456,65 +456,35 @@ public final class TopologyModificationUtils {
         voltageLevel.getConnectables().forEach(connectable -> {
             ConnectablePosition<?> position = (ConnectablePosition<?>) connectable.getExtension(ConnectablePosition.class);
             if (position != null) {
-                List<Integer> orders = getOrders(position, voltageLevel, connectable, false, Reporter.NO_OP);
+                List<Integer> orders = getOrderPositions(position, voltageLevel, connectable, false, Reporter.NO_OP);
                 feederPositionsOrders.put(connectable.getId(), orders);
             }
         });
         return feederPositionsOrders;
     }
 
-    private static void addOrder(Connectable<?> connectable, VoltageLevel voltageLevel, Collection<Integer> feederPositionsOrders) {
-        addOrder(connectable, voltageLevel, feederPositionsOrders, false, Reporter.NO_OP);
+    private static void addOrderPositions(Connectable<?> connectable, VoltageLevel voltageLevel, Collection<Integer> feederPositionsOrders) {
+        addOrderPositions(connectable, voltageLevel, feederPositionsOrders, false, Reporter.NO_OP);
     }
 
     /**
-     * Method adding order(s) of a connectable on a given voltage level to the given collection.
+     * Method adding order position(s) of a connectable on a given voltage level to the given collection.
      */
-    private static void addOrder(Connectable<?> connectable, VoltageLevel voltageLevel, Collection<Integer> feederPositionsOrders, boolean throwException, Reporter reporter) {
+    private static void addOrderPositions(Connectable<?> connectable, VoltageLevel voltageLevel, Collection<Integer> feederPositionsOrders, boolean throwException, Reporter reporter) {
         ConnectablePosition<?> position = (ConnectablePosition<?>) connectable.getExtension(ConnectablePosition.class);
         if (position != null) {
-            List<Integer> orders = getOrders(position, voltageLevel, connectable, throwException, reporter);
+            List<Integer> orders = getOrderPositions(position, voltageLevel, connectable, throwException, reporter);
             feederPositionsOrders.addAll(orders);
         }
     }
 
-    private static List<Integer> getOrders(ConnectablePosition<?> position, VoltageLevel voltageLevel, Connectable<?> connectable, boolean throwException, Reporter reporter) {
-        List<Integer> orders = new ArrayList<>();
+    private static List<Integer> getOrderPositions(ConnectablePosition<?> position, VoltageLevel voltageLevel, Connectable<?> connectable, boolean throwException, Reporter reporter) {
         if (connectable instanceof Injection) {
-            position.getFeeder().getOrder().ifPresent(orders::add);
+            return getInjectionOrder(position, voltageLevel, (Injection<?>) connectable, throwException, reporter);
         } else if (connectable instanceof Branch) {
-            Branch<?> branch = (Branch<?>) connectable;
-            if (branch.getTerminal1().getVoltageLevel() == voltageLevel) {
-                position.getFeeder1().getOrder().ifPresent(orders::add);
-            }
-            if (branch.getTerminal2().getVoltageLevel() == voltageLevel) {
-                position.getFeeder2().getOrder().ifPresent(orders::add);
-            }
-            if (orders.isEmpty()) {
-                LOGGER.error("Given connectable {} not in voltageLevel {}", connectable.getId(), voltageLevel.getId());
-                connectableNotInVoltageLevel(reporter, connectable, voltageLevel);
-                if (throwException) {
-                    throw new AssertionError(String.format("Given connectable %s not in voltageLevel %s ", connectable.getId(), voltageLevel.getId()));
-                }
-            }
+            return getBranchOrders(position, voltageLevel, (Branch<?>) connectable, throwException, reporter);
         } else if (connectable instanceof ThreeWindingsTransformer) {
-            ThreeWindingsTransformer twt = (ThreeWindingsTransformer) connectable;
-            if (twt.getLeg1().getTerminal().getVoltageLevel() == voltageLevel) {
-                position.getFeeder1().getOrder().ifPresent(orders::add);
-            }
-            if (twt.getLeg2().getTerminal().getVoltageLevel() == voltageLevel) {
-                position.getFeeder2().getOrder().ifPresent(orders::add);
-            }
-            if (twt.getLeg3().getTerminal().getVoltageLevel() == voltageLevel) {
-                position.getFeeder3().getOrder().ifPresent(orders::add);
-            }
-            if (orders.isEmpty()) {
-                LOGGER.error("Given connectable {} not in voltageLevel {}", connectable.getId(), voltageLevel.getId());
-                connectableNotInVoltageLevel(reporter, connectable, voltageLevel);
-                if (throwException) {
-                    throw new AssertionError(String.format("Given connectable %s not in voltageLevel %s ", connectable.getId(), voltageLevel.getId()));
-                }
-            }
+            return get3wtOrders(position, voltageLevel, (ThreeWindingsTransformer) connectable, throwException, reporter);
         } else {
             LOGGER.error("Given connectable not supported: {}", connectable.getClass().getName());
             connectableNotSupported(reporter, connectable);
@@ -522,10 +492,52 @@ public final class TopologyModificationUtils {
                 throw new AssertionError("Given connectable not supported: " + connectable.getClass().getName());
             }
         }
-        if (orders.size() > 1) {
-            Collections.sort(orders);
+        return Collections.emptyList();
+    }
+
+    private static List<Integer> getInjectionOrder(ConnectablePosition<?> position, VoltageLevel voltageLevel, Injection<?> injection, boolean throwException, Reporter reporter) {
+        List<Integer> singleOrder = position.getFeeder().getOrder().map(List::of).orElse(Collections.emptyList());
+        checkConnectableInVoltageLevel(singleOrder, voltageLevel, injection, throwException, reporter);
+        return singleOrder;
+    }
+
+    private static List<Integer> getBranchOrders(ConnectablePosition<?> position, VoltageLevel voltageLevel, Branch<?> branch, boolean throwException, Reporter reporter) {
+        List<Integer> orders = new ArrayList<>();
+        if (branch.getTerminal1().getVoltageLevel() == voltageLevel) {
+            position.getFeeder1().getOrder().ifPresent(orders::add);
         }
+        if (branch.getTerminal2().getVoltageLevel() == voltageLevel) {
+            position.getFeeder2().getOrder().ifPresent(orders::add);
+        }
+        checkConnectableInVoltageLevel(orders, voltageLevel, branch, throwException, reporter);
+        Collections.sort(orders);
         return orders;
+    }
+
+    private static List<Integer> get3wtOrders(ConnectablePosition<?> position, VoltageLevel voltageLevel, ThreeWindingsTransformer twt, boolean throwException, Reporter reporter) {
+        List<Integer> orders = new ArrayList<>();
+        if (twt.getLeg1().getTerminal().getVoltageLevel() == voltageLevel) {
+            position.getFeeder1().getOrder().ifPresent(orders::add);
+        }
+        if (twt.getLeg2().getTerminal().getVoltageLevel() == voltageLevel) {
+            position.getFeeder2().getOrder().ifPresent(orders::add);
+        }
+        if (twt.getLeg3().getTerminal().getVoltageLevel() == voltageLevel) {
+            position.getFeeder3().getOrder().ifPresent(orders::add);
+        }
+        checkConnectableInVoltageLevel(orders, voltageLevel, twt, throwException, reporter);
+        Collections.sort(orders);
+        return orders;
+    }
+
+    private static void checkConnectableInVoltageLevel(List<Integer> orders, VoltageLevel voltageLevel, Connectable<?> connectable, boolean throwException, Reporter reporter) {
+        if (orders.isEmpty()) {
+            LOGGER.error("Given connectable {} not in voltageLevel {}", connectable.getId(), voltageLevel.getId());
+            connectableNotInVoltageLevel(reporter, connectable, voltageLevel);
+            if (throwException) {
+                throw new AssertionError(String.format("Given connectable %s not in voltageLevel %s ", connectable.getId(), voltageLevel.getId()));
+            }
+        }
     }
 
     /**

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
@@ -21,11 +21,10 @@ import org.apache.commons.lang3.Range;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
-import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.*;
+import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.getUnusedOrderPositionsAfter;
+import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.getUnusedOrderPositionsBefore;
 import static com.powsybl.iidm.network.extensions.ConnectablePosition.Direction.BOTTOM;
 import static com.powsybl.iidm.network.extensions.ConnectablePosition.Direction.TOP;
 import static org.junit.Assert.*;
@@ -83,10 +82,6 @@ public class CreateBranchFeederBaysTest extends AbstractXmlConverterTest {
         modification.apply(network);
         roundTripXmlTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead,
                 "/network-node-breaker-with-new-internal-line.xml");
-
-        Map<String, List<Integer>> positionsByConnectable = getFeederPositionsByConnectable(network.getVoltageLevel("vl1"));
-        assertEquals(List.of(14, 105), positionsByConnectable.get("lineTest"));
-        assertEquals(14, positionsByConnectable.size());
     }
 
     @Test

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
@@ -18,12 +18,10 @@ import org.apache.commons.lang3.Range;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
-import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.*;
+import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.getUnusedOrderPositionsAfter;
+import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.getUnusedOrderPositionsBefore;
 import static com.powsybl.iidm.network.extensions.ConnectablePosition.Direction.BOTTOM;
 import static com.powsybl.iidm.network.extensions.ConnectablePosition.Direction.TOP;
 import static org.junit.Assert.*;
@@ -291,18 +289,6 @@ public class CreateFeederBayTest extends AbstractXmlConverterTest  {
     }
 
     @Test
-    public void testFeederOrders() {
-        Network network = Importers.loadNetwork("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
-        Set<Integer> feederOrders = TopologyModificationUtils.getFeederPositions(network.getVoltageLevel("vl1"));
-        assertEquals(13, feederOrders.size());
-        assertTrue(feederOrders.contains(100));
-        Set<Integer> feederOrders2 = TopologyModificationUtils.getFeederPositions(network.getVoltageLevel("vl2"));
-        assertEquals(9, feederOrders2.size());
-        Set<Integer> feederOrders3 = TopologyModificationUtils.getFeederPositions(network.getVoltageLevel("vlSubst2"));
-        assertEquals(1, feederOrders3.size());
-    }
-
-    @Test
     public void testWithoutExtension() {
         Network network = Importers.loadNetwork("testNetworkNodeBreakerWithoutExtensions.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreakerWithoutExtensions.xiidm"));
         LoadAdder loadAdder = network.getVoltageLevel("vl1").newLoad()
@@ -329,14 +315,5 @@ public class CreateFeederBayTest extends AbstractXmlConverterTest  {
 
         PowsyblException exception2 = assertThrows(PowsyblException.class, () -> getUnusedOrderPositionsAfter(bbs));
         assertEquals("busbarSection has no BusbarSectionPosition extension", exception2.getMessage());
-    }
-
-    @Test
-    public void testGetPositionsByConnectable() {
-        Network network = Importers.loadNetwork("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
-        Map<String, List<Integer>> positionsByConnectable = getFeederPositionsByConnectable(network.getVoltageLevel("vl1"));
-        assertTrue(positionsByConnectable.containsKey("load1"));
-        assertEquals(List.of(70), positionsByConnectable.get("line1"));
-        assertEquals(13, positionsByConnectable.size());
     }
 }

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/TopologyModificationUtilsTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/TopologyModificationUtilsTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.modification.topology;
+
+import com.powsybl.iidm.import_.Importers;
+import com.powsybl.iidm.network.BusbarSection;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.extensions.BusbarSectionPosition;
+import com.powsybl.iidm.network.impl.extensions.BusbarSectionPositionImpl;
+import com.powsybl.iidm.xml.AbstractXmlConverterTest;
+import org.apache.commons.lang3.Range;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.getFeederPositionsByConnectable;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Coline Piloquet <coline.piloquet at rte-france.com>
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class TopologyModificationUtilsTest extends AbstractXmlConverterTest  {
+
+    @Test
+    public void testFeederOrders() {
+        Network network = Importers.loadNetwork("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
+        Set<Integer> feederOrders = TopologyModificationUtils.getFeederPositions(network.getVoltageLevel("vl1"));
+        assertEquals(13, feederOrders.size());
+        assertTrue(feederOrders.contains(100));
+        Set<Integer> feederOrders2 = TopologyModificationUtils.getFeederPositions(network.getVoltageLevel("vl2"));
+        assertEquals(9, feederOrders2.size());
+        Set<Integer> feederOrders3 = TopologyModificationUtils.getFeederPositions(network.getVoltageLevel("vlSubst2"));
+        assertEquals(1, feederOrders3.size());
+    }
+
+    @Test
+    public void testGetPositionsByConnectable() {
+        Network network = Importers.loadNetwork("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
+        Map<String, List<Integer>> positionsByConnectable = getFeederPositionsByConnectable(network.getVoltageLevel("vl1"));
+        assertTrue(positionsByConnectable.containsKey("load1"));
+        assertEquals(List.of(70), positionsByConnectable.get("line1"));
+        assertEquals(13, positionsByConnectable.size());
+    }
+
+    @Test
+    public void testGetPositionsByConnectableWithInternalLine() {
+        Network network = Importers.loadNetwork("network-node-breaker-with-new-internal-line.xml", getClass().getResourceAsStream("/network-node-breaker-with-new-internal-line.xml"));
+        Map<String, List<Integer>> positionsByConnectable = getFeederPositionsByConnectable(network.getVoltageLevel("vl1"));
+        assertEquals(List.of(14, 105), positionsByConnectable.get("lineTest"));
+        assertEquals(14, positionsByConnectable.size());
+    }
+
+    @Test
+    public void testGetUnusedPositionsWithEmptyVoltageLevel() {
+        Network network = Network.create("n", "test");
+        VoltageLevel vl1 = network.newVoltageLevel().setId("vl1").setNominalV(400).setTopologyKind(TopologyKind.NODE_BREAKER).add();
+        BusbarSection bbs = vl1.getNodeBreakerView().newBusbarSection().setId("b1").setNode(2).add();
+        bbs.addExtension(BusbarSectionPosition.class, new BusbarSectionPositionImpl(bbs, 0, 0));
+
+        Optional<Range<Integer>> unusedOrderPositionsAfter = TopologyModificationUtils.getUnusedOrderPositionsAfter(bbs);
+        assertTrue(unusedOrderPositionsAfter.isPresent());
+        assertEquals(Integer.MIN_VALUE, (int) unusedOrderPositionsAfter.get().getMinimum());
+        assertEquals(Integer.MAX_VALUE, (int) unusedOrderPositionsAfter.get().getMaximum());
+
+        Optional<Range<Integer>> unusedOrderPositionsBefore = TopologyModificationUtils.getUnusedOrderPositionsAfter(bbs);
+        assertTrue(unusedOrderPositionsBefore.isPresent());
+        assertEquals(Integer.MIN_VALUE, (int) unusedOrderPositionsBefore.get().getMinimum());
+        assertEquals(Integer.MAX_VALUE, (int) unusedOrderPositionsBefore.get().getMaximum());
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?** *(You can also link to an open issue here)*
Wrong range in `TopologyModificationUtils::getUnusedOrderPositionsAfter` if no orders before


**What is the new behavior (if this is a feature change)?**
Range fixed


**Does this PR introduce a breaking change or deprecate an API?** 
No