### PR TITLE
Create voltage level topology with only one section

### DIFF
--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelTopologyTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelTopologyTest.java
@@ -9,8 +9,10 @@ package com.powsybl.iidm.modification.topology;
 import com.powsybl.commons.AbstractConverterTest;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.reporter.Reporter;
+import com.powsybl.iidm.network.BusbarSection;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.extensions.BusbarSectionPosition;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.xml.NetworkXml;
 import org.junit.Test;
@@ -19,8 +21,7 @@ import java.io.IOException;
 
 import static com.powsybl.iidm.modification.topology.TopologyTestUtils.VLTEST;
 import static com.powsybl.iidm.modification.topology.TopologyTestUtils.createNbNetwork;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.*;
 
 /**
  * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
@@ -88,6 +89,33 @@ public class CreateVoltageLevelTopologyTest extends AbstractConverterTest {
                 .withSwitchKinds(SwitchKind.BREAKER, SwitchKind.DISCONNECTOR, SwitchKind.DISCONNECTOR);
         PowsyblException e = assertThrows(PowsyblException.class, modification::build);
         assertEquals("busBar count must be >= 1", e.getMessage());
+    }
+
+    @Test
+    public void testWithOneSection() {
+        Network network = createNbNetwork();
+        CreateVoltageLevelTopology modification = new CreateVoltageLevelTopologyBuilder()
+                .withVoltageLevelId(VLTEST)
+                .withBusbarCount(2)
+                .withSectionCount(1)
+                .build();
+        modification.apply(network);
+
+        BusbarSection bbs1 = network.getBusbarSection("VLTEST_1_1");
+        BusbarSection bbs2 = network.getBusbarSection("VLTEST_2_1");
+        assertNotNull(bbs1);
+        assertNotNull(bbs2);
+
+        BusbarSectionPosition bbsp1 = bbs1.getExtension(BusbarSectionPosition.class);
+        BusbarSectionPosition bbsp2 = bbs2.getExtension(BusbarSectionPosition.class);
+        assertNotNull(bbsp1);
+        assertNotNull(bbsp2);
+
+        assertEquals(1, bbsp1.getBusbarIndex());
+        assertEquals(1, bbsp1.getSectionIndex());
+
+        assertEquals(2, bbsp2.getBusbarIndex());
+        assertEquals(1, bbsp2.getSectionIndex());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
Switch kinds need to be specified even if only one section (thus kinds is an empty array)

**What is the new behavior (if this is a feature change)?**
Switch kinds do not need to be specified if only one section

**Does this PR introduce a breaking change or deprecate an API?**
No