### PR TITLE
Fix default implementation of deprecated method of StandbyAutomatonAdder

### DIFF
--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/StandbyAutomatonAdder.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/StandbyAutomatonAdder.java
@@ -58,7 +58,7 @@ public interface StandbyAutomatonAdder extends ExtensionAdder<StaticVarCompensat
      */
     @Deprecated(since = "4.11.0")
     default StandbyAutomatonAdder withLowVoltageSetPoint(float lowVoltageSetpoint) {
-        return withHighVoltageSetpoint(lowVoltageSetpoint);
+        return withLowVoltageSetpoint(lowVoltageSetpoint);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix: deprecated `setLowVoltageSetPoint` called `setHighVoltageSetpoint` instead of `setLowVoltageSetpoint`

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
