### PR TITLE
Add findAll convenient method to all providers

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.loadflow;
 
+import com.google.common.collect.Lists;
 import com.powsybl.commons.Versionable;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.config.PlatformConfigNamedProvider;
@@ -37,6 +38,10 @@ import java.util.concurrent.CompletableFuture;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public interface LoadFlowProvider extends Versionable, PlatformConfigNamedProvider {
+
+    static List<LoadFlowProvider> findAll() {
+        return Lists.newArrayList(ServiceLoader.load(LoadFlowProvider.class, LoadFlowProvider.class.getClassLoader()));
+    }
 
     /**
      * Run a loadflow on variant {@code workingVariantId} of {@code network} delegating external program execution to

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderTest.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.loadflow;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class LoadFlowProviderTest {
+
+    @Test
+    public void findAllProvidersTest() {
+        assertEquals(1, LoadFlowProvider.findAll().size());
+    }
+}

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisProvider.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisProvider.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.security;
 
+import com.google.common.collect.Lists;
 import com.powsybl.commons.Versionable;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.config.PlatformConfigNamedProvider;
@@ -20,10 +21,7 @@ import com.powsybl.security.interceptors.SecurityAnalysisInterceptor;
 import com.powsybl.security.monitor.StateMonitor;
 import com.powsybl.security.strategy.OperatorStrategy;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -42,6 +40,10 @@ import java.util.concurrent.CompletableFuture;
  * @author Thomas Adam <tadam at silicom.fr>
  */
 public interface SecurityAnalysisProvider extends Versionable, PlatformConfigNamedProvider {
+
+    static List<SecurityAnalysisProvider> findAll() {
+        return Lists.newArrayList(ServiceLoader.load(SecurityAnalysisProvider.class, SecurityAnalysisProvider.class.getClassLoader()));
+    }
 
     /**
      * Run an asynchronous single security analysis job.

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisProviderTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisProviderTest.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.security;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class SecurityAnalysisProviderTest {
+
+    @Test
+    public void findAllProvidersTest() {
+        assertEquals(5, SecurityAnalysisProvider.findAll().size());
+    }
+}

--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityAnalysisProvider.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityAnalysisProvider.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sensitivity;
 
+import com.google.common.collect.Lists;
 import com.powsybl.commons.Versionable;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.config.PlatformConfigNamedProvider;
@@ -16,10 +17,7 @@ import com.powsybl.computation.ComputationManager;
 import com.powsybl.contingency.Contingency;
 import com.powsybl.iidm.network.Network;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -39,6 +37,10 @@ import java.util.concurrent.CompletableFuture;
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  */
 public interface SensitivityAnalysisProvider extends Versionable, PlatformConfigNamedProvider {
+
+    static List<SensitivityAnalysisProvider> findAll() {
+        return Lists.newArrayList(ServiceLoader.load(SensitivityAnalysisProvider.class, SensitivityAnalysisProvider.class.getClassLoader()));
+    }
 
     /**
      * Run a single sensitivity analysis.

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisProviderTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisProviderTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sensitivity;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class SensitivityAnalysisProviderTest {
+
+    @Test
+    public void findAllProvidersTest() {
+        assertEquals(1, SensitivityAnalysisProvider.findAll().size());
+    }
+}

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/ShortCircuitAnalysisProvider.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/ShortCircuitAnalysisProvider.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.shortcircuit;
 
+import com.google.common.collect.Lists;
 import com.powsybl.commons.Versionable;
 import com.powsybl.commons.config.PlatformConfigNamedProvider;
 import com.powsybl.commons.reporter.Reporter;
@@ -13,6 +14,7 @@ import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -24,6 +26,10 @@ import java.util.concurrent.CompletableFuture;
  * @author Anne Tilloy <anne.tilloy at rte-france.com>
  */
 public interface ShortCircuitAnalysisProvider extends Versionable, PlatformConfigNamedProvider {
+
+    static List<ShortCircuitAnalysisProvider> findAll() {
+        return Lists.newArrayList(ServiceLoader.load(ShortCircuitAnalysisProvider.class, ShortCircuitAnalysisProvider.class.getClassLoader()));
+    }
 
     /**
      * Run an asynchronous single short circuit analysis job.

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisProviderTest.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisProviderTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.shortcircuit;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class ShortCircuitAnalysisProviderTest {
+
+    @Test
+    public void findAllProvidersTest() {
+        assertEquals(1, ShortCircuitAnalysisProvider.findAll().size());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature



**What is the new behavior (if this is a feature change)?**
A findAll method has been added to all providers (loadflow, security analysis, sensitivity analysis and short circuit) to easily get all available providers.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
