### PR TITLE
Add CGMES post-processor to import short-circuit data

### DIFF
--- a/cgmes/cgmes-shortcircuit/src/main/java/com/powsybl/cgmes/shorcircuit/CgmesShortCircuitPostProcessor.java
+++ b/cgmes/cgmes-shortcircuit/src/main/java/com/powsybl/cgmes/shorcircuit/CgmesShortCircuitPostProcessor.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.cgmes.shorcircuit;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.cgmes.conversion.CgmesImportPostProcessor;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.triplestore.api.TripleStore;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(CgmesImportPostProcessor.class)
+public class CgmesShortCircuitPostProcessor implements CgmesImportPostProcessor {
+
+    @Override
+    public String getName() {
+        return "shortcircuit";
+    }
+
+    @Override
+    public void process(Network network, TripleStore tripleStore) {
+        new CgmesShortCircuitImporter(new CgmesShortCircuitModel(tripleStore), network).importShortcircuitData();
+    }
+}

--- a/cgmes/cgmes-shortcircuit/src/test/java/com/powsybl/cgmes/shortcircuit/CgmesImporterTest.java
+++ b/cgmes/cgmes-shortcircuit/src/test/java/com/powsybl/cgmes/shortcircuit/CgmesImporterTest.java
@@ -1,9 +1,10 @@
-package com.powsybl.cgmes.shortcircuit; /**
+/**
  * Copyright (c) 2021, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+package com.powsybl.cgmes.shortcircuit;
 
 import com.powsybl.cgmes.conformity.Cgmes3Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
@@ -24,6 +25,7 @@ import com.powsybl.iidm.network.extensions.IdentifiableShortCircuit;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -34,16 +36,10 @@ public class CgmesImporterTest {
 
     @Test
     public void testImportCgmesGeneratorShortCircuitData() {
+        Properties p = new Properties();
+        p.put(CgmesImport.POST_PROCESSORS, List.of("shortcircuit"));
         Network network = new CgmesImport().importData(CgmesConformity1Catalog.miniBusBranch().dataSource(),
-            NetworkFactory.findDefault(), new Properties());
-
-        CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
-        Assert.assertNotNull(cgmesModelExtension);
-        CgmesModel cgmesModel = cgmesModelExtension.getCgmesModel();
-        Assert.assertNotNull(cgmesModel);
-
-        CgmesShortCircuitModel cgmesScModel = new CgmesShortCircuitModel(cgmesModel.tripleStore());
-        new CgmesShortCircuitImporter(cgmesScModel, network).importShortcircuitData();
+                NetworkFactory.findDefault(), p);
 
         Generator generator = network.getGenerator("392ea173-4f8e-48fa-b2a3-5c3721e93196");
         Assert.assertNotNull(generator);
@@ -60,7 +56,7 @@ public class CgmesImporterTest {
     @Test
     public void testImportCgmes3GeneratorShortCircuitData() {
         Network network = new CgmesImport().importData(Cgmes3Catalog.miniGrid().dataSource(),
-            NetworkFactory.findDefault(), new Properties());
+                NetworkFactory.findDefault(), new Properties());
 
         CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
         Assert.assertNotNull(cgmesModelExtension);
@@ -85,7 +81,7 @@ public class CgmesImporterTest {
     @Test
     public void testImportCgmesBranchModelBusbarSectionShortCircuitData() {
         Network network = new CgmesImport().importData(CgmesConformity1ModifiedCatalog.smallGridBusBranchWithBusbarSectionsAndIpMax().dataSource(),
-            NetworkFactory.findDefault(), new Properties());
+                NetworkFactory.findDefault(), new Properties());
 
         CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
         Assert.assertNotNull(cgmesModelExtension);
@@ -108,7 +104,7 @@ public class CgmesImporterTest {
     @Test
     public void testImportCgmesBusbarSectionShortCircuitData() {
         Network network = new CgmesImport().importData(CgmesConformity1Catalog.miniNodeBreaker().dataSource(),
-            NetworkFactory.findDefault(), new Properties());
+                NetworkFactory.findDefault(), new Properties());
 
         CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
         Assert.assertNotNull(cgmesModelExtension);
@@ -128,7 +124,7 @@ public class CgmesImporterTest {
     @Test
     public void testImportCgmes3BusbarSectionShortCircuitData() {
         Network network = new CgmesImport().importData(Cgmes3Catalog.microGrid().dataSource(),
-            NetworkFactory.findDefault(), new Properties());
+                NetworkFactory.findDefault(), new Properties());
 
         CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
         Assert.assertNotNull(cgmesModelExtension);


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add CGMES post-processor to import short-circuit data


**What is the current behavior?** *(You can also link to an open issue here)*
No post-processor: only way to import short-circuit data is to call the explicit class


**What is the new behavior (if this is a feature change)?**
It is possible to import short-circuit data by setting the correct property during CGMES import

