### PR TITLE
Fix SVC bMin/bMax during CGMES if capacitive and/or inductive rating are undefined or 0

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
@@ -30,8 +30,8 @@ public class StaticVarCompensatorConversion extends AbstractConductingEquipmentC
         double inductiveRating = p.asDouble("inductiveRating", 0.0);
 
         StaticVarCompensatorAdder adder = voltageLevel().newStaticVarCompensator()
-            .setBmin(1 / inductiveRating)
-            .setBmax(1 / capacitiveRating);
+            .setBmin(getB(inductiveRating, "inductive"))
+            .setBmax(getB(capacitiveRating, "capacitive"));
         identify(adder);
         connect(adder);
         RegulatingControlMappingForStaticVarCompensators.initialize(adder);
@@ -44,6 +44,14 @@ public class StaticVarCompensatorConversion extends AbstractConductingEquipmentC
         }
 
         context.regulatingControlMapping().forStaticVarCompensators().add(svc.getId(), p);
+    }
+
+    private double getB(double rating, String name) {
+        if (rating == 0.0) {
+            fixed(name + "Rating", "Undefined or equal to 0. Corresponding susceptance is Double.MAX_VALUE");
+            return Double.MAX_VALUE;
+        }
+        return 1 / rating;
     }
 
     private double checkSlope(double slope) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/StaticVarCompensatorConversion.java
@@ -49,7 +49,7 @@ public class StaticVarCompensatorConversion extends AbstractConductingEquipmentC
     private double getB(double rating, String name) {
         if (rating == 0.0) {
             fixed(name + "Rating", "Undefined or equal to 0. Corresponding susceptance is Double.MAX_VALUE");
-            return Double.MAX_VALUE;
+            return name.equals("inductive") ? -Double.MAX_VALUE : Double.MAX_VALUE;
         }
         return 1 / rating;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If inductive or capacitive ratings are undefined or 0 for SVC during CGMES import, bMin or bMax are infinite.


**What is the new behavior (if this is a feature change)?**
In this case, bMin or bMax are `Double.MAX_VALUE`


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
