### PR TITLE
CGMES Export: export missing load groups

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -180,16 +180,16 @@ public final class CgmesExportUtil {
             // Conform load if fixed part is zero and variable part is non-zero
             if (loadDetail.getFixedActivePower() == 0 && loadDetail.getFixedReactivePower() == 0
                     && (loadDetail.getVariableActivePower() != 0 || loadDetail.getVariableReactivePower() != 0)) {
-                return "ConformLoad";
+                return CgmesNames.CONFORM_LOAD;
             }
             // NonConform load if fixed part is non-zero and variable part is all zero
             if (loadDetail.getVariableActivePower() == 0 && loadDetail.getVariableReactivePower() == 0
                     && (loadDetail.getFixedActivePower() != 0 || loadDetail.getFixedReactivePower() != 0)) {
-                return "NonConformLoad";
+                return CgmesNames.NONCONFORM_LOAD;
             }
         }
         LOG.warn("It is not possible to determine the type of load");
-        return "EnergyConsumer";
+        return CgmesNames.ENERGY_CONSUMER;
     }
 
     /**

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -243,47 +243,6 @@ public final class EquipmentExport {
         }
     }
 
-    static class LoadGroup {
-        final String className;
-        final String id;
-        final String name;
-
-        LoadGroup(String className, String id, String name) {
-            this.className = className;
-            this.id = id;
-            this.name = name;
-        }
-    }
-
-    static class LoadGroups {
-        Map<String, LoadGroup> uniqueGroupByClass = new HashMap<>();
-
-        Collection<LoadGroup> found() {
-            return uniqueGroupByClass.values();
-        }
-
-        String groupFor(String loadClassName) {
-            if (loadClassName.equals(CgmesNames.ENERGY_CONSUMER)) {
-                return null;
-            }
-            return uniqueGroupByClass.computeIfAbsent(loadClassName, this::createGroupFor).id;
-        }
-
-        LoadGroup createGroupFor(String loadClassName) {
-            String id = CgmesExportUtil.getUniqueId();
-            String className = GROUP_CLASS_NAMES.get(loadClassName);
-            String groupName = GROUP_NAMES.get(loadClassName);
-            return new LoadGroup(className, id, groupName);
-        }
-
-        static final Map<String, String> GROUP_CLASS_NAMES = Map.of(
-                CgmesNames.CONFORM_LOAD, CgmesNames.CONFORM_LOAD_GROUP,
-                CgmesNames.NONCONFORM_LOAD, CgmesNames.NONCONFORM_LOAD_GROUP);
-        static final Map<String, String> GROUP_NAMES = Map.of(
-                CgmesNames.CONFORM_LOAD, "Conform loads",
-                CgmesNames.NONCONFORM_LOAD, "NonConform loads");
-    }
-
     // We may receive a warning if we define an empty load group,
     // So we will output only the load groups that have been found during export of loads
     private static void writeLoadGroups(Collection<LoadGroup> foundLoadGroups, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/LoadGroup.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/LoadGroup.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.export;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+class LoadGroup {
+    final String className;
+    final String id;
+    final String name;
+
+    LoadGroup(String className, String id, String name) {
+        this.className = className;
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/LoadGroups.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/LoadGroups.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.conversion.export;
+
+import com.powsybl.cgmes.model.CgmesNames;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+class LoadGroups {
+    Map<String, LoadGroup> uniqueGroupByClass = new HashMap<>();
+
+    Collection<LoadGroup> found() {
+        return uniqueGroupByClass.values();
+    }
+
+    String groupFor(String loadClassName) {
+        if (loadClassName.equals(CgmesNames.ENERGY_CONSUMER)) {
+            return null;
+        }
+        return uniqueGroupByClass.computeIfAbsent(loadClassName, this::createGroupFor).id;
+    }
+
+    LoadGroup createGroupFor(String loadClassName) {
+        String id = CgmesExportUtil.getUniqueId();
+        String className = GROUP_CLASS_NAMES.get(loadClassName);
+        String groupName = GROUP_NAMES.get(loadClassName);
+        return new LoadGroup(className, id, groupName);
+    }
+
+    static final Map<String, String> GROUP_CLASS_NAMES = Map.of(
+            CgmesNames.CONFORM_LOAD, CgmesNames.CONFORM_LOAD_GROUP,
+            CgmesNames.NONCONFORM_LOAD, CgmesNames.NONCONFORM_LOAD_GROUP);
+    static final Map<String, String> GROUP_NAMES = Map.of(
+            CgmesNames.CONFORM_LOAD, "Conform loads",
+            CgmesNames.NONCONFORM_LOAD, "NonConform loads");
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/elements/EnergyConsumerEq.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/elements/EnergyConsumerEq.java
@@ -7,7 +7,6 @@
 package com.powsybl.cgmes.conversion.export.elements;
 
 import com.powsybl.cgmes.conversion.export.CgmesExportUtil;
-import com.powsybl.iidm.network.extensions.LoadDetail;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -17,9 +16,12 @@ import javax.xml.stream.XMLStreamWriter;
  */
 public final class EnergyConsumerEq {
 
-    public static void write(String id, String loadName, LoadDetail loadDetail, String equipmentContainer, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {
-        CgmesExportUtil.writeStartIdName(CgmesExportUtil.loadClassName(loadDetail), id, loadName, cimNamespace, writer);
+    public static void write(String className, String id, String loadName, String loadGroup, String equipmentContainer, String cimNamespace, XMLStreamWriter writer) throws XMLStreamException {
+        CgmesExportUtil.writeStartIdName(className, id, loadName, cimNamespace, writer);
         CgmesExportUtil.writeReference("Equipment.EquipmentContainer", equipmentContainer, cimNamespace, writer);
+        if (loadGroup != null) {
+            CgmesExportUtil.writeReference(className + ".LoadGroup", loadGroup, cimNamespace, writer);
+        }
         writer.writeEndElement();
     }
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
@@ -23,10 +23,10 @@ import com.powsybl.commons.datasource.ResourceDataSource;
 import com.powsybl.commons.datasource.ResourceSet;
 import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.computation.local.LocalComputationManager;
-import com.powsybl.iidm.xml.ExportOptions;
 import com.powsybl.iidm.import_.ImportConfig;
 import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.xml.ExportOptions;
 import com.powsybl.iidm.xml.NetworkXml;
 import com.powsybl.iidm.xml.XMLImporter;
 import org.junit.Test;
@@ -247,6 +247,16 @@ public class EquipmentExportTest extends AbstractConverterTest {
                     expected.getAliasFromType(aliasType).get(),
                     actual2.getAliasFromType(aliasType).get());
         }
+    }
+
+    @Test
+    public void testLoadGroups() throws XMLStreamException, IOException {
+        Properties properties = new Properties();
+        properties.put(CgmesImport.CREATE_CGMES_EXPORT_MAPPING, "true");
+        ReadOnlyDataSource dataSource = CgmesConformity1ModifiedCatalog.microGridBaseCaseBEConformNonConformLoads().dataSource();
+        Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), properties);
+        Network actual = exportImportBusBranch(expected, dataSource);
+        compareNetworksEQdata(expected, actual);
     }
 
     private Network exportImportNodeBreaker(Network expected, ReadOnlyDataSource dataSource) throws IOException, XMLStreamException {

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNames.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesNames.java
@@ -105,6 +105,12 @@ public final class CgmesNames {
 
     public static final Set<String> SWITCH_TYPES = Set.of(SWITCH, "Breaker", "Disconnector", "LoadBreakSwitch", "ProtectedSwitch", "GroundDisconnector");
 
+    public static final String CONFORM_LOAD = "ConformLoad";
+    public static final String NONCONFORM_LOAD = "NonConformLoad";
+    public static final String ENERGY_CONSUMER = "EnergyConsumer";
+    public static final String CONFORM_LOAD_GROUP = "ConformLoadGroup";
+    public static final String NONCONFORM_LOAD_GROUP = "NonConformLoadGroup";
+
     private CgmesNames() {
     }
 }


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Exported EQ must contain load groups if Conform or NonConform energy consumers are present.


**What is the current behavior?** *(You can also link to an open issue here)*
No load groups were exported, resulting in warnings when the output instance files were validated against the profile.


**What is the new behavior (if this is a feature change)?**
A unique `ConformLoadGroup` is created and referred in all `Conform` loads.
A unique `NonConformLoadGroup` is created and referred in all `NonConform` loads.
Groups are created only if there are loads of each type.

`LoadGroup` objects are contained in `SubLoadArea` and `LoadArea` objects in the `Operation` profile. These containers are not created in this PR. 

