### PR TITLE
Powerfactory: Generator converter, for targetP and targetQ use pgini_a and qgini_a if are available

### DIFF
--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
@@ -84,7 +84,7 @@ class GeneratorConverter extends AbstractConverter {
         private static GeneratorModel create(DataObject elmSym) {
             boolean voltageRegulatorOn = voltageRegulatorOn(elmSym);
 
-            float pgini = elmSym.getFloatAttributeValue("pgini");
+            float pgini = elmSym.findFloatAttributeValue("pgini_a").orElse(elmSym.getFloatAttributeValue("pgini"));
             float qgini = elmSym.getFloatAttributeValue("qgini");
             double usetp = elmSym.getFloatAttributeValue("usetp");
             double pMinUc = minP(elmSym, pgini);

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/GeneratorConverter.java
@@ -85,7 +85,7 @@ class GeneratorConverter extends AbstractConverter {
             boolean voltageRegulatorOn = voltageRegulatorOn(elmSym);
 
             float pgini = elmSym.findFloatAttributeValue("pgini_a").orElse(elmSym.getFloatAttributeValue("pgini"));
-            float qgini = elmSym.getFloatAttributeValue("qgini");
+            float qgini = elmSym.findFloatAttributeValue("qgini_a").orElse(elmSym.getFloatAttributeValue("qgini"));
             double usetp = elmSym.getFloatAttributeValue("usetp");
             double pMinUc = minP(elmSym, pgini);
             double pMaxUc = maxP(elmSym, pgini);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*

pgini and qgini is used for targetP and targetQ in generators.

**What is the new behavior (if this is a feature change)?**

pgini_a and qgini_a is used for targetP and targetQ in generators when they are available otherwise pgini and qgini is used.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
