### PR TITLE
Import ignored ACLineSegment linked to boundary as dangling lines

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -599,15 +599,17 @@ public class Conversion {
                 .filter(beq -> !beq.isAcLineSegmentDisconnected(context)).collect(Collectors.toList());
             if (connectedBeqs.size() == 2) {
                 convertTwoEquipmentsAtBoundaryNode(context, node, connectedBeqs.get(0), connectedBeqs.get(1));
-                // Log ignored AcLineSegments
+                // There can be multiple disconnected ACLineSegment to the same X-node (for example, for planning purposes)
                 beqs.stream().filter(beq -> !connectedBeqs.contains(beq)).collect(Collectors.toList())
                     .forEach(beq -> {
                         context.fixed("convertEquipmentAtBoundaryNode",
-                                String.format("Multiple AcLineSegments at boundary %s. Disconnected AcLineSegment %s is imported as dangling lines", node, beq.getAcLineSegmentId()));
+                                String.format("Multiple AcLineSegments at boundary %s. Disconnected AcLineSegment %s is imported as a dangling line.", node, beq.getAcLineSegmentId()));
                         beq.createConversion(context).convertAtBoundary();
                     });
             } else {
-                context.fixed(node, "More than two connected AcLineSegments at boundary: only dangling lines are created");
+                // This case should not happen and will not result in an equivalent network at the end of the conversion
+                context.fixed(node, "More than two connected AcLineSegments at boundary: only dangling lines are created." +
+                        " Please note that the converted IIDM network will probably not be equivalent to the CGMES network.");
                 beqs.forEach(beq -> beq.createConversion(context).convertAtBoundary());
             }
         }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -601,10 +601,14 @@ public class Conversion {
                 convertTwoEquipmentsAtBoundaryNode(context, node, connectedBeqs.get(0), connectedBeqs.get(1));
                 // Log ignored AcLineSegments
                 beqs.stream().filter(beq -> !connectedBeqs.contains(beq)).collect(Collectors.toList())
-                    .forEach(beq -> context.ignored("convertEquipmentAtBoundaryNode",
-                        String.format("Multiple AcLineSegments at boundary %s. Disconnected AcLineSegment %s is ignored", node, beq.getAcLineSegmentId())));
+                    .forEach(beq -> {
+                        context.fixed("convertEquipmentAtBoundaryNode",
+                                String.format("Multiple AcLineSegments at boundary %s. Disconnected AcLineSegment %s is imported as dangling lines", node, beq.getAcLineSegmentId()));
+                        beq.createConversion(context).convertAtBoundary();
+                    });
             } else {
-                context.invalid(node, "Too many equipment at boundary node");
+                context.fixed(node, "More than two connected AcLineSegments at boundary: only dangling lines are created");
+                beqs.forEach(beq -> beq.createConversion(context).convertAtBoundary());
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix in CGMES dangling lines import


**What is the current behavior?** *(You can also link to an open issue here)*
Only two ACLineSegment linked to a X-node are imported at the maximum and other are ignored.


**What is the new behavior (if this is a feature change)?**
If exactly two connected ACLineSegments are linked to a X-node but other **disconnected** ACLineSegments are linked to the same X-node, the disconnected ACLineSegments are imported as dangling lines.
If more than two connected ACLineSegments are linked to a X-node, they are all imported as dangling lines

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
