### PR TITLE
Check overload using flow limits holder

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/FlowsLimitsHolder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/FlowsLimitsHolder.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.iidm.network;
 
+import com.powsybl.iidm.network.util.LimitViolationUtils;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -38,4 +40,45 @@ public interface FlowsLimitsHolder {
     ApparentPowerLimitsAdder newApparentPowerLimits();
 
     ActivePowerLimitsAdder newActivePowerLimits();
+
+    default boolean isOverloaded(Terminal terminal) {
+        return isOverloaded(terminal, 1.0f);
+    }
+
+    default boolean isOverloaded(Terminal terminal, float limitReduction) {
+        return checkPermanentLimit(terminal, limitReduction, LimitType.CURRENT);
+    }
+
+    default boolean checkPermanentLimit(Terminal terminal, float limitReduction, LimitType type) {
+        return LimitViolationUtils.checkPermanentLimit(this, limitReduction, getValueForLimit(terminal, type), type);
+    }
+
+    default Optional<? extends LoadingLimits> getLimits(LimitType type) {
+        switch (type) {
+            case ACTIVE_POWER:
+                return getActivePowerLimits();
+            case APPARENT_POWER:
+                return getApparentPowerLimits();
+            case CURRENT:
+                return getCurrentLimits();
+            case VOLTAGE:
+            default:
+                throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
+        }
+    }
+
+    default double getValueForLimit(Terminal t, LimitType type) {
+        switch (type) {
+            case ACTIVE_POWER:
+                return t.getP();
+            case APPARENT_POWER:
+                return Math.sqrt(t.getP() * t.getP() + t.getQ() * t.getQ());
+            case CURRENT:
+                return t.getI();
+            case VOLTAGE:
+            default:
+                throw new UnsupportedOperationException(String.format("Getting %s limits is not supported.", type.name()));
+        }
+    }
+
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LimitViolationUtils.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LimitViolationUtils.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.network.util;
 
 import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.FlowsLimitsHolder;
 import com.powsybl.iidm.network.LimitType;
 import com.powsybl.iidm.network.LoadingLimits;
 
@@ -64,11 +65,16 @@ public final class LimitViolationUtils {
     }
 
     public static boolean checkPermanentLimit(Branch<?> branch, Branch.Side side, float limitReduction, double i, LimitType type) {
-        return branch.getLimits(type, side)
-                .map(l -> !Double.isNaN(l.getPermanentLimit()) &&
-                        !Double.isNaN(i) &&
-                        (i >= l.getPermanentLimit() * limitReduction))
-                .orElse(false);
+        return branch.getLimits(type, side).map(l -> checkPermanentLimit(l, limitReduction, i)).orElse(false);
     }
 
+    public static boolean checkPermanentLimit(FlowsLimitsHolder holder, float limitReduction, double i, LimitType type) {
+        return holder.getLimits(type).map(l -> checkPermanentLimit(l, limitReduction, i)).orElse(false);
+    }
+
+    public static boolean checkPermanentLimit(LoadingLimits limits, float limitReduction, double i) {
+        return !Double.isNaN(limits.getPermanentLimit()) &&
+                !Double.isNaN(i) &&
+                i >= limits.getPermanentLimit() * limitReduction;
+    }
 }


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Dangling lines can not be checked for overloads.


**What is the new behavior (if this is a feature change)?**
Dangling lines are able to hold limits for flows, they implement the interface `FlowsLimitsHolder`, but there is no direct way to check if they are overloaded. This PR proposes to add a few methods to the the `FlowLimitsHolder` interface to check the flow at a given terminal against the limits it contains.

