### PR TITLE
PowerFactory: allow empty matrices in DGS parser

### DIFF
--- a/powerfactory/powerfactory-dgs/src/test/java/com/powsybl/powerfactory/dgs/DgsDataTest.java
+++ b/powerfactory/powerfactory-dgs/src/test/java/com/powsybl/powerfactory/dgs/DgsDataTest.java
@@ -10,6 +10,7 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.TestUtil;
+import com.powsybl.powerfactory.model.PowerFactoryException;
 import com.powsybl.powerfactory.model.StudyCase;
 import org.junit.Test;
 
@@ -19,6 +20,7 @@ import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -64,6 +66,12 @@ public class DgsDataTest extends AbstractConverterTest {
     @Test
     public void twoBusesCommaAsDecimalSeparatorTest() throws IOException {
         assertTrue(test("/TwoBusesCommaAsDecimalSeparator.dgs", "/TwoBusesCommaAsDecimalSeparator.json"));
+    }
+
+    @Test
+    public void emptyMatrixTest() throws IOException {
+        PowerFactoryException e = assertThrows(PowerFactoryException.class, () -> loadCase("/EmptyMatrix.dgs"));
+        assertEquals("RealMatrix: Unexpected number of cols: 'GPScoords' rows: 1 cols: 1 expected cols: 2", e.getMessage());
     }
 
     private boolean test(String dgs, String json) throws IOException {

--- a/powerfactory/powerfactory-dgs/src/test/resources/EmptyMatrix.dgs
+++ b/powerfactory/powerfactory-dgs/src/test/resources/EmptyMatrix.dgs
@@ -1,0 +1,61 @@
+$$General;ID(a:40);Descr(a:40);Val(a:40)
+  1;Version;5.0
+
+$$ElmLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);dline(r);fline(r);GPScoords:SIZEROW(i);GPScoords:SIZECOL(i);GPScoords:0:0(r);GPScoords:0:1(r);GPScoords:1:0(r);GPScoords:1:1(r);nlnum(i);inAir(i)
+  2;lne_1_2_1;;4;23;52;1;1;1;0.5;1;0
+
+
+$$ElmLod;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);mode_inp(a:3);slini(r);plini(r);qlini(r);coslini(r);pf_recap(i);scale0(r);i_scale(i);outserv(i);classif(a:20)
+  3;lod_3_1;;4;24;PQ;55,9017;50;25;0,894427;0;1;0;0;
+
+
+$$ElmNet;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);frnom(r);pDiagram(p)
+  4;1 aux_1;;;60;
+
+
+$$ElmSym;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);cCategory(a);ngnum(i);i_mot(i);pgini(r);qgini(r);cosgini(r);usetp(r);pf_recap(i);q_min(r);q_max(r);outserv(i);av_mode(a);phtech(i)
+  5;sym_1_1;;4;25;Others;1;0;50,47;0;1;1,06;0;0;0;0;constv;1
+
+
+$$ElmTerm;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);typ_id(p);systype(i);iUsage(i);uknom(r);unknom(r);iminus(i);outserv(i);GPSlat(r);GPSlon(r);vtarget(r)
+  6;1 Bus 1-Slack;;4;;0;0;110;110,0;0;0;0;0;1
+  7;2 Bus 2;;4;;0;0;110;110.0;0;0;0;0;1
+  8;3 Bus 2-Load;;4;;0;0;110;110,0;0;0;0;0;1
+
+$$ElmZpu;ID(a:40);loc_name(a:40);outserv(i);Sn(r);nphases(i);nphshift(i);ag(r);fold_id(p);r_pu(r);r_pu_ji(r);x_pu(r);x_pu_ji(r);gi_pu(r);gj_pu(r);bi_pu(r);bj_pu(r)
+  9;zpu_2_3_1;0;1500;3;0;0;4;-3,162450075149536;-3,162450075149536;20,544599533081055;20,544599533081055;0,0;0,0;0,0;0,0
+  
+
+$$ElmZone;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);icolor(i);curscale(r)
+  10;1_aux_1;;;1;1
+
+
+$$StaCubic;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);obj_bus(i);obj_id(p);it2p1(i);it2p2(i);it2p3(i)
+  11;lne_1_2_1;;6;0;2;0;1;2
+  12;sym_1_1;;6;0;5;0;1;2
+  13;lne_1_2_1;;7;1;2;0;1;2
+  14;zpu_2_3_1;;7;0;9;0;1;2
+  15;lod_3_1;;8;0;3;0;1;2
+  16;zpu_2_3_1;;8;1;9;0;1;2
+
+
+$$StaSwitch;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);on_off(i);typ_id(p);aUsage(a)
+  17;Switch;;11;1;;cbk
+  18;Switch;;12;1;;cbk
+  19;Switch;;13;1;;cbk
+  20;Switch;;14;1;;cbk
+  21;Switch;;15;1;;cbk
+  22;Switch;;16;1;;cbk
+
+
+$$TypLne;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);uline(r);sline(r);InomAir(r);cohl_(i);rline(r);xline(r);rline0(r);xline0(r);Ithr(r);tmax(r);rtemp(r);systp(i);nlnph(i);nneutral(i);frnom(r);mlei(a:2);bline(r);bline0(r)
+  23;tlne_1_2_1;;4;380;7,216878;1;0;0,596307;1,820615;999999;999999;0;80;80;0;3;0;60;Cu;4,159616;0
+
+
+$$TypLod;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);systp(i);phtech(i);aP(r);bP(r);kpu0(r);kpu1(r);kpu(r);aQ(r);bQ(r);kqu0(r);kqu1(r);kqu(r)
+  24;lodtyp_pq;;4;0;0;1;0;0;1;2;1;0;0;1;2
+
+
+$$TypSym;ID(a:40);loc_name(a:40);for_name(a:50);fold_id(p);sgn(r);ugn(r);cosn(r);xd(r);xq(r);xdsss(r);rstr(r);xdsat(r);satur(i);nphase(i);nslty(i);x0sy(r);r0sy(r);x2sy(r);r2sy(r);iopt_data(i);xds(r);xqs(r);xl(r);xdss(r);xqss(r);xrlq(r);tds(r);tqs(r);tdss(r);tqss(r)
+  25;tsym_1_1;;4;615;380;1;2;2;1;0;1,2;0;3;2;1;0;1;0;1;0,3;0,3;0,1;1;1;0;1;0;0,05;0,05
+


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
DGS lines in a data block may have empty matrices (mTaps), even if the header declared a specific size.
The parser always expected at least the number of rows and cols declared in the header.


**What is the new behavior (if this is a feature change)?**
The DGS lines may have empty matrices (with either columns or rows equal to zero).
All matrices must have exactly the number of columns declared in the header .


