### PR TITLE
Add configurable feeder names in hypotheses creating feeders' bays

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
@@ -44,6 +44,8 @@ abstract class AbstractCreateConnectableFeederBays extends AbstractNetworkModifi
 
     protected abstract int getPositionOrder(int side);
 
+    protected abstract Optional<String> getFeederName(int side);
+
     protected abstract ConnectablePosition.Direction getDirection(int side);
 
     protected abstract int getNode(int side, Connectable<?> connectable);
@@ -98,7 +100,7 @@ abstract class AbstractCreateConnectableFeederBays extends AbstractNetworkModifi
                     getFeederAdder(side, connectablePositionAdder)
                             .withDirection(getDirection(side))
                             .withOrder(positionOrder)
-                            .withName(connectableId)
+                            .withName(getFeederName(side).orElse(connectableId))
                             .add();
                     createConnectablePosition = true;
                 } else {

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.extensions.ConnectablePosition;
 import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * This class allows to add a new branch's feeders on existing busbar sections. The voltage level containing the
@@ -27,17 +28,21 @@ public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays 
     private final String bbsId2;
     private final int positionOrder1;
     private final int positionOrder2;
+    private final String feederName1;
+    private final String feederName2;
     private final ConnectablePosition.Direction direction1;
     private final ConnectablePosition.Direction direction2;
 
     CreateBranchFeederBays(BranchAdder<?> branchAdder, String bbsId1, String bbsId2, Integer positionOrder1, Integer positionOrder2,
-                           ConnectablePosition.Direction direction1, ConnectablePosition.Direction direction2) {
+                           String feederName1, String feederName2, ConnectablePosition.Direction direction1, ConnectablePosition.Direction direction2) {
         super(1, 2);
         this.branchAdder = Objects.requireNonNull(branchAdder);
         this.bbsId1 = Objects.requireNonNull(bbsId1);
         this.bbsId2 = Objects.requireNonNull(bbsId2);
         this.positionOrder1 = Objects.requireNonNull(positionOrder1);
         this.positionOrder2 = Objects.requireNonNull(positionOrder2);
+        this.feederName1 = feederName1;
+        this.feederName2 = feederName2;
         this.direction1 = Objects.requireNonNull(direction1);
         this.direction2 = Objects.requireNonNull(direction2);
     }
@@ -94,6 +99,17 @@ public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays 
         }
         if (side == 2) {
             return positionOrder2;
+        }
+        throw createSideAssertionError(side);
+    }
+
+    @Override
+    protected Optional<String> getFeederName(int side) {
+        if (side == 1) {
+            return Optional.ofNullable(feederName1);
+        }
+        if (side == 2) {
+            return Optional.ofNullable(feederName2);
         }
         throw createSideAssertionError(side);
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysBuilder.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysBuilder.java
@@ -19,11 +19,13 @@ public class CreateBranchFeederBaysBuilder {
     private String bbsId2 = null;
     private Integer positionOrder1 = null;
     private Integer positionOrder2 = null;
+    private String feederName1 = null;
+    private String feederName2 = null;
     private ConnectablePosition.Direction direction1 = ConnectablePosition.Direction.TOP;
     private ConnectablePosition.Direction direction2 = ConnectablePosition.Direction.TOP;
 
     public CreateBranchFeederBays build() {
-        return new CreateBranchFeederBays(branchAdder, bbsId1, bbsId2, positionOrder1, positionOrder2, direction1, direction2);
+        return new CreateBranchFeederBays(branchAdder, bbsId1, bbsId2, positionOrder1, positionOrder2, feederName1, feederName2, direction1, direction2);
     }
 
     public CreateBranchFeederBaysBuilder withBranchAdder(BranchAdder<?> branchAdder) {
@@ -48,6 +50,16 @@ public class CreateBranchFeederBaysBuilder {
 
     public CreateBranchFeederBaysBuilder withPositionOrder2(int positionOrder2) {
         this.positionOrder2 = positionOrder2;
+        return this;
+    }
+
+    public CreateBranchFeederBaysBuilder withFeederName1(String feederName1) {
+        this.feederName1 = feederName1;
+        return this;
+    }
+
+    public CreateBranchFeederBaysBuilder withFeederName2(String feederName2) {
+        this.feederName2 = feederName2;
         return this;
     }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBay.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBay.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.extensions.ConnectablePosition;
 import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * This method adds a new injection bay on an existing busbar section. The voltage level containing the
@@ -25,22 +26,24 @@ public class CreateFeederBay extends AbstractCreateConnectableFeederBays {
     private final InjectionAdder<?> injectionAdder;
     private final String bbsId;
     private final int injectionPositionOrder;
+    private final String injectionFeederName;
     private final ConnectablePosition.Direction injectionDirection;
 
     /**
-     * Constructor.
-     *
      * @param injectionAdder         The injection adder.
      * @param bbsId                  The ID of the existing busbar section where we want to connect the injection.
      *                               Please note that there will be switches between this busbar section and the connection point of the injection. This switch will be closed.
      * @param injectionPositionOrder The order of the injection to be attached from its extension {@link ConnectablePosition}.
+     * @param injectionFeederName    The name of the feeder indicated in the extension {@link ConnectablePosition}.
      * @param injectionDirection     The direction of the injection to be attached from its extension {@link ConnectablePosition}.
      */
-    CreateFeederBay(InjectionAdder<?> injectionAdder, String bbsId, Integer injectionPositionOrder, ConnectablePosition.Direction injectionDirection) {
+    CreateFeederBay(InjectionAdder<?> injectionAdder, String bbsId, Integer injectionPositionOrder,
+                    String injectionFeederName, ConnectablePosition.Direction injectionDirection) {
         super(0);
         this.injectionAdder = Objects.requireNonNull(injectionAdder);
         this.bbsId = Objects.requireNonNull(bbsId);
         this.injectionPositionOrder = injectionPositionOrder;
+        this.injectionFeederName = injectionFeederName;
         this.injectionDirection = Objects.requireNonNull(injectionDirection);
     }
 
@@ -85,6 +88,11 @@ public class CreateFeederBay extends AbstractCreateConnectableFeederBays {
     @Override
     protected int getPositionOrder(int side) {
         return injectionPositionOrder;
+    }
+
+    @Override
+    protected Optional<String> getFeederName(int side) {
+        return Optional.ofNullable(injectionFeederName);
     }
 
     @Override

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBayBuilder.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBayBuilder.java
@@ -17,10 +17,11 @@ public class CreateFeederBayBuilder {
     private InjectionAdder<?> injectionAdder = null;
     private String bbsId = null;
     private Integer injectionPositionOrder = null;
+    private String injectionFeederName = null;
     private ConnectablePosition.Direction injectionDirection = ConnectablePosition.Direction.BOTTOM;
 
     public CreateFeederBay build() {
-        return new CreateFeederBay(injectionAdder, bbsId, injectionPositionOrder, injectionDirection);
+        return new CreateFeederBay(injectionAdder, bbsId, injectionPositionOrder, injectionFeederName, injectionDirection);
     }
 
     public CreateFeederBayBuilder withInjectionAdder(InjectionAdder<?> injectionAdder) {
@@ -35,6 +36,11 @@ public class CreateFeederBayBuilder {
 
     public CreateFeederBayBuilder withInjectionPositionOrder(int injectionPositionOrder) {
         this.injectionPositionOrder = injectionPositionOrder;
+        return this;
+    }
+
+    public CreateFeederBayBuilder withInjectionFeederName(String injectionFeederName) {
+        this.injectionFeederName = injectionFeederName;
         return this;
     }
 

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
@@ -51,8 +51,10 @@ public class CreateBranchFeederBaysTest extends AbstractXmlConverterTest {
                 .withBbsId1("bbs5")
                 .withPositionOrder1(85)
                 .withDirection1(BOTTOM)
+                .withFeederName1("lineTestFeeder1")
                 .withBbsId2("bbs1")
                 .withPositionOrder2(75)
+                .withFeederName2("lineTestFeeder2")
                 .withDirection2(TOP)
                 .build();
         modification.apply(network);

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
@@ -43,6 +43,7 @@ public class CreateFeederBayTest extends AbstractXmlConverterTest  {
                 .withInjectionAdder(loadAdder)
                 .withBbsId("bbs4")
                 .withInjectionPositionOrder(115)
+                .withInjectionFeederName("newLoadFeeder")
                 .withInjectionDirection(BOTTOM)
                 .build();
         modification.apply(network);

--- a/iidm/iidm-modification/src/test/resources/network-node-breaker-with-new-line.xml
+++ b/iidm/iidm-modification/src/test/resources/network-node-breaker-with-new-line.xml
@@ -168,8 +168,8 @@
     </iidm:extension>
     <iidm:extension id="lineTest">
         <cp:position>
-            <cp:feeder1 name="lineTest" order="85" direction="BOTTOM"/>
-            <cp:feeder2 name="lineTest" order="75" direction="TOP"/>
+            <cp:feeder1 name="lineTestFeeder1" order="85" direction="BOTTOM"/>
+            <cp:feeder2 name="lineTestFeeder2" order="75" direction="TOP"/>
         </cp:position>
     </iidm:extension>
     <iidm:extension id="line1">

--- a/iidm/iidm-modification/src/test/resources/network-node-breaker-with-new-load-bbs4.xml
+++ b/iidm/iidm-modification/src/test/resources/network-node-breaker-with-new-load-bbs4.xml
@@ -159,7 +159,7 @@
     </iidm:extension>
     <iidm:extension id="newLoad">
         <cp:position>
-            <cp:feeder name="newLoad" order="115" direction="BOTTOM"/>
+            <cp:feeder name="newLoadFeeder" order="115" direction="BOTTOM"/>
         </cp:position>
     </iidm:extension>
     <iidm:extension id="bbs1">


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add configurable feeder names in hypotheses creating feeders' bays


**What is the current behavior?** *(You can also link to an open issue here)*
The connectable ID is used for feeders' names.


**What is the new behavior (if this is a feature change)?**
They can be manually set. If not set, connectable ID is used.
