### PR TITLE
Rename contingency status enum

### DIFF
--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityAnalysisResult.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityAnalysisResult.java
@@ -57,8 +57,8 @@ public class SensitivityAnalysisResult {
     private final Map<String, SensitivityContingencyStatus> statusByContingencyId = new HashMap<>();
 
     public enum Status {
-        CONVERGED,
-        FAILED,
+        SUCCEED,
+        FAIL,
         NO_IMPACT
     }
 

--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityAnalysisResult.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityAnalysisResult.java
@@ -57,8 +57,8 @@ public class SensitivityAnalysisResult {
     private final Map<String, SensitivityContingencyStatus> statusByContingencyId = new HashMap<>();
 
     public enum Status {
-        SUCCEED,
-        FAIL,
+        SUCCESS,
+        FAILURE,
         NO_IMPACT
     }
 

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisParametersTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisParametersTest.java
@@ -218,7 +218,7 @@ public class SensitivityAnalysisParametersTest extends AbstractConverterTest {
 
     @Test
     public void testSensitivityAnalysisResultContingencyStatusSerializer() throws IOException {
-        SensitivityAnalysisResult.SensitivityContingencyStatus value = new SensitivityAnalysisResult.SensitivityContingencyStatus("C1", SensitivityAnalysisResult.Status.SUCCEED);
+        SensitivityAnalysisResult.SensitivityContingencyStatus value = new SensitivityAnalysisResult.SensitivityContingencyStatus("C1", SensitivityAnalysisResult.Status.SUCCESS);
         ObjectMapper objectMapper = JsonUtil.createObjectMapper().registerModule(new SensitivityJsonModule());
         roundTripTest(value, (value2, jsonFile) -> JsonUtil.writeJson(jsonFile, value, objectMapper),
             jsonFile -> JsonUtil.readJson(jsonFile, SensitivityAnalysisResult.SensitivityContingencyStatus.class, objectMapper), "/contingencyStatusRef.json");

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisParametersTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisParametersTest.java
@@ -218,7 +218,7 @@ public class SensitivityAnalysisParametersTest extends AbstractConverterTest {
 
     @Test
     public void testSensitivityAnalysisResultContingencyStatusSerializer() throws IOException {
-        SensitivityAnalysisResult.SensitivityContingencyStatus value = new SensitivityAnalysisResult.SensitivityContingencyStatus("C1", SensitivityAnalysisResult.Status.CONVERGED);
+        SensitivityAnalysisResult.SensitivityContingencyStatus value = new SensitivityAnalysisResult.SensitivityContingencyStatus("C1", SensitivityAnalysisResult.Status.SUCCEED);
         ObjectMapper objectMapper = JsonUtil.createObjectMapper().registerModule(new SensitivityJsonModule());
         roundTripTest(value, (value2, jsonFile) -> JsonUtil.writeJson(jsonFile, value, objectMapper),
             jsonFile -> JsonUtil.readJson(jsonFile, SensitivityAnalysisResult.SensitivityContingencyStatus.class, objectMapper), "/contingencyStatusRef.json");

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisProviderMock.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisProviderMock.java
@@ -53,7 +53,7 @@ public class SensitivityAnalysisProviderMock implements SensitivityAnalysisProvi
             }
         });
         for (int contingencyIndex = 0; contingencyIndex < contingencies.size(); contingencyIndex++) {
-            resultWriter.writeContingencyStatus(contingencyIndex, SensitivityAnalysisResult.Status.SUCCEED);
+            resultWriter.writeContingencyStatus(contingencyIndex, SensitivityAnalysisResult.Status.SUCCESS);
         }
         return CompletableFuture.completedFuture(null);
     }

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisProviderMock.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisProviderMock.java
@@ -53,7 +53,7 @@ public class SensitivityAnalysisProviderMock implements SensitivityAnalysisProvi
             }
         });
         for (int contingencyIndex = 0; contingencyIndex < contingencies.size(); contingencyIndex++) {
-            resultWriter.writeContingencyStatus(contingencyIndex, SensitivityAnalysisResult.Status.CONVERGED);
+            resultWriter.writeContingencyStatus(contingencyIndex, SensitivityAnalysisResult.Status.SUCCEED);
         }
         return CompletableFuture.completedFuture(null);
     }

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisResultTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisResultTest.java
@@ -47,7 +47,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
         SensitivityValue value3 = new SensitivityValue(2, 0, 1d, 2d);
         SensitivityValue value4 = new SensitivityValue(3, -1, 3d, 4d);
         List<SensitivityAnalysisResult.SensitivityContingencyStatus> contingencyStatus = new ArrayList<>();
-        contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus("NHV1_NHV2_2", SensitivityAnalysisResult.Status.CONVERGED));
+        contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus("NHV1_NHV2_2", SensitivityAnalysisResult.Status.SUCCEED));
         contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus("NHV2_NHV3", SensitivityAnalysisResult.Status.NO_IMPACT));
 
         List<SensitivityValue> values = List.of(value1, value2, value3, value4);
@@ -74,7 +74,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
         assertEquals(4d, result.getBranchCurrent1FunctionReferenceValue("l2"), 0d);
         assertEquals(2, result.getPreContingencyValues().size());
 
-        assertEquals(SensitivityAnalysisResult.Status.CONVERGED, result.getContingencyStatus("NHV1_NHV2_2"));
+        assertEquals(SensitivityAnalysisResult.Status.SUCCEED, result.getContingencyStatus("NHV1_NHV2_2"));
         assertEquals(SensitivityAnalysisResult.Status.NO_IMPACT, result.getContingencyStatus("NHV2_NHV3"));
     }
 
@@ -101,7 +101,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
         SensitivityValue value4 = new SensitivityValue(3, -1, 3d, 4d);
         List<SensitivityValue> values = List.of(value1, value2, value3, value4);
         List<SensitivityAnalysisResult.SensitivityContingencyStatus> contingencyStatus = new ArrayList<>();
-        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.CONVERGED)));
+        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.SUCCEED)));
         SensitivityAnalysisResult result = new SensitivityAnalysisResult(factors, contingencyStatus, values);
         assertEquals(4, result.getValues().size());
         assertEquals(2, result.getValues("NHV1_NHV2_2").size());
@@ -140,7 +140,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
         SensitivityValue value2 = new SensitivityValue(1, -1, 3d, 4d);
         List<SensitivityValue> values = List.of(value1, value2);
         List<SensitivityAnalysisResult.SensitivityContingencyStatus> contingencyStatus = new ArrayList<>();
-        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.CONVERGED)));
+        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.SUCCEED)));
         SensitivityAnalysisResult result = new SensitivityAnalysisResult(factors, contingencyStatus, values);
         assertEquals(2, result.getValues().size());
         assertEquals(1, result.getValues("NHV1_NHV2_2").size());
@@ -193,7 +193,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
 
         List<Contingency> contingencies = List.of(new Contingency("NHV1_NHV2_2", new BranchContingency("NHV1_NHV2_2")));
         List<SensitivityAnalysisResult.SensitivityContingencyStatus> contingencyStatus = new ArrayList<>();
-        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.CONVERGED)));
+        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.SUCCEED)));
         SensitivityAnalysisResult result = new SensitivityAnalysisResult(factors, contingencyStatus, values);
         ObjectMapper objectMapper = JsonUtil.createObjectMapper().registerModule(new SensitivityJsonModule());
         roundTripTest(result, (result2, jsonFile) -> JsonUtil.writeJson(jsonFile, result, objectMapper),

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisResultTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisResultTest.java
@@ -47,7 +47,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
         SensitivityValue value3 = new SensitivityValue(2, 0, 1d, 2d);
         SensitivityValue value4 = new SensitivityValue(3, -1, 3d, 4d);
         List<SensitivityAnalysisResult.SensitivityContingencyStatus> contingencyStatus = new ArrayList<>();
-        contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus("NHV1_NHV2_2", SensitivityAnalysisResult.Status.SUCCEED));
+        contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus("NHV1_NHV2_2", SensitivityAnalysisResult.Status.SUCCESS));
         contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus("NHV2_NHV3", SensitivityAnalysisResult.Status.NO_IMPACT));
 
         List<SensitivityValue> values = List.of(value1, value2, value3, value4);
@@ -74,7 +74,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
         assertEquals(4d, result.getBranchCurrent1FunctionReferenceValue("l2"), 0d);
         assertEquals(2, result.getPreContingencyValues().size());
 
-        assertEquals(SensitivityAnalysisResult.Status.SUCCEED, result.getContingencyStatus("NHV1_NHV2_2"));
+        assertEquals(SensitivityAnalysisResult.Status.SUCCESS, result.getContingencyStatus("NHV1_NHV2_2"));
         assertEquals(SensitivityAnalysisResult.Status.NO_IMPACT, result.getContingencyStatus("NHV2_NHV3"));
     }
 
@@ -101,7 +101,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
         SensitivityValue value4 = new SensitivityValue(3, -1, 3d, 4d);
         List<SensitivityValue> values = List.of(value1, value2, value3, value4);
         List<SensitivityAnalysisResult.SensitivityContingencyStatus> contingencyStatus = new ArrayList<>();
-        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.SUCCEED)));
+        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.SUCCESS)));
         SensitivityAnalysisResult result = new SensitivityAnalysisResult(factors, contingencyStatus, values);
         assertEquals(4, result.getValues().size());
         assertEquals(2, result.getValues("NHV1_NHV2_2").size());
@@ -140,7 +140,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
         SensitivityValue value2 = new SensitivityValue(1, -1, 3d, 4d);
         List<SensitivityValue> values = List.of(value1, value2);
         List<SensitivityAnalysisResult.SensitivityContingencyStatus> contingencyStatus = new ArrayList<>();
-        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.SUCCEED)));
+        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.SUCCESS)));
         SensitivityAnalysisResult result = new SensitivityAnalysisResult(factors, contingencyStatus, values);
         assertEquals(2, result.getValues().size());
         assertEquals(1, result.getValues("NHV1_NHV2_2").size());
@@ -193,7 +193,7 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
 
         List<Contingency> contingencies = List.of(new Contingency("NHV1_NHV2_2", new BranchContingency("NHV1_NHV2_2")));
         List<SensitivityAnalysisResult.SensitivityContingencyStatus> contingencyStatus = new ArrayList<>();
-        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.SUCCEED)));
+        contingencies.forEach(c -> contingencyStatus.add(new SensitivityAnalysisResult.SensitivityContingencyStatus(c.getId(), SensitivityAnalysisResult.Status.SUCCESS)));
         SensitivityAnalysisResult result = new SensitivityAnalysisResult(factors, contingencyStatus, values);
         ObjectMapper objectMapper = JsonUtil.createObjectMapper().registerModule(new SensitivityJsonModule());
         roundTripTest(result, (result2, jsonFile) -> JsonUtil.writeJson(jsonFile, result, objectMapper),

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisToolTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisToolTest.java
@@ -132,7 +132,7 @@ public class SensitivityAnalysisToolTest extends AbstractToolTest {
         assertEquals(1, status.size());
         SensitivityAnalysisResult.SensitivityContingencyStatus status0 = status.get(0);
         assertEquals("NHV1_NHV2_2", status0.getContingencyId());
-        assertEquals(SensitivityAnalysisResult.Status.SUCCEED, status0.getStatus());
+        assertEquals(SensitivityAnalysisResult.Status.SUCCESS, status0.getStatus());
     }
 
     @Test
@@ -163,7 +163,7 @@ public class SensitivityAnalysisToolTest extends AbstractToolTest {
         String outputContingencyStatusCsvRef = TestUtil.normalizeLineSeparator(String.join(System.lineSeparator(),
                 "Sensitivity analysis contingency status result",
                 "Contingency ID;Contingency Status",
-                "NHV1_NHV2_2;SUCCEED")
+                "NHV1_NHV2_2;SUCCESS")
                 + System.lineSeparator());
         assertEquals(outputContingencyStatusCsvRef, TestUtil.normalizeLineSeparator(Files.readString(outputContingencyStatusCsvFile)));
 
@@ -254,7 +254,7 @@ public class SensitivityAnalysisToolTest extends AbstractToolTest {
         assertEquals(1, result.getContingencyStatuses().size());
         SensitivityAnalysisResult.SensitivityContingencyStatus status0 = result.getContingencyStatuses().get(0);
         assertEquals("NHV1_NHV2_2", status0.getContingencyId());
-        assertEquals(SensitivityAnalysisResult.Status.SUCCEED, status0.getStatus());
+        assertEquals(SensitivityAnalysisResult.Status.SUCCESS, status0.getStatus());
 
         assertEquals(2, result.getFactors().size());
         SensitivityFactor factor0 = result.getFactors().get(0);

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisToolTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisToolTest.java
@@ -132,7 +132,7 @@ public class SensitivityAnalysisToolTest extends AbstractToolTest {
         assertEquals(1, status.size());
         SensitivityAnalysisResult.SensitivityContingencyStatus status0 = status.get(0);
         assertEquals("NHV1_NHV2_2", status0.getContingencyId());
-        assertEquals(SensitivityAnalysisResult.Status.CONVERGED, status0.getStatus());
+        assertEquals(SensitivityAnalysisResult.Status.SUCCEED, status0.getStatus());
     }
 
     @Test
@@ -163,7 +163,7 @@ public class SensitivityAnalysisToolTest extends AbstractToolTest {
         String outputContingencyStatusCsvRef = TestUtil.normalizeLineSeparator(String.join(System.lineSeparator(),
                 "Sensitivity analysis contingency status result",
                 "Contingency ID;Contingency Status",
-                "NHV1_NHV2_2;CONVERGED")
+                "NHV1_NHV2_2;SUCCEED")
                 + System.lineSeparator());
         assertEquals(outputContingencyStatusCsvRef, TestUtil.normalizeLineSeparator(Files.readString(outputContingencyStatusCsvFile)));
 
@@ -254,7 +254,7 @@ public class SensitivityAnalysisToolTest extends AbstractToolTest {
         assertEquals(1, result.getContingencyStatuses().size());
         SensitivityAnalysisResult.SensitivityContingencyStatus status0 = result.getContingencyStatuses().get(0);
         assertEquals("NHV1_NHV2_2", status0.getContingencyId());
-        assertEquals(SensitivityAnalysisResult.Status.CONVERGED, status0.getStatus());
+        assertEquals(SensitivityAnalysisResult.Status.SUCCEED, status0.getStatus());
 
         assertEquals(2, result.getFactors().size());
         SensitivityFactor factor0 = result.getFactors().get(0);

--- a/sensitivity-analysis-api/src/test/resources/SensitivityAnalysisResultRefV1.json
+++ b/sensitivity-analysis-api/src/test/resources/SensitivityAnalysisResultRefV1.json
@@ -50,6 +50,6 @@
   } ],
   "contingencyStatus" : [ {
     "contingencyId" : "NHV1_NHV2_2",
-    "contingencyStatus" : "CONVERGED"
+    "contingencyStatus" : "SUCCEED"
   } ]
 }

--- a/sensitivity-analysis-api/src/test/resources/SensitivityAnalysisResultRefV1.json
+++ b/sensitivity-analysis-api/src/test/resources/SensitivityAnalysisResultRefV1.json
@@ -50,6 +50,6 @@
   } ],
   "contingencyStatus" : [ {
     "contingencyId" : "NHV1_NHV2_2",
-    "contingencyStatus" : "SUCCEED"
+    "contingencyStatus" : "SUCCESS"
   } ]
 }

--- a/sensitivity-analysis-api/src/test/resources/contingencyStatusRef.json
+++ b/sensitivity-analysis-api/src/test/resources/contingencyStatusRef.json
@@ -1,4 +1,4 @@
 {
   "contingencyId" : "C1",
-  "contingencyStatus" : "SUCCEED"
+  "contingencyStatus" : "SUCCESS"
 }

--- a/sensitivity-analysis-api/src/test/resources/contingencyStatusRef.json
+++ b/sensitivity-analysis-api/src/test/resources/contingencyStatusRef.json
@@ -1,4 +1,4 @@
 {
   "contingencyId" : "C1",
-  "contingencyStatus" : "CONVERGED"
+  "contingencyStatus" : "SUCCEED"
 }


### PR DESCRIPTION
After some discussion with @annetill it has been decided to rename some of the contingency status enum : 

CONVERGED is now SUCCEED
FAILED is now FAIL

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
