### PR TITLE
CGMES SV export: use naming strategy to obtain proper topological node identifiers

### DIFF
--- a/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_Assembled_v2_bad_ids/MicroGridTestConfiguration_BC_NL_TP_V2.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_Assembled_v2_bad_ids/MicroGridTestConfiguration_BC_NL_TP_V2.xml
@@ -11,7 +11,7 @@
     <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES/2.4.15</md:Model.modelingAuthoritySet>
     <md:Model.profile>http://entsoe.eu/CIM/Topology/4/1</md:Model.profile>
   </md:FullModel>
-  <cim:TopologicalNode rdf:ID="_97d7d14a-7294-458f-a8d7-024700a08717">
+  <cim:TopologicalNode rdf:ID="_97d7d14a-7294-458f-a8d7-024700a08717_badid_tp_node">
     <cim:IdentifiedObject.name>NL_TR_BUS2</cim:IdentifiedObject.name>
     <cim:TopologicalNode.BaseVoltage rdf:resource="#_c1d5bff18f8011e08e4d00247eb1f55e"/>
     <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8"/>
@@ -94,7 +94,7 @@
     <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9"/>
   </cim:Terminal>
   <cim:Terminal rdf:about="#_4f1c405f-07c9-4fb0-b64e-551896a29aa8">
-    <cim:Terminal.TopologicalNode rdf:resource="#_97d7d14a-7294-458f-a8d7-024700a08717"/>
+    <cim:Terminal.TopologicalNode rdf:resource="#_97d7d14a-7294-458f-a8d7-024700a08717_badid_tp_node"/>
   </cim:Terminal>
   <cim:Terminal rdf:about="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64">
     <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615"/>
@@ -103,7 +103,7 @@
     <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615"/>
   </cim:Terminal>
   <cim:Terminal rdf:about="#_faab7959-f9bf-421b-bc3f-d364e0c1388b">
-    <cim:Terminal.TopologicalNode rdf:resource="#_97d7d14a-7294-458f-a8d7-024700a08717"/>
+    <cim:Terminal.TopologicalNode rdf:resource="#_97d7d14a-7294-458f-a8d7-024700a08717_badid_tp_node"/>
   </cim:Terminal>
   <cim:Terminal rdf:about="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c">
     <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc"/>
@@ -136,7 +136,7 @@
     <cim:Terminal.TopologicalNode rdf:resource="#_795a117d-7caf-4fc2-a8d9-dc8f4cf2344a"/>
   </cim:Terminal>
   <cim:Terminal rdf:about="#_42800bad-5e47-42e6-b9b0-1fb8fc5831aa">
-    <cim:Terminal.TopologicalNode rdf:resource="#_97d7d14a-7294-458f-a8d7-024700a08717"/>
+    <cim:Terminal.TopologicalNode rdf:resource="#_97d7d14a-7294-458f-a8d7-024700a08717_badid_tp_node"/>
   </cim:Terminal>
   <cim:Terminal rdf:about="#_0f199d49-0093-4b51-b357-70371424d174">
     <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615"/>

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesMappingTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesMappingTest.java
@@ -245,7 +245,11 @@ public class CgmesMappingTest extends AbstractConverterTest {
                         cgmes.terminals().stream().map(o -> o.getId(CgmesNames.TERMINAL)),
                         cgmes.connectivityNodes().stream().map(o -> o.getId(CgmesNames.CONNECTIVITY_NODE)),
                         cgmes.topologicalNodes().stream().map(o -> o.getId(CgmesNames.TOPOLOGICAL_NODE)),
-                        cgmes.topologicalIslands().stream().map(o -> o.getId(CgmesNames.TOPOLOGICAL_ISLAND)),
+                        cgmes.topologicalIslands().stream().flatMap(o -> Stream.of(
+                                o.getId(CgmesNames.TOPOLOGICAL_ISLAND),
+                                o.getId(CgmesNames.ANGLEREF_TOPOLOGICALNODE),
+                                o.getId(CgmesNames.TOPOLOGICAL_NODES))),
+                        cgmes.topologicalIslands().stream().map(o -> o.getId(CgmesNames.ANGLEREF_TOPOLOGICALNODE)),
                         cgmes.transformerEnds().stream().map(o -> o.getId(CgmesNames.TRANSFORMER_END)),
                         cgmes.phaseTapChangers().stream().map(o -> o.getId(CgmesNames.PHASE_TAP_CHANGER)),
                         cgmes.ratioTapChangers().stream().map(o -> o.getId(CgmesNames.RATIO_TAP_CHANGER)),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Identifiers of topological nodes in the SV output may not match the identifiers exported to TP file.
When buses have ids that are invalid mRIDs and they are fixed in the export, the TP uses the fixed ids, while the SV uses directly the bus ids.


**What is the new behavior (if this is a feature change)?**
Identifiers of topological nodes in the SV export match the identifiers in the TP file.
