### PR TITLE
[Network modification] Fix extension creation in case of no connectables in the voltage level.

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
@@ -94,7 +94,7 @@ abstract class AbstractCreateConnectableFeederBays extends AbstractNetworkModifi
             VoltageLevel voltageLevel = getVoltageLevel(side, connectable);
             Set<Integer> takenFeederPositions = TopologyModificationUtils.getFeederPositions(voltageLevel);
             int positionOrder = getPositionOrder(side);
-            if (!takenFeederPositions.isEmpty() || (voltageLevel.getConnectableStream().filter(c -> !(c instanceof BusbarSection)).count() == 1)) {
+            if (!takenFeederPositions.isEmpty() || voltageLevel.getConnectableStream().filter(c -> !(c instanceof BusbarSection)).count() == 1) {
                 // check that there is only one connectable (that we added) or there are existing position extensions on other connectables
                 if (!takenFeederPositions.contains(positionOrder)) {
                     getFeederAdder(side, connectablePositionAdder)

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
@@ -94,7 +94,7 @@ abstract class AbstractCreateConnectableFeederBays extends AbstractNetworkModifi
             VoltageLevel voltageLevel = getVoltageLevel(side, connectable);
             Set<Integer> takenFeederPositions = TopologyModificationUtils.getFeederPositions(voltageLevel);
             int positionOrder = getPositionOrder(side);
-            if (!takenFeederPositions.isEmpty() || voltageLevel.getConnectableStream().count() == 1) {
+            if (!takenFeederPositions.isEmpty() || (voltageLevel.getConnectableStream().count() == 1 + voltageLevel.getNodeBreakerView().getBusbarSectionCount())) {
                 // check that there is only one connectable (that we added) or there are existing position extensions on other connectables
                 if (!takenFeederPositions.contains(positionOrder)) {
                     getFeederAdder(side, connectablePositionAdder)

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
@@ -94,7 +94,7 @@ abstract class AbstractCreateConnectableFeederBays extends AbstractNetworkModifi
             VoltageLevel voltageLevel = getVoltageLevel(side, connectable);
             Set<Integer> takenFeederPositions = TopologyModificationUtils.getFeederPositions(voltageLevel);
             int positionOrder = getPositionOrder(side);
-            if (!takenFeederPositions.isEmpty() || (voltageLevel.getConnectableStream().count() == 1 + voltageLevel.getNodeBreakerView().getBusbarSectionCount())) {
+            if (!takenFeederPositions.isEmpty() || (voltageLevel.getConnectableStream().filter(c -> !(c instanceof BusbarSection)).count() == 1)) {
                 // check that there is only one connectable (that we added) or there are existing position extensions on other connectables
                 if (!takenFeederPositions.contains(positionOrder)) {
                     getFeederAdder(side, connectablePositionAdder)

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
@@ -317,4 +317,27 @@ public class CreateFeederBayTest extends AbstractXmlConverterTest  {
         PowsyblException exception2 = assertThrows(PowsyblException.class, () -> getUnusedOrderPositionsAfter(bbs));
         assertEquals("busbarSection has no BusbarSectionPosition extension", exception2.getMessage());
     }
+
+    @Test
+    public void testExtensionsAreCreatedIfNoOtherConnectables() {
+        Network network = Importers.loadNetwork("network_one_voltage_level.xiidm", getClass().getResourceAsStream("/network_one_voltage_level.xiidm"));
+        LoadAdder loadAdder = network.getVoltageLevel("VLTEST").newLoad()
+                .setId("newLoad")
+                .setLoadType(LoadType.UNDEFINED)
+                .setP0(0)
+                .setQ0(0);
+        new CreateFeederBayBuilder()
+                .withInjectionAdder(loadAdder)
+                .withBbsId("VLTEST12")
+                .withInjectionPositionOrder(10)
+                .build()
+                .apply(network, true, Reporter.NO_OP);
+
+        Load load = network.getLoad("newLoad");
+        assertNotNull(load);
+        ConnectablePosition<Load> position = load.getExtension(ConnectablePosition.class);
+        assertNotNull(position);
+        assertEquals(BOTTOM, position.getFeeder().getDirection());
+        assertEquals(Optional.of(10), position.getFeeder().getOrder());
+    }
 }

--- a/iidm/iidm-modification/src/test/resources/network_one_voltage_level.xiidm
+++ b/iidm/iidm-modification/src/test/resources/network_one_voltage_level.xiidm
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" xmlns:bbsp="http://www.itesla_project.eu/schema/iidm/ext/busbarsectionposition/1_0" id="fictitious" caseDate="2021-08-27T14:44:56.567+02:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:voltageLevel id="VLTEST" nominalV="380.0" topologyKind="NODE_BREAKER">
+        <iidm:nodeBreakerTopology>
+            <iidm:busbarSection id="VLTEST11" node="0"/>
+            <iidm:busbarSection id="VLTEST21" node="1"/>
+            <iidm:busbarSection id="VLTEST31" node="2"/>
+            <iidm:busbarSection id="VLTEST12" node="3"/>
+            <iidm:busbarSection id="VLTEST22" node="4"/>
+            <iidm:busbarSection id="VLTEST32" node="5"/>
+            <iidm:busbarSection id="VLTEST13" node="6"/>
+            <iidm:busbarSection id="VLTEST23" node="7"/>
+            <iidm:busbarSection id="VLTEST33" node="8"/>
+            <iidm:busbarSection id="VLTEST14" node="9"/>
+            <iidm:busbarSection id="VLTEST24" node="10"/>
+            <iidm:busbarSection id="VLTEST34" node="11"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR11_1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="12"/>
+            <iidm:switch id="VLTEST_BREAKER11" kind="BREAKER" retained="true" open="false" node1="12" node2="13"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR11_2" kind="DISCONNECTOR" retained="false" open="false" node1="13" node2="3"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR21_1" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="14"/>
+            <iidm:switch id="VLTEST_BREAKER21" kind="BREAKER" retained="true" open="false" node1="14" node2="15"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR21_2" kind="DISCONNECTOR" retained="false" open="false" node1="15" node2="4"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR31_1" kind="DISCONNECTOR" retained="false" open="false" node1="2" node2="16"/>
+            <iidm:switch id="VLTEST_BREAKER31" kind="BREAKER" retained="true" open="false" node1="16" node2="17"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR31_2" kind="DISCONNECTOR" retained="false" open="false" node1="17" node2="5"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR12" kind="DISCONNECTOR" retained="false" open="false" node1="3" node2="6"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR22" kind="DISCONNECTOR" retained="false" open="false" node1="4" node2="7"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR32" kind="DISCONNECTOR" retained="false" open="false" node1="5" node2="8"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR13" kind="DISCONNECTOR" retained="false" open="false" node1="6" node2="9"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR23" kind="DISCONNECTOR" retained="false" open="false" node1="7" node2="10"/>
+            <iidm:switch id="VLTEST_DISCONNECTOR33" kind="DISCONNECTOR" retained="false" open="false" node1="8" node2="11"/>
+        </iidm:nodeBreakerTopology>
+    </iidm:voltageLevel>
+    <iidm:substation id="A" country="FR">
+        <iidm:voltageLevel id="C" nominalV="225.0" lowVoltageLimit="0.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="D" name="E" node="0"/>
+                <iidm:switch id="F" name="G" fictitious="true" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="H" name="I" fictitious="true" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="J" name="K" fictitious="true" kind="BREAKER" retained="true" open="false" node1="1" node2="2"/>
+                <iidm:switch id="L" name="M" fictitious="true" kind="BREAKER" retained="true" open="false" node1="3" node2="4"/>
+                <iidm:bus v="234.40912" angle="0.0" nodes="0,1,2,3,4"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="N" nominalV="225.0" lowVoltageLimit="220.0" highVoltageLimit="245.00002" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="O" name="E" node="0"/>
+                <iidm:busbarSection id="P" name="Q" node="1"/>
+                <iidm:switch id="R" name="S" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="19"/>
+                <iidm:switch id="T" name="U" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="17"/>
+                <iidm:switch id="V" name="W" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="21"/>
+                <iidm:switch id="X" name="Y" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="11"/>
+                <iidm:switch id="Z" name="AA" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="13"/>
+                <iidm:switch id="AB" name="AC" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="15"/>
+                <iidm:switch id="AD" name="AE" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="8"/>
+                <iidm:switch id="AF" name="AG" fictitious="true" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="2"/>
+                <iidm:switch id="AH" name="AI" kind="DISCONNECTOR" retained="false" open="false" node1="7" node2="0"/>
+                <iidm:switch id="AJ" name="AK" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="6"/>
+                <iidm:switch id="AL" name="AM" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="19"/>
+                <iidm:switch id="AN" name="AO" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="17"/>
+                <iidm:switch id="AP" name="AQ" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="21"/>
+                <iidm:switch id="AR" name="AS" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="11"/>
+                <iidm:switch id="AT" name="AU" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="13"/>
+                <iidm:switch id="AV" name="AW" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="15"/>
+                <iidm:switch id="AX" name="AY" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="8"/>
+                <iidm:switch id="AZ" name="BA" fictitious="true" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="2"/>
+                <iidm:switch id="BB" name="BC" fictitious="true" kind="BREAKER" retained="true" open="true" node1="2" node2="3"/>
+                <iidm:switch id="BD" name="BE" kind="BREAKER" retained="true" open="false" node1="3" node2="4"/>
+                <iidm:switch id="BF" name="BG" kind="DISCONNECTOR" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="BH" name="BI" kind="DISCONNECTOR" retained="false" open="true" node1="9" node2="3"/>
+                <iidm:switch id="BJ" name="BK" kind="BREAKER" retained="true" open="false" node1="6" node2="7"/>
+                <iidm:switch id="BL" name="BM" kind="BREAKER" retained="true" open="false" node1="8" node2="9"/>
+                <iidm:switch id="BN" name="BO" kind="DISCONNECTOR" retained="false" open="false" node1="9" node2="10"/>
+                <iidm:switch id="BP" name="BQ" kind="BREAKER" retained="true" open="true" node1="11" node2="12"/>
+                <iidm:switch id="BR" name="BS" kind="BREAKER" retained="true" open="true" node1="13" node2="14"/>
+                <iidm:switch id="BT" name="BU" kind="BREAKER" retained="true" open="false" node1="15" node2="16"/>
+                <iidm:switch id="BV" name="BW" kind="BREAKER" retained="true" open="false" node1="17" node2="18"/>
+                <iidm:switch id="BX" name="BY" kind="BREAKER" retained="true" open="false" node1="19" node2="20"/>
+                <iidm:switch id="BZ" name="CA" kind="BREAKER" retained="true" open="false" node1="21" node2="22"/>
+                <iidm:bus v="236.44736" angle="15.250391" nodes="0,1,6,7,8,9,10,15,16,17,18,19,20,21,22"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="CB" energySource="HYDRO" minP="0.0" maxP="70.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" node="12">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>
+                    <iidm:point p="70.0" minQ="-54.55" maxQ="46.25"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CC" energySource="HYDRO" minP="0.0" maxP="80.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" node="14">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-56.8" maxQ="57.4"/>
+                    <iidm:point p="80.0" minQ="-53.514" maxQ="36.4"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CD" energySource="HYDRO" minP="0.0" maxP="35.0" voltageRegulatorOn="true" targetP="21.789589" targetV="236.44736" targetQ="-20.701546" node="16" p="-21.789589" q="20.693394">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-20.6" maxQ="18.1"/>
+                    <iidm:point p="35.0" minQ="-21.725" maxQ="6.3500004"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:load id="CE" loadType="UNDEFINED" p0="-72.18689" q0="50.168945" node="4" p="-72.18689" q="50.168945"/>
+            <iidm:load id="CF" loadType="UNDEFINED" p0="8.455854" q0="-23.695925" node="18" p="8.455854" q="-23.695925"/>
+            <iidm:load id="CG" loadType="UNDEFINED" p0="90.39911" q0="-51.96869" node="20" p="90.39911" q="-51.96869"/>
+            <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249" q="4.9081216"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+                <iidm:terminalRef id="CI" side="ONE"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="-37.54"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="-34.9"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="-32.26"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="-29.6"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="-26.94"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="-24.26"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="-21.58"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="-18.9"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="-16.22"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="-13.52"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="-10.82"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="-8.12"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="-5.42"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="-2.7"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="2.7"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="5.42"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="8.12"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="10.82"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="13.52"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="16.22"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="18.9"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="21.58"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="24.26"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="26.94"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="29.6"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="32.26"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="34.9"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="37.54"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="40.18"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="42.8"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits1 permanentLimit="931.0"/>
+            <iidm:currentLimits2 permanentLimit="931.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="CJ" r="0.009999999" x="0.100000024" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="4" voltageLevelId1="C" node2="5" voltageLevelId2="N">
+        <iidm:currentLimits1 permanentLimit="931.0"/>
+        <iidm:currentLimits2 permanentLimit="931.0">
+            <iidm:temporaryLimit name="IST" value="1640.0" fictitious="true"/>
+            <iidm:temporaryLimit name="IT1" acceptableDuration="60"/>
+        </iidm:currentLimits2>
+    </iidm:line>
+    <iidm:extension id="VLTEST12">
+        <bbsp:busbarSectionPosition busbarIndex="1" sectionIndex="2"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST11">
+        <bbsp:busbarSectionPosition busbarIndex="1" sectionIndex="1"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST14">
+        <bbsp:busbarSectionPosition busbarIndex="1" sectionIndex="4"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST13">
+        <bbsp:busbarSectionPosition busbarIndex="1" sectionIndex="3"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST23">
+        <bbsp:busbarSectionPosition busbarIndex="2" sectionIndex="3"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST22">
+        <bbsp:busbarSectionPosition busbarIndex="2" sectionIndex="2"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST24">
+        <bbsp:busbarSectionPosition busbarIndex="2" sectionIndex="4"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST21">
+        <bbsp:busbarSectionPosition busbarIndex="2" sectionIndex="1"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST34">
+        <bbsp:busbarSectionPosition busbarIndex="3" sectionIndex="4"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST33">
+        <bbsp:busbarSectionPosition busbarIndex="3" sectionIndex="3"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST32">
+        <bbsp:busbarSectionPosition busbarIndex="3" sectionIndex="2"/>
+    </iidm:extension>
+    <iidm:extension id="VLTEST31">
+        <bbsp:busbarSectionPosition busbarIndex="3" sectionIndex="1"/>
+    </iidm:extension>
+</iidm:network>


### PR DESCRIPTION
Signed-off-by: Coline PILOQUET <coline.piloquet@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix.


**What is the current behavior?** *(You can also link to an open issue here)*
If a voltage level has busbar sections but no connectable and a modification is applied, the extensions are not created because a busbar section is considered as a Connectable (it is an Injection).


**What is the new behavior (if this is a feature change)?**
Now, if there are busbar sections but no connectables, the extension is created.