### PR TITLE
Allow to create feeder bays in a bus-breaker voltage level

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
@@ -76,13 +76,13 @@ abstract class AbstractCreateConnectableFeederBays extends AbstractNetworkModifi
     private boolean setAdderConnectivity(Network network, Reporter reporter, boolean throwException) {
         Map<VoltageLevel, Integer> firstAvailableNodes = new HashMap<>();
         for (int side : sides) {
-            String busorBusbarSectionId = getBusOrBusbarSectionId(side);
-            Identifiable<?> busOrBusbarSection = network.getIdentifiable(busorBusbarSectionId);
+            String busOrBusbarSectionId = getBusOrBusbarSectionId(side);
+            Identifiable<?> busOrBusbarSection = network.getIdentifiable(busOrBusbarSectionId);
             if (busOrBusbarSection == null) {
-                LOGGER.error("Identifiable {} not found.", busorBusbarSectionId);
-                notFoundIdentifiableReport(reporter, busorBusbarSectionId);
+                LOGGER.error("Identifiable {} not found.", busOrBusbarSectionId);
+                notFoundIdentifiableReport(reporter, busOrBusbarSectionId);
                 if (throwException) {
-                    throw new PowsyblException(String.format("Identifiable %s not found.", busorBusbarSectionId));
+                    throw new PowsyblException(String.format("Identifiable %s not found.", busOrBusbarSectionId));
                 }
                 return false;
             }
@@ -95,10 +95,10 @@ abstract class AbstractCreateConnectableFeederBays extends AbstractNetworkModifi
                 int connectableNode = firstAvailableNodes.compute(voltageLevel, (vl, node) -> node == null ? vl.getNodeBreakerView().getMaximumNodeIndex() + 1 : node + 1);
                 setNode(side, connectableNode, voltageLevel.getId());
             } else {
-                LOGGER.error("Unsupported type {} for identifiable {}", busOrBusbarSection.getType(), busorBusbarSectionId);
-                unsupportedIdentifiableType(reporter, busOrBusbarSection.getType(), busorBusbarSectionId);
+                LOGGER.error("Unsupported type {} for identifiable {}", busOrBusbarSection.getType(), busOrBusbarSectionId);
+                unsupportedIdentifiableType(reporter, busOrBusbarSection.getType(), busOrBusbarSectionId);
                 if (throwException) {
-                    throw new PowsyblException(String.format("Unsupported type %s for identifiable %s", busOrBusbarSection.getType(), busorBusbarSectionId));
+                    throw new PowsyblException(String.format("Unsupported type %s for identifiable %s", busOrBusbarSection.getType(), busOrBusbarSectionId));
                 }
                 return false;
             }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/AbstractCreateConnectableFeederBays.java
@@ -87,18 +87,8 @@ abstract class AbstractCreateConnectableFeederBays extends AbstractNetworkModifi
                 return false;
             }
             if (busOrBusbarSection instanceof Bus) {
-                Bus bus = (Bus) busOrBusbarSection;
-                VoltageLevel voltageLevel = bus.getVoltageLevel();
-                if (voltageLevel.getTopologyKind() != TopologyKind.BUS_BREAKER) {
-                    LOGGER.error("Voltage level {} has an unsupported topology {}. Should be BUS_BREAKER", voltageLevel.getId(), voltageLevel.getTopologyKind());
-                    unsupportedVoltageLevelTopologyKind(reporter, voltageLevel.getId(), TopologyKind.BUS_BREAKER, voltageLevel.getTopologyKind());
-                    if (throwException) {
-                        throw new PowsyblException(String.format("Voltage level %s has an unsupported topology %s. Should be BUS_BREAKER",
-                                voltageLevel.getId(), voltageLevel.getTopologyKind()));
-                    }
-                    return false;
-                }
-                setBus(side, bus, voltageLevel.getId());
+                Bus bus = (Bus) busOrBusbarSection; // if bus is an identifiable, the voltage level is BUS_BREAKER
+                setBus(side, bus, bus.getVoltageLevel().getId());
             } else if (busOrBusbarSection instanceof BusbarSection) {
                 BusbarSection bbs = (BusbarSection) busOrBusbarSection; // if bbs exists, the voltage level is NODE_BREAKER: no necessary topology kind check
                 VoltageLevel voltageLevel = bbs.getTerminal().getVoltageLevel();

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
@@ -59,13 +59,14 @@ public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays 
     }
 
     @Override
-    protected void setBus(int side, Bus bus) {
+    protected void setBus(int side, Bus bus, String voltageLevelId) {
         if (side == 1) {
-            branchAdder.setConnectableBus1(bus.getId()).setBus1(bus.getId());
+            branchAdder.setConnectableBus1(bus.getId()).setBus1(bus.getId()).setVoltageLevel1(voltageLevelId);
         } else if (side == 2) {
-            branchAdder.setConnectableBus2(bus.getId()).setBus2(bus.getId());
+            branchAdder.setConnectableBus2(bus.getId()).setBus2(bus.getId()).setVoltageLevel2(voltageLevelId);
+        } else {
+            throw createSideAssertionError(side);
         }
-        throw createSideAssertionError(side);
     }
 
     @Override

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
@@ -24,8 +24,8 @@ import java.util.Optional;
 public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays {
 
     private final BranchAdder<?> branchAdder;
-    private final String bbsId1;
-    private final String bbsId2;
+    private final String busOrBbsId1;
+    private final String busOrBbsId2;
     private final int positionOrder1;
     private final int positionOrder2;
     private final String feederName1;
@@ -33,12 +33,12 @@ public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays 
     private final ConnectablePosition.Direction direction1;
     private final ConnectablePosition.Direction direction2;
 
-    CreateBranchFeederBays(BranchAdder<?> branchAdder, String bbsId1, String bbsId2, Integer positionOrder1, Integer positionOrder2,
+    CreateBranchFeederBays(BranchAdder<?> branchAdder, String busOrBbsId1, String busOrBbsId2, Integer positionOrder1, Integer positionOrder2,
                            String feederName1, String feederName2, ConnectablePosition.Direction direction1, ConnectablePosition.Direction direction2) {
         super(1, 2);
         this.branchAdder = Objects.requireNonNull(branchAdder);
-        this.bbsId1 = Objects.requireNonNull(bbsId1);
-        this.bbsId2 = Objects.requireNonNull(bbsId2);
+        this.busOrBbsId1 = Objects.requireNonNull(busOrBbsId1);
+        this.busOrBbsId2 = Objects.requireNonNull(busOrBbsId2);
         this.positionOrder1 = Objects.requireNonNull(positionOrder1);
         this.positionOrder2 = Objects.requireNonNull(positionOrder2);
         this.feederName1 = feederName1;
@@ -50,10 +50,10 @@ public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays 
     @Override
     protected String getBusOrBusbarSectionId(int side) {
         if (side == 1) {
-            return bbsId1;
+            return busOrBbsId1;
         }
         if (side == 2) {
-            return bbsId2;
+            return busOrBbsId2;
         }
         throw createSideAssertionError(side);
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
@@ -26,8 +26,8 @@ public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays 
     private final BranchAdder<?> branchAdder;
     private final String busOrBbsId1;
     private final String busOrBbsId2;
-    private final int positionOrder1;
-    private final int positionOrder2;
+    private final Integer positionOrder1;
+    private final Integer positionOrder2;
     private final String feederName1;
     private final String feederName2;
     private final ConnectablePosition.Direction direction1;
@@ -39,8 +39,8 @@ public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays 
         this.branchAdder = Objects.requireNonNull(branchAdder);
         this.busOrBbsId1 = Objects.requireNonNull(busOrBbsId1);
         this.busOrBbsId2 = Objects.requireNonNull(busOrBbsId2);
-        this.positionOrder1 = Objects.requireNonNull(positionOrder1);
-        this.positionOrder2 = Objects.requireNonNull(positionOrder2);
+        this.positionOrder1 = positionOrder1;
+        this.positionOrder2 = positionOrder2;
         this.feederName1 = feederName1;
         this.feederName2 = feederName2;
         this.direction1 = Objects.requireNonNull(direction1);
@@ -104,7 +104,7 @@ public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays 
     }
 
     @Override
-    protected int getPositionOrder(int side) {
+    protected Integer getPositionOrder(int side) {
         if (side == 1) {
             return positionOrder1;
         }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBays.java
@@ -48,12 +48,22 @@ public class CreateBranchFeederBays extends AbstractCreateConnectableFeederBays 
     }
 
     @Override
-    protected String getBbsId(int side) {
+    protected String getBusOrBusbarSectionId(int side) {
         if (side == 1) {
             return bbsId1;
         }
         if (side == 2) {
             return bbsId2;
+        }
+        throw createSideAssertionError(side);
+    }
+
+    @Override
+    protected void setBus(int side, Bus bus) {
+        if (side == 1) {
+            branchAdder.setConnectableBus1(bus.getId()).setBus1(bus.getId());
+        } else if (side == 2) {
+            branchAdder.setConnectableBus2(bus.getId()).setBus2(bus.getId());
         }
         throw createSideAssertionError(side);
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysBuilder.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysBuilder.java
@@ -59,11 +59,21 @@ public class CreateBranchFeederBaysBuilder {
         return this;
     }
 
+    /**
+     * Set position order for end 1.
+     * Should not be defined if voltage level attached to end 1 is BUS_BREAKER (ignored if it is).
+     * Required if the latter is NODE_BREAKER.
+     */
     public CreateBranchFeederBaysBuilder withPositionOrder1(int positionOrder1) {
         this.positionOrder1 = positionOrder1;
         return this;
     }
 
+    /**
+     * Set position orders for end 2.
+     * Should not be defined if voltage level attached to end 2 is BUS_BREAKER (ignored if it is).
+     * Required if the latter is NODE_BREAKER.
+     */
     public CreateBranchFeederBaysBuilder withPositionOrder2(int positionOrder2) {
         this.positionOrder2 = positionOrder2;
         return this;

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysBuilder.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysBuilder.java
@@ -15,8 +15,8 @@ import com.powsybl.iidm.network.extensions.ConnectablePosition;
 public class CreateBranchFeederBaysBuilder {
 
     private BranchAdder<?> branchAdder = null;
-    private String bbsId1 = null;
-    private String bbsId2 = null;
+    private String busOrBbs1 = null;
+    private String busOrBbs2 = null;
     private Integer positionOrder1 = null;
     private Integer positionOrder2 = null;
     private String feederName1 = null;
@@ -25,7 +25,7 @@ public class CreateBranchFeederBaysBuilder {
     private ConnectablePosition.Direction direction2 = ConnectablePosition.Direction.TOP;
 
     public CreateBranchFeederBays build() {
-        return new CreateBranchFeederBays(branchAdder, bbsId1, bbsId2, positionOrder1, positionOrder2, feederName1, feederName2, direction1, direction2);
+        return new CreateBranchFeederBays(branchAdder, busOrBbs1, busOrBbs2, positionOrder1, positionOrder2, feederName1, feederName2, direction1, direction2);
     }
 
     public CreateBranchFeederBaysBuilder withBranchAdder(BranchAdder<?> branchAdder) {
@@ -33,13 +33,29 @@ public class CreateBranchFeederBaysBuilder {
         return this;
     }
 
-    public CreateBranchFeederBaysBuilder withBbsId1(String bbsId1) {
-        this.bbsId1 = bbsId1;
+    /**
+     * @deprecated Use {@link #withBusOrBusbarSectionId1(String)} instead.
+     */
+    @Deprecated(since = "5.1.0")
+    public CreateBranchFeederBaysBuilder withBbs1(String bbs1) {
+        return withBusOrBusbarSectionId1(bbs1);
+    }
+
+    public CreateBranchFeederBaysBuilder withBusOrBusbarSectionId1(String busOrBbs1) {
+        this.busOrBbs1 = busOrBbs1;
         return this;
     }
 
+    /**
+     * @deprecated Use {@link #withBusOrBusbarSectionId2(String)} instead.
+     */
+    @Deprecated(since = "5.1.0")
     public CreateBranchFeederBaysBuilder withBbsId2(String bbsId2) {
-        this.bbsId2 = bbsId2;
+        return withBusOrBusbarSectionId2(bbsId2);
+    }
+
+    public CreateBranchFeederBaysBuilder withBusOrBusbarSectionId2(String busOrBbs2) {
+        this.busOrBbs2 = busOrBbs2;
         return this;
     }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBay.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBay.java
@@ -53,7 +53,7 @@ public class CreateFeederBay extends AbstractCreateConnectableFeederBays {
     }
 
     @Override
-    protected void setBus(int side, Bus bus) {
+    protected void setBus(int side, Bus bus, String voltageLevelId) {
         injectionAdder.setConnectableBus(bus.getId()).setBus(bus.getId());
     }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBay.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBay.java
@@ -24,24 +24,24 @@ import java.util.Optional;
 public class CreateFeederBay extends AbstractCreateConnectableFeederBays {
 
     private final InjectionAdder<?> injectionAdder;
-    private final String bbsId;
-    private final int injectionPositionOrder;
+    private final String busOrBbsId;
+    private final Integer injectionPositionOrder;
     private final String injectionFeederName;
     private final ConnectablePosition.Direction injectionDirection;
 
     /**
      * @param injectionAdder         The injection adder.
-     * @param bbsId                  The ID of the existing busbar section where we want to connect the injection.
+     * @param busOrBbsId                  The ID of the existing busbar section where we want to connect the injection.
      *                               Please note that there will be switches between this busbar section and the connection point of the injection. This switch will be closed.
      * @param injectionPositionOrder The order of the injection to be attached from its extension {@link ConnectablePosition}.
      * @param injectionFeederName    The name of the feeder indicated in the extension {@link ConnectablePosition}.
      * @param injectionDirection     The direction of the injection to be attached from its extension {@link ConnectablePosition}.
      */
-    CreateFeederBay(InjectionAdder<?> injectionAdder, String bbsId, Integer injectionPositionOrder,
+    CreateFeederBay(InjectionAdder<?> injectionAdder, String busOrBbsId, Integer injectionPositionOrder,
                     String injectionFeederName, ConnectablePosition.Direction injectionDirection) {
         super(0);
         this.injectionAdder = Objects.requireNonNull(injectionAdder);
-        this.bbsId = Objects.requireNonNull(bbsId);
+        this.busOrBbsId = Objects.requireNonNull(busOrBbsId);
         this.injectionPositionOrder = injectionPositionOrder;
         this.injectionFeederName = injectionFeederName;
         this.injectionDirection = Objects.requireNonNull(injectionDirection);
@@ -49,7 +49,7 @@ public class CreateFeederBay extends AbstractCreateConnectableFeederBays {
 
     @Override
     protected String getBusOrBusbarSectionId(int side) {
-        return bbsId;
+        return busOrBbsId;
     }
 
     @Override
@@ -91,7 +91,7 @@ public class CreateFeederBay extends AbstractCreateConnectableFeederBays {
     }
 
     @Override
-    protected int getPositionOrder(int side) {
+    protected Integer getPositionOrder(int side) {
         return injectionPositionOrder;
     }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBay.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBay.java
@@ -48,8 +48,13 @@ public class CreateFeederBay extends AbstractCreateConnectableFeederBays {
     }
 
     @Override
-    protected String getBbsId(int side) {
+    protected String getBusOrBusbarSectionId(int side) {
         return bbsId;
+    }
+
+    @Override
+    protected void setBus(int side, Bus bus) {
+        injectionAdder.setConnectableBus(bus.getId()).setBus(bus.getId());
     }
 
     @Override

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBayBuilder.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBayBuilder.java
@@ -42,6 +42,11 @@ public class CreateFeederBayBuilder {
         return this;
     }
 
+    /**
+     * Set position order.
+     * Should not be defined in BUS_BREAKER (ignored if they are).
+     * Required in NODE_BREAKER.
+     */
     public CreateFeederBayBuilder withInjectionPositionOrder(int injectionPositionOrder) {
         this.injectionPositionOrder = injectionPositionOrder;
         return this;

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBayBuilder.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBayBuilder.java
@@ -30,14 +30,14 @@ public class CreateFeederBayBuilder {
     }
 
     /**
-     * @deprecated Use {@link #withBusOrBusBarSectionId(String)} instead.
+     * @deprecated Use {@link #withBusOrBusbarSectionId(String)} instead.
      */
     @Deprecated(since = "5.1.0")
     public CreateFeederBayBuilder withBbsId(String bbsId) {
-        return withBusOrBusBarSectionId(bbsId);
+        return withBusOrBusbarSectionId(bbsId);
     }
 
-    public CreateFeederBayBuilder withBusOrBusBarSectionId(String busOrBusbarSection) {
+    public CreateFeederBayBuilder withBusOrBusbarSectionId(String busOrBusbarSection) {
         this.busOrBusbarSection = busOrBusbarSection;
         return this;
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBayBuilder.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateFeederBayBuilder.java
@@ -15,13 +15,13 @@ import com.powsybl.iidm.network.extensions.ConnectablePosition;
 public class CreateFeederBayBuilder {
 
     private InjectionAdder<?> injectionAdder = null;
-    private String bbsId = null;
+    private String busOrBusbarSection = null;
     private Integer injectionPositionOrder = null;
     private String injectionFeederName = null;
     private ConnectablePosition.Direction injectionDirection = ConnectablePosition.Direction.BOTTOM;
 
     public CreateFeederBay build() {
-        return new CreateFeederBay(injectionAdder, bbsId, injectionPositionOrder, injectionFeederName, injectionDirection);
+        return new CreateFeederBay(injectionAdder, busOrBusbarSection, injectionPositionOrder, injectionFeederName, injectionDirection);
     }
 
     public CreateFeederBayBuilder withInjectionAdder(InjectionAdder<?> injectionAdder) {
@@ -29,8 +29,16 @@ public class CreateFeederBayBuilder {
         return this;
     }
 
+    /**
+     * @deprecated Use {@link #withBusOrBusBarSectionId(String)} instead.
+     */
+    @Deprecated(since = "5.1.0")
     public CreateFeederBayBuilder withBbsId(String bbsId) {
-        this.bbsId = bbsId;
+        return withBusOrBusBarSectionId(bbsId);
+    }
+
+    public CreateFeederBayBuilder withBusOrBusBarSectionId(String busOrBusbarSection) {
+        this.busOrBusbarSection = busOrBusbarSection;
         return this;
     }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
@@ -87,7 +87,7 @@ final class ModificationReports {
                 .withKey("newCouplingDeviceAdded")
                 .withDefaultMessage("New coupling device was created on voltage level ${voltageLevelId}. It connects busbar sections ${bbsId1} and ${bbsId2} with closed disconnectors" +
                         "and ${nbOpenDisconnectors} were created on parallel busbar sections.")
-                .withValue(voltageLevelId, voltageLevelId)
+                .withValue(VOLTAGE_LEVEL_ID, voltageLevelId)
                 .withValue("bbsId1", bbsId1)
                 .withValue("bbsId2", bbsId2)
                 .withValue("nbOpenDisconnectors", nbOpenDisconnectors)
@@ -251,7 +251,7 @@ final class ModificationReports {
     static void removeFeederBayBusbarSectionReport(Reporter reporter, String busbarSectionConnectableId) {
         reporter.report(Report.builder()
                 .withKey("removeBayBusbarSectionConnectable")
-                .withDefaultMessage("Cannot remove feeder bay for connectable ${busbarSectionConnectableId}, as it is a busbarSection")
+                .withDefaultMessage("Cannot remove feeder bay for connectable ${connectableId}, as it is a busbarSection")
                 .withValue(CONNECTABLE_ID, busbarSectionConnectableId)
                 .withSeverity(TypedValue.ERROR_SEVERITY)
                 .build());

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
@@ -146,6 +146,16 @@ final class ModificationReports {
     }
 
     // WARN
+    static void ignoredPositionOrder(Reporter reporter, int positionOrder, VoltageLevel voltageLevel) {
+        reporter.report(Report.builder()
+                .withKey("ignoredPositionOrder")
+                .withDefaultMessage("Voltage level ${voltageLevelId} is BUS_BREAKER. Position order ${positionOrder} is ignored.")
+                .withValue(VOLTAGE_LEVEL_ID, voltageLevel.getId())
+                .withValue("positionOrder", positionOrder)
+                .withSeverity(TypedValue.WARN_SEVERITY)
+                .build());
+    }
+
     static void noBusbarSectionPositionExtensionReport(Reporter reporter, BusbarSection bbs) {
         reporter.report(Report.builder()
                 .withKey("noBusbarSectionPositionExtension")
@@ -343,6 +353,15 @@ final class ModificationReports {
                 .withDefaultMessage("Unsupported type ${identifiableType} for identifiable ${identifiableId}")
                 .withValue("identifiableType", type.name())
                 .withValue("identifiableId", identifiableId)
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .build());
+    }
+
+    static void unexpectedNullPositionOrder(Reporter reporter, VoltageLevel voltageLevel) {
+        reporter.report(Report.builder()
+                .withKey("unexpectedNullPositionOrder")
+                .withDefaultMessage("Position order is null for attachment in node-breaker voltage level ${voltageLevelId}")
+                .withValue(VOLTAGE_LEVEL_ID, voltageLevel.getId())
                 .withSeverity(TypedValue.ERROR_SEVERITY)
                 .build());
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
@@ -19,120 +19,30 @@ final class ModificationReports {
     private static final String VOLTAGE_LEVEL_ID = "voltageLevelId";
     private static final String LINE_ID = "lineId";
     private static final String BBS_ID = "bbsId";
+    private static final String CONNECTABLE_ID = "connectableId";
 
-    static void notFoundBusbarSectionReport(Reporter reporter, String bbsId) {
+    // INFO
+    static void createdConnectable(Reporter reporter, Connectable<?> connectable) {
         reporter.report(Report.builder()
-                .withKey("notFoundBusbarSection")
-                .withDefaultMessage("Busbar section ${busbarSectionId} not found")
-                .withValue("busbarSectionId", bbsId)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .withKey("connectableCreated")
+                .withDefaultMessage("New connectable ${connectableId} of type ${connectableType} created.")
+                .withValue(CONNECTABLE_ID, connectable.getId())
+                .withValue("connectableType", connectable.getType().name())
+                .withSeverity(TypedValue.INFO_SEVERITY)
                 .build());
     }
 
-    static void networkMismatchReport(Reporter reporter, String injectionId, IdentifiableType identifiableType) {
-        reporter.report(Report.builder()
-                .withKey("networkMismatch")
-                .withDefaultMessage("Network given in parameters and in injectionAdder are different. Injection '${injectionId}' of type {identifiableType} was added then removed")
-                .withValue("injectionId", injectionId)
-                .withValue("identifiableType", identifiableType.toString())
-                .withSeverity(TypedValue.ERROR_SEVERITY)
-                .build());
-    }
-
-    static void positionOrderAlreadyTakenReport(Reporter reporter, int positionOrder) {
-        reporter.report(Report.builder()
-                .withKey("positionOrderAlreadyTaken")
-                .withDefaultMessage("positionOrder ${positionOrder} already taken.")
-                .withValue("positionOrder", positionOrder)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
-                .build());
-    }
-
-    static void newConnectableAddedReport(Reporter reporter, String voltageLevelId, String bbsId, Connectable<?> connectable, int parallelBbsNumber) {
+    static void createdNodeBreakerFeederBay(Reporter reporter, String voltageLevelId, String bbsId, Connectable<?> connectable, int parallelBbsNumber) {
         reporter.report(Report.builder()
                 .withKey("newConnectableAdded")
                 .withDefaultMessage("New feeder bay associated to ${connectableId} of type ${connectableType} was created and connected to voltage level ${voltageLevelId} on busbar section ${bbsId} with a closed disconnector" +
                         "and on ${parallelBbsNumber} parallel busbar sections with an open disconnector.")
-                .withValue("connectableId", connectable.getId())
+                .withValue(CONNECTABLE_ID, connectable.getId())
                 .withValue("connectableType", connectable.getType().toString())
                 .withValue(VOLTAGE_LEVEL_ID, voltageLevelId)
                 .withValue(BBS_ID, bbsId)
                 .withValue("parallelBbsNumber", parallelBbsNumber)
                 .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
-    static void noBusbarSectionPositionExtensionReport(Reporter reporter, BusbarSection bbs) {
-        reporter.report(Report.builder()
-                .withKey("noBusbarSectionPositionExtension")
-                .withDefaultMessage("No busbar section position extension found on ${bbsId}, only one disconnector is created.")
-                .withValue(BBS_ID, bbs.getId())
-                .withSeverity(TypedValue.WARN_SEVERITY)
-                .build());
-    }
-
-    static void connectableNotSupported(Reporter reporter, Connectable<?> connectable) {
-        reporter.report(Report.builder()
-                .withKey("connectableNotSupported")
-                .withDefaultMessage("Given connectable not supported: ${connectableClassName}.")
-                .withValue("connectableClassName", connectable.getClass().getName())
-                .withSeverity(TypedValue.ERROR_SEVERITY)
-                .build());
-    }
-
-    static void connectableNotInVoltageLevel(Reporter reporter, Connectable<?> connectable, VoltageLevel voltageLevel) {
-        reporter.report(Report.builder()
-                .withKey("connectableNotInVoltageLevel")
-                .withDefaultMessage("Given connectable ${connectableId} not in voltageLevel ${voltageLevelId}")
-                .withValue("connectableId", connectable.getId())
-                .withValue(VOLTAGE_LEVEL_ID, voltageLevel.getId())
-                .withSeverity(TypedValue.ERROR_SEVERITY)
-                .build());
-    }
-
-    static void noConnectablePositionExtension(Reporter reporter, VoltageLevel voltageLevel) {
-        reporter.report(Report.builder()
-                .withKey("noConnectablePositionExtensions")
-                .withDefaultMessage("No extensions found on voltageLevel ${voltageLevel}. The extension on the connectable is not created.")
-                .withValue("voltageLevel", voltageLevel.getId())
-                .withSeverity(TypedValue.WARN_SEVERITY)
-                .build());
-    }
-
-    static void notFoundLineReport(Reporter reporter, String lineId) {
-        reporter.report(Report.builder()
-                .withKey("lineNotFound")
-                .withDefaultMessage("Line ${lineId} is not found")
-                .withValue(LINE_ID, lineId)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
-                .build());
-    }
-
-    static void notFoundConnectableReport(Reporter reporter, String connectableId) {
-        reporter.report(Report.builder()
-                .withKey("connectableNotFound")
-                .withDefaultMessage("Connectable ${connectableId} is not found")
-                .withValue("connectableId", connectableId)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
-                .build());
-    }
-
-    static void removeFeederBayBusbarSectionReport(Reporter reporter, String busbarSectionConnectableId) {
-        reporter.report(Report.builder()
-                .withKey("removeBayBusbarSectionConnectable")
-                .withDefaultMessage("Cannot remove feeder bay for connectable ${busbarSectionConnectableId}, as it is a busbarSection")
-                .withValue("connectableId", busbarSectionConnectableId)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
-                .build());
-    }
-
-    static void noVoltageLevelInCommonReport(Reporter reporter, String line1Id, String line2Id) {
-        reporter.report(Report.builder()
-                .withKey("noVoltageLevelInCommon")
-                .withDefaultMessage("Lines ${line1Id} and ${line2Id} should have one and only one voltage level in common at their extremities")
-                .withValue("line1Id", line1Id)
-                .withValue("line2Id", line2Id)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
                 .build());
     }
 
@@ -163,6 +73,106 @@ final class ModificationReports {
                 .build());
     }
 
+    static void substationRemovedReport(Reporter reporter, String substationId) {
+        reporter.report(Report.builder()
+                .withKey("substationRemoved")
+                .withDefaultMessage("Substation ${substationId} removed")
+                .withValue("substationId", substationId)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    static void newCouplingDeviceAddedReport(Reporter reporter, String voltageLevelId, String bbsId1, String bbsId2, int nbOpenDisconnectors) {
+        reporter.report(Report.builder()
+                .withKey("newCouplingDeviceAdded")
+                .withDefaultMessage("New coupling device was created on voltage level ${voltageLevelId}. It connects busbar sections ${bbsId1} and ${bbsId2} with closed disconnectors" +
+                        "and ${nbOpenDisconnectors} were created on parallel busbar sections.")
+                .withValue(voltageLevelId, voltageLevelId)
+                .withValue("bbsId1", bbsId1)
+                .withValue("bbsId2", bbsId2)
+                .withValue("nbOpenDisconnectors", nbOpenDisconnectors)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    static void createdNewSymmetricalTopology(Reporter reporter, String voltageLevelId, int busbarCount, int sectionCount) {
+        reporter.report(Report.builder()
+                .withKey("SymmetricalTopologyCreated")
+                .withDefaultMessage("New symmetrical topology in voltage level ${voltageLevelId}: creation of ${busbarCount} busbar(s) with ${sectionCount} section(s) each.")
+                .withValue(VOLTAGE_LEVEL_ID, voltageLevelId)
+                .withValue("busbarCount", busbarCount)
+                .withValue("sectionCount", sectionCount)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    public static void removedSwitchReport(Reporter reporter, String switchId) {
+        reporter.report(Report.builder()
+                .withKey("SwitchRemoved")
+                .withDefaultMessage("Switch ${switchId} removed")
+                .withValue("switchId", switchId)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    static void removedInternalConnectionReport(Reporter reporter, int node1, int node2) {
+        reporter.report(Report.builder()
+                .withKey("InternalConnectionRemoved")
+                .withDefaultMessage("Internal connection between ${node1} and ${node2} removed")
+                .withValue("node1", node1)
+                .withValue("node2", node2)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    static void removedConnectableReport(Reporter reporter, String connectableId) {
+        reporter.report(Report.builder()
+                .withKey("ConnectableRemoved")
+                .withDefaultMessage("Connectable ${connectableId} removed")
+                .withValue(CONNECTABLE_ID, connectableId)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    static void removeFeederBayAborted(Reporter reporter, String connectableId, int node, String otherConnectableId) {
+        reporter.report(Report.builder()
+                .withKey("RemoveFeederBayAborted")
+                .withDefaultMessage("Remove feeder bay of ${connectableId} cannot go further node ${node}, as it is connected to ${otherConnectableId}")
+                .withValue(CONNECTABLE_ID, connectableId)
+                .withValue("node", node)
+                .withValue("otherConnectableId", otherConnectableId)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    // WARN
+    static void noBusbarSectionPositionExtensionReport(Reporter reporter, BusbarSection bbs) {
+        reporter.report(Report.builder()
+                .withKey("noBusbarSectionPositionExtension")
+                .withDefaultMessage("No busbar section position extension found on ${bbsId}, only one disconnector is created.")
+                .withValue(BBS_ID, bbs.getId())
+                .withSeverity(TypedValue.WARN_SEVERITY)
+                .build());
+    }
+
+    static void positionOrderAlreadyTakenReport(Reporter reporter, int positionOrder) {
+        reporter.report(Report.builder()
+                .withKey("positionOrderAlreadyTaken")
+                .withDefaultMessage("PositionOrder ${positionOrder} already taken. No position extension created.")
+                .withValue("positionOrder", positionOrder)
+                .withSeverity(TypedValue.WARN_SEVERITY)
+                .build());
+    }
+
+    static void noConnectablePositionExtension(Reporter reporter, VoltageLevel voltageLevel) {
+        reporter.report(Report.builder()
+                .withKey("noConnectablePositionExtensions")
+                .withDefaultMessage("No extensions found on voltageLevel ${voltageLevel}. The extension on the connectable is not created.")
+                .withValue("voltageLevel", voltageLevel.getId())
+                .withSeverity(TypedValue.WARN_SEVERITY)
+                .build());
+    }
+
     static void voltageLevelRemovingEquipmentsLeftReport(Reporter reporter, String vlId) {
         reporter.report(Report.builder()
                 .withKey("voltageLevelRemovingEquipmentsLeft")
@@ -172,12 +182,88 @@ final class ModificationReports {
                 .build());
     }
 
-    static void substationRemovedReport(Reporter reporter, String substationId) {
+    // ERROR
+    static void notFoundIdentifiableReport(Reporter reporter, String identifiableId) {
         reporter.report(Report.builder()
-                .withKey("substationRemoved")
-                .withDefaultMessage("Substation ${substationId} removed")
-                .withValue("substationId", substationId)
-                .withSeverity(TypedValue.INFO_SEVERITY)
+                .withKey("notFoundIdentifiable")
+                .withDefaultMessage("Identifiable ${busbarSectionId} not found")
+                .withValue("identifiableId", identifiableId)
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .build());
+    }
+
+    static void notFoundBusbarSectionReport(Reporter reporter, String bbsId) {
+        reporter.report(Report.builder()
+                .withKey("notFoundBusbarSection")
+                .withDefaultMessage("Busbar section ${busbarSectionId} not found")
+                .withValue("busbarSectionId", bbsId)
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .build());
+    }
+
+    static void networkMismatchReport(Reporter reporter, String injectionId, IdentifiableType identifiableType) {
+        reporter.report(Report.builder()
+                .withKey("networkMismatch")
+                .withDefaultMessage("Network given in parameters and in injectionAdder are different. Injection '${injectionId}' of type {identifiableType} was added then removed")
+                .withValue("injectionId", injectionId)
+                .withValue("identifiableType", identifiableType.toString())
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .build());
+    }
+
+    static void connectableNotSupported(Reporter reporter, Connectable<?> connectable) {
+        reporter.report(Report.builder()
+                .withKey("connectableNotSupported")
+                .withDefaultMessage("Given connectable not supported: ${connectableClassName}.")
+                .withValue("connectableClassName", connectable.getClass().getName())
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .build());
+    }
+
+    static void connectableNotInVoltageLevel(Reporter reporter, Connectable<?> connectable, VoltageLevel voltageLevel) {
+        reporter.report(Report.builder()
+                .withKey("connectableNotInVoltageLevel")
+                .withDefaultMessage("Given connectable ${connectableId} not in voltageLevel ${voltageLevelId}")
+                .withValue(CONNECTABLE_ID, connectable.getId())
+                .withValue(VOLTAGE_LEVEL_ID, voltageLevel.getId())
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .build());
+    }
+
+    static void notFoundLineReport(Reporter reporter, String lineId) {
+        reporter.report(Report.builder()
+                .withKey("lineNotFound")
+                .withDefaultMessage("Line ${lineId} is not found")
+                .withValue(LINE_ID, lineId)
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .build());
+    }
+
+    static void notFoundConnectableReport(Reporter reporter, String connectableId) {
+        reporter.report(Report.builder()
+                .withKey("connectableNotFound")
+                .withDefaultMessage("Connectable ${connectableId} is not found")
+                .withValue(CONNECTABLE_ID, connectableId)
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .build());
+    }
+
+    static void removeFeederBayBusbarSectionReport(Reporter reporter, String busbarSectionConnectableId) {
+        reporter.report(Report.builder()
+                .withKey("removeBayBusbarSectionConnectable")
+                .withDefaultMessage("Cannot remove feeder bay for connectable ${busbarSectionConnectableId}, as it is a busbarSection")
+                .withValue(CONNECTABLE_ID, busbarSectionConnectableId)
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .build());
+    }
+
+    static void noVoltageLevelInCommonReport(Reporter reporter, String line1Id, String line2Id) {
+        reporter.report(Report.builder()
+                .withKey("noVoltageLevelInCommon")
+                .withDefaultMessage("Lines ${line1Id} and ${line2Id} should have one and only one voltage level in common at their extremities")
+                .withValue("line1Id", line1Id)
+                .withValue("line2Id", line2Id)
+                .withSeverity(TypedValue.ERROR_SEVERITY)
                 .build());
     }
 
@@ -240,77 +326,24 @@ final class ModificationReports {
                 .build());
     }
 
-    static void newCouplingDeviceAddedReport(Reporter reporter, String voltageLevelId, String bbsId1, String bbsId2, int nbOpenDisconnectors) {
-        reporter.report(Report.builder()
-                .withKey("newCouplingDeviceAdded")
-                .withDefaultMessage("New coupling device was created on voltage level ${voltageLevelId}. It connects busbar sections ${bbsId1} and ${bbsId2} with closed disconnectors" +
-                        "and ${nbOpenDisconnectors} were created on parallel busbar sections.")
-                .withValue(voltageLevelId, voltageLevelId)
-                .withValue("bbsId1", bbsId1)
-                .withValue("bbsId2", bbsId2)
-                .withValue("nbOpenDisconnectors", nbOpenDisconnectors)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
     static void unsupportedVoltageLevelTopologyKind(Reporter reporter, String voltageLevelId, TopologyKind expected, TopologyKind actual) {
         reporter.report(Report.builder()
                 .withKey("unsupportedVoltageLevelTopologyKind")
                 .withDefaultMessage("Voltage Level ${voltageLevelId} has an unsupported topology ${actualTopology}. Should be ${expectedTopology}")
-                .withValue("voltageLevelId", voltageLevelId)
+                .withValue(VOLTAGE_LEVEL_ID, voltageLevelId)
                 .withValue("actualTopology", actual.name())
                 .withValue("expectedTopology", expected.name())
                 .withSeverity(TypedValue.ERROR_SEVERITY)
                 .build());
     }
 
-    static void createdNewSymmetricalTopology(Reporter reporter, String voltageLevelId, int busbarCount, int sectionCount) {
+    static void unsupportedIdentifiableType(Reporter reporter, IdentifiableType type, String identifiableId) {
         reporter.report(Report.builder()
-                .withKey("SymmetricalTopologyCreated")
-                .withDefaultMessage("New symmetrical topology in voltage level ${voltageLevelId}: creation of ${busbarCount} busbar(s) with ${sectionCount} section(s) each.")
-                .withValue("voltageLevelId", voltageLevelId)
-                .withValue("busbarCount", busbarCount)
-                .withValue("sectionCount", sectionCount)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
-    public static void removedSwitchReport(Reporter reporter, String switchId) {
-        reporter.report(Report.builder()
-                .withKey("SwitchRemoved")
-                .withDefaultMessage("Switch ${switchId} removed")
-                .withValue("switchId", switchId)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
-    public static void removedInternalConnectionReport(Reporter reporter, int node1, int node2) {
-        reporter.report(Report.builder()
-                .withKey("InternalConnectionRemoved")
-                .withDefaultMessage("Internal connection between ${node1} and ${node2} removed")
-                .withValue("node1", node1)
-                .withValue("node2", node2)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
-    public static void removedConnectableReport(Reporter reporter, String connectableId) {
-        reporter.report(Report.builder()
-                .withKey("ConnectableRemoved")
-                .withDefaultMessage("Connectable ${connectableId} removed")
-                .withValue("connectableId", connectableId)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
-    public static void removeFeederBayAborted(Reporter reporter, String connectableId, int node, String otherConnectableId) {
-        reporter.report(Report.builder()
-                .withKey("RemoveFeederBayAborted")
-                .withDefaultMessage("Remove feeder bay of ${connectableId} cannot go further node ${node}, as it is connected to ${otherConnectableId}")
-                .withValue("connectableId", connectableId)
-                .withValue("node", node)
-                .withValue("otherConnectableId", otherConnectableId)
-                .withSeverity(TypedValue.INFO_SEVERITY)
+                .withKey("unsupportedIdentifiableType")
+                .withDefaultMessage("Unsupported type ${identifiableType} for identifiable ${identifiableId}")
+                .withValue("identifiableType", type.name())
+                .withValue("identifiableId", identifiableId)
+                .withSeverity(TypedValue.ERROR_SEVERITY)
                 .build());
     }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/TopologyModificationUtils.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/TopologyModificationUtils.java
@@ -34,11 +34,14 @@ public final class TopologyModificationUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TopologyModificationUtils.class);
 
+    private TopologyModificationUtils() {
+    }
+
     static final class LoadingLimitsBags {
 
-        private LoadingLimitsBag activePowerLimits;
-        private LoadingLimitsBag apparentPowerLimits;
-        private LoadingLimitsBag currentLimits;
+        private final LoadingLimitsBag activePowerLimits;
+        private final LoadingLimitsBag apparentPowerLimits;
+        private final LoadingLimitsBag currentLimits;
 
         LoadingLimitsBags(Supplier<Optional<ActivePowerLimits>> activePowerLimitsGetter, Supplier<Optional<ApparentPowerLimits>> apparentPowerLimitsGetter,
                           Supplier<Optional<CurrentLimits>> currentLimitsGetter) {
@@ -68,7 +71,7 @@ public final class TopologyModificationUtils {
 
     private static final class LoadingLimitsBag {
 
-        private double permanentLimit;
+        private final double permanentLimit;
         private List<TemporaryLimitsBag> temporaryLimits = new ArrayList<>();
 
         private LoadingLimitsBag(LoadingLimits limits) {
@@ -340,6 +343,16 @@ public final class TopologyModificationUtils {
     }
 
     /**
+     * Creates open disconnectors between the fork node and every busbar section of the list in a voltage level
+     */
+    static void createTopologyFromBusbarSectionList(VoltageLevel voltageLevel, int forkNode, String baseId, List<BusbarSection> bbsList) {
+        bbsList.forEach(b -> {
+            int bbsNode = b.getTerminal().getNodeBreakerView().getNode();
+            createNBDisconnector(forkNode, bbsNode, "_" + forkNode + "_" + bbsNode, baseId, voltageLevel.getNodeBreakerView(), true);
+        });
+    }
+
+    /**
      * Get all the unused positions before the lowest used position on the busbar section bbs.
      * It is a range between the maximum used position on the busbar section with the highest section index lower than the section
      * index of the given busbar section and the minimum position on the given busbar section.
@@ -547,19 +560,6 @@ public final class TopologyModificationUtils {
             throw new PowsyblException(String.format("Voltage level %s has no busbar section.", voltageLevel.getId()));
         }
         return bbs;
-    }
-
-    /**
-     * Creates open disconnectors between the fork node and every busbar section of the list in a voltage level
-     */
-    static void createTopologyFromBusbarSectionList(VoltageLevel voltageLevel, int forkNode, String baseId, List<BusbarSection> bbsList) {
-        bbsList.forEach(b -> {
-            int bbsNode = b.getTerminal().getNodeBreakerView().getNode();
-            createNBDisconnector(forkNode, bbsNode, "_" + forkNode + "_" + bbsNode, baseId, voltageLevel.getNodeBreakerView(), true);
-        });
-    }
-
-    private TopologyModificationUtils() {
     }
 
     private static Optional<LoadingLimitsBag> mergeLimits(String lineId,

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
@@ -47,11 +47,11 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
                 .setB2(0.0);
         NetworkModification modification = new CreateBranchFeederBaysBuilder()
                 .withBranchAdder(lineAdder)
-                .withBbsId1("bbs5")
+                .withBusOrBusbarSectionId1("bbs5")
                 .withPositionOrder1(85)
                 .withDirection1(BOTTOM)
                 .withFeederName1("lineTestFeeder1")
-                .withBbsId2("bbs1")
+                .withBusOrBusbarSectionId2("bbs1")
                 .withPositionOrder2(75)
                 .withFeederName2("lineTestFeeder2")
                 .withDirection2(TOP)
@@ -73,15 +73,15 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
                 .setB2(0.0);
         NetworkModification modification = new CreateBranchFeederBaysBuilder()
                 .withBranchAdder(lineAdder)
-                .withBbsId1("bbs1")
+                .withBusOrBusbarSectionId1("bbs1")
                 .withPositionOrder1(70)
                 .withDirection1(TOP)
-                .withBbsId2("bbs5")
+                .withBusOrBusbarSectionId2("bbs5")
                 .withPositionOrder2(85)
                 .withDirection2(BOTTOM)
                 .build();
         modification.apply(network);
-        roundTripXmlTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead,
+        roundTripTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead,
                 "/network-node-breaker-with-new-line-order-used.xml");
     }
 
@@ -97,10 +97,10 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
                 .setB2(0.0);
         NetworkModification modification = new CreateBranchFeederBaysBuilder()
                 .withBranchAdder(lineAdder)
-                .withBbsId1("bbs2")
+                .withBusOrBusbarSectionId1("bbs2")
                 .withPositionOrder1(105)
                 .withDirection1(TOP)
-                .withBbsId2("bbs1")
+                .withBusOrBusbarSectionId2("bbs1")
                 .withPositionOrder2(14)
                 .withDirection2(BOTTOM)
                 .build();
@@ -127,10 +127,10 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
         int positionOrder1 = unusedOrderPositionsAfter.get().getMinimum();
         NetworkModification modification = new CreateBranchFeederBaysBuilder()
                 .withBranchAdder(lineAdder)
-                .withBbsId1("bbs1")
+                .withBusOrBusbarSectionId1("bbs1")
                 .withPositionOrder1(positionOrder1)
                 .withDirection1(TOP)
-                .withBbsId2("bbs5")
+                .withBusOrBusbarSectionId2("bbs5")
                 .withPositionOrder2(115)
                 .withDirection2(BOTTOM)
                 .build();
@@ -159,10 +159,10 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
 
         NetworkModification modification = new CreateBranchFeederBaysBuilder()
                 .withBranchAdder(lineAdder)
-                .withBbsId1("bbs5")
+                .withBusOrBusbarSectionId1("bbs5")
                 .withPositionOrder1(115)
                 .withDirection1(BOTTOM)
-                .withBbsId2("bbs2")
+                .withBusOrBusbarSectionId2("bbs2")
                 .withPositionOrder2(positionOrder1)
                 .withDirection2(BOTTOM)
                 .build();
@@ -188,10 +188,10 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
         Network network1 = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
         CreateBranchFeederBays modification0 = new CreateBranchFeederBaysBuilder().
                 withBranchAdder(lineAdder)
-                .withBbsId1("bbs1")
+                .withBusOrBusbarSectionId1("bbs1")
                 .withPositionOrder1(115)
                 .withDirection1(BOTTOM)
-                .withBbsId2("bbs5")
+                .withBusOrBusbarSectionId2("bbs5")
                 .withPositionOrder2(115)
                 .withDirection2(BOTTOM)
                 .build();
@@ -201,28 +201,15 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
         //wrong bbsId
         CreateBranchFeederBays modification1 = new CreateBranchFeederBaysBuilder().
                 withBranchAdder(lineAdder)
-                .withBbsId1("bbs")
+                .withBusOrBusbarSectionId1("bbs")
                 .withPositionOrder1(115)
                 .withDirection1(BOTTOM)
-                .withBbsId2("bbs5")
+                .withBusOrBusbarSectionId2("bbs5")
                 .withPositionOrder2(115)
                 .withDirection2(BOTTOM)
                 .build();
         PowsyblException e1 = assertThrows(PowsyblException.class, () -> modification1.apply(network, true, Reporter.NO_OP));
-        assertEquals("Busbar section bbs not found.", e1.getMessage());
-
-        //wrong injectionPositionOrder
-        CreateBranchFeederBays modification2 = new CreateBranchFeederBaysBuilder().
-                withBranchAdder(lineAdder)
-                .withBbsId1("bbs1")
-                .withPositionOrder1(0)
-                .withDirection1(BOTTOM)
-                .withBbsId2("bbs5")
-                .withPositionOrder2(115)
-                .withDirection2(BOTTOM)
-                .build();
-        PowsyblException e2 = assertThrows(PowsyblException.class, () -> modification2.apply(network, true, Reporter.NO_OP));
-        assertEquals("PositionOrder 0 already taken.", e2.getMessage());
+        assertEquals("Identifiable bbs not found.", e1.getMessage());
     }
 
     @Test
@@ -238,10 +225,10 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
                 .setRatedU2(400.0);
         NetworkModification modification = new CreateBranchFeederBaysBuilder()
                 .withBranchAdder(twtAdder)
-                .withBbsId1("bbs5")
+                .withBusOrBusbarSectionId1("bbs5")
                 .withPositionOrder1(115)
                 .withDirection1(BOTTOM)
-                .withBbsId2("bbs1")
+                .withBusOrBusbarSectionId2("bbs1")
                 .withPositionOrder2(121)
                 .withDirection2(TOP)
                 .build();
@@ -263,10 +250,10 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
                 .setB2(0.0);
         new CreateBranchFeederBaysBuilder()
                 .withBranchAdder(lineAdder)
-                .withBbsId1("bbs5")
+                .withBusOrBusbarSectionId1("bbs5")
                 .withPositionOrder1(115)
                 .withDirection1(BOTTOM)
-                .withBbsId2("bbs1")
+                .withBusOrBusbarSectionId2("bbs1")
                 .withPositionOrder2(121)
                 .withDirection2(TOP)
                 .build()

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
@@ -227,7 +227,7 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
         PowsyblException e0 = assertThrows(PowsyblException.class, () -> modification0.apply(network1, true, Reporter.NO_OP));
         assertEquals("Network given in parameters and in connectableAdder are different. Connectable was added then removed", e0.getMessage());
 
-        //wrong bbsId
+        // not found id
         CreateBranchFeederBays modification1 = new CreateBranchFeederBaysBuilder().
                 withBranchAdder(lineAdder)
                 .withBusOrBusbarSectionId1("bbs")
@@ -239,6 +239,19 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
                 .build();
         PowsyblException e1 = assertThrows(PowsyblException.class, () -> modification1.apply(nbNetwork, true, Reporter.NO_OP));
         assertEquals("Identifiable bbs not found.", e1.getMessage());
+
+        // wrong identifiable type
+        CreateBranchFeederBays modification2 = new CreateBranchFeederBaysBuilder().
+                withBranchAdder(lineAdder)
+                .withBusOrBusbarSectionId1("gen1")
+                .withPositionOrder1(115)
+                .withDirection1(BOTTOM)
+                .withBusOrBusbarSectionId2("bbs5")
+                .withPositionOrder2(115)
+                .withDirection2(BOTTOM)
+                .build();
+        PowsyblException e2 = assertThrows(PowsyblException.class, () -> modification2.apply(nbNetwork, true, Reporter.NO_OP));
+        assertEquals("Unsupported type GENERATOR for identifiable gen1", e2.getMessage());
     }
 
     @Test

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
@@ -81,7 +81,6 @@ public class CreateBranchFeederBaysTest extends AbstractConverterTest {
                 .withDirection1(BOTTOM)
                 .withFeederName1("lineTestFeeder1")
                 .withBusOrBusbarSectionId2("NHV1")
-                .withPositionOrder2(75)
                 .withFeederName2("lineTestFeeder2")
                 .withDirection2(TOP)
                 .build();

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
@@ -145,7 +145,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         PowsyblException e0 = assertThrows(PowsyblException.class, () -> modification0.apply(network1, true, Reporter.NO_OP));
         assertEquals("Network given in parameters and in connectableAdder are different. Connectable was added then removed", e0.getMessage());
 
-        //wrong bbsId
+        // not found id
         CreateFeederBay modification1 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
                 .withBusOrBusBarSectionId("bbs")
@@ -154,6 +154,16 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .build();
         PowsyblException e1 = assertThrows(PowsyblException.class, () -> modification1.apply(network, true, Reporter.NO_OP));
         assertEquals("Identifiable bbs not found.", e1.getMessage());
+
+        // wrong identifiable type
+        CreateFeederBay modification2 = new CreateFeederBayBuilder()
+                .withInjectionAdder(loadAdder)
+                .withBusOrBusBarSectionId("gen1")
+                .withInjectionPositionOrder(115)
+                .withInjectionDirection(BOTTOM)
+                .build();
+        PowsyblException e2 = assertThrows(PowsyblException.class, () -> modification2.apply(network, true, Reporter.NO_OP));
+        assertEquals("Unsupported type GENERATOR for identifiable gen1", e2.getMessage());
     }
 
     @Test

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
@@ -42,7 +42,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setQ0(0);
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("bbs4")
+                .withBusOrBusbarSectionId("bbs4")
                 .withInjectionPositionOrder(115)
                 .withInjectionFeederName("newLoadFeeder")
                 .withInjectionDirection(BOTTOM)
@@ -62,7 +62,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setQ0(0);
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("NGEN")
+                .withBusOrBusbarSectionId("NGEN")
                 .withInjectionPositionOrder(115)
                 .withInjectionFeederName("newLoadFeeder")
                 .withInjectionDirection(BOTTOM)
@@ -88,7 +88,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int loadPositionOrder = unusedOrderPositionsAfter.get().getMinimum();
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("bbs1")
+                .withBusOrBusbarSectionId("bbs1")
                 .withInjectionPositionOrder(loadPositionOrder)
                 .withInjectionDirection(TOP)
                 .build();
@@ -115,7 +115,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
 
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("bbs2")
+                .withBusOrBusbarSectionId("bbs2")
                 .withInjectionPositionOrder(loadPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -138,7 +138,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         Network network1 = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
         CreateFeederBay modification0 = new CreateFeederBayBuilder().
                 withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("bbs1")
+                .withBusOrBusbarSectionId("bbs1")
                 .withInjectionPositionOrder(115)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -148,7 +148,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         // not found id
         CreateFeederBay modification1 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("bbs")
+                .withBusOrBusbarSectionId("bbs")
                 .withInjectionPositionOrder(115)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -158,7 +158,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         // wrong identifiable type
         CreateFeederBay modification2 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("gen1")
+                .withBusOrBusbarSectionId("gen1")
                 .withInjectionPositionOrder(115)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -182,7 +182,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setEnsureIdUnicity(true);
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(generatorAdder)
-                .withBusOrBusBarSectionId("bbs1")
+                .withBusOrBusbarSectionId("bbs1")
                 .withInjectionPositionOrder(115)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -202,7 +202,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setTargetQ(50);
         NetworkModification addBatteryModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(batteryAdder)
-                .withBusOrBusBarSectionId("bbs1")
+                .withBusOrBusbarSectionId("bbs1")
                 .withInjectionPositionOrder(115)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -223,7 +223,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int danglingLinePositionOrder = unusedOrderPositionsAfter0.get().getMinimum();
         NetworkModification addDanglingLineModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(danglingLineAdder)
-                .withBusOrBusBarSectionId("bbs5")
+                .withBusOrBusbarSectionId("bbs5")
                 .withInjectionPositionOrder(danglingLinePositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -243,7 +243,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int shuntCompensatorPositionOrder = unusedOrderPositionsAfter1.get().getMinimum();
         NetworkModification addShuntCompensatorModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(shuntCompensatorAdder)
-                .withBusOrBusBarSectionId("bbs5")
+                .withBusOrBusbarSectionId("bbs5")
                 .withInjectionPositionOrder(shuntCompensatorPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -264,7 +264,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int staticVarCompensatorPositionOrder = unusedOrderPositionsAfter2.get().getMinimum();
         NetworkModification addSVCompensatorModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(staticVarCompensatorAdder)
-                .withBusOrBusBarSectionId("bbs5")
+                .withBusOrBusbarSectionId("bbs5")
                 .withInjectionPositionOrder(staticVarCompensatorPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -282,7 +282,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int lccConverterStationPositionOrder = unusedOrderPositionsAfter3.get().getMinimum();
         NetworkModification addLccConverterStationModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(lccConverterStationAdder)
-                .withBusOrBusBarSectionId("bbs5")
+                .withBusOrBusbarSectionId("bbs5")
                 .withInjectionPositionOrder(lccConverterStationPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -301,7 +301,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int vscConverterStationPositionOrder = unusedOrderPositionsAfter4.get().getMinimum();
         NetworkModification addVscConverterStationModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(vscConverterStationAdder)
-                .withBusOrBusBarSectionId("bbs5")
+                .withBusOrBusbarSectionId("bbs5")
                 .withInjectionPositionOrder(vscConverterStationPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -320,7 +320,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setQ0(0);
         new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("bbs4")
+                .withBusOrBusbarSectionId("bbs4")
                 .withInjectionPositionOrder(115)
                 .build()
                 .apply(network, true, Reporter.NO_OP);
@@ -349,7 +349,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setQ0(0);
         new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("VLTEST12")
+                .withBusOrBusbarSectionId("VLTEST12")
                 .withInjectionPositionOrder(10)
                 .build()
                 .apply(network, true, Reporter.NO_OP);

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
@@ -40,7 +40,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setQ0(0);
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBbsId("bbs4")
+                .withBusOrBusBarSectionId("bbs4")
                 .withInjectionPositionOrder(115)
                 .withInjectionFeederName("newLoadFeeder")
                 .withInjectionDirection(BOTTOM)
@@ -66,7 +66,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int loadPositionOrder = unusedOrderPositionsAfter.get().getMinimum();
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBbsId("bbs1")
+                .withBusOrBusBarSectionId("bbs1")
                 .withInjectionPositionOrder(loadPositionOrder)
                 .withInjectionDirection(TOP)
                 .build();
@@ -93,7 +93,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
 
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBbsId("bbs2")
+                .withBusOrBusBarSectionId("bbs2")
                 .withInjectionPositionOrder(loadPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -116,7 +116,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         Network network1 = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
         CreateFeederBay modification0 = new CreateFeederBayBuilder().
                 withInjectionAdder(loadAdder)
-                .withBbsId("bbs1")
+                .withBusOrBusBarSectionId("bbs1")
                 .withInjectionPositionOrder(115)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -126,22 +126,12 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         //wrong bbsId
         CreateFeederBay modification1 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBbsId("bbs")
+                .withBusOrBusBarSectionId("bbs")
                 .withInjectionPositionOrder(115)
                 .withInjectionDirection(BOTTOM)
                 .build();
         PowsyblException e1 = assertThrows(PowsyblException.class, () -> modification1.apply(network, true, Reporter.NO_OP));
-        assertEquals("Busbar section bbs not found.", e1.getMessage());
-
-        //wrong injectionPositionOrder
-        CreateFeederBay modification2 = new CreateFeederBayBuilder()
-                .withInjectionAdder(loadAdder)
-                .withBbsId("bbs4")
-                .withInjectionPositionOrder(0)
-                .withInjectionDirection(BOTTOM)
-                .build();
-        PowsyblException e2 = assertThrows(PowsyblException.class, () -> modification2.apply(network, true, Reporter.NO_OP));
-        assertEquals("PositionOrder 0 already taken.", e2.getMessage());
+        assertEquals("Identifiable bbs not found.", e1.getMessage());
     }
 
     @Test
@@ -160,7 +150,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setEnsureIdUnicity(true);
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(generatorAdder)
-                .withBbsId("bbs1")
+                .withBusOrBusBarSectionId("bbs1")
                 .withInjectionPositionOrder(115)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -180,7 +170,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setTargetQ(50);
         NetworkModification addBatteryModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(batteryAdder)
-                .withBbsId("bbs1")
+                .withBusOrBusBarSectionId("bbs1")
                 .withInjectionPositionOrder(115)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -201,7 +191,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int danglingLinePositionOrder = unusedOrderPositionsAfter0.get().getMinimum();
         NetworkModification addDanglingLineModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(danglingLineAdder)
-                .withBbsId("bbs5")
+                .withBusOrBusBarSectionId("bbs5")
                 .withInjectionPositionOrder(danglingLinePositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -221,7 +211,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int shuntCompensatorPositionOrder = unusedOrderPositionsAfter1.get().getMinimum();
         NetworkModification addShuntCompensatorModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(shuntCompensatorAdder)
-                .withBbsId("bbs5")
+                .withBusOrBusBarSectionId("bbs5")
                 .withInjectionPositionOrder(shuntCompensatorPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -242,7 +232,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int staticVarCompensatorPositionOrder = unusedOrderPositionsAfter2.get().getMinimum();
         NetworkModification addSVCompensatorModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(staticVarCompensatorAdder)
-                .withBbsId("bbs5")
+                .withBusOrBusBarSectionId("bbs5")
                 .withInjectionPositionOrder(staticVarCompensatorPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -260,7 +250,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int lccConverterStationPositionOrder = unusedOrderPositionsAfter3.get().getMinimum();
         NetworkModification addLccConverterStationModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(lccConverterStationAdder)
-                .withBbsId("bbs5")
+                .withBusOrBusBarSectionId("bbs5")
                 .withInjectionPositionOrder(lccConverterStationPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -279,7 +269,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         int vscConverterStationPositionOrder = unusedOrderPositionsAfter4.get().getMinimum();
         NetworkModification addVscConverterStationModification = new CreateFeederBayBuilder()
                 .withInjectionAdder(vscConverterStationAdder)
-                .withBbsId("bbs5")
+                .withBusOrBusBarSectionId("bbs5")
                 .withInjectionPositionOrder(vscConverterStationPositionOrder)
                 .withInjectionDirection(BOTTOM)
                 .build();
@@ -298,7 +288,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setQ0(0);
         new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBbsId("bbs4")
+                .withBusOrBusBarSectionId("bbs4")
                 .withInjectionPositionOrder(115)
                 .build()
                 .apply(network, true, Reporter.NO_OP);
@@ -327,7 +317,7 @@ public class CreateFeederBayTest extends AbstractConverterTest {
                 .setQ0(0);
         new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBbsId("VLTEST12")
+                .withBusOrBusBarSectionId("VLTEST12")
                 .withInjectionPositionOrder(10)
                 .build()
                 .apply(network, true, Reporter.NO_OP);

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
@@ -12,8 +12,10 @@ import com.powsybl.commons.test.AbstractConverterTest;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.ConnectablePosition;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.xml.NetworkXml;
 import org.apache.commons.lang3.Range;
+import org.joda.time.DateTime;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -31,7 +33,7 @@ import static org.junit.Assert.*;
 public class CreateFeederBayTest extends AbstractConverterTest {
 
     @Test
-    public void baseLoadTest() throws IOException {
+    public void baseNodeBreakerLoadTest() throws IOException {
         Network network = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
         LoadAdder loadAdder = network.getVoltageLevel("vl1").newLoad()
                 .setId("newLoad")
@@ -48,6 +50,26 @@ public class CreateFeederBayTest extends AbstractConverterTest {
         modification.apply(network);
         roundTripXmlTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead,
                 "/network-node-breaker-with-new-load-bbs4.xml");
+    }
+
+    @Test
+    public void baseBusBreakerLoadTest() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create().setCaseDate(DateTime.parse("2013-01-15T18:45:00.000+01:00"));
+        LoadAdder loadAdder = network.getVoltageLevel("VLGEN").newLoad()
+                .setId("newLoad")
+                .setLoadType(LoadType.UNDEFINED)
+                .setP0(0)
+                .setQ0(0);
+        NetworkModification modification = new CreateFeederBayBuilder()
+                .withInjectionAdder(loadAdder)
+                .withBusOrBusBarSectionId("NGEN")
+                .withInjectionPositionOrder(115)
+                .withInjectionFeederName("newLoadFeeder")
+                .withInjectionDirection(BOTTOM)
+                .build();
+        modification.apply(network);
+        roundTripXmlTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead,
+                "/eurostag-create-load-feeder-bay.xml");
     }
 
     @Test

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveFeederBayTest.java
@@ -165,7 +165,7 @@ public class RemoveFeederBayTest {
                 .setQ0(0);
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBusOrBusBarSectionId("BBS_TEST_1_1")
+                .withBusOrBusbarSectionId("BBS_TEST_1_1")
                 .withInjectionPositionOrder(10)
                 .withInjectionFeederName("L1")
                 .withInjectionDirection(BOTTOM)
@@ -179,7 +179,7 @@ public class RemoveFeederBayTest {
                 .setQ0(0);
         NetworkModification modification2 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder2)
-                .withBusOrBusBarSectionId("BBS_TEST_1_1")
+                .withBusOrBusbarSectionId("BBS_TEST_1_1")
                 .withInjectionPositionOrder(20)
                 .withInjectionFeederName("L2")
                 .withInjectionDirection(BOTTOM)
@@ -200,7 +200,7 @@ public class RemoveFeederBayTest {
                 .setQ0(0);
         NetworkModification modification3 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder3)
-                .withBusOrBusBarSectionId("BBS_TEST_1_1")
+                .withBusOrBusbarSectionId("BBS_TEST_1_1")
                 .withInjectionPositionOrder(30)
                 .withInjectionFeederName("L3")
                 .withInjectionDirection(BOTTOM)

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveFeederBayTest.java
@@ -165,7 +165,7 @@ public class RemoveFeederBayTest {
                 .setQ0(0);
         NetworkModification modification = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
-                .withBbsId("BBS_TEST_1_1")
+                .withBusOrBusBarSectionId("BBS_TEST_1_1")
                 .withInjectionPositionOrder(10)
                 .withInjectionFeederName("L1")
                 .withInjectionDirection(BOTTOM)
@@ -179,7 +179,7 @@ public class RemoveFeederBayTest {
                 .setQ0(0);
         NetworkModification modification2 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder2)
-                .withBbsId("BBS_TEST_1_1")
+                .withBusOrBusBarSectionId("BBS_TEST_1_1")
                 .withInjectionPositionOrder(20)
                 .withInjectionFeederName("L2")
                 .withInjectionDirection(BOTTOM)
@@ -200,7 +200,7 @@ public class RemoveFeederBayTest {
                 .setQ0(0);
         NetworkModification modification3 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder3)
-                .withBbsId("BBS_TEST_1_1")
+                .withBusOrBusBarSectionId("BBS_TEST_1_1")
                 .withInjectionPositionOrder(30)
                 .withInjectionFeederName("L3")
                 .withInjectionDirection(BOTTOM)

--- a/iidm/iidm-modification/src/test/resources/eurostag-create-line-feeder-bays.xml
+++ b/iidm/iidm-modification/src/test/resources/eurostag-create-line-feeder-bays.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="lineTest" r="1.0" x="1.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+</iidm:network>

--- a/iidm/iidm-modification/src/test/resources/eurostag-create-load-feeder-bay.xml
+++ b/iidm/iidm-modification/src/test/resources/eurostag-create-load-feeder-bay.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+            <iidm:load id="newLoad" loadType="UNDEFINED" p0="0.0" q0="0.0" bus="NGEN" connectableBus="NGEN"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+</iidm:network>

--- a/iidm/iidm-modification/src/test/resources/eurostag-create-twt-feeder-bays.xml
+++ b/iidm/iidm-modification/src/test/resources/eurostag-create-twt-feeder-bays.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+        <iidm:twoWindingsTransformer id="twtTest" r="1.0" x="1.0" g="0.0" b="0.0" ratedU1="220.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+</iidm:network>


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature: allow to use modifications to create feeder bays in a bus-breaker voltage level.


**What is the current behavior?** *(You can also link to an open issue here)*
Modifications to create feeder bays only work in node-breaker voltage levels.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
Yes, deprecation
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
