### PR TITLE
Move AbstractXmlConverterTest to src to be used in other repositories

### DIFF
--- a/iidm/iidm-xml-converter/pom.xml
+++ b/iidm/iidm-xml-converter/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-commons-test</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -109,12 +114,6 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-test</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-commons-test</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/test/AbstractXmlConverterTest.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/test/AbstractXmlConverterTest.java
@@ -4,10 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.iidm.xml;
+package com.powsybl.iidm.xml.test;
 
 import com.powsybl.commons.test.AbstractConverterTest;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.xml.ExportOptions;
+import com.powsybl.iidm.xml.IidmXmlVersion;
+import com.powsybl.iidm.xml.NetworkXml;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/BatteryXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/BatteryXmlTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.test.BatteryNetworkFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/BusBreakerAnonymiserBugTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/BusBreakerAnonymiserBugTest.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/DanglingLineXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/DanglingLineXmlTest.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.xml;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.DanglingLineNetworkFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.joda.time.DateTime;
 import org.junit.Test;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/EurostagXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/EurostagXmlTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/FictitiousInjectionsXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/FictitiousInjectionsXmlTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.xml;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.joda.time.DateTime;
 import org.junit.Test;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/FictitiousSwitchTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/FictitiousSwitchTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/HvdcXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/HvdcXmlTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.test.HvdcTestNetwork;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/IdentifiableExtensionXmlSerializerTest.java
@@ -20,6 +20,7 @@ import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.LoadZipModel;
 import com.powsybl.iidm.network.test.MultipleExtensionsTestNetworkFactory;
 import com.powsybl.iidm.network.test.TerminalMockExt;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/LoadingLimitsXmlTest.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.DanglingLineNetworkFactory;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.joda.time.DateTime;
 import org.junit.Test;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
@@ -17,6 +17,7 @@ import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.BusbarSectionExt;
 import com.powsybl.iidm.network.test.ScadaNetworkFactory;
 import com.powsybl.iidm.network.test.NetworkTest1Factory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.joda.time.DateTime;
 import org.junit.Test;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NodeBreakerInternalConnectionsTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NodeBreakerInternalConnectionsTest.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.VoltageLevel.NodeBreakerView;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.joda.time.DateTime;
 import org.junit.Test;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/OptionalLoadTypeBugTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/OptionalLoadTypeBugTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.xml;
 
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PhaseShifterXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PhaseShifterXmlTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.test.PhaseShifterTestCaseFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PropertiesXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/PropertiesXmlTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.xml;
 
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ReactiveLimitsXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ReactiveLimitsXmlTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.test.ReactiveLimitsTestNetworkFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ShuntCompensatorXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ShuntCompensatorXmlTest.java
@@ -10,6 +10,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ShuntCompensator;
 import com.powsybl.iidm.network.test.ShuntTestCaseFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SimpleAnonymizerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SimpleAnonymizerTest.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.NetworkFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SkipExtensionTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SkipExtensionTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/StaticVarCompensatorXmlTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.xml;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.SvcTestCaseFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SwitchTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/SwitchTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalMockXmlSerializer.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalMockXmlSerializer.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionDir;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionDir;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 
 /**

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalRefNotFoundTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalRefNotFoundTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.xml;
 
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalRefTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TerminalRefTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.iidm.xml;
 
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXmlTest.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.PhaseTapChanger;
 import com.powsybl.iidm.network.PhaseTapChangerAdder;
 import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TieLineWithAliasesXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TieLineWithAliasesXmlTest.java
@@ -7,6 +7,7 @@
 
 package com.powsybl.iidm.xml;
 
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TieLineXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TieLineXmlTest.java
@@ -7,6 +7,7 @@
 
 package com.powsybl.iidm.xml;
 
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TopologyLevelTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TopologyLevelTest.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.iidm.network.TopologyLevel;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLExporterTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLExporterTest.java
@@ -17,6 +17,7 @@ import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.extensions.SlackTerminalAdder;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.MultipleExtensionsTestNetworkFactory;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import org.joda.time.DateTime;
 import org.junit.Test;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/ActivePowerControlXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/ActivePowerControlXmlTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/BranchObservabilityXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/BranchObservabilityXmlTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.*;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/CoordinatedReactiveControlXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/CoordinatedReactiveControlXmlTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/DiscreteMeasurementsXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/DiscreteMeasurementsXmlTest.java
@@ -13,7 +13,7 @@ import com.powsybl.iidm.network.extensions.DiscreteMeasurement;
 import com.powsybl.iidm.network.extensions.DiscreteMeasurements;
 import com.powsybl.iidm.network.extensions.DiscreteMeasurementsAdder;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
-import com.powsybl.iidm.xml.AbstractXmlConverterTest;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import com.powsybl.iidm.xml.IidmXmlConstants;
 import com.powsybl.iidm.xml.IidmXmlVersion;
 import com.powsybl.iidm.xml.NetworkXml;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/GeneratorEntsoeCategoryXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/GeneratorEntsoeCategoryXmlTest.java
@@ -9,7 +9,7 @@ package com.powsybl.iidm.xml.extensions;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.GeneratorEntsoeCategory;
 import com.powsybl.iidm.network.extensions.GeneratorEntsoeCategoryAdder;
-import com.powsybl.iidm.xml.AbstractXmlConverterTest;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import com.powsybl.iidm.xml.IidmXmlConstants;
 import com.powsybl.iidm.xml.NetworkXml;
 import org.joda.time.DateTime;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/GeneratorStartupXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/GeneratorStartupXmlTest.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.xml.ExportOptions;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.GeneratorStartup;
 import com.powsybl.iidm.network.extensions.GeneratorStartupAdder;
-import com.powsybl.iidm.xml.AbstractXmlConverterTest;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import com.powsybl.iidm.xml.IidmXmlConstants;
 import com.powsybl.iidm.xml.NetworkXml;
 import org.joda.time.DateTime;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/HvdcAngleDroopActivePowerControlXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/HvdcAngleDroopActivePowerControlXmlTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/HvdcOperatorActiveRangeXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/HvdcOperatorActiveRangeXmlTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/InjectionObservabilityXmlTest.java
@@ -21,7 +21,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.*;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/LoadDetailXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/LoadDetailXmlTest.java
@@ -9,7 +9,7 @@ package com.powsybl.iidm.xml.extensions;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.LoadDetail;
 import com.powsybl.iidm.network.extensions.LoadDetailAdder;
-import com.powsybl.iidm.xml.AbstractXmlConverterTest;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import com.powsybl.iidm.xml.IidmXmlConstants;
 import com.powsybl.iidm.xml.IidmXmlVersion;
 import com.powsybl.iidm.xml.NetworkXml;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/MeasurementsXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/MeasurementsXmlTest.java
@@ -13,7 +13,7 @@ import com.powsybl.iidm.network.extensions.Measurement;
 import com.powsybl.iidm.network.extensions.Measurements;
 import com.powsybl.iidm.network.extensions.MeasurementsAdder;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
-import com.powsybl.iidm.xml.AbstractXmlConverterTest;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import com.powsybl.iidm.xml.IidmXmlConstants;
 import com.powsybl.iidm.xml.NetworkXml;
 import org.joda.time.DateTime;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/SlackTerminalXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/SlackTerminalXmlTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Properties;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.*;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/SubstationAndLinePositionXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/SubstationAndLinePositionXmlTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertNotNull;
 

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/ThreeWindingsTransformerPhaseAngleClockXmlSerializerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/ThreeWindingsTransformerPhaseAngleClockXmlSerializerTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/ThreeWindingsTransformerToBeEstimatedXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/ThreeWindingsTransformerToBeEstimatedXmlTest.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.iidm.network.extensions.ThreeWindingsTransformerToBeEstimatedAdder;
 import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
-import com.powsybl.iidm.xml.AbstractXmlConverterTest;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import com.powsybl.iidm.xml.IidmXmlConstants;
 import com.powsybl.iidm.xml.NetworkXml;
 import org.joda.time.DateTime;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/TwoWindingsTransformerPhaseAngleClockXmlSerializerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/TwoWindingsTransformerPhaseAngleClockXmlSerializerTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/TwoWindingsTransformerToBeEstimatedXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/TwoWindingsTransformerToBeEstimatedXmlTest.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.iidm.network.extensions.TwoWindingsTransformerToBeEstimatedAdder;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
-import com.powsybl.iidm.xml.AbstractXmlConverterTest;
+import com.powsybl.iidm.xml.test.AbstractXmlConverterTest;
 import com.powsybl.iidm.xml.IidmXmlConstants;
 import com.powsybl.iidm.xml.NetworkXml;
 import org.joda.time.DateTime;

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/VoltagePerReactivePowerControlXmlSerializerTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/extensions/VoltagePerReactivePowerControlXmlSerializerTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.powsybl.iidm.xml.AbstractXmlConverterTest.getVersionedNetworkPath;
+import static com.powsybl.iidm.xml.test.AbstractXmlConverterTest.getVersionedNetworkPath;
 import static com.powsybl.iidm.xml.IidmXmlConstants.CURRENT_IIDM_XML_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Moving code following removal of test jars: `AbstractXmlConverterTest` is used in powsybl-rte-core



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
