### PR TITLE
Use contingency context in operator strategies

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandler.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandler.java
@@ -229,7 +229,7 @@ public class SecurityAnalysisExecutionHandler<R> extends AbstractExecutionHandle
         options.strategiesFile(path);
         LOGGER.debug("Writing operator strategies to file {}", path);
         new OperatorStrategyList(operatorStrategies)
-                .writeFile(path);
+                .write(path);
     }
 
     /**

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/OperatorStrategyDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/OperatorStrategyDeserializer.java
@@ -16,6 +16,8 @@ import com.powsybl.commons.extensions.Extension;
 import com.powsybl.commons.extensions.ExtensionJsonSerializer;
 import com.powsybl.commons.extensions.ExtensionProviders;
 import com.powsybl.commons.json.JsonUtil;
+import com.powsybl.contingency.ContingencyContext;
+import com.powsybl.contingency.ContingencyContextType;
 import com.powsybl.security.condition.Condition;
 import com.powsybl.security.strategy.OperatorStrategy;
 
@@ -37,6 +39,7 @@ public class OperatorStrategyDeserializer extends StdDeserializer<OperatorStrate
 
     private static class ParsingContext {
         String id;
+        ContingencyContextType contingencyContextType;
         String contingencyId;
         Condition condition;
         List<String> actionIds;
@@ -51,6 +54,9 @@ public class OperatorStrategyDeserializer extends StdDeserializer<OperatorStrate
                 case "id":
                     parser.nextToken();
                     context.id = parser.getValueAsString();
+                    return true;
+                case "contingencyContextType":
+                    context.contingencyContextType = ContingencyContextType.valueOf(parser.nextTextValue());
                     return true;
                 case "contingencyId":
                     parser.nextToken();
@@ -73,7 +79,9 @@ public class OperatorStrategyDeserializer extends StdDeserializer<OperatorStrate
                     return false;
             }
         });
-        OperatorStrategy operatorStrategy = new OperatorStrategy(context.id, context.contingencyId, context.condition, context.actionIds);
+        ContingencyContext contingencyContext = new ContingencyContext(context.contingencyId,
+                context.contingencyContextType != null ? context.contingencyContextType : ContingencyContextType.SPECIFIC);
+        OperatorStrategy operatorStrategy = new OperatorStrategy(context.id, contingencyContext, context.condition, context.actionIds);
         SUPPLIER.get().addExtensions(operatorStrategy, context.extensions);
         return operatorStrategy;
     }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/OperatorStrategyDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/OperatorStrategyDeserializer.java
@@ -79,6 +79,9 @@ public class OperatorStrategyDeserializer extends StdDeserializer<OperatorStrate
                     return false;
             }
         });
+        // First version of the operator strategy only allows association to one contingency. Next versions use contingency
+        // context. So, for backward compatibility purposes, we consider that if contingencyContextType is null, we have
+        // a specific contingency context type.
         ContingencyContext contingencyContext = new ContingencyContext(context.contingencyId,
                 context.contingencyContextType != null ? context.contingencyContextType : ContingencyContextType.SPECIFIC);
         OperatorStrategy operatorStrategy = new OperatorStrategy(context.id, contingencyContext, context.condition, context.actionIds);

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/OperatorStrategyListDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/OperatorStrategyListDeserializer.java
@@ -49,8 +49,8 @@ public class OperatorStrategyListDeserializer extends StdDeserializer<OperatorSt
                     return false;
             }
         });
-        if (context.version == null || !context.version.equals(OperatorStrategyList.VERSION)) {
-            throw new JsonMappingException(parser, "version is missing or not equal to 1.0");
+        if (context.version == null) {
+            throw new JsonMappingException(parser, "version is missing");
         }
         return new OperatorStrategyList(context.operatorStrategies);
     }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/OperatorStrategySerializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/OperatorStrategySerializer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.powsybl.commons.json.JsonUtil;
+import com.powsybl.contingency.ContingencyContext;
 import com.powsybl.security.strategy.OperatorStrategy;
 
 import java.io.IOException;
@@ -27,7 +28,11 @@ public class OperatorStrategySerializer extends StdSerializer<OperatorStrategy> 
     public void serialize(OperatorStrategy operatorStrategy, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         jsonGenerator.writeStartObject();
         jsonGenerator.writeStringField("id", operatorStrategy.getId());
-        jsonGenerator.writeStringField("contingencyId", operatorStrategy.getContingencyId());
+        ContingencyContext contingencyContext = operatorStrategy.getContingencyContext();
+        jsonGenerator.writeStringField("contingencyContextType", contingencyContext.getContextType().name());
+        if (contingencyContext.getContingencyId() != null) {
+            jsonGenerator.writeStringField("contingencyId", contingencyContext.getContingencyId());
+        }
         jsonGenerator.writeObjectField("condition", operatorStrategy.getCondition());
         jsonGenerator.writeObjectField("actionIds", operatorStrategy.getActionIds());
         JsonUtil.writeExtensions(operatorStrategy, jsonGenerator, serializerProvider);

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/strategy/OperatorStrategy.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/strategy/OperatorStrategy.java
@@ -8,6 +8,7 @@ package com.powsybl.security.strategy;
 
 import com.google.common.collect.ImmutableList;
 import com.powsybl.commons.extensions.AbstractExtendable;
+import com.powsybl.contingency.ContingencyContext;
 import com.powsybl.security.condition.Condition;
 
 import java.util.List;
@@ -26,13 +27,13 @@ import java.util.Objects;
  */
 public class OperatorStrategy extends AbstractExtendable<OperatorStrategy> {
     private final String id;
-    private final String contingencyId;
+    private final ContingencyContext contingencyContext;
     private final Condition condition;  // under which circumstances do I want to trigger my action
     private final List<String> actionIds;
 
-    public OperatorStrategy(String id, String contingencyId, Condition condition, List<String> actionIds) {
+    public OperatorStrategy(String id, ContingencyContext contingencyContext, Condition condition, List<String> actionIds) {
         this.id = Objects.requireNonNull(id);
-        this.contingencyId = Objects.requireNonNull(contingencyId);
+        this.contingencyContext = Objects.requireNonNull(contingencyContext);
         this.condition = Objects.requireNonNull(condition);
         this.actionIds = ImmutableList.copyOf(Objects.requireNonNull(actionIds));
     }
@@ -47,8 +48,8 @@ public class OperatorStrategy extends AbstractExtendable<OperatorStrategy> {
     /**
      * The contingency which this strategy applies to.
      */
-    public String getContingencyId() {
-        return contingencyId;
+    public ContingencyContext getContingencyContext() {
+        return contingencyContext;
     }
 
     /**

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/strategy/OperatorStrategyList.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/strategy/OperatorStrategyList.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 public class OperatorStrategyList {
     private final List<OperatorStrategy> operatorStrategies;
-    public static final String VERSION = "1.0";
+    public static final String VERSION = "1.1";
 
     public OperatorStrategyList(List<OperatorStrategy> operatorStrategies) {
         this.operatorStrategies = ImmutableList.copyOf(Objects.requireNonNull(operatorStrategies));
@@ -39,15 +39,15 @@ public class OperatorStrategyList {
         return operatorStrategies;
     }
 
-    public static OperatorStrategyList readFile(Path jsonFile) {
+    public static OperatorStrategyList read(Path jsonFile) {
         try (InputStream is = Files.newInputStream(jsonFile)) {
-            return readOutputStream(is);
+            return read(is);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    public static OperatorStrategyList readOutputStream(InputStream is) {
+    public static OperatorStrategyList read(InputStream is) {
         Objects.requireNonNull(is);
 
         ObjectMapper objectMapper = JsonUtil.createObjectMapper()
@@ -62,10 +62,10 @@ public class OperatorStrategyList {
     /**
      * Writes action list as JSON to a file.
      */
-    public void writeFile(Path jsonFile) {
+    public void write(Path jsonFile) {
         Objects.requireNonNull(jsonFile);
         try (OutputStream outputStream = Files.newOutputStream(jsonFile)) {
-            writeOutputStream(outputStream);
+            write(outputStream);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -74,7 +74,7 @@ public class OperatorStrategyList {
     /**
      * Writes action list as JSON to an output stream.
      */
-    public void writeOutputStream(OutputStream outputStream) {
+    public void write(OutputStream outputStream) {
         try {
             ObjectMapper objectMapper = createObjectMapper();
             ObjectWriter writer = objectMapper.writerWithDefaultPrettyPrinter();

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/tools/SecurityAnalysisTool.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/tools/SecurityAnalysisTool.java
@@ -301,7 +301,7 @@ public class SecurityAnalysisTool implements Tool {
             .setParameters(parametersLoader.get());
 
         options.getPath(MONITORING_FILE).ifPresent(monitorFilePath -> executionInput.setMonitors(StateMonitor.read(monitorFilePath)));
-        options.getPath(STRATEGIES_FILE).ifPresent(operatorStrategyFilePath -> executionInput.setOperatorStrategies(OperatorStrategyList.readFile(operatorStrategyFilePath).getOperatorStrategies()));
+        options.getPath(STRATEGIES_FILE).ifPresent(operatorStrategyFilePath -> executionInput.setOperatorStrategies(OperatorStrategyList.read(operatorStrategyFilePath).getOperatorStrategies()));
         options.getPath(ACTIONS_FILE).ifPresent(actionFilePath -> executionInput.setActions(ActionList.readJsonFile(actionFilePath).getActions()));
 
         updateInput(options, executionInput);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisResultBuilderTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisResultBuilderTest.java
@@ -1,6 +1,7 @@
 package com.powsybl.security;
 
 import com.powsybl.contingency.Contingency;
+import com.powsybl.contingency.ContingencyContext;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -214,7 +215,7 @@ public class SecurityAnalysisResultBuilderTest {
     @Test
     public void operatorStrategyResultCreation() {
         //Build result with 1 operator strategy
-        OperatorStrategy operatorStrategy = new OperatorStrategy("strat1", "cont1", new TrueCondition(),
+        OperatorStrategy operatorStrategy = new OperatorStrategy("strat1", ContingencyContext.specificContingency("cont1"), new TrueCondition(),
                 List.of("action1", "action2"));
 
         SecurityAnalysisResultBuilder builder = new SecurityAnalysisResultBuilder(new LimitViolationFilter(),

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
@@ -70,7 +70,7 @@ public class ExporterTest extends AbstractConverterTest {
         List<BusResult> preContingencyBusResults = List.of(new BusResult("voltageLevelId", "busId", 400, 3.14));
         List<ThreeWindingsTransformerResult> threeWindingsTransformerResults = List.of(new ThreeWindingsTransformerResult("threeWindingsTransformerId", 1, 2, 3, 1.1, 2.1, 3.1, 1.2, 2.2, 3.2));
         List<OperatorStrategyResult> operatorStrategyResults = new ArrayList<>();
-        operatorStrategyResults.add(new OperatorStrategyResult(new OperatorStrategy("strategyId", "contingency1", new AtLeastOneViolationCondition(Collections.singletonList("violationId1")),
+        operatorStrategyResults.add(new OperatorStrategyResult(new OperatorStrategy("strategyId", ContingencyContext.specificContingency("contingency1"), new AtLeastOneViolationCondition(Collections.singletonList("violationId1")),
                 Collections.singletonList("actionId1")), PostContingencyComputationStatus.CONVERGED, new LimitViolationsResult(Collections.emptyList()),
                 new NetworkResult(Collections.emptyList(), Collections.emptyList(), Collections.emptyList())));
         SecurityAnalysisResult result = new SecurityAnalysisResult(preContingencyResult, LoadFlowResult.ComponentResult.Status.CONVERGED,

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandlersTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandlersTest.java
@@ -13,6 +13,7 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.computation.*;
 import com.powsybl.contingency.Contingency;
+import com.powsybl.contingency.ContingencyContext;
 import com.powsybl.iidm.network.VariantManagerConstants;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.loadflow.LoadFlowResult;
@@ -117,7 +118,7 @@ public class SecurityAnalysisExecutionHandlersTest {
     @Test
     public void forwardedBeforeWithCompleteInput() throws IOException {
         Action action = new SwitchAction("action", "switch", false);
-        OperatorStrategy strategy = new OperatorStrategy("strat", "cont", new TrueCondition(), List.of("action"));
+        OperatorStrategy strategy = new OperatorStrategy("strat", ContingencyContext.specificContingency("cont"), new TrueCondition(), List.of("action"));
 
         SecurityAnalysisExecutionInput input = new SecurityAnalysisExecutionInput()
                 .setParameters(new SecurityAnalysisParameters())

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/JsonOperatorStrategyExtensionTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/JsonOperatorStrategyExtensionTest.java
@@ -21,6 +21,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.commons.extensions.ExtensionJsonSerializer;
 import com.powsybl.commons.json.JsonUtil;
+import com.powsybl.contingency.ContingencyContext;
 import com.powsybl.security.condition.TrueCondition;
 import com.powsybl.security.strategy.OperatorStrategy;
 import com.powsybl.security.strategy.OperatorStrategyList;
@@ -37,24 +38,24 @@ public class JsonOperatorStrategyExtensionTest extends AbstractConverterTest {
 
     @Test
     public void testWrite() throws IOException {
-        OperatorStrategy operatorStrategy = new OperatorStrategy("id1", "contingencyId1",
+        OperatorStrategy operatorStrategy = new OperatorStrategy("id1", ContingencyContext.specificContingency("contingencyId1"),
                 new TrueCondition(), Arrays.asList("actionId1", "actionId2", "actionId3"));
         operatorStrategy.addExtension(DummyExtension.class, new DummyExtension());
         OperatorStrategyList operatorStrategyList = new OperatorStrategyList(Collections.singletonList(operatorStrategy));
-        writeTest(operatorStrategyList, OperatorStrategyList::writeFile, ComparisonUtils::compareTxt,
+        writeTest(operatorStrategyList, OperatorStrategyList::write, ComparisonUtils::compareTxt,
                 "/OperatorStrategyFileExtensionsTest.json");
     }
 
     @Test
     public void testRoundTrip() throws IOException {
-        OperatorStrategy operatorStrategy = new OperatorStrategy("id1", "contingencyId1",
+        OperatorStrategy operatorStrategy = new OperatorStrategy("id1", ContingencyContext.specificContingency("contingencyId1"),
                 new TrueCondition(), Arrays.asList("actionId1", "actionId2", "actionId3"));
         operatorStrategy.addExtension(DummyExtension.class, new DummyExtension());
-        OperatorStrategy operatorStrategy2 = new OperatorStrategy("id2", "contingencyId2",
+        OperatorStrategy operatorStrategy2 = new OperatorStrategy("id2", ContingencyContext.specificContingency("contingencyId2"),
                 new TrueCondition(), Collections.singletonList("actionId4"));
         operatorStrategy2.addExtension(DummyExtension.class, new DummyExtension());
         OperatorStrategyList operatorStrategyList = new OperatorStrategyList(Arrays.asList(operatorStrategy, operatorStrategy2));
-        roundTripTest(operatorStrategyList, OperatorStrategyList::writeFile, OperatorStrategyList::readFile,
+        roundTripTest(operatorStrategyList, OperatorStrategyList::write, OperatorStrategyList::read,
                 "/OperatorStrategyFileExtensionsTest2.json");
     }
 

--- a/security-analysis/security-analysis-api/src/test/resources/OperatorStrategyFileExtensionsTest.json
+++ b/security-analysis/security-analysis-api/src/test/resources/OperatorStrategyFileExtensionsTest.json
@@ -1,7 +1,8 @@
 {
-  "version" : "1.0",
+  "version" : "1.1",
   "operatorStrategies" : [ {
     "id" : "id1",
+    "contingencyContextType" : "SPECIFIC",
     "contingencyId" : "contingencyId1",
     "condition" : {
       "type" : "TRUE_CONDITION"

--- a/security-analysis/security-analysis-api/src/test/resources/OperatorStrategyFileExtensionsTest2.json
+++ b/security-analysis/security-analysis-api/src/test/resources/OperatorStrategyFileExtensionsTest2.json
@@ -1,7 +1,8 @@
 {
-  "version" : "1.0",
+  "version" : "1.1",
   "operatorStrategies" : [ {
     "id" : "id1",
+    "contingencyContextType" : "SPECIFIC",
     "contingencyId" : "contingencyId1",
     "condition" : {
       "type" : "TRUE_CONDITION"
@@ -16,6 +17,7 @@
     }
   }, {
     "id" : "id2",
+    "contingencyContextType" : "SPECIFIC",
     "contingencyId" : "contingencyId2",
     "condition" : {
       "type" : "TRUE_CONDITION"

--- a/security-analysis/security-analysis-api/src/test/resources/OperatorStrategyFileTestV1.0.json
+++ b/security-analysis/security-analysis-api/src/test/resources/OperatorStrategyFileTestV1.0.json
@@ -1,8 +1,7 @@
 {
-  "version" : "1.1",
+  "version" : "1.0",
   "operatorStrategies" : [ {
     "id" : "id1",
-    "contingencyContextType" : "SPECIFIC",
     "contingencyId" : "contingencyId1",
     "condition" : {
       "type" : "TRUE_CONDITION"
@@ -10,7 +9,6 @@
     "actionIds" : [ "actionId1", "actionId2", "actionId3" ]
   }, {
     "id" : "id1",
-    "contingencyContextType" : "SPECIFIC",
     "contingencyId" : "contingencyId1",
     "condition" : {
       "type" : "TRUE_CONDITION"

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResultV1.3.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResultV1.3.json
@@ -148,7 +148,6 @@
   "operatorStrategyResults" : [ {
     "operatorStrategy" : {
       "id" : "strategyId",
-      "contingencyContextType" : "SPECIFIC",
       "contingencyId" : "contingency1",
       "condition" : {
         "type" : "AT_LEAST_ONE_VIOLATION",

--- a/security-analysis/security-analysis-default/src/test/java/com/powsybl/security/impl/SecurityAnalysisTest.java
+++ b/security-analysis/security-analysis-default/src/test/java/com/powsybl/security/impl/SecurityAnalysisTest.java
@@ -115,7 +115,7 @@ public class SecurityAnalysisTest {
         SecurityAnalysisInterceptorMock interceptorMock = new SecurityAnalysisInterceptorMock();
         List<SecurityAnalysisInterceptor> interceptors = new ArrayList<>();
         List<OperatorStrategy> operatorStrategies = new ArrayList<>();
-        operatorStrategies.add(new OperatorStrategy("operatorStrategy", "c1",
+        operatorStrategies.add(new OperatorStrategy("operatorStrategy", ContingencyContext.specificContingency("c1"),
                 new AnyViolationCondition(), Collections.singletonList("action1")));
 
         List<Action> actions = new ArrayList<>();
@@ -165,7 +165,7 @@ public class SecurityAnalysisTest {
         interceptors.add(interceptorMock);
 
         List<OperatorStrategy> operatorStrategies = new ArrayList<>();
-        operatorStrategies.add(new OperatorStrategy("operatorStrategy", "c1", new AnyViolationCondition(), Collections.singletonList("action1")));
+        operatorStrategies.add(new OperatorStrategy("operatorStrategy", ContingencyContext.specificContingency("c1"), new AnyViolationCondition(), Collections.singletonList("action1")));
 
         List<Action> actions = new ArrayList<>();
         actions.add(new SwitchAction("action1", "switchId", true));


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
We can only associate an operator strategy to one contingency.


**What is the new behavior (if this is a feature change)?**
We can thanks to contingency context associate an operator strategy to not only one contingency but also to non or all contingencies.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
