### PR TITLE
Bbv cache not invalidated for a retained switch when opened/closed

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerVoltageLevel.java
@@ -370,7 +370,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     }
 
     @Override
-    public void invalidateCache() {
+    public void invalidateCache(boolean exceptBusBreakerView) {
         calculatedBusTopology.invalidateCache();
         getNetwork().getBusView().invalidateCache();
         getNetwork().getBusBreakerView().invalidateCache();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -575,11 +575,13 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     }
 
     @Override
-    public void invalidateCache() {
-        variants.get().calculatedBusBreakerTopology.invalidateCache();
+    public void invalidateCache(boolean exceptBusBreakerView) {
+        if (!exceptBusBreakerView) {
+            variants.get().calculatedBusBreakerTopology.invalidateCache();
+            getNetwork().getBusBreakerView().invalidateCache();
+        }
         variants.get().calculatedBusTopology.invalidateCache();
         getNetwork().getBusView().invalidateCache();
-        getNetwork().getBusBreakerView().invalidateCache();
         getNetwork().getConnectedComponentsManager().invalidate();
         getNetwork().getSynchronousComponentsManager().invalidate();
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
@@ -66,7 +66,13 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
             this.open.set(index, open);
             String variantId = network.getVariantManager().getVariantId(index);
             network.getListeners().notifyUpdate(this, "open", variantId, oldValue, open);
-            voltageLevel.invalidateCache();
+            if (isRetained()) {
+                // calculated buses don't change whatever the state of the switch is, but connected components might.
+                network.getConnectedComponentsManager().invalidate();
+                network.getSynchronousComponentsManager().invalidate();
+            } else {
+                voltageLevel.invalidateCache();
+            }
         }
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
@@ -66,13 +66,7 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
             this.open.set(index, open);
             String variantId = network.getVariantManager().getVariantId(index);
             network.getListeners().notifyUpdate(this, "open", variantId, oldValue, open);
-            if (isRetained()) {
-                // calculated buses don't change whatever the state of the switch is, but connected components might.
-                network.getConnectedComponentsManager().invalidate();
-                network.getSynchronousComponentsManager().invalidate();
-            } else {
-                voltageLevel.invalidateCache();
-            }
+            voltageLevel.invalidateCache(isRetained());
         }
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
@@ -52,5 +52,9 @@ interface VoltageLevelExt extends VoltageLevel, MultiVariantObject {
 
     boolean disconnect(TerminalExt terminal);
 
-    void invalidateCache();
+    default void invalidateCache() {
+        invalidateCache(false);
+    }
+
+    void invalidateCache(boolean exceptBusBreakerView);
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSwitchSetRetainedTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSwitchSetRetainedTest.java
@@ -10,6 +10,9 @@ import com.google.common.collect.Iterables;
 import com.powsybl.iidm.network.*;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.junit.Assert.*;
 
 /**
@@ -69,5 +72,29 @@ public abstract class AbstractSwitchSetRetainedTest {
         variantManager.setWorkingVariant("backup");
         assertTrue(b1.isRetained());
         assertEquals(2, Iterables.size(vl.getBusBreakerView().getBuses()));
+    }
+
+    @Test
+    public void testCloseRetainedSwitch() {
+        Network network = createNetwork();
+        VoltageLevel vl = network.getVoltageLevel("VL");
+        assertNotNull(vl);
+
+        Switch b1 = network.getSwitch("B1");
+        assertNotNull(b1);
+        assertTrue(b1.isRetained());
+        assertFalse(b1.isOpen());
+
+        List<Bus> buses0 = vl.getBusBreakerView().getBusStream().collect(Collectors.toList());
+
+        b1.setOpen(true);
+
+        List<Bus> buses1 = vl.getBusBreakerView().getBusStream().collect(Collectors.toList());
+        assertEquals(buses0, buses1);
+
+        b1.setOpen(false);
+
+        List<Bus> buses2 = vl.getBusBreakerView().getBusStream().collect(Collectors.toList());
+        assertEquals(buses0, buses2);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Feature



**What is the current behavior?**
Bus breaker view cache invalidate when switch opened/closed even if switch is retained


**What is the new behavior (if this is a feature change)?**
If switch is retained, bus breaker view cache not invalidated when switch opened/closed


**Does this PR introduce a breaking change or deprecate an API?**
No