### PR TITLE
Make SecurityAnalysis.Runner constructor public

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysis.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysis.java
@@ -47,7 +47,7 @@ public final class SecurityAnalysis {
 
         private final SecurityAnalysisProvider provider;
 
-        private Runner(SecurityAnalysisProvider provider) {
+        public Runner(SecurityAnalysisProvider provider) {
             this.provider = Objects.requireNonNull(provider);
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Feature

**What is the current behavior?** *(You can also link to an open issue here)*

`SecurityAnalysis.Runner(provider)` is private.

**What is the new behavior (if this is a feature change)?**

In some situations, in particular unit tests,
it's useful to be able to use a security analysis provider which is defined programmatically, and not in config.

This is consistent with loadflow and sensitivity analysis API
