### PR TITLE
Add docker based local computation manager test utilities

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build with Maven
         if: matrix.os == 'ubuntu-latest'
-        run: mvn --batch-mode -Pjacoco install
+        run: mvn --batch-mode -Pjacoco,docker-unit-tests install
 
       - name: Build with Maven
         if: matrix.os != 'ubuntu-latest'

--- a/commons-test/src/main/java/com/powsybl/commons/test/DockerTests.java
+++ b/commons-test/src/main/java/com/powsybl/commons/test/DockerTests.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.commons.test;
+
+/**
+ * A marker interface for tagging unit tests that need docker runtime.
+ *
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public interface DockerTests {
+}

--- a/computation-local-test/pom.xml
+++ b/computation-local-test/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.powsybl</groupId>
+        <artifactId>powsybl-core</artifactId>
+        <version>5.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>powsybl-computation-local-test</artifactId>
+    <name>Local computation test</name>
+    <description>Some utilities for local computation manager testing</description>
+
+    <dependencies>
+        <!-- Compilation dependencies -->
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-commons-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-computation-local</artifactId>
+        </dependency>
+
+        <!-- junit is required by testcontainers, and powsybl parent pom implies test scope, we need to override it -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/computation-local-test/src/main/java/com/powsybl/computation/local/test/ComputationDockerConfig.java
+++ b/computation-local-test/src/main/java/com/powsybl/computation/local/test/ComputationDockerConfig.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.computation.local.test;
+
+import com.powsybl.commons.config.ConfigurationException;
+import com.powsybl.commons.config.ModuleConfig;
+import com.powsybl.commons.config.PlatformConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * @author Etienne Lesot <etienne.lesot at rte-france.com>
+ */
+public class ComputationDockerConfig {
+
+    private String dockerImageId;
+    public static final String IMAGE = "image";
+    public static final String MODULE = "computationDocker";
+
+    public static ComputationDockerConfig load(PlatformConfig config) {
+        Map<String, String> properties = new HashMap<>();
+        ModuleConfig module = config.getOptionalModuleConfig(MODULE).orElseThrow(() ->
+                new ConfigurationException("module computationDocker is missing in your configuration file"));
+        module.getOptionalStringProperty(IMAGE).ifPresent(value -> properties.put(IMAGE, value));
+        return load(properties);
+    }
+
+    public static ComputationDockerConfig load(Map<String, String> properties) {
+        return new ComputationDockerConfig().update(properties);
+    }
+
+    public void setDockerImageId(String dockerImageId) {
+        this.dockerImageId = dockerImageId;
+    }
+
+    public ComputationDockerConfig update(Map<String, String> properties) {
+        Objects.requireNonNull(properties);
+        Optional.ofNullable(properties.get(IMAGE)).ifPresent(this::setDockerImageId);
+        return this;
+    }
+
+    public String getDockerImageId() {
+        return dockerImageId;
+    }
+}

--- a/computation-local-test/src/main/java/com/powsybl/computation/local/test/DockerLocalCommandExecutor.java
+++ b/computation-local-test/src/main/java/com/powsybl/computation/local/test/DockerLocalCommandExecutor.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.computation.local.test;
+
+import com.powsybl.computation.local.LocalCommandExecutor;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Etienne Lesot <etienne.lesot at rte-france.com>
+ */
+public class DockerLocalCommandExecutor implements LocalCommandExecutor {
+
+    private final String dockerImage;
+    private final Path hostVolumePath;
+    private final Path containerVolumePath;
+    private final Map<Path, GenericContainer<?>> containers = new ConcurrentHashMap<>();
+
+    public DockerLocalCommandExecutor(Path hostVolumePath, Path containerVolumePath, ComputationDockerConfig config) {
+        this.dockerImage = Objects.requireNonNull(config.getDockerImageId());
+        this.hostVolumePath = Objects.requireNonNull(hostVolumePath);
+        this.containerVolumePath = Objects.requireNonNull(containerVolumePath);
+    }
+
+    @Override
+    public int execute(String program, List<String> args, Path outFile, Path errFile, Path workingDir, Map<String, String> env) throws IOException, InterruptedException {
+        try (GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse(dockerImage))
+                .withFileSystemBind(hostVolumePath.toString(), containerVolumePath.toString(), BindMode.READ_WRITE)
+                .withCommand("sleep", "infinity")) {
+            Container.ExecResult execResult;
+            containers.put(workingDir, container);
+            try {
+                env.entrySet().stream().filter(entry -> !entry.getKey().equals("PATH"))
+                        .forEach(entry -> container.withEnv(entry.getKey(), entry.getValue()));
+                container.withWorkingDirectory(containerVolumePath.resolve(hostVolumePath
+                        .relativize(workingDir)).toString());
+                List<String> arguments = new ArrayList<>(args);
+                arguments.add(0, program);
+                container.start();
+                execResult = container.execInContainer(arguments.toArray(new String[0]));
+                container.stop();
+                Files.write(errFile, execResult.getStderr().getBytes(StandardCharsets.UTF_8));
+                Files.write(outFile, execResult.getStdout().getBytes(StandardCharsets.UTF_8));
+            } finally {
+                containers.remove(workingDir);
+            }
+            return execResult.getExitCode();
+        }
+    }
+
+    @Override
+    public void stop(Path path) {
+        GenericContainer<?> container = containers.get(path);
+        if (container != null && container.isRunning()) {
+            container.stop();
+        }
+    }
+
+    @Override
+    public void stopForcibly(Path path) {
+        stop(path);
+    }
+}

--- a/computation-local-test/src/test/java/com/powsybl/computation/local/test/DockerLocalCommandExecutorTest.java
+++ b/computation-local-test/src/test/java/com/powsybl/computation/local/test/DockerLocalCommandExecutorTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.computation.local.test;
+
+import com.powsybl.commons.config.PlatformConfig;
+import com.powsybl.commons.test.DockerTests;
+import com.powsybl.computation.*;
+import com.powsybl.computation.local.LocalComputationConfig;
+import com.powsybl.computation.local.LocalComputationManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+@Category(DockerTests.class)
+public class DockerLocalCommandExecutorTest {
+
+    private static final String COMMAND_ID = "test";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private ComputationManager computationManager;
+
+    @Before
+    public void setup() throws IOException {
+        Path localDir = tempFolder.getRoot().toPath();
+        Path dockerDir = Path.of("/tmp");
+        ComputationDockerConfig config = ComputationDockerConfig.load(PlatformConfig.defaultConfig());
+        computationManager = new LocalComputationManager(new LocalComputationConfig(localDir),
+                new DockerLocalCommandExecutor(localDir, dockerDir, config), Executors.newCachedThreadPool());
+    }
+
+    @After
+    public void tearDown() {
+        computationManager.close();
+    }
+
+    @Test
+    public void test() {
+        List<String> lines = computationManager.execute(ExecutionEnvironment.createDefault(), new AbstractExecutionHandler<List<String>>() {
+            @Override
+            public List<CommandExecution> before(Path workingDir) {
+                return List.of(new CommandExecution(new SimpleCommandBuilder()
+                        .id(COMMAND_ID)
+                        .program("ls")
+                        .arg("/")
+                        .build(), 1));
+            }
+
+            @Override
+            public List<String> after(Path workingDir, ExecutionReport report) throws IOException {
+                return Files.readAllLines(workingDir.resolve(COMMAND_ID + "_0.out"));
+            }
+        }).join();
+        assertEquals(List.of("bin", "dev", "etc", "home", "lib", "media", "mnt", "opt", "proc", "root", "run", "sbin", "srv", "sys", "tmp", "usr", "var"), lines);
+    }
+}

--- a/computation-local-test/src/test/resources/com/powsybl/config/test/config.yml
+++ b/computation-local-test/src/test/resources/com/powsybl/config/test/config.yml
@@ -1,0 +1,2 @@
+computationDocker:
+    image: alpine:3.14

--- a/computation-local-test/src/test/resources/com/powsybl/config/test/filelist.txt
+++ b/computation-local-test/src/test/resources/com/powsybl/config/test/filelist.txt
@@ -1,0 +1,1 @@
+config.yml

--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -158,6 +158,12 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-computation-local-test</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-config-classic</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <module>commons-test</module>
         <module>computation</module>
         <module>computation-local</module>
+        <module>computation-local-test</module>
         <module>config-classic</module>
         <module>config-test</module>
         <module>contingency</module>
@@ -127,6 +128,7 @@
         <snakeyaml.version>1.33</snakeyaml.version>
         <staxutils.version>20070216</staxutils.version>
         <stringtemplate.version>4.3.4</stringtemplate.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
         <threeten.version>1.5.0</threeten.version>
         <trove4j.version>3.0.3</trove4j.version>
         <univocity-parsers.version>2.8.3</univocity-parsers.version>
@@ -156,6 +158,26 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>docker-unit-tests</id>
+            <activation>
+                <property>
+                    <name>powsybl.docker-unit-tests.skip</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups>com.powsybl.commons.test.DockerTests</excludedGroups>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -789,6 +811,11 @@
                 <groupId>org.scijava</groupId>
                 <artifactId>native-lib-loader</artifactId>
                 <version>${nativelibloader.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainers.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.threeten</groupId>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
There is no easy way to test something that is based on local computation manager, because the command should be installed on the system.


**What is the new behavior (if this is a feature change)?**
We can specify a docker image that will be used for executing commands of a local computation manager.  


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
