### PR TITLE
DiscreteMeasurements can not extend Network

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/DiscreteMeasurementsAdderImplProvider.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/DiscreteMeasurementsAdderImplProvider.java
@@ -7,8 +7,10 @@
 package com.powsybl.iidm.network.impl.extensions;
 
 import com.google.auto.service.AutoService;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.extensions.ExtensionAdderProvider;
 import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.extensions.DiscreteMeasurements;
 
 /**
@@ -33,6 +35,9 @@ public class DiscreteMeasurementsAdderImplProvider<I extends Identifiable<I>> im
 
     @Override
     public DiscreteMeasurementsAdderImpl<I> newAdder(I extendable) {
+        if (extendable instanceof Network) {
+            throw new PowsyblException("Discrete measurements not supported for networks");
+        }
         return new DiscreteMeasurementsAdderImpl<>(extendable);
     }
 }


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Added a restriction for extendable of DiscreteMeasurements (cannot be Network)




**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
