### PR TITLE
CGMES importer: handle GeographicalRegion in BoundarySet

### DIFF
--- a/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/Cgmes3ModifiedCatalog.java
+++ b/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/Cgmes3ModifiedCatalog.java
@@ -86,5 +86,15 @@ public final class Cgmes3ModifiedCatalog {
                 new ResourceSet(base, "20210209T1930Z_1D_BE_9.xml"));
     }
 
+    public static GridModelReferenceResources microGridBaseCaseGeographicalRegionInBoundary() {
+        String base = CGMES_3_MODIFIED_TEST_MODELS
+                + "/MicroGrid/geographicalRegionInBoundary/";
+        return new GridModelReferenceResources(
+                "MicroGrid-geographical-region-in-boundary",
+                null,
+                new ResourceSet(base, "20210209T1930Z_1D_BE_EQ_9.xml"),
+                new ResourceSet(base, "20171002T0930Z_ENTSO-E_EQ_BD_2.xml"));
+    }
+
     private static final String CGMES_3_MODIFIED_TEST_MODELS = "/cgmes3-test-models-modified";
 }

--- a/cgmes/cgmes-conformity/src/main/resources/cgmes3-test-models-modified/MicroGrid/geographicalRegionInBoundary/20171002T0930Z_ENTSO-E_EQ_BD_2.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/cgmes3-test-models-modified/MicroGrid/geographicalRegionInBoundary/20171002T0930Z_ENTSO-E_EQ_BD_2.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:eu="http://iec.ch/TC57/CIM100-European#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:536f9bf1-3f8f-a546-87e3-7af2272f29b7">
+    <md:Model.scenarioTime>2030-01-25T19:00:00Z</md:Model.scenarioTime>
+    <md:Model.created>2021-01-25T19:00:00Z</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/3.0</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://entsoe.eu/boundary</md:Model.modelingAuthoritySet>
+    <md:Model.version>5</md:Model.version>
+  </md:FullModel>
+  <cim:GeographicalRegion rdf:ID="_7bf89875-1476-4d1a-a56d-a2965cce3575">
+    <cim:IdentifiedObject.name>BE</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>_7bf89875-1476-4d1a-a56d-a2965cce3575</cim:IdentifiedObject.mRID>
+  </cim:GeographicalRegion>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/cgmes3-test-models-modified/MicroGrid/geographicalRegionInBoundary/20210209T1930Z_1D_BE_EQ_9.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/cgmes3-test-models-modified/MicroGrid/geographicalRegionInBoundary/20210209T1930Z_1D_BE_EQ_9.xml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:9e7050a8-960b-4e1a-8e34-7f56bc2b2a7b">
+    <md:Model.created>2021-02-09T19:28:14Z</md:Model.created>
+    <md:Model.scenarioTime>2021-02-09T19:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0</md:Model.profile>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/Operation-EU/3.0</md:Model.profile>
+    <md:Model.version>5</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66" />
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/3.0</md:Model.profile>
+  </md:FullModel>
+  <cim:SubGeographicalRegion rdf:ID="_02047c0b-b5a4-4e0d-bae6-fc5437a55e74">
+    <cim:IdentifiedObject.name>ELIA-Anvers</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_7bf89875-1476-4d1a-a56d-a2965cce3575" />
+    <cim:IdentifiedObject.mRID>02047c0b-b5a4-4e0d-bae6-fc5437a55e74</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_87f7002b-056f-4a6a-a872-1744eea757e3">
+    <cim:IdentifiedObject.name>Anvers</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>Anvers</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_02047c0b-b5a4-4e0d-bae6-fc5437a55e74" />
+    <cim:IdentifiedObject.mRID>87f7002b-056f-4a6a-a872-1744eea757e3</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+  <cim:SubGeographicalRegion rdf:ID="_61378219-a236-4070-bbec-4e30a6ac848d">
+    <cim:IdentifiedObject.name>ELIA-Brussels</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_7bf89875-1476-4d1a-a56d-a2965cce3575" />
+    <cim:IdentifiedObject.mRID>61378219-a236-4070-bbec-4e30a6ac848d</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_37e14a0f-5e34-4647-a062-8bfd9305fa9d">
+    <cim:IdentifiedObject.name>PP_Brussels</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PP_Brussels</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>37e14a0f-5e34-4647-a062-8bfd9305fa9d</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+</rdf:RDF>

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/modified/Cgmes3ModifiedConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/modified/Cgmes3ModifiedConversionTest.java
@@ -13,6 +13,7 @@ import com.powsybl.cgmes.conformity.Cgmes3ModifiedCatalog;
 import com.powsybl.cgmes.conversion.CgmesModelExtension;
 import com.powsybl.iidm.network.Importers;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Substation;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,7 +21,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * @author Luma Zamarreño <zamarrenolm at aia.es>
@@ -45,6 +46,21 @@ public class Cgmes3ModifiedConversionTest {
         System.out.println(network.getExtension(CgmesModelExtension.class).getCgmesModel().boundaryNodes().tabulateLocals());
         assertEquals(6, network.getExtension(CgmesModelExtension.class).getCgmesModel().boundaryNodes().size());
         assertEquals(5, network.getDanglingLineCount());
+    }
+
+    @Test
+    public void microGridGeographicalRegionInBoundary() {
+        Network network = Importers.importData("CGMES", Cgmes3ModifiedCatalog.microGridBaseCaseGeographicalRegionInBoundary().dataSource(), null);
+        Substation anvers = network.getSubstation("87f7002b-056f-4a6a-a872-1744eea757e3");
+        Substation brussels = network.getSubstation("37e14a0f-5e34-4647-a062-8bfd9305fa9d");
+        assertNotNull(anvers);
+        assertNotNull(brussels);
+        assertTrue(anvers.getGeographicalTags().contains("ELIA-Anvers"));
+        assertTrue(brussels.getGeographicalTags().contains("ELIA-Brussels"));
+        assertNotNull(anvers.getNullableCountry());
+        assertNotNull(brussels.getNullableCountry());
+        assertEquals("BE", anvers.getNullableCountry().toString());
+        assertEquals("BE", brussels.getNullableCountry().toString());
     }
 
     private FileSystem fileSystem;

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -121,16 +121,18 @@ SELECT *
 
 # query: substations
 SELECT ?Substation ?name ?SubRegion ?subRegionName ?Region ?regionName
-{
+{ GRAPH ?graph {
     ?Substation
         a cim:Substation ;
         cim:IdentifiedObject.name ?name ;
         cim:Substation.Region ?SubRegion .
+} GRAPH ?graph2 {
     ?SubRegion
         cim:SubGeographicalRegion.Region ?Region ;
         cim:IdentifiedObject.name ?subRegionName .
-    ?Region cim:IdentifiedObject.name ?regionName
-}
+} GRAPH ?graph3 {
+    ?Region cim:IdentifiedObject.name ?regionName .
+}}
 
 # query: voltageLevels
 SELECT *

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -121,7 +121,7 @@ SELECT *
 
 # query: substations
 SELECT ?Substation ?name ?SubRegion ?subRegionName ?Region ?regionName
-{ GRAPH ?graph {
+{
     ?Substation
         a cim:Substation ;
         cim:IdentifiedObject.name ?name ;
@@ -130,7 +130,7 @@ SELECT ?Substation ?name ?SubRegion ?subRegionName ?Region ?regionName
         cim:SubGeographicalRegion.Region ?Region ;
         cim:IdentifiedObject.name ?subRegionName .
     ?Region cim:IdentifiedObject.name ?regionName
-}}
+}
 
 # query: voltageLevels
 SELECT *


### PR DESCRIPTION
CGMES importer: fix Substation import error when the associated GeographicalRegion is defined in EquipmentBoundary profile instance

Signed-off-by: Damien Jeandemange <damien.jeandemange@artelys.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix / remove a limitation that shouldn't exist


**What is the current behavior?**
If a cim:Substation links to a cim:GeographicalRegion (via cim:SubgeographicalRegion) that is defined in the boundary set, the substation is not converted and the CGMES import fails later on because of the missing substations.


**What is the new behavior (if this is a feature change)?**
SPARQL Substation query does not require anymore the cim:Substation, cim:SubgeographicalRegion and cim:GeographicalRegion to be in the same graph / in the same model instance


**Does this PR introduce a breaking change or deprecate an API?**
No
