### PR TITLE
Powerfactory: common impedance, fix conversion to engineering units when it has different nominal at both ends

### DIFF
--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/AbstractConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/AbstractConverter.java
@@ -57,6 +57,18 @@ public abstract class AbstractConverter {
         return admitance * sbase / (vnom * vnom);
     }
 
+    static double impedanceToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(double impedance, double vnom1, double vnom2, double sbase) {
+        return impedance * vnom1 * vnom2 / sbase;
+    }
+
+    static double admittanceEnd1ToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(double admittanceTransmissionEu, double shuntAdmittance, double vnom1, double vnom2, double sbase) {
+        return shuntAdmittance * sbase / (vnom1 * vnom1) - (1 - vnom2 / vnom1) * admittanceTransmissionEu;
+    }
+
+    static double admittanceEnd2ToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(double admittanceTransmissionEu, double shuntAdmittance, double vnom1, double vnom2, double sbase) {
+        return shuntAdmittance * sbase / (vnom2 * vnom2) - (1 - vnom1 / vnom2) * admittanceTransmissionEu;
+    }
+
     static void createInternalConnection(VoltageLevel vl, int node1, int node2) {
         vl.getNodeBreakerView().newInternalConnection()
             .setNode1(node1)

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/CommonImpedanceConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/CommonImpedanceConverter.java
@@ -13,6 +13,8 @@ import com.powsybl.powerfactory.model.DataObject;
 
 import java.util.List;
 
+import org.apache.commons.math3.complex.Complex;
+
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
  * @author José Antonio Marqués <marquesja at aia.es>
@@ -74,17 +76,22 @@ class CommonImpedanceConverter extends AbstractConverter {
         private static CommonImpedanceModel create(DataObject elmZpu, double vn1, double vn2) {
             CommonImpedanceModel puModel = commonImpedancePerUnitModel(elmZpu);
 
+            // Support common impedance lines with different nominal voltage at ends
+
             float sn = elmZpu.getFloatAttributeValue("Sn");
 
-            puModel.r12 = impedanceFromPerUnitToEngineeringUnits(puModel.r12, vn1, sn);
-            puModel.x12 = impedanceFromPerUnitToEngineeringUnits(puModel.x12, vn1, sn);
-            puModel.r21 = impedanceFromPerUnitToEngineeringUnits(puModel.r21, vn2, sn);
-            puModel.x21 = impedanceFromPerUnitToEngineeringUnits(puModel.x21, vn2, sn);
+            puModel.r12 = impedanceToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(puModel.r12, vn1, vn2, sn);
+            puModel.x12 = impedanceToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(puModel.x12, vn1, vn2, sn);
+            puModel.r21 = impedanceToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(puModel.r21, vn1, vn2, sn);
+            puModel.x21 = impedanceToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(puModel.x21, vn1, vn2, sn);
 
-            puModel.g1 = admittanceFromPerUnitToEngineeringUnits(puModel.g1, vn1, sn);
-            puModel.b1 = admittanceFromPerUnitToEngineeringUnits(puModel.b1, vn1, sn);
-            puModel.g2 = admittanceFromPerUnitToEngineeringUnits(puModel.g2, vn2, sn);
-            puModel.b2 = admittanceFromPerUnitToEngineeringUnits(puModel.b2, vn2, sn);
+            Complex y12Eu = new Complex(puModel.r12, puModel.x12).reciprocal();
+            puModel.g1 = admittanceEnd1ToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(y12Eu.getReal(), puModel.g1, vn1, vn2, sn);
+            puModel.b1 = admittanceEnd1ToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(y12Eu.getImaginary(), puModel.b1, vn1, vn2, sn);
+
+            Complex y21Eu = new Complex(puModel.r21, puModel.x21).reciprocal();
+            puModel.g2 = admittanceEnd1ToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(y21Eu.getReal(), puModel.g2, vn1, vn2, sn);
+            puModel.b2 = admittanceEnd1ToEngineeringUnitsForLinesWithDifferentNominalVoltageAtEnds(y21Eu.getImaginary(), puModel.b2, vn1, vn2, sn);
 
             return puModel;
         }


### PR DESCRIPTION
Signed-off-by: José Antonio Marqués <marquesja@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
