### PR TITLE
allow to serialize redundancy equal to false

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlUtil.java
@@ -17,6 +17,7 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
@@ -148,6 +149,12 @@ public final class XmlUtil {
     public static void writeOptionalBoolean(String name, boolean value, boolean absentValue, XMLStreamWriter writer) throws XMLStreamException {
         if (value != absentValue) {
             writer.writeAttribute(name, Boolean.toString(value));
+        }
+    }
+
+    public static void writeOptionalBoolean(String name, Optional<Boolean> value, XMLStreamWriter writer) throws XMLStreamException {
+        if (value.isPresent()) {
+            writer.writeAttribute(name, Boolean.toString(value.get()));
         }
     }
 

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ObservabilityQuality.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ObservabilityQuality.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.iidm.network.extensions;
 
+import java.util.Optional;
+
 /**
  * Quality information.
  *
@@ -24,7 +26,7 @@ public interface ObservabilityQuality<T> {
     /**
      * Value optional. Can be empty.
      */
-    boolean isRedundant();
+    Optional<Boolean> isRedundant();
 
-    ObservabilityQuality<T> setRedundant(boolean redundant);
+    ObservabilityQuality<T> setRedundant(Boolean redundant);
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ObservabilityQualityImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ObservabilityQualityImpl.java
@@ -8,6 +8,8 @@ package com.powsybl.iidm.network.impl.extensions;
 
 import com.powsybl.iidm.network.extensions.ObservabilityQuality;
 
+import java.util.Optional;
+
 /**
  * @author Thomas Adam <tadam at silicom.fr>
  */
@@ -15,7 +17,7 @@ public class ObservabilityQualityImpl<T> implements ObservabilityQuality<T> {
 
     private double standardDeviation;
 
-    private boolean redundant = false;
+    private Boolean redundant = null;
 
     public ObservabilityQualityImpl(double standardDeviation, Boolean redundant) {
         this.standardDeviation = standardDeviation;
@@ -38,12 +40,12 @@ public class ObservabilityQualityImpl<T> implements ObservabilityQuality<T> {
     }
 
     @Override
-    public boolean isRedundant() {
-        return redundant;
+    public Optional<Boolean> isRedundant() {
+        return Optional.ofNullable(redundant);
     }
 
     @Override
-    public ObservabilityQuality<T> setRedundant(boolean redundant) {
+    public ObservabilityQuality<T> setRedundant(Boolean redundant) {
         this.redundant = redundant;
         return this;
     }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractBranchObservabilityTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractBranchObservabilityTest.java
@@ -52,12 +52,16 @@ public abstract class AbstractBranchObservabilityTest {
         branchObservability.getQualityP2().setStandardDeviation(0.08d);
         assertEquals(0.08d, branchObservability.getQualityP2().getStandardDeviation(), 0d);
 
-        assertTrue(branchObservability.getQualityP1().isRedundant());
+        assertTrue(branchObservability.getQualityP1().isRedundant().isPresent());
+        assertTrue(branchObservability.getQualityP1().isRedundant().get());
         branchObservability.getQualityP1().setRedundant(false);
-        assertFalse(branchObservability.getQualityP1().isRedundant());
-        assertFalse(branchObservability.getQualityP2().isRedundant());
+        assertTrue(branchObservability.getQualityP1().isRedundant().isPresent());
+        assertFalse(branchObservability.getQualityP1().isRedundant().get());
+        assertTrue(branchObservability.getQualityP2().isRedundant().isPresent());
+        assertFalse(branchObservability.getQualityP2().isRedundant().get());
         branchObservability.getQualityP2().setRedundant(true);
-        assertTrue(branchObservability.getQualityP2().isRedundant());
+        assertTrue(branchObservability.getQualityP2().isRedundant().isPresent());
+        assertTrue(branchObservability.getQualityP2().isRedundant().get());
 
         // Q
         assertEquals(0.5d, branchObservability.getQualityQ1().getStandardDeviation(), 0d);
@@ -67,12 +71,18 @@ public abstract class AbstractBranchObservabilityTest {
         branchObservability.getQualityQ2().setStandardDeviation(1.01d);
         assertEquals(1.01d, branchObservability.getQualityQ2().getStandardDeviation(), 0d);
 
-        assertTrue(branchObservability.getQualityQ1().isRedundant());
+        assertTrue(branchObservability.getQualityQ1().isRedundant().isPresent());
+        assertTrue(branchObservability.getQualityQ1().isRedundant().get());
         branchObservability.getQualityQ1().setRedundant(false);
-        assertFalse(branchObservability.getQualityQ1().isRedundant());
-        assertFalse(branchObservability.getQualityQ2().isRedundant());
+        assertTrue(branchObservability.getQualityQ1().isRedundant().isPresent());
+        assertFalse(branchObservability.getQualityQ1().isRedundant().get());
+        assertTrue(branchObservability.getQualityQ1().isRedundant().isPresent());
+        assertFalse(branchObservability.getQualityQ1().isRedundant().get());
+        assertTrue(branchObservability.getQualityQ2().isRedundant().isPresent());
+        assertFalse(branchObservability.getQualityQ2().isRedundant().get());
         branchObservability.getQualityQ2().setRedundant(true);
-        assertTrue(branchObservability.getQualityQ2().isRedundant());
+        assertTrue(branchObservability.getQualityQ2().isRedundant().isPresent());
+        assertTrue(branchObservability.getQualityQ2().isRedundant().get());
     }
 
     @Test
@@ -96,10 +106,10 @@ public abstract class AbstractBranchObservabilityTest {
         assertEquals(0.03d, branchObservability.getQualityP1().getStandardDeviation(), 0d);
         assertSame(branchObservability, branchObservability.setQualityP1(0.04d));
         assertEquals(0.04d, branchObservability.getQualityP1().getStandardDeviation(), 0d);
-
-        assertFalse(branchObservability.getQualityP1().isRedundant());
+        assertFalse(branchObservability.getQualityP1().isRedundant().isPresent());
         branchObservability.getQualityP1().setRedundant(true);
-        assertTrue(branchObservability.getQualityP1().isRedundant());
+        assertTrue(branchObservability.getQualityP1().isRedundant().isPresent());
+        assertTrue(branchObservability.getQualityP1().isRedundant().get());
 
         // P2
         assertSame(branchObservability, branchObservability.setQualityP2(0.031d));
@@ -107,9 +117,10 @@ public abstract class AbstractBranchObservabilityTest {
         assertSame(branchObservability, branchObservability.setQualityP2(0.041d));
         assertEquals(0.041d, branchObservability.getQualityP2().getStandardDeviation(), 0d);
 
-        assertFalse(branchObservability.getQualityP2().isRedundant());
+        assertFalse(branchObservability.getQualityP2().isRedundant().isPresent());
         branchObservability.getQualityP2().setRedundant(true);
-        assertTrue(branchObservability.getQualityP2().isRedundant());
+        assertTrue(branchObservability.getQualityP2().isRedundant().isPresent());
+        assertTrue(branchObservability.getQualityP2().isRedundant().get());
 
         // Q1
         assertSame(branchObservability, branchObservability.setQualityQ1(0.6d));
@@ -117,9 +128,10 @@ public abstract class AbstractBranchObservabilityTest {
         assertSame(branchObservability, branchObservability.setQualityQ1(0.61d));
         assertEquals(0.61d, branchObservability.getQualityQ1().getStandardDeviation(), 0d);
 
-        assertFalse(branchObservability.getQualityQ1().isRedundant());
+        assertFalse(branchObservability.getQualityQ1().isRedundant().isPresent());
         branchObservability.getQualityQ1().setRedundant(true);
-        assertTrue(branchObservability.getQualityQ1().isRedundant());
+        assertTrue(branchObservability.getQualityQ1().isRedundant().isPresent());
+        assertTrue(branchObservability.getQualityQ1().isRedundant().get());
 
         // Q2
         assertSame(branchObservability, branchObservability.setQualityQ2(0.6d));
@@ -127,8 +139,9 @@ public abstract class AbstractBranchObservabilityTest {
         assertSame(branchObservability, branchObservability.setQualityQ2(0.61d));
         assertEquals(0.61d, branchObservability.getQualityQ2().getStandardDeviation(), 0d);
 
-        assertFalse(branchObservability.getQualityQ2().isRedundant());
+        assertFalse(branchObservability.getQualityQ2().isRedundant().isPresent());
         branchObservability.getQualityQ2().setRedundant(true);
-        assertTrue(branchObservability.getQualityQ2().isRedundant());
+        assertTrue(branchObservability.getQualityQ2().isRedundant().isPresent());
+        assertTrue(branchObservability.getQualityQ2().isRedundant().get());
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractInjectionObservabilityTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractInjectionObservabilityTest.java
@@ -46,25 +46,31 @@ public abstract class AbstractInjectionObservabilityTest {
         injectionObservability.getQualityP().setStandardDeviation(0.03d);
         assertEquals(0.03d, injectionObservability.getQualityP().getStandardDeviation(), 0d);
 
-        assertTrue(injectionObservability.getQualityP().isRedundant());
+        assertTrue(injectionObservability.getQualityP().isRedundant().isPresent());
+        assertTrue(injectionObservability.getQualityP().isRedundant().get());
         injectionObservability.getQualityP().setRedundant(false);
-        assertFalse(injectionObservability.getQualityP().isRedundant());
+        assertTrue(injectionObservability.getQualityP().isRedundant().isPresent());
+        assertFalse(injectionObservability.getQualityP().isRedundant().get());
 
         assertEquals(0.5d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
         injectionObservability.getQualityQ().setStandardDeviation(0.6d);
         assertEquals(0.6d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
 
-        assertTrue(injectionObservability.getQualityQ().isRedundant());
+        assertTrue(injectionObservability.getQualityQ().isRedundant().isPresent());
+        assertTrue(injectionObservability.getQualityQ().isRedundant().get());
         injectionObservability.getQualityQ().setRedundant(false);
-        assertFalse(injectionObservability.getQualityQ().isRedundant());
+        assertTrue(injectionObservability.getQualityQ().isRedundant().isPresent());
+        assertFalse(injectionObservability.getQualityQ().isRedundant().get());
 
         assertEquals(0.0d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
         injectionObservability.getQualityV().setStandardDeviation(0.01d);
         assertEquals(0.01d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
 
-        assertTrue(injectionObservability.getQualityV().isRedundant());
+        assertTrue(injectionObservability.getQualityV().isRedundant().isPresent());
+        assertTrue(injectionObservability.getQualityV().isRedundant().get());
         injectionObservability.getQualityV().setRedundant(false);
-        assertFalse(injectionObservability.getQualityV().isRedundant());
+        assertTrue(injectionObservability.getQualityV().isRedundant().isPresent());
+        assertFalse(injectionObservability.getQualityV().isRedundant().get());
     }
 
     @Test
@@ -87,26 +93,29 @@ public abstract class AbstractInjectionObservabilityTest {
         assertSame(injectionObservability, injectionObservability.setQualityP(0.04d));
         assertEquals(0.04d, injectionObservability.getQualityP().getStandardDeviation(), 0d);
 
-        assertFalse(injectionObservability.getQualityP().isRedundant());
+        assertFalse(injectionObservability.getQualityP().isRedundant().isPresent());
         injectionObservability.getQualityP().setRedundant(true);
-        assertTrue(injectionObservability.getQualityP().isRedundant());
+        assertTrue(injectionObservability.getQualityP().isRedundant().isPresent());
+        assertTrue(injectionObservability.getQualityP().isRedundant().get());
 
         assertSame(injectionObservability, injectionObservability.setQualityQ(0.6d));
         assertEquals(0.6d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
         assertSame(injectionObservability, injectionObservability.setQualityQ(0.61d));
         assertEquals(0.61d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
 
-        assertFalse(injectionObservability.getQualityQ().isRedundant());
+        assertFalse(injectionObservability.getQualityQ().isRedundant().isPresent());
         injectionObservability.getQualityQ().setRedundant(true);
-        assertTrue(injectionObservability.getQualityQ().isRedundant());
+        assertTrue(injectionObservability.getQualityQ().isRedundant().isPresent());
+        assertTrue(injectionObservability.getQualityQ().isRedundant().get());
 
         assertSame(injectionObservability, injectionObservability.setQualityV(0.01d));
         assertEquals(0.01d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
         assertSame(injectionObservability, injectionObservability.setQualityV(0.02d));
         assertEquals(0.02d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
 
-        assertFalse(injectionObservability.getQualityV().isRedundant());
+        assertFalse(injectionObservability.getQualityV().isRedundant().isPresent());
         injectionObservability.getQualityV().setRedundant(true);
-        assertTrue(injectionObservability.getQualityV().isRedundant());
+        assertTrue(injectionObservability.getQualityV().isRedundant().isPresent());
+        assertTrue(injectionObservability.getQualityV().isRedundant().get());
     }
 }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/BranchObservabilityXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/BranchObservabilityXmlSerializer.java
@@ -63,7 +63,7 @@ public class BranchObservabilityXmlSerializer<T extends Branch<T>> extends Abstr
         context.getWriter().writeEmptyElement(getNamespaceUri(), type);
         context.getWriter().writeAttribute(SIDE, side.name());
         XmlUtil.writeDouble(STANDARD_DEVIATION, quality.getStandardDeviation(), context.getWriter());
-        XmlUtil.writeOptionalBoolean(REDUNDANT, quality.isRedundant(), false, context.getWriter());
+        XmlUtil.writeOptionalBoolean(REDUNDANT, quality.isRedundant(), context.getWriter());
     }
 
     @Override

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlSerializer.java
@@ -51,7 +51,7 @@ public class InjectionObservabilityXmlSerializer<T extends Injection<T>> extends
         if (quality != null) {
             writer.writeEmptyElement(getNamespaceUri(), elementName);
             XmlUtil.writeDouble(STANDARD_DEVIATION, quality.getStandardDeviation(), writer);
-            XmlUtil.writeOptionalBoolean(REDUNDANT, quality.isRedundant(), false, writer);
+            XmlUtil.writeOptionalBoolean(REDUNDANT, quality.isRedundant(), writer);
         }
     }
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlTest.java
@@ -47,7 +47,6 @@ public class InjectionObservabilityXmlTest extends AbstractConverterTest {
 
         Generator generator = network.getGenerator("GEN");
         generator.addExtension(InjectionObservability.class, new InjectionObservabilityImpl<>(generator, false, 0.02d, true, 0.5d, true, 0.0d, true));
-
         Network network2 = roundTripXmlTest(network,
                 NetworkXml::writeAndValidate,
                 NetworkXml::validateAndRead,

--- a/iidm/iidm-xml-converter/src/test/resources/V1_6/branchObservabilityRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_6/branchObservabilityRoundTripRef.xml
@@ -44,9 +44,9 @@
     </iidm:extension>
     <iidm:extension id="NHV1_NHV2_1">
         <bo:branchObservability observable="true">
-            <bo:qualityP side="ONE" standardDeviation="0.03"/>
-            <bo:qualityP side="TWO" standardDeviation="0.6"/>
-            <bo:qualityQ side="ONE" standardDeviation="0.1"/>
+            <bo:qualityP side="ONE" standardDeviation="0.03" redundant="false"/>
+            <bo:qualityP side="TWO" standardDeviation="0.6" redundant="false"/>
+            <bo:qualityQ side="ONE" standardDeviation="0.1" redundant="false"/>
             <bo:qualityQ side="TWO" standardDeviation="0.04" redundant="true"/>
         </bo:branchObservability>
     </iidm:extension>
@@ -55,7 +55,7 @@
             <bo:qualityP side="ONE" standardDeviation="0.1" redundant="true"/>
             <bo:qualityP side="TWO" standardDeviation="0.2" redundant="true"/>
             <bo:qualityQ side="ONE" standardDeviation="0.3" redundant="true"/>
-            <bo:qualityQ side="TWO" standardDeviation="0.4"/>
+            <bo:qualityQ side="TWO" standardDeviation="0.4" redundant="false"/>
         </bo:branchObservability>
     </iidm:extension>
 </iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_7/branchObservabilityRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_7/branchObservabilityRoundTripRef.xml
@@ -44,9 +44,9 @@
     </iidm:extension>
     <iidm:extension id="NHV1_NHV2_1">
         <bo:branchObservability observable="true">
-            <bo:qualityP side="ONE" standardDeviation="0.03"/>
-            <bo:qualityP side="TWO" standardDeviation="0.6"/>
-            <bo:qualityQ side="ONE" standardDeviation="0.1"/>
+            <bo:qualityP side="ONE" standardDeviation="0.03" redundant="false"/>
+            <bo:qualityP side="TWO" standardDeviation="0.6" redundant="false"/>
+            <bo:qualityQ side="ONE" standardDeviation="0.1" redundant="false"/>
             <bo:qualityQ side="TWO" standardDeviation="0.04" redundant="true"/>
         </bo:branchObservability>
     </iidm:extension>
@@ -55,7 +55,7 @@
             <bo:qualityP side="ONE" standardDeviation="0.1" redundant="true"/>
             <bo:qualityP side="TWO" standardDeviation="0.2" redundant="true"/>
             <bo:qualityQ side="ONE" standardDeviation="0.3" redundant="true"/>
-            <bo:qualityQ side="TWO" standardDeviation="0.4"/>
+            <bo:qualityQ side="TWO" standardDeviation="0.4" redundant="false"/>
         </bo:branchObservability>
     </iidm:extension>
 </iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_8/branchObservabilityRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_8/branchObservabilityRoundTripRef.xml
@@ -44,9 +44,9 @@
     </iidm:extension>
     <iidm:extension id="NHV1_NHV2_1">
         <bo:branchObservability observable="true">
-            <bo:qualityP side="ONE" standardDeviation="0.03"/>
-            <bo:qualityP side="TWO" standardDeviation="0.6"/>
-            <bo:qualityQ side="ONE" standardDeviation="0.1"/>
+            <bo:qualityP side="ONE" standardDeviation="0.03" redundant="false"/>
+            <bo:qualityP side="TWO" standardDeviation="0.6" redundant="false"/>
+            <bo:qualityQ side="ONE" standardDeviation="0.1" redundant="false"/>
             <bo:qualityQ side="TWO" standardDeviation="0.04" redundant="true"/>
         </bo:branchObservability>
     </iidm:extension>
@@ -55,7 +55,7 @@
             <bo:qualityP side="ONE" standardDeviation="0.1" redundant="true"/>
             <bo:qualityP side="TWO" standardDeviation="0.2" redundant="true"/>
             <bo:qualityQ side="ONE" standardDeviation="0.3" redundant="true"/>
-            <bo:qualityQ side="TWO" standardDeviation="0.4"/>
+            <bo:qualityQ side="TWO" standardDeviation="0.4" redundant="false"/>
         </bo:branchObservability>
     </iidm:extension>
 </iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_8/injectionObservabilityRoundTripRef.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_8/injectionObservabilityRoundTripRef.xml
@@ -38,8 +38,8 @@
     </iidm:extension>
     <iidm:extension id="BAT">
         <io:injectionObservability observable="true">
-            <io:qualityP standardDeviation="0.03"/>
-            <io:qualityQ standardDeviation="0.6"/>
+            <io:qualityP standardDeviation="0.03" redundant="false"/>
+            <io:qualityQ standardDeviation="0.6" redundant="false"/>
         </io:injectionObservability>
     </iidm:extension>
 </iidm:network>


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*
for observability extensions quality P Q and V have a redundancy false by default and it is not exported with iidm if it is false


**What is the new behavior (if this is a feature change)?**
redundancy can be null and it is exported if it is false


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [X] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

