### PR TITLE
add getConnectable(string) in network

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
@@ -825,6 +825,19 @@ public interface Network extends Container<Network> {
     }
 
     /**
+     * Get a connectable by its ID or alias
+     *
+     * @param id the id or an alias of the equipment
+     */
+    default Connectable<?> getConnectable(String id) {
+        Identifiable<?> identifiable = getIdentifiable(id);
+        if (identifiable instanceof Connectable<?>) {
+            return (Connectable<?>) identifiable;
+        }
+        return null;
+    }
+
+    /**
      * Count the connectables of the network
      *
      * @return the count of all the connectables

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -684,6 +684,11 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
     }
 
     @Override
+    public Connectable<?> getConnectable(String id) {
+        return index.get(id, Connectable.class);
+    }
+
+    @Override
     public int getConnectableCount() {
         return Ints.checkedCast(getConnectableStream().count());
     }

--- a/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
+++ b/iidm/iidm-mergingview/src/main/java/com/powsybl/iidm/mergingview/MergingView.java
@@ -368,6 +368,12 @@ public final class MergingView implements Network, MultiVariantObject {
     }
 
     @Override
+    public Connectable<?> getConnectable(String id) {
+        return Optional.ofNullable((Connectable) index.getMergedLine(id))
+                .orElse(index.get(n -> n.getConnectable(id), index::getConnectable));
+    }
+
+    @Override
     public int getConnectableCount() {
         return index.getConnectables().size();
     }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -365,6 +365,15 @@ public abstract class AbstractNetworkTest {
     }
 
     @Test
+    public void testGetConnectable() {
+        Network n = EurostagTutorialExample1Factory.create();
+        assertEquals(6, n.getConnectableCount());
+        assertNotNull(n.getConnectable("GEN"));
+        assertTrue(n.getConnectable("GEN") instanceof Generator);
+        assertEquals("GEN", n.getConnectable("GEN").getId());
+    }
+
+    @Test
     public void testStreams() {
         Function<Stream<? extends Identifiable>, List<String>> mapper = stream -> stream.map(Identifiable::getId).collect(Collectors.toList());
         Function<Stream<? extends Identifiable>, Set<String>> mapperSet = stream -> stream.map(Identifiable::getId).collect(Collectors.toSet());


### PR DESCRIPTION
Signed-off-by: Etienne LESOT <etienne.lesot@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the new behavior (if this is a feature change)?**
it allow to directly get a specified connectable from a Network
