### PR TITLE
Fix IdentifiableShortCircuit so that it only applies to voltage levels, buses and busbar sections.

### DIFF
--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/GeneratorShortCircuit.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/GeneratorShortCircuit.java
@@ -10,6 +10,7 @@ import com.powsybl.commons.extensions.Extension;
 import com.powsybl.iidm.network.Generator;
 
 /**
+ * Extension storing the reactance of generators for short-circuit calculations.
  *
  * @author Coline Piloquet <coline.piloquet@rte-france.fr>
  */

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/IdentifiableShortCircuit.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/IdentifiableShortCircuit.java
@@ -11,6 +11,9 @@ import com.powsybl.commons.extensions.Extension;
 import com.powsybl.iidm.network.Identifiable;
 
 /**
+ * Extension storing the minimum admissible short circuit current (IpMin) and the maximum allowable
+ * short-circuit current (IpMax) for voltage levels, buses and busbar sections.
+ *
  * @author Coline Piloquet <coline.piloquet@rte-france.com>
  */
 public interface IdentifiableShortCircuit<I extends Identifiable<I>> extends Extension<I> {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/IdentifiableShortCircuitAdderImplProvider.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/IdentifiableShortCircuitAdderImplProvider.java
@@ -7,8 +7,12 @@
 package com.powsybl.iidm.network.impl.extensions;
 
 import com.google.auto.service.AutoService;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.extensions.ExtensionAdderProvider;
+import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.BusbarSection;
 import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.extensions.IdentifiableShortCircuit;
 
 
@@ -36,6 +40,10 @@ public class IdentifiableShortCircuitAdderImplProvider<I extends Identifiable<I>
 
     @Override
     public IdentifiableShortCircuitAdderImpl<I> newAdder(I extendable) {
+        //TODO: replace bus by ConfiguredBus when it is public
+        if (!(extendable instanceof VoltageLevel) && !(extendable instanceof Bus) && !(extendable instanceof BusbarSection)) {
+            throw new PowsyblException("IdentifiableShortCircuit extension only supported for voltage levels, buses and busbar sections");
+        }
         return new IdentifiableShortCircuitAdderImpl<>(extendable);
     }
 }


### PR DESCRIPTION
Signed-off-by: Coline PILOQUET <coline.piloquet@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
IdentifiableShortCircuit extension is supported for every Identifiable.


**What is the new behavior (if this is a feature change)?**
Supported only for voltage levels, buses and busbar section.