### PR TITLE
Added SVCs reactive power and voltage comparison in NetworkStateComparator

### DIFF
--- a/iidm/iidm-comparator/src/main/java/com/powsybl/iidm/comparator/NetworkStateComparator.java
+++ b/iidm/iidm-comparator/src/main/java/com/powsybl/iidm/comparator/NetworkStateComparator.java
@@ -303,6 +303,10 @@ public class NetworkStateComparator {
 
     private static final InjectionQColumnMapper<ShuntCompensator> SHUNT_Q = new InjectionQColumnMapper<>();
 
+    private static final InjectionVColumnMapper<StaticVarCompensator> SVC_V = new InjectionVColumnMapper<>();
+
+    private static final InjectionQColumnMapper<StaticVarCompensator> SVC_Q = new InjectionQColumnMapper<>();
+
     private static final class DiffColumnMapper<T extends Identifiable> implements ColumnMapper<T> {
 
         private final String title;
@@ -391,6 +395,8 @@ public class NetworkStateComparator {
     private static final List<ColumnMapper<Load>> LOAD_MAPPERS = List.of(LOAD_P, LOAD_Q);
 
     private static final List<ColumnMapper<ShuntCompensator>> SHUNT_MAPPERS = List.of(SHUNT_SECTIONS, SHUNT_P, SHUNT_Q);
+
+    private static final List<ColumnMapper<StaticVarCompensator>> SVC_MAPPERS = List.of(SVC_Q, SVC_V);
 
     private final Network network;
 
@@ -506,6 +512,7 @@ public class NetworkStateComparator {
         createSheet(Lists.newArrayList(network.getHvdcConverterStations()), wb, titleCellStyle, "HVDC converter stations", HVDC_MAPPERS);
         createSheet(Lists.newArrayList(network.getLoads()), wb, titleCellStyle, "Loads", LOAD_MAPPERS);
         createSheet(Lists.newArrayList(network.getShuntCompensators()), wb, titleCellStyle, "Shunts", SHUNT_MAPPERS);
+        createSheet(Lists.newArrayList(network.getStaticVarCompensators()), wb, titleCellStyle, "Static VAR Compensators", SVC_MAPPERS);
     }
 
     public void generateXls(Path xsl) {

--- a/iidm/iidm-comparator/src/test/java/com/powsybl/iidm/comparator/NetworkStateComparatorTest.java
+++ b/iidm/iidm-comparator/src/test/java/com/powsybl/iidm/comparator/NetworkStateComparatorTest.java
@@ -80,7 +80,7 @@ public class NetworkStateComparatorTest {
 
         try (InputStream is = Files.newInputStream(xlsFile)) {
             Workbook wb = new XSSFWorkbook(is);
-            assertEquals(7, wb.getNumberOfSheets());
+            assertEquals(8, wb.getNumberOfSheets());
             Sheet busesSheet = wb.getSheet("Buses");
             Sheet linesSheet = wb.getSheet("Lines");
             Sheet transformersSheet = wb.getSheet("Transformers");
@@ -88,6 +88,7 @@ public class NetworkStateComparatorTest {
             Sheet hvdcConverterStationsSheet = wb.getSheet("HVDC converter stations");
             Sheet loadsSheet = wb.getSheet("Loads");
             Sheet shuntsSheet = wb.getSheet("Shunts");
+            Sheet svcsSheet = wb.getSheet("Static VAR Compensators");
             assertNotNull(busesSheet);
             assertNotNull(linesSheet);
             assertNotNull(transformersSheet);
@@ -95,6 +96,7 @@ public class NetworkStateComparatorTest {
             assertNotNull(generatorsSheet);
             assertNotNull(loadsSheet);
             assertNotNull(shuntsSheet);
+            assertNotNull(svcsSheet);
 
             FormulaEvaluator evaluator = wb.getCreationHelper().createFormulaEvaluator();
             evaluator.evaluateAll();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?**
No SVC state comparison


**What is the new behavior (if this is a feature change)?**
SVC state comparison in comparison Excel: v and q in new 'Static VAR Compensators' worksheet


**Does this PR introduce a breaking change or deprecate an API?**
No
