### PR TITLE
Fix regression in distributed security analysis

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/SecurityAnalysisCommandOptions.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/SecurityAnalysisCommandOptions.java
@@ -43,6 +43,8 @@ public class SecurityAnalysisCommandOptions {
     private Path caseFile;
     private Path contingenciesFile;
     private Path parametersFile;
+    private Path actionsFile;
+    private Path strategiesFile;
     private Integer taskCount;
     private Function<Integer, Path> outputFile;
     private Function<Integer, Path> logFile;
@@ -87,6 +89,16 @@ public class SecurityAnalysisCommandOptions {
 
     public SecurityAnalysisCommandOptions parametersFile(Path parametersFile) {
         this.parametersFile = requireNonNull(parametersFile);
+        return this;
+    }
+
+    public SecurityAnalysisCommandOptions actionsFile(Path actionsFile) {
+        this.actionsFile = actionsFile;
+        return this;
+    }
+
+    public SecurityAnalysisCommandOptions strategiesFile(Path strategiesFile) {
+        this.strategiesFile = strategiesFile;
         return this;
     }
 
@@ -170,6 +182,8 @@ public class SecurityAnalysisCommandOptions {
                 .option(CASE_FILE_OPTION, pathToString(caseFile));
 
         setOptionIfPresent(commandBuilder, PARAMETERS_FILE_OPTION, parametersFile, this::pathToString);
+        setOptionIfPresent(commandBuilder, ACTIONS_FILE, actionsFile, this::pathToString);
+        setOptionIfPresent(commandBuilder, STRATEGIES_FILE, strategiesFile, this::pathToString);
         setOptionIfPresent(commandBuilder, CONTINGENCIES_FILE_OPTION, contingenciesFile, this::pathToString);
         setOptionIfPresent(commandBuilder, OUTPUT_FILE_OPTION, outputFile, this::pathToString);
         setOptionIfPresent(commandBuilder, OUTPUT_FORMAT_OPTION, outputFileFormat);

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandler.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandler.java
@@ -50,6 +50,8 @@ public class SecurityAnalysisExecutionHandler<R> extends AbstractExecutionHandle
     private static final String NETWORK_FILE = "network.xiidm";
     private static final String CONTINGENCIES_FILE = "contingencies.groovy";
     private static final String PARAMETERS_FILE = "parameters.json";
+    private static final String ACTIONS_FILE = "actions.json";
+    private static final String STRATEGIES_FILE = "strategies.json";
 
     private final ResultReader<R> reader;
     private final OptionsCustomizer optionsCustomizer;
@@ -174,6 +176,14 @@ public class SecurityAnalysisExecutionHandler<R> extends AbstractExecutionHandle
         return workingDir.resolve(PARAMETERS_FILE);
     }
 
+    private static Path getActionsPath(Path workingDir) {
+        return workingDir.resolve(ACTIONS_FILE);
+    }
+
+    private static Path getStrategiesPath(Path workingDir) {
+        return workingDir.resolve(STRATEGIES_FILE);
+    }
+
     private static Path getContingenciesPath(Path workingDir) {
         return workingDir.resolve(CONTINGENCIES_FILE);
     }
@@ -203,7 +213,7 @@ public class SecurityAnalysisExecutionHandler<R> extends AbstractExecutionHandle
      */
     private static void addParametersFile(SecurityAnalysisCommandOptions options, Path workingDir, SecurityAnalysisParameters parameters) {
         Path parametersPath = getParametersPath(workingDir);
-        options.parametersFile(getParametersPath(workingDir));
+        options.parametersFile(parametersPath);
         LOGGER.debug("Writing parameters to file {}", parametersPath);
         JsonSecurityAnalysisParameters.write(parameters, parametersPath);
     }
@@ -212,22 +222,28 @@ public class SecurityAnalysisExecutionHandler<R> extends AbstractExecutionHandle
      * Add operator strategies file option, and write it as JSON to working directory.
      */
     private static void addOperatorStrategyFile(SecurityAnalysisCommandOptions options, Path workingDir, List<OperatorStrategy> operatorStrategies) {
-        Path parametersPath = getParametersPath(workingDir);
-        options.parametersFile(getParametersPath(workingDir));
-        LOGGER.debug("Writing operator strategies to file {}", parametersPath);
-        OperatorStrategyList operatorStrategiesList = new OperatorStrategyList(operatorStrategies);
-        operatorStrategiesList.writeFile(parametersPath);
+        if (operatorStrategies.isEmpty()) {
+            return;
+        }
+        Path path = getStrategiesPath(workingDir);
+        options.strategiesFile(path);
+        LOGGER.debug("Writing operator strategies to file {}", path);
+        new OperatorStrategyList(operatorStrategies)
+                .writeFile(path);
     }
 
     /**
      * Add action file option, and write it as JSON to working directory.
      */
     private static void addActionFile(SecurityAnalysisCommandOptions options, Path workingDir, List<Action> actions) {
-        Path parametersPath = getParametersPath(workingDir);
-        options.parametersFile(getParametersPath(workingDir));
-        LOGGER.debug("Writing actions to file {}", parametersPath);
-        ActionList actionsList = new ActionList(actions);
-        actionsList.writeJsonFile(parametersPath);
+        if (actions.isEmpty()) {
+            return;
+        }
+        Path path = getActionsPath(workingDir);
+        options.actionsFile(path);
+        LOGGER.debug("Writing actions to file {}", path);
+        new ActionList(actions)
+                .writeJsonFile(path);
     }
 
     /**

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisCommandOptionsTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisCommandOptionsTest.java
@@ -123,4 +123,26 @@ public class SecurityAnalysisCommandOptionsTest {
                         "--log-file=log_4.zip");
     }
 
+    @Test
+    public void testStrategies() {
+        SecurityAnalysisCommandOptions options = new SecurityAnalysisCommandOptions()
+                .caseFile(fileSystem.getPath("test.xiidm"))
+                .parametersFile(fileSystem.getPath("params.json"))
+                .actionsFile(fileSystem.getPath("actions.json"))
+                .strategiesFile(fileSystem.getPath("strategies.json"));
+
+        SimpleCommand cmd = options.toCommand();
+        String expectedDefaultProgram = SystemUtils.IS_OS_WINDOWS ? "itools.bat" : "itools";
+        assertEquals(expectedDefaultProgram, cmd.getProgram());
+        assertEquals("security-analysis", cmd.getId());
+        List<String> args = cmd.getArgs(0);
+        Assertions.assertThat(args)
+                .containsExactly("security-analysis",
+                        "--case-file=test.xiidm",
+                        "--parameters-file=params.json",
+                        "--actions-file=actions.json",
+                        "--strategies-file=strategies.json");
+
+    }
+
 }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandlersTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandlersTest.java
@@ -19,7 +19,6 @@ import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.security.*;
 import com.powsybl.security.action.Action;
 import com.powsybl.security.action.SwitchAction;
-import com.powsybl.security.condition.Condition;
 import com.powsybl.security.condition.TrueCondition;
 import com.powsybl.security.converter.JsonSecurityAnalysisResultExporter;
 import com.powsybl.security.execution.SecurityAnalysisExecutionInput;

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandlersTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandlersTest.java
@@ -17,9 +17,14 @@ import com.powsybl.iidm.network.VariantManagerConstants;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.security.*;
+import com.powsybl.security.action.Action;
+import com.powsybl.security.action.SwitchAction;
+import com.powsybl.security.condition.Condition;
+import com.powsybl.security.condition.TrueCondition;
 import com.powsybl.security.converter.JsonSecurityAnalysisResultExporter;
 import com.powsybl.security.execution.SecurityAnalysisExecutionInput;
 import com.powsybl.security.results.PostContingencyResult;
+import com.powsybl.security.strategy.OperatorStrategy;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -112,12 +117,17 @@ public class SecurityAnalysisExecutionHandlersTest {
 
     @Test
     public void forwardedBeforeWithCompleteInput() throws IOException {
+        Action action = new SwitchAction("action", "switch", false);
+        OperatorStrategy strategy = new OperatorStrategy("strat", "cont", new TrueCondition(), List.of("action"));
+
         SecurityAnalysisExecutionInput input = new SecurityAnalysisExecutionInput()
                 .setParameters(new SecurityAnalysisParameters())
                 .setNetworkVariant(EurostagTutorialExample1Factory.create(), VariantManagerConstants.INITIAL_VARIANT_ID)
                 .setContingenciesSource(ByteSource.wrap("contingencies definition".getBytes(StandardCharsets.UTF_8)))
                 .addResultExtensions(ImmutableList.of("ext1", "ext2"))
-                .addViolationTypes(ImmutableList.of(LimitViolationType.CURRENT));
+                .addViolationTypes(ImmutableList.of(LimitViolationType.CURRENT))
+                .setActions(List.of(action))
+                .setOperatorStrategies(List.of(strategy));
         ExecutionHandler<SecurityAnalysisReport> handler = SecurityAnalysisExecutionHandlers.forwarded(input, 12);
 
         Path workingDir = fileSystem.getPath("/work");
@@ -130,6 +140,8 @@ public class SecurityAnalysisExecutionHandlersTest {
                         "--output-file=/work/result.json",
                         "--output-format=JSON",
                         "--contingencies-file=/work/contingencies.groovy",
+                        "--actions-file=/work/actions.json",
+                        "--strategies-file=/work/strategies.json",
                         "--with-extensions=ext1,ext2",
                         "--limit-types=CURRENT",
                         "--task-count=12");
@@ -137,6 +149,8 @@ public class SecurityAnalysisExecutionHandlersTest {
         assertThat(workingDir.resolve("network.xiidm")).exists();
         assertThat(workingDir.resolve("parameters.json")).exists();
         assertThat(workingDir.resolve("contingencies.groovy")).exists();
+        assertThat(workingDir.resolve("strategies.json")).exists();
+        assertThat(workingDir.resolve("actions.json")).exists();
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug

**What is the current behavior?** *(You can also link to an open issue here)*

The distributed security analysis is not working since operator strategies:
we write actions instead of parameters into the parameters file, this causes the distributed security analysis to fail systematically when trying to parse parameters.

**What is the new behavior (if this is a feature change)?**

We correctly write new files to `actions.json` and `strategies.json`.

