### PR TITLE
CGMES fix network id for CGMES3; conformity test configurations v3

### DIFF
--- a/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/CgmesCatalogsConstants.java
+++ b/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/CgmesCatalogsConstants.java
@@ -14,6 +14,7 @@ final class CgmesCatalogsConstants {
 
     static final String CGMES_3_TEST_MODELS = "/cgmes3-test-models";
     static final String ENTSOE_CONFORMITY_1 = "/conformity/cas-1.1.3-data-4.0.3";
+    static final String ENTSOE_CONFORMITY_3 = "/conformity/cas-3-data-3.0.2";
 
     static final String MICRO_GRID_BE_BASE = ENTSOE_CONFORMITY_1
             + "/MicroGrid/BaseCase/CGMES_v2.4.15_MicroGridTestConfiguration_BC_BE_v2/";
@@ -41,6 +42,13 @@ final class CgmesCatalogsConstants {
             + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_BaseCase_Complete_v3.0.0/";
     static final String SMALL_GRID_NODE_BREAKER_BD_BASE = ENTSOE_CONFORMITY_1
             + "/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0/";
+
+    static final String MICRO_GRID_3_BE_BASE = ENTSOE_CONFORMITY_3
+            + "/MicroGrid/BaseCase/MicroGrid-BE-MAS/";
+    static final String MICRO_GRID_3_NL_BASE = ENTSOE_CONFORMITY_3
+            + "/MicroGrid/BaseCase/MicroGrid-NL-MAS/";
+    static final String MICRO_GRID_3_BD_BASE = ENTSOE_CONFORMITY_3
+            + "/MicroGrid/BaseCase/MicroGrid-BD-MAS/";
 
     static final String CGMES_3_MICRO_GRID_BASE = CGMES_3_TEST_MODELS + "/MicroGrid/";
     static final String CGMES_3_MINI_GRID_BASE = CGMES_3_TEST_MODELS + "/MiniGrid/";

--- a/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/CgmesConformity3Catalog.java
+++ b/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/CgmesConformity3Catalog.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conformity;
+
+import com.powsybl.cgmes.model.GridModelReferenceResources;
+import com.powsybl.commons.datasource.ResourceSet;
+
+import static com.powsybl.cgmes.conformity.CgmesCatalogsConstants.*;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+public final class CgmesConformity3Catalog {
+
+    private CgmesConformity3Catalog() {
+    }
+
+    public static ResourceSet microGridBaseCaseBoundaries() {
+        return new ResourceSet(MICRO_GRID_3_BD_BASE, "20171002T0930Z_ENTSO-E_EQ_BD_2.xml");
+    }
+
+    public static GridModelReferenceResources microGridBaseCaseBE() {
+        return new GridModelReferenceResources(
+                "MicroGrid-3-BaseCase-BE",
+                null,
+                new ResourceSet(MICRO_GRID_3_BE_BASE,
+                        "20210325T1530Z_1D_BE_DL_001.xml",
+                        "20210325T1530Z_1D_BE_EQ_001.xml",
+                        "20210325T1530Z_1D_BE_GL_001.xml",
+                        "20210325T1530Z_1D_BE_SSH_001.xml",
+                        "20210325T1530Z_1D_BE_SV_001.xml",
+                        "20210325T1530Z_1D_BE_TP_001.xml",
+                        "20210420T1730Z_1D_BE_DY_001.xml"
+                ),
+                microGridBaseCaseBoundaries());
+    }
+
+    public static GridModelReferenceResources microGridBaseCaseNL() {
+        return new GridModelReferenceResources(
+                "MicroGrid-3-BaseCase-NL",
+                null,
+                new ResourceSet(MICRO_GRID_3_NL_BASE,
+                        "20210325T1530Z_1D_NL_DL_001.xml",
+                        "20210325T1530Z_1D_NL_EQ_001.xml",
+                        "20210325T1530Z_1D_NL_GL_001.xml",
+                        "20210325T1530Z_1D_NL_SSH_001.xml",
+                        "20210325T1530Z_1D_NL_SV_001.xml",
+                        "20210325T1530Z_1D_NL_TP_001.xml",
+                        "20210420T1730Z_1D_NL_DY_001.xml"
+                ),
+                microGridBaseCaseBoundaries());
+    }
+}

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BD-MAS/20171002T0930Z_ENTSO-E_EQ_BD_2.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BD-MAS/20171002T0930Z_ENTSO-E_EQ_BD_2.xml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:eu="http://iec.ch/TC57/CIM100-European#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:536f9bf1-3f8f-a546-87e3-7af2272f29b7">
+    <md:Model.scenarioTime>2030-01-25T19:00:00Z</md:Model.scenarioTime>
+    <md:Model.created>2021-01-25T19:00:00Z</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/3.0</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://entsoe.eu/boundary</md:Model.modelingAuthoritySet>
+    <md:Model.version>5</md:Model.version>
+  </md:FullModel>
+  <cim:BaseVoltage rdf:ID="_a7f1d8de-d658-428a-821b-3a5ae5965fd1">
+    <cim:IdentifiedObject.description>Base Voltage 220 kV</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>220 kV</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>220</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>220</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>a7f1d8de-d658-428a-821b-3a5ae5965fd1</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_63893f24-5b4e-407c-9a1e-4ff71121f33c">
+    <cim:IdentifiedObject.description>Base Voltage 225 kV</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>225 kV</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>225</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>225</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>63893f24-5b4e-407c-9a1e-4ff71121f33c</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6">
+    <cim:IdentifiedObject.description>Base Voltage 380 kV</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>380 kV</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>380</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>380</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>35cf638d-9a9d-4ae5-ae90-2f01ef898cb6</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_597e44dc-2a6e-4c62-82f3-f82cc46e0e14">
+    <cim:IdentifiedObject.description>Base Voltage 400 kV</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>400 kV</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>400</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>400</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>597e44dc-2a6e-4c62-82f3-f82cc46e0e14</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:ConnectivityNode rdf:ID="_b675a570-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_AL11</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XCA_AL11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-ES-PT-10004U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:IdentifiedObject.mRID>b675a570-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_b67c8340-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_GY11</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XWI_GY11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-HU-00002U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:IdentifiedObject.mRID>b67c8340-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_b67cf870-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_MA11</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XKA_MA11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-SI-00001T</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:IdentifiedObject.mRID>b67cf870-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_b66f15c0-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_ST23</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XZE_ST23</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00016Z</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:IdentifiedObject.mRID>b66f15c0-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_b6978550-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_ST24</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XZE_ST24</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00017X</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:IdentifiedObject.mRID>b6978550-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:EnergySchedulingType rdf:ID="_24C12434-E42B-497f-928F-119C6AE92079">
+    <cim:IdentifiedObject.name>Biomass</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Biomass</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>EST-Biomass</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>24C12434-E42B-497f-928F-119C6AE92079</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_FB6F43D6-E71E-423a-8CEB-084BC504FD1A">
+    <cim:IdentifiedObject.name>Co-generation</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Co-generation</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>CoGen</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>FB6F43D6-E71E-423a-8CEB-084BC504FD1A</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_1CDFB476-4E01-4488-B5A2-FDDEA0488C59">
+    <cim:IdentifiedObject.name>Geothermal</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Geothermal</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>Geotherm</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>1CDFB476-4E01-4488-B5A2-FDDEA0488C59</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_2C897906-9B7F-4508-B132-74EA3EE1D3B0">
+    <cim:IdentifiedObject.name>Marine</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Marine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>ES-Marine</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>2C897906-9B7F-4508-B132-74EA3EE1D3B0</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_A43C7A90-B4C7-460c-A607-942EFA3EFB79">
+    <cim:IdentifiedObject.name>Other renewable</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Other renewable</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>OtherRenew</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>A43C7A90-B4C7-460c-A607-942EFA3EFB79</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_1C405140-0F45-4534-9C90-F38F4905362C">
+    <cim:IdentifiedObject.name>Waste</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Waste</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>EST-Waste</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>1C405140-0F45-4534-9C90-F38F4905362C</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:GeographicalRegion rdf:ID="_fb980bdf-ced5-4f87-8264-998e95e065a5">
+    <cim:IdentifiedObject.description>Economic and political union of member states located primarily in Europe</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>EU</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-EU-EU-000001</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>EU</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>fb980bdf-ced5-4f87-8264-998e95e065a5</cim:IdentifiedObject.mRID>
+  </cim:GeographicalRegion>
+  <cim:Line rdf:ID="_eac31e3d-fdf5-4656-b10e-66481bfcfec5">
+    <cim:IdentifiedObject.name>TieLine_XCA_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XCA_AL11</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XCA_AL11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10314U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>eac31e3d-fdf5-4656-b10e-66481bfcfec5</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_54a2e470-ef70-443f-ae81-bcf2d117caa2">
+    <cim:IdentifiedObject.name>TieLine_XKA_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XKA_MA11</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XKA_MA11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10114U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>54a2e470-ef70-443f-ae81-bcf2d117caa2</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_bd25e87a-c626-4dd7-a846-7fba517fbb8f">
+    <cim:IdentifiedObject.name>TieLine_XWI_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XWI_GY11</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XWI_GY11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10014U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>bd25e87a-c626-4dd7-a846-7fba517fbb8f</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1">
+    <cim:IdentifiedObject.name>TieLine_XZE_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XZE_ST23</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST23</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10234U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae2">
+    <cim:IdentifiedObject.name>TieLine_HVDC-NL</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>HVDC TieLine at NL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>HVDC_NL</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10344U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae2</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_54a2e470-ef70-443f-ae81-bcf2d117caa3">
+    <cim:IdentifiedObject.name>TieLine_XZE_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XZE_ST24</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST24</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10274U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>54a2e470-ef70-443f-ae81-bcf2d117caa2</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:SubGeographicalRegion rdf:ID="_fbcc6679-6da5-4cfd-b50c-8ce23f450c78">
+    <cim:IdentifiedObject.name>ENTSO-E</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_fb980bdf-ced5-4f87-8264-998e95e065a5" />
+    <cim:IdentifiedObject.description>ENTSO-E region</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>ENTSO-E</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>fbcc6679-6da5-4cfd-b50c-8ce23f450c78</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <eu:BoundaryPoint rdf:ID="_8fe8c999-a939-5d43-b857-02dd312f2dea">
+    <cim:IdentifiedObject.name>Border_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XCA_AL11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-ES-PT-10004U</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>ES</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Cartelle</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>REE</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>PT</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Alto Lindoso</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>REN</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>8fe8c999-a939-5d43-b857-02dd312f2dea</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+  <eu:BoundaryPoint rdf:ID="_af1d901f-98de-574f-abc3-6c3025e7a685">
+    <cim:IdentifiedObject.name>Border_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XWI_GY11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-HU-00002U</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>AT</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Wien</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>APG</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>HU</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Győr</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>MAVIR</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>af1d901f-98de-574f-abc3-6c3025e7a685</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+  <eu:BoundaryPoint rdf:ID="_7976cd48-d51c-8e4b-9595-56299cb5b4f8">
+    <cim:IdentifiedObject.name>Border_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XKA_MA11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-SI-00001T</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>AT</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Kainachtal</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>APG</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>SI</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Maribor</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>ELES</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>7976cd48-d51c-8e4b-9595-56299cb5b4f8</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+  <eu:BoundaryPoint rdf:ID="_c65325ed-92a7-384a-834b-99c1ceea32ef">
+    <cim:IdentifiedObject.name>Border_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST23</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00016Z</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>AT</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Zell/Ziller</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>APG</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>DE</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Strass</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>TIWAG-Netz</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>c65325ed-92a7-384a-834b-99c1ceea32ef</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+  <eu:BoundaryPoint rdf:ID="_fd0e36b7-817f-4547-9e0f-a07011aecd48">
+    <cim:IdentifiedObject.name>Border_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST24</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00017X</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>AT</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Zell/Ziller</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>APG</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>DE</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Strass</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>TIWAG-Netz</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>fd0e36b7-817f-4547-9e0f-a07011aecd48</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_DL_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_DL_001.xml
@@ -1,0 +1,1194 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:948c6905-cc3e-4174-9240-bf748d7252dc">
+    <md:Model.created>2021-04-23T00:13:30Z</md:Model.created>
+    <md:Model.scenarioTime>2021-04-23T17:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d" />
+  </md:FullModel>
+  <cim:Diagram rdf:ID="_894dbbdf-fdca-4e0f-d968-39fc0dd20857">
+    <cim:IdentifiedObject.name>BE</cim:IdentifiedObject.name>
+    <cim:Diagram.orientation rdf:resource="http://iec.ch/TC57/CIM100#OrientationKind.negative" />
+    <cim:IdentifiedObject.mRID>894dbbdf-fdca-4e0f-d968-39fc0dd20857</cim:IdentifiedObject.mRID>
+  </cim:Diagram>
+  <cim:DiagramObject rdf:ID="_13ddc417-59cc-6609-1809-39fc0dd20857">
+    <cim:IdentifiedObject.name>G-Link-356832441</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_8171fc34-6891-40e0-92d1-da9f4ba69e26" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>13ddc417-59cc-6609-1809-39fc0dd20857</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_07025480-b573-a9fb-5e0a-39fc0dd20857">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>342.6354</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>242.0938</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_13ddc417-59cc-6609-1809-39fc0dd20857" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_df8b88b6-6a1a-188f-142b-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>339.5683</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>242.0938</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_13ddc417-59cc-6609-1809-39fc0dd20857" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_81af2352-cdd2-4e29-05ba-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>339.5683</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>242.0938</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_13ddc417-59cc-6609-1809-39fc0dd20857" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_3fb18917-de71-6bfa-2ed8-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>242.0938</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_13ddc417-59cc-6609-1809-39fc0dd20857" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5ccffe60-1b7e-f839-2bbd-39fc0dd20858">
+    <cim:IdentifiedObject.name>G-Link-356832394</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>5ccffe60-1b7e-f839-2bbd-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_1f1401cc-3a15-916e-821a-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>284</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>148</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5ccffe60-1b7e-f839-2bbd-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_29d1dfc0-9e95-ff75-5f0d-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>277.0794</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>148</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5ccffe60-1b7e-f839-2bbd-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_117d0c69-183b-4ac9-672b-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>277.0794</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>178.5321</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5ccffe60-1b7e-f839-2bbd-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_da40580d-90fe-8dab-14dc-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>269.875</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>178.5321</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5ccffe60-1b7e-f839-2bbd-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_a5a39142-01c5-de56-5d0d-39fc0dd20858">
+    <cim:IdentifiedObject.name>G-Link-356832502</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_5a7b80f3-eeb3-4253-a792-5157c0946b15" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>a5a39142-01c5-de56-5d0d-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_4c5dbdd8-ba0d-99fd-1785-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>239.4479</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a5a39142-01c5-de56-5d0d-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_7a46e664-bf03-ea40-b332-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>254.8252</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a5a39142-01c5-de56-5d0d-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b271d76c-a182-700d-36e7-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>254.8252</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a5a39142-01c5-de56-5d0d-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_34865223-9748-c083-7d1e-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>269.875</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a5a39142-01c5-de56-5d0d-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e5e0f610-c61c-5a6c-4127-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>e5e0f610-c61c-5a6c-4127-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ef6fe7f1-5f57-c969-60d3-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>198</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e5e0f610-c61c-5a6c-4127-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_cf1a9e0f-0a3b-7138-0cd3-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e5e0f610-c61c-5a6c-4127-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5b6fd1ef-e98a-9a5a-d0b9-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>5b6fd1ef-e98a-9a5a-d0b9-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_cda4b0cc-7ada-3361-ae08-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>140</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5b6fd1ef-e98a-9a5a-d0b9-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_65f2480b-ace1-3d61-f529-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>124</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5b6fd1ef-e98a-9a5a-d0b9-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_df9d9fd7-c84a-e359-023f-39fc0dd20858">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XZE_ST23-567797459</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_87ea56f3-962a-427a-85d6-13b1f9295174" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>df9d9fd7-c84a-e359-023f-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_50430bdd-61e0-ad48-bc42-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>426.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_df9d9fd7-c84a-e359-023f-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_00d70ddf-f5ef-2c7f-0a31-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>00d70ddf-f5ef-2c7f-0a31-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_885e8fa9-b8d3-7db0-2d55-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>180</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>238</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_00d70ddf-f5ef-2c7f-0a31-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_2d7e4547-0283-0ee5-b8d7-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>180</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>76</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_00d70ddf-f5ef-2c7f-0a31-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_46e02e0a-17f5-8901-5a48-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>46e02e0a-17f5-8901-5a48-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_c5b0aca0-cac5-1033-e922-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>250.2</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_46e02e0a-17f5-8901-5a48-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_890a93b3-b577-7f78-417e-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>240</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_46e02e0a-17f5-8901-5a48-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_166a4340-2fa7-0aef-c23d-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>166a4340-2fa7-0aef-c23d-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_55777c66-1734-9f62-b69e-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>368</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>252</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_166a4340-2fa7-0aef-c23d-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_19ace026-5b1a-5a77-add0-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>368</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>234</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_166a4340-2fa7-0aef-c23d-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_d7e15e08-151f-1c77-d403-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>d7e15e08-151f-1c77-d403-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_9f262d85-034e-adc4-3a12-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>322</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>78</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d7e15e08-151f-1c77-d403-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_ffdfd7c8-7c7f-ecc3-ea9e-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>322</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d7e15e08-151f-1c77-d403-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_da205cd2-3f2f-ed91-332e-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>da205cd2-3f2f-ed91-332e-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ac80e000-8dc5-b123-6f06-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>100</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>210</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_da205cd2-3f2f-ed91-332e-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_1ccd12ce-b527-10c0-7800-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>100</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_da205cd2-3f2f-ed91-332e-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_b9c208c5-ed4c-57e8-da61-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>b9c208c5-ed4c-57e8-da61-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_29412f18-fab1-5a52-8a8f-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>336</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>188</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b9c208c5-ed4c-57e8-da61-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_481ac22c-62df-039a-682e-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>336</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>258</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b9c208c5-ed4c-57e8-da61-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_08b8722f-e28c-4d76-9eec-39fc0dd20858">
+    <cim:IdentifiedObject.name>GR-BE-TR2_2-1727325206</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>08b8722f-e28c-4d76-9eec-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_95dd7921-10f2-4fde-b874-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>229.4479</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_08b8722f-e28c-4d76-9eec-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_90f9c9a6-0497-9349-1778-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>90f9c9a6-0497-9349-1778-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_7a491995-d9ee-cd4c-768b-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>152</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_90f9c9a6-0497-9349-1778-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_f93ef289-07b8-e652-a251-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>170</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_90f9c9a6-0497-9349-1778-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_4eed5ffb-f287-9461-00cf-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>4eed5ffb-f287-9461-00cf-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_0d563a6c-68be-78a1-f98c-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>270</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>246</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4eed5ffb-f287-9461-00cf-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_146bd9bf-09cb-d515-dcd4-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>270</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>172</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4eed5ffb-f287-9461-00cf-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e07600cf-dc76-c7a7-4db6-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>e07600cf-dc76-c7a7-4db6-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_9f24d808-433c-775e-c2ea-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>240</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>155</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e07600cf-dc76-c7a7-4db6-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_07371b5d-5085-86b0-efad-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>240</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>142</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e07600cf-dc76-c7a7-4db6-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_aabe38f2-b813-7fe1-5303-39fc0dd20858">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>aabe38f2-b813-7fe1-5303-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_a616b558-e06f-9e01-f264-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>88</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_aabe38f2-b813-7fe1-5303-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_c48b0894-cf9b-f927-7cfe-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>104</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_aabe38f2-b813-7fe1-5303-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_08d26f85-c98d-a324-6df8-39fc0dd20858">
+    <cim:IdentifiedObject.name>GR-BE-TR3_1-588996490</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>08d26f85-c98d-a324-6df8-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d174aa61-84de-63e6-0ff8-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>293</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>156</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_08d26f85-c98d-a324-6df8-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_ca52f20e-04b0-d846-2752-39fc0dd20858">
+    <cim:IdentifiedObject.name>GR-L-1230804819-107271114</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>ca52f20e-04b0-d846-2752-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d9c00a70-0820-dd9f-1c5b-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>330</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>259.8</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ca52f20e-04b0-d846-2752-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_09913e78-1235-f4d9-115a-39fc0dd20858">
+    <cim:IdentifiedObject.name>GR-L-590589455</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>09913e78-1235-f4d9-115a-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_621126d4-8744-9592-c5cb-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>228</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>152</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_09913e78-1235-f4d9-115a-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_2aa6768a-df85-8c9f-f42f-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>240</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>152</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_09913e78-1235-f4d9-115a-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_009154e0-3a2d-5e73-9ce4-39fc0dd20858">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XCA_AL11-2032402764</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_24413233-26c3-4f7e-9f72-4461796938be" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>009154e0-3a2d-5e73-9ce4-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_02245266-2555-d138-d875-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>422.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_009154e0-3a2d-5e73-9ce4-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_b573e376-2eca-da5a-87f9-39fc0dd20858">
+    <cim:IdentifiedObject.name>GR-L-528357588</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_d238885e-d9b6-4edc-8567-6a68c605ed67" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>b573e376-2eca-da5a-87f9-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d30c9b93-543e-8250-2aff-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>430</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b573e376-2eca-da5a-87f9-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_580c4b0f-a7f8-ea71-a4ea-39fc0dd20858">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>213.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b573e376-2eca-da5a-87f9-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_d944a8db-67c5-a716-3960-39fc0dd20858">
+    <cim:IdentifiedObject.name>GR-L-1275183736</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>d944a8db-67c5-a716-3960-39fc0dd20858</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_5d9398a4-709b-1bf1-4bdf-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>330</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>256</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d944a8db-67c5-a716-3960-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_eccc2daf-a30e-ae22-4696-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>336</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>256</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d944a8db-67c5-a716-3960-39fc0dd20858" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_91ad6462-91af-a626-8a8c-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE-Load_2-1031602377</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>91ad6462-91af-a626-8a8c-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_1a9e643d-5606-9414-1ce2-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>252.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>196</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_91ad6462-91af-a626-8a8c-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_920d5ae0-3b72-ee3f-b97e-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-801938665</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_53072f42-f77b-47e2-bd9a-e097c910b173" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>920d5ae0-3b72-ee3f-b97e-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ad858c4d-1529-d26c-8217-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>426</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_920d5ae0-3b72-ee3f-b97e-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b3f77af0-6181-e03d-f872-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138.1</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_920d5ae0-3b72-ee3f-b97e-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_9fde973e-6b93-fdbe-db7a-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-1308868918</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a036b765-1669-4f64-acd3-1e8fbd513312" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>9fde973e-6b93-fdbe-db7a-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ce4f416b-23ca-d100-61b1-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>256</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>196</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9fde973e-6b93-fdbe-db7a-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_0600289e-2704-8a53-4da6-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>270</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>196</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9fde973e-6b93-fdbe-db7a-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_ac44406f-7c7f-3b7d-f884-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE-G2-1116156353</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>ac44406f-7c7f-3b7d-f884-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_b5a635cd-d29b-2448-c2c8-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>222.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>152</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ac44406f-7c7f-3b7d-f884-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_843c8e8a-b750-4c83-3fcd-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-88950007</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b9539c41-d114-4280-8a54-8ecec398091e" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>843c8e8a-b750-4c83-3fcd-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_83838430-7c24-c900-896f-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>426</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>100</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_843c8e8a-b750-4c83-3fcd-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_86d27524-b682-2ce7-67a7-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>99.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_843c8e8a-b750-4c83-3fcd-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_30f02826-2e1b-5f2c-9776-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XKA_MA11-2022038108</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_14b352cb-5574-40c5-bf83-0ed3574554a3" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>30f02826-2e1b-5f2c-9776-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_2a70b21d-02a9-d21b-5d1f-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>424.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_30f02826-2e1b-5f2c-9776-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_565019ca-67a5-2e24-5c88-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-416266794</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>565019ca-67a5-2e24-5c88-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_904be865-a72b-3149-acc7-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>240</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_565019ca-67a5-2e24-5c88-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_62c71abd-11c9-c7e7-55c6-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>210.0364</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_565019ca-67a5-2e24-5c88-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_185f34fb-a56b-a5a3-39d6-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>210.0364</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>109.9902</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_565019ca-67a5-2e24-5c88-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_2b2c417f-5a90-742d-34c5-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>179.9167</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>109.9902</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_565019ca-67a5-2e24-5c88-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_8dbcf1d8-ac24-8c0f-b7c5-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-SER-RLC-1230822986-1370200677</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>270</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>8dbcf1d8-ac24-8c0f-b7c5-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_2c0a0d55-8007-9149-ab22-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>352.6354</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>242.0938</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8dbcf1d8-ac24-8c0f-b7c5-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_52ab363e-6558-57fc-2a0f-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE-TR2_3-2107319875</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>52ab363e-6558-57fc-2a0f-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_7199343b-a544-59a9-5457-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>136</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_52ab363e-6558-57fc-2a0f-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_2ac777e9-31be-ce93-d42d-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-1013791171</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>2ac777e9-31be-ce93-d42d-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_a42e22d4-8bf0-e59d-4324-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>126</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2ac777e9-31be-ce93-d42d-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b4dbf963-221c-0e74-1047-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>100</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2ac777e9-31be-ce93-d42d-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_284b904a-d782-e268-d39d-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE_S2-984836859</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>284b904a-d782-e268-d39d-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_f1b9346b-118d-e6df-586b-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>301.7</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_284b904a-d782-e268-d39d-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_c378aeae-89f6-27ef-6c2e-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE-TR2_1-1880804297</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>c378aeae-89f6-27ef-6c2e-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_c1384dcb-a462-753a-2d9c-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>250</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c378aeae-89f6-27ef-6c2e-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_96eb00da-a102-cdd0-ad2b-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-2063620735</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>96eb00da-a102-cdd0-ad2b-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_78b5083c-2aed-f4b6-b710-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>428</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_96eb00da-a102-cdd0-ad2b-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_ce3676f5-d7fd-fc03-369e-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>247.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_96eb00da-a102-cdd0-ad2b-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_c21407e3-b29e-cffd-d838-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE-Load_1-1632019080</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_cb459405-cc14-4215-a45c-416789205904" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>c21407e3-b29e-cffd-d838-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_f5c163da-bb53-8dc1-e0b5-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>160.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>132</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c21407e3-b29e-cffd-d838-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_a1014825-fb3e-c6db-11b7-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-421252201</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>a1014825-fb3e-c6db-11b7-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_802621b2-dbd3-7e71-0775-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>177.5</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a1014825-fb3e-c6db-11b7-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_1caa192c-28fc-c3bd-41d5-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>180</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a1014825-fb3e-c6db-11b7-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5b84b248-a1b9-04f3-79a6-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XZE_ST24-1604012077</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>5b84b248-a1b9-04f3-79a6-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_1896391f-7ab9-6c5f-3af5-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>424.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5b84b248-a1b9-04f3-79a6-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_583df5be-c1a1-d315-a75e-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE-G1-1630856750</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>583df5be-c1a1-d315-a75e-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_93d7e7ea-f54a-09b1-4133-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>78.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_583df5be-c1a1-d315-a75e-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_1e32a003-26c9-d719-5c5c-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-378961811</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_beffa353-7d10-421d-9c08-036b744b1cee" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>1e32a003-26c9-d719-5c5c-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_fd85a284-8f28-3bce-cba8-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>84</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1e32a003-26c9-d719-5c5c-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_0e2e31d9-840e-986b-d30d-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>100</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1e32a003-26c9-d719-5c5c-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_58da13a1-7fc4-d71a-a5db-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XWI_GY11-504554590</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>58da13a1-7fc4-d71a-a5db-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_f0583acd-0274-1ed1-68e2-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>422.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>100</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_58da13a1-7fc4-d71a-a5db-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_c59f6864-9eed-1de7-fa08-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-1898814619</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_22af3121-1a66-4546-bd80-4371f417c644" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>c59f6864-9eed-1de7-fa08-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_95fd5258-fc77-7eea-f0c6-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>309.5</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c59f6864-9eed-1de7-fa08-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_c56fd1d7-3d1b-5764-80a0-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>322</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c59f6864-9eed-1de7-fa08-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_32e2f1be-cdbd-fc4f-a760-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-BE_S1-872951107</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>32e2f1be-cdbd-fc4f-a760-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_2c14ce66-5f56-34e8-9fda-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>169.7</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_32e2f1be-cdbd-fc4f-a760-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_b6ed4089-4595-bdce-8c67-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-1418390997</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>b6ed4089-4595-bdce-8c67-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_669f2aaf-ff88-d0a2-02f6-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>260</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b6ed4089-4595-bdce-8c67-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_92c4bfde-adab-1e69-4bac-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>290.931</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b6ed4089-4595-bdce-8c67-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_e1e0ab88-884e-2eda-2e08-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>290.931</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>109.8021</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b6ed4089-4595-bdce-8c67-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_4ae14a58-e846-9999-42ec-39fc0dd20859">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.9979</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>109.8021</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b6ed4089-4595-bdce-8c67-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_cba04a7c-13a1-83a1-0d50-39fc0dd20859">
+    <cim:IdentifiedObject.name>GR-L-613633054</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>cba04a7c-13a1-83a1-0d50-39fc0dd20859</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_a90a34a6-d580-c2f9-4f7e-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>164</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>132</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_cba04a7c-13a1-83a1-0d50-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_86136f8f-40d4-9e11-4cc7-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>180</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>132</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_cba04a7c-13a1-83a1-0d50-39fc0dd20859" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_001f1d78-34ef-983a-3f56-39fc0dd2085a">
+    <cim:IdentifiedObject.name>GR-L-971040548</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_c41978db-794b-4bae-953e-60fc519e87dd" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>001f1d78-34ef-983a-3f56-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_017550b7-9214-1bc2-4348-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>428</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_001f1d78-34ef-983a-3f56-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_ce244eb2-7918-0c00-2bca-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_001f1d78-34ef-983a-3f56-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_c44fa1ad-0ac7-d629-4bcd-39fc0dd2085a">
+    <cim:IdentifiedObject.name>GR-BE-Line_1-2014872019</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>c44fa1ad-0ac7-d629-4bcd-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_1df71fc6-a62b-8b66-a356-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>204</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c44fa1ad-0ac7-d629-4bcd-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d7cba74e-5e94-044f-b497-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>203.7292</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c44fa1ad-0ac7-d629-4bcd-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_a98b8518-f0aa-4f8a-716c-39fc0dd2085a">
+    <cim:IdentifiedObject.name>GR-BE-Line_6-532186611</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>a98b8518-f0aa-4f8a-716c-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_60dbecdf-9b43-617b-be50-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>269.875</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>234.1563</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a98b8518-f0aa-4f8a-716c-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_1cd8247e-9da0-0854-27b6-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>234.1563</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a98b8518-f0aa-4f8a-716c-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_a7378fc1-94f4-ea7f-2ae0-39fc0dd2085a">
+    <cim:IdentifiedObject.name>GR-BE-Line_2-652640566</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>a7378fc1-94f4-ea7f-2ae0-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d123ad2a-bf87-6836-6d06-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>269.875</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a7378fc1-94f4-ea7f-2ae0-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_277397c6-55e7-3d68-ff2c-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a7378fc1-94f4-ea7f-2ae0-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_59359679-3fd1-0d61-dc1e-39fc0dd2085a">
+    <cim:IdentifiedObject.name>GR-BE-Line_4-421288522</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>59359679-3fd1-0d61-dc1e-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ede64391-c754-c5c5-304b-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>322</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>158</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_59359679-3fd1-0d61-dc1e-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_f6236d1b-40ed-18bd-a4a5-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>158</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_59359679-3fd1-0d61-dc1e-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_74d880c8-ccb1-08b3-845a-39fc0dd2085a">
+    <cim:IdentifiedObject.name>GR-BE-Line_3-270727583</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>74d880c8-ccb1-08b3-845a-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_22f2b7d6-27ea-e772-867c-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.9979</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>129.6474</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_74d880c8-ccb1-08b3-845a-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_e62df09e-8391-8e74-e465-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>130</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_74d880c8-ccb1-08b3-845a-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_caa758db-a1ba-0fd2-4bc8-39fc0dd2085a">
+    <cim:IdentifiedObject.name>GR-BE-Line_7-1830067902</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>caa758db-a1ba-0fd2-4bc8-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_823ee3e4-181c-1a78-32b0-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_caa758db-a1ba-0fd2-4bc8-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_ce253a0b-b176-32dc-5acf-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>367.7708</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>243.4167</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_caa758db-a1ba-0fd2-4bc8-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_522f32cb-9f3d-a752-26e4-39fc0dd2085a">
+    <cim:IdentifiedObject.name>GR-BE-Line_5-609606907</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>522f32cb-9f3d-a752-26e4-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_e44430a2-b28e-f0b1-54f7-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.9979</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>96.57291</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_522f32cb-9f3d-a752-26e4-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_40cf9a35-1722-23d4-4d69-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>96.57291</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_522f32cb-9f3d-a752-26e4-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5cf00688-0d01-da37-2303-39fc0dd2085a">
+    <cim:IdentifiedObject.name>GR-SVC-1230797516-663010278</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>5cf00688-0d01-da37-2303-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_0ae5f512-9b9c-b735-e632-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>316.1771</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>263.1771</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5cf00688-0d01-da37-2303-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_50bbeb6d-9066-b0c7-23a0-39fc0dd2085a">
+    <cim:IdentifiedObject.name>G-Link-356832572</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>50bbeb6d-9066-b0c7-23a0-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_805afba6-e0a5-e428-1744-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>146</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_50bbeb6d-9066-b0c7-23a0-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d366a59a-1112-fde4-d23c-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>162.7188</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_50bbeb6d-9066-b0c7-23a0-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_1c6e0a8d-17e6-c480-de5d-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>162.7188</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>195.7917</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_50bbeb6d-9066-b0c7-23a0-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_484d614a-85d8-8bca-54c0-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>179.9167</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>195.7917</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_50bbeb6d-9066-b0c7-23a0-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_740646af-36a8-a679-27dc-39fc0dd2085a">
+    <cim:IdentifiedObject.name>G-Link-356832474</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_67bb74f1-8620-4a32-9d7d-a44092d11d22" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>740646af-36a8-a679-27dc-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_969ac8af-cb9f-29d5-38d0-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>316.1771</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>252.6771</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_740646af-36a8-a679-27dc-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_41192586-2bd9-5261-8b95-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>316.1771</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248.7083</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_740646af-36a8-a679-27dc-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_63d21d78-caa8-bad7-0a17-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248.7083</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_740646af-36a8-a679-27dc-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_9701aa93-53ee-8922-be4d-39fc0dd2085a">
+    <cim:IdentifiedObject.name>G-Link-356832352</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>9701aa93-53ee-8922-be4d-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_2b522abb-a0a0-799d-3800-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>302</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>156</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9701aa93-53ee-8922-be4d-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_9fc26044-ada5-731a-dad3-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>311.8561</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>156</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9701aa93-53ee-8922-be4d-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_3e1a7b26-76a2-bd82-5b6a-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>311.8561</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>149.7144</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9701aa93-53ee-8922-be4d-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_3606f265-2154-04f2-b7e7-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.9979</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>149.7144</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9701aa93-53ee-8922-be4d-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_91619e13-3094-8e85-413c-39fc0dd2085a">
+    <cim:IdentifiedObject.name>G-Link-356832382</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>91619e13-3094-8e85-413c-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_856c008e-9edd-fed8-d6f8-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>284</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>164</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_91619e13-3094-8e85-413c-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_5e7ee013-4bad-4c3b-886d-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>262.1697</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>164</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_91619e13-3094-8e85-413c-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_a76bed5c-afd4-5942-6fc3-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>262.1697</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>147.0561</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_91619e13-3094-8e85-413c-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_57529d54-7293-f315-0949-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>239.9771</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>147.0561</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_91619e13-3094-8e85-413c-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_36940aa5-3621-d98d-6640-39fc0dd2085a">
+    <cim:IdentifiedObject.name>G-Link-356832519</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_0ac86078-8267-4fd9-b6c2-27984975ffcc" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>36940aa5-3621-d98d-6640-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_e1c48bae-824e-b8f3-ec13-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>219.4479</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_36940aa5-3621-d98d-6640-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_007dfe4c-3f22-7718-f29a-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>199.8046</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_36940aa5-3621-d98d-6640-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_fc2af4d7-06b6-5143-eee0-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>199.8046</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_36940aa5-3621-d98d-6640-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d3362bfc-c7d2-00d2-0a31-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>179.9167</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_36940aa5-3621-d98d-6640-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_00352832-d885-611b-50af-39fc0dd2085a">
+    <cim:IdentifiedObject.name>G-Link-356832447</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7" />
+    <cim:DiagramObject.Diagram rdf:resource="#_894dbbdf-fdca-4e0f-d968-39fc0dd20857" />
+    <cim:IdentifiedObject.mRID>00352832-d885-611b-50af-39fc0dd2085a</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ab4c344f-92ba-4b22-bedf-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>362.6354</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>242.0938</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_00352832-d885-611b-50af-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_2ceedb31-7a63-ad33-ad26-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>365.3088</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>242.0938</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_00352832-d885-611b-50af-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_e7395fd2-97d3-8468-7d3d-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>365.3088</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>242.0938</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_00352832-d885-611b-50af-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_4a40756e-1fe5-b9ba-fbe0-39fc0dd2085a">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>367.7708</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>242.0938</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_00352832-d885-611b-50af-39fc0dd2085a" />
+  </cim:DiagramObjectPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_EQ_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_EQ_001.xml
@@ -1,0 +1,1806 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:536f9bf1-3f8f-a546-87e3-7af2272f29b7" />
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/3.0</md:Model.profile>
+  </md:FullModel>
+  <cim:LoadArea rdf:ID="_516c5401-f9f7-4cf8-89b5-853f9cd75f29">
+    <cim:IdentifiedObject.name>BE LoadArea</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>516c5401-f9f7-4cf8-89b5-853f9cd75f29</cim:IdentifiedObject.mRID>
+  </cim:LoadArea>
+  <cim:SubLoadArea rdf:ID="_0051c797-996b-42b8-86b7-3176e9b52cd3">
+    <cim:IdentifiedObject.name>ELIA-Anvers SubLoadArea</cim:IdentifiedObject.name>
+    <cim:SubLoadArea.LoadArea rdf:resource="#_516c5401-f9f7-4cf8-89b5-853f9cd75f29" />
+    <cim:IdentifiedObject.mRID>0051c797-996b-42b8-86b7-3176e9b52cd3</cim:IdentifiedObject.mRID>
+  </cim:SubLoadArea>
+  <cim:SubLoadArea rdf:ID="_f217eb1a-92c4-4e9e-ad95-8ac8e527f0fc">
+    <cim:IdentifiedObject.name>ELIA-Brussels SubLoadArea</cim:IdentifiedObject.name>
+    <cim:SubLoadArea.LoadArea rdf:resource="#_516c5401-f9f7-4cf8-89b5-853f9cd75f29" />
+    <cim:IdentifiedObject.mRID>f217eb1a-92c4-4e9e-ad95-8ac8e527f0fc</cim:IdentifiedObject.mRID>
+  </cim:SubLoadArea>
+  <cim:GeographicalRegion rdf:ID="_7bf89875-1476-4d1a-a56d-a2965cce3575">
+    <cim:IdentifiedObject.name>BE</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>7bf89875-1476-4d1a-a56d-a2965cce3575</cim:IdentifiedObject.mRID>
+  </cim:GeographicalRegion>
+  <cim:SubGeographicalRegion rdf:ID="_61378219-a236-4070-bbec-4e30a6ac848d">
+    <cim:IdentifiedObject.name>ELIA-Brussels</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_7bf89875-1476-4d1a-a56d-a2965cce3575" />
+    <cim:IdentifiedObject.mRID>61378219-a236-4070-bbec-4e30a6ac848d</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_37e14a0f-5e34-4647-a062-8bfd9305fa9d">
+    <cim:IdentifiedObject.name>PP_Brussels</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PP_Brussels</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>37e14a0f-5e34-4647-a062-8bfd9305fa9d</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+  <cim:SubGeographicalRegion rdf:ID="_02047c0b-b5a4-4e0d-bae6-fc5437a55e74">
+    <cim:IdentifiedObject.name>ELIA-Anvers</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_7bf89875-1476-4d1a-a56d-a2965cce3575" />
+    <cim:IdentifiedObject.mRID>02047c0b-b5a4-4e0d-bae6-fc5437a55e74</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_87f7002b-056f-4a6a-a872-1744eea757e3">
+    <cim:IdentifiedObject.name>Anvers</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>Anvers</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_02047c0b-b5a4-4e0d-bae6-fc5437a55e74" />
+    <cim:IdentifiedObject.mRID>87f7002b-056f-4a6a-a872-1744eea757e3</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+  <cim:VoltageLevel rdf:ID="_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c">
+    <cim:IdentifiedObject.name>225.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>247.5</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>202.5</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:IdentifiedObject.mRID>b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_bf851342-832e-4ea2-b2ad-b09729b3af23">
+    <cim:IdentifiedObject.name>BE-Busbar_3</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_3</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>bf851342-832e-4ea2-b2ad-b09729b3af23</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_5caf27ed-d2f8-458a-834a-6b3193a982e6">
+    <cim:IdentifiedObject.name>BE-Busbar_3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>5caf27ed-d2f8-458a-834a-6b3193a982e6</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:IdentifiedObject.name>BE-Busbar_3_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5caf27ed-d2f8-458a-834a-6b3193a982e6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_469df5f7-058f-4451-a998-57a48e8a56fe">
+    <cim:IdentifiedObject.name>380.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>418</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>342</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:IdentifiedObject.mRID>469df5f7-058f-4451-a998-57a48e8a56fe</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_4836f99b-c6e9-4ee8-a956-b1e3da882d46">
+    <cim:IdentifiedObject.name>BE-Busbar_1</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_1</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>4836f99b-c6e9-4ee8-a956-b1e3da882d46</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c">
+    <cim:IdentifiedObject.name>BE-Busbar_1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:IdentifiedObject.name>BE-Busbar_1_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>fa9e0f4d-8a2f-45e1-9e36-3611600d1c94</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_929ba893-c9dc-44d7-b1fd-30834bd3ab85">
+    <cim:IdentifiedObject.name>21.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>23.1</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>18.9</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2" />
+    <cim:IdentifiedObject.mRID>929ba893-c9dc-44d7-b1fd-30834bd3ab85</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33">
+    <cim:IdentifiedObject.name>BE-Busbar_5</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_5</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:IdentifiedObject.mRID>f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:VoltageLevel rdf:ID="_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0">
+    <cim:IdentifiedObject.name>110.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>121</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>99</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:IdentifiedObject.mRID>8bbd7e74-ae20-4dce-8780-c20f8e18c2e0</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_1695eb20-9044-4133-a3fd-2147f55f170d">
+    <cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_6</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:IdentifiedObject.mRID>1695eb20-9044-4133-a3fd-2147f55f170d</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_364c9ca2-0d1d-4363-8f46-e586f8f66a8c">
+    <cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:BusbarSection.ipMax>5000</cim:BusbarSection.ipMax>
+    <cim:IdentifiedObject.mRID>364c9ca2-0d1d-4363-8f46-e586f8f66a8c</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:IdentifiedObject.name>BE-Busbar_6_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_364c9ca2-0d1d-4363-8f46-e586f8f66a8c" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>a1b46f53-86f1-497e-bf57-c3b6268bcd6c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_69ef0dbd-da79-4eef-a02f-690cb8a28361">
+    <cim:IdentifiedObject.name>225.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>247.5</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>202.5</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_87f7002b-056f-4a6a-a872-1744eea757e3" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:IdentifiedObject.mRID>69ef0dbd-da79-4eef-a02f-690cb8a28361</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_ae99bd74-26b1-443a-b1a5-656320283a36">
+    <cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_2</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>ae99bd74-26b1-443a-b1a5-656320283a36</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_ef45b632-3028-4afe-bc4c-a4fa323d83fe">
+    <cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>ef45b632-3028-4afe-bc4c-a4fa323d83fe</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:IdentifiedObject.name>BE-Busbar_2_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ef45b632-3028-4afe-bc4c-a4fa323d83fe" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>800ada75-8c8c-4568-aec5-20f799e45f3c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386">
+    <cim:IdentifiedObject.name>10.5</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>11.55</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>9.45</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75" />
+    <cim:IdentifiedObject.mRID>4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c">
+    <cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_4</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:IdentifiedObject.mRID>0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_fd649fe1-bdf5-4062-98ea-bbb66f50402d">
+    <cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:IdentifiedObject.mRID>fd649fe1-bdf5-4062-98ea-bbb66f50402d</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:IdentifiedObject.name>BE-Busbar_4_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fd649fe1-bdf5-4062-98ea-bbb66f50402d" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:IdentifiedObject.mRID>65b8c937-9b25-4b9e-addf-602dbc1337f9</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_af14c8ab-eb51-42be-89cb-abbcf37e20a3">
+    <cim:IdentifiedObject.name>Series Compensator</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>af14c8ab-eb51-42be-89cb-abbcf37e20a3</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:EquivalentInjection rdf:ID="_87ea56f3-962a-427a-85d6-13b1f9295174">
+    <cim:IdentifiedObject.name>BE-Inj-XZE_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Equipment.EquipmentContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>87ea56f3-962a-427a-85d6-13b1f9295174</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_24413233-26c3-4f7e-9f72-4461796938be">
+    <cim:IdentifiedObject.name>BE-Inj-XCA_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XCA_AL1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>24413233-26c3-4f7e-9f72-4461796938be</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_f7f61a91-eca2-4492-8bd7-9ec2b28fc837">
+    <cim:IdentifiedObject.name>BE-Inj-XZE_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>f7f61a91-eca2-4492-8bd7-9ec2b28fc837</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf">
+    <cim:IdentifiedObject.name>BE-Inj-XWI_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XWI_GY1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_14b352cb-5574-40c5-bf83-0ed3574554a3">
+    <cim:IdentifiedObject.name>BE-Inj-XKA_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XKA_MA1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>14b352cb-5574-40c5-bf83-0ed3574554a3</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:Line rdf:ID="_cc4b99a5-e20d-407c-9d8e-a682b9723613">
+    <cim:IdentifiedObject.name>container of BE-Line_6</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>cc4b99a5-e20d-407c-9d8e-a682b9723613</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:ACLineSegment rdf:ID="_ffbabc27-1ccd-4fdc-b037-e341706c8d29">
+    <cim:IdentifiedObject.name>BE-Line_6</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TYNDP project BE-4; map reference 567</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_6</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>true</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cc4b99a5-e20d-407c-9d8e-a682b9723613" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:Conductor.length>100</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0.0001476549</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.00119E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0.00012</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0.00012</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>5.203</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>15</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>71</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>213</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>ffbabc27-1ccd-4fdc-b037-e341706c8d29</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_6 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_05a17350-55f5-4a00-9a50-8c0048a25495" />
+    <cim:IdentifiedObject.mRID>cb5b5011-9f6c-4af2-93f9-26ae7e30c8db</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_d1de5f7a-b11d-4c34-9628-1ce03b8f1989">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1312</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>d1de5f7a-b11d-4c34-9628-1ce03b8f1989</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_6696b2a8-77fa-43a0-a019-f33287b03071">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>6696b2a8-77fa-43a0-a019-f33287b03071</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_30cbcb48-f02e-4791-83ab-486d7688874c">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_6 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809" />
+    <cim:IdentifiedObject.mRID>30cbcb48-f02e-4791-83ab-486d7688874c</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_fc61a99c-b255-4f1e-96eb-16198b2fbfc3">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1312</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>fc61a99c-b255-4f1e-96eb-16198b2fbfc3</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2c987138-9078-4f6a-b4f9-93d159b04fae">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2c987138-9078-4f6a-b4f9-93d159b04fae</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_17086487-56ba-4979-b8de-064025a6b4da">
+    <cim:IdentifiedObject.name>BE-Line_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000061</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>22</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>2.62637E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>8.2938E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>3.08E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>3.08E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>2.2</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>6.6</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>68.2</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>204.6</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>17086487-56ba-4979-b8de-064025a6b4da</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_a5b37323-8f73-449a-8931-f73193d95587">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_70d962fb-a492-4c36-8cad-b5c584df53bd" />
+    <cim:IdentifiedObject.mRID>a5b37323-8f73-449a-8931-f73193d95587</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_a2efb67d-28de-4243-aa59-8c297122b4f6">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>a2efb67d-28de-4243-aa59-8c297122b4f6</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_718557d0-e400-47e7-ab87-0c466237672e">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>718557d0-e400-47e7-ab87-0c466237672e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_aef3c15e-c567-476a-83ad-3fe46c817fb2">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_1ef0715a-d5a9-477b-b6e7-b635529ac140" />
+    <cim:IdentifiedObject.mRID>aef3c15e-c567-476a-83ad-3fe46c817fb2</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_fbfb079a-f42a-49e4-a1cd-10a17b44e443">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>fbfb079a-f42a-49e4-a1cd-10a17b44e443</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_9dd1c4cf-344a-4174-8000-430434090202">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>9dd1c4cf-344a-4174-8000-430434090202</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4">
+    <cim:IdentifiedObject.name>BE-Line_7</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000061</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_7</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>23</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>2.89027E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.1677E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>5.75E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>5.75E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>4.6</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>13.8</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>69</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>207</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_56c9ef56-9268-47e6-bed2-044324c03830">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_7 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_57ae9251-c022-4c67-a8eb-611ad54c963c" />
+    <cim:IdentifiedObject.mRID>56c9ef56-9268-47e6-bed2-044324c03830</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_a1c57d7a-447a-4a1a-b69c-94653ca4756e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1062</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>a1c57d7a-447a-4a1a-b69c-94653ca4756e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_05715ad5-5667-41e9-8eec-b7d20dac0921">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>05715ad5-5667-41e9-8eec-b7d20dac0921</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_00672e1a-599a-44f3-aeaa-5a3c99c29ba1">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_7 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1" />
+    <cim:IdentifiedObject.mRID>00672e1a-599a-44f3-aeaa-5a3c99c29ba1</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_8a04fac9-7f86-47e7-b0d4-723b413113da">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1062</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>8a04fac9-7f86-47e7-b0d4-723b413113da</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_f772a663-0557-4de1-94ca-a0fc86ada89f">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>f772a663-0557-4de1-94ca-a0fc86ada89f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_b18cd1aa-7808-49b9-a7cf-605eaf07b006">
+    <cim:IdentifiedObject.name>BE-Line_5</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_5</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:Conductor.length>35</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>3.40863E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>6.59734E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>4.2E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>4.2E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.42</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>1.26</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>6.3</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>18.9</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>b18cd1aa-7808-49b9-a7cf-605eaf07b006</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_b639998f-3a5c-496d-96fd-759131b6c307">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_5 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22" />
+    <cim:IdentifiedObject.mRID>b639998f-3a5c-496d-96fd-759131b6c307</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_c27027b3-61e5-47ae-8f25-140808039152">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>c27027b3-61e5-47ae-8f25-140808039152</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_a3b55712-7319-4725-aaef-d89be09e8e81">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>a3b55712-7319-4725-aaef-d89be09e8e81</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_4af71c73-fd57-45d2-aa83-f1b52fcc3bee">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_5 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_051d49ba-4360-4372-86bf-50eb8cf29778" />
+    <cim:IdentifiedObject.mRID>4af71c73-fd57-45d2-aa83-f1b52fcc3bee</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_7f32e38e-73e1-4699-b00c-c9ce63f5faa4">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>7f32e38e-73e1-4699-b00c-c9ce63f5faa4</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_cd1641e0-7dbd-4db2-8292-e87d65e2eeb5">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>cd1641e0-7dbd-4db2-8292-e87d65e2eeb5</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_ed0c5d75-4a54-43c8-b782-b20d7431630b">
+    <cim:IdentifiedObject.name>BE-Line_4</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>to be connected to the boundary set</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_4</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:Conductor.length>40</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>6.28319E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.51956E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>4E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>4E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.24</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>0.72</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>2</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>6</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>ed0c5d75-4a54-43c8-b782-b20d7431630b</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_b93ba071-c1d4-4c7a-960d-48dcd5d7c389">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_4 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0" />
+    <cim:IdentifiedObject.mRID>b93ba071-c1d4-4c7a-960d-48dcd5d7c389</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e17d44b1-c678-40a3-a736-9f77781fb33e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1226</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>e17d44b1-c678-40a3-a736-9f77781fb33e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_770404e9-b224-4cda-b9bf-8b23d4fa7822">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>770404e9-b224-4cda-b9bf-8b23d4fa7822</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_67fa7320-7477-47e9-89ff-e3a407644aef">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_4 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe" />
+    <cim:IdentifiedObject.mRID>67fa7320-7477-47e9-89ff-e3a407644aef</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2560b6d7-ee39-4f18-ba27-9e9ec505bc9e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1226</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2560b6d7-ee39-4f18-ba27-9e9ec505bc9e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_ec82058b-5d1a-4f8d-a0e6-fa4c3940b273">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>ec82058b-5d1a-4f8d-a0e6-fa4c3940b273</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:Line rdf:ID="_b5d6ed2b-c961-4521-8aef-b943d7dc6c15">
+    <cim:IdentifiedObject.name>container of BE-Line_2</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>b5d6ed2b-c961-4521-8aef-b943d7dc6c15</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:ACLineSegment rdf:ID="_b58bf21a-096a-4dae-9a01-3f03b60c24c7">
+    <cim:IdentifiedObject.name>BE-Line_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00010A</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00010A</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>true</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b5d6ed2b-c961-4521-8aef-b943d7dc6c15" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:Conductor.length>45</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>6.64447E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>4.24115E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>6.75E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>6.75E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.935</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.195</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>34.2</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>102.6</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>b58bf21a-096a-4dae-9a01-3f03b60c24c7</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_7168dee1-15a7-4444-839f-feef071e956d">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_77f04391-aa23-49b6-b3e9-6089130bb5d5" />
+    <cim:IdentifiedObject.mRID>7168dee1-15a7-4444-839f-feef071e956d</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e8b7722a-97b5-4831-b944-89c0a63a96fa">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>e8b7722a-97b5-4831-b944-89c0a63a96fa</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_3ecb9d91-8fdc-4161-81a1-8c5cedd66844">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>3ecb9d91-8fdc-4161-81a1-8c5cedd66844</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_ecc2f619-5716-4af0-9d76-0631a3832e4f">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_699545b9-82b9-4331-bc80-538d73b4ba56" />
+    <cim:IdentifiedObject.mRID>ecc2f619-5716-4af0-9d76-0631a3832e4f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_4602330f-46c5-41d0-bbbe-4b207ff06dbd">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>4602330f-46c5-41d0-bbbe-4b207ff06dbd</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_7b7bb979-e984-4a1a-a977-6f78ddcbc9d3">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>7b7bb979-e984-4a1a-a977-6f78ddcbc9d3</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_78736387-5f60-4832-b3fe-d50daf81b0a6">
+    <cim:IdentifiedObject.name>BE-Line_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00008Y</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00008Y</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:Conductor.length>30</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>2.92168E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0.000149854</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>6E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>6E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.05</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.15</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>12</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>36</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>78736387-5f60-4832-b3fe-d50daf81b0a6</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_0acd95d7-aff7-41f6-aa8a-863c42f4bc36">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_f3b56334-4638-49d3-a6a0-3f417422b8f5" />
+    <cim:IdentifiedObject.mRID>0acd95d7-aff7-41f6-aa8a-863c42f4bc36</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_008c7f00-df41-430c-b94c-37aa08c2e993">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>008c7f00-df41-430c-b94c-37aa08c2e993</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_34d77ffb-666c-4651-9e25-956af0979088">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>34d77ffb-666c-4651-9e25-956af0979088</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_99941f7a-11bb-4a7b-928b-ef8145db7799">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_231a4cf8-5069-4d53-96e4-e839f073f1ea" />
+    <cim:IdentifiedObject.mRID>99941f7a-11bb-4a7b-928b-ef8145db7799</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e68e3e07-101e-42a7-9d85-1d4b7d284ca3">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>e68e3e07-101e-42a7-9d85-1d4b7d284ca3</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_601df66c-7ba7-4ec8-8f8d-a30315f1a88f">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>601df66c-7ba7-4ec8-8f8d-a30315f1a88f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ConformLoad rdf:ID="_b1480a00-b427-4001-a26c-51954d2bb7e9">
+    <cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>L-1230804819</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:EnergyConsumer.LoadResponse rdf:resource="#_8e3e7a69-a64a-43a8-906e-82cc63edfcd3" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_62b480de-1bcd-4771-b24d-e2ca1dac5610" />
+    <cim:IdentifiedObject.mRID>b1480a00-b427-4001-a26c-51954d2bb7e9</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoadGroup rdf:ID="_62b480de-1bcd-4771-b24d-e2ca1dac5610">
+    <cim:IdentifiedObject.name>ELIA-AnversconfLoadGr</cim:IdentifiedObject.name>
+    <cim:LoadGroup.SubLoadArea rdf:resource="#_0051c797-996b-42b8-86b7-3176e9b52cd3" />
+    <cim:IdentifiedObject.mRID>62b480de-1bcd-4771-b24d-e2ca1dac5610</cim:IdentifiedObject.mRID>
+  </cim:ConformLoadGroup>
+  <cim:LoadResponseCharacteristic rdf:ID="_8e3e7a69-a64a-43a8-906e-82cc63edfcd3">
+    <cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+    <cim:LoadResponseCharacteristic.exponentModel>false</cim:LoadResponseCharacteristic.exponentModel>
+    <cim:LoadResponseCharacteristic.pConstantCurrent>0</cim:LoadResponseCharacteristic.pConstantCurrent>
+    <cim:LoadResponseCharacteristic.pConstantImpedance>0</cim:LoadResponseCharacteristic.pConstantImpedance>
+    <cim:LoadResponseCharacteristic.pConstantPower>1</cim:LoadResponseCharacteristic.pConstantPower>
+    <cim:LoadResponseCharacteristic.qConstantCurrent>0</cim:LoadResponseCharacteristic.qConstantCurrent>
+    <cim:LoadResponseCharacteristic.qConstantImpedance>0</cim:LoadResponseCharacteristic.qConstantImpedance>
+    <cim:LoadResponseCharacteristic.qConstantPower>1</cim:LoadResponseCharacteristic.qConstantPower>
+    <cim:IdentifiedObject.mRID>8e3e7a69-a64a-43a8-906e-82cc63edfcd3</cim:IdentifiedObject.mRID>
+  </cim:LoadResponseCharacteristic>
+  <cim:ConformLoad rdf:ID="_cb459405-cc14-4215-a45c-416789205904">
+    <cim:IdentifiedObject.name>BE-Load_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Electrabel</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_12ee1483-1cbf-47c6-8d8a-772053bb6ff2" />
+    <cim:IdentifiedObject.mRID>cb459405-cc14-4215-a45c-416789205904</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoadGroup rdf:ID="_12ee1483-1cbf-47c6-8d8a-772053bb6ff2">
+    <cim:IdentifiedObject.name>ELIA-BrusselsconfLoadGr</cim:IdentifiedObject.name>
+    <cim:LoadGroup.SubLoadArea rdf:resource="#_f217eb1a-92c4-4e9e-ad95-8ac8e527f0fc" />
+    <cim:IdentifiedObject.mRID>12ee1483-1cbf-47c6-8d8a-772053bb6ff2</cim:IdentifiedObject.mRID>
+  </cim:ConformLoadGroup>
+  <cim:ConformLoad rdf:ID="_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8">
+    <cim:IdentifiedObject.name>BE-Load_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>EVN</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_12ee1483-1cbf-47c6-8d8a-772053bb6ff2" />
+    <cim:IdentifiedObject.mRID>1c6beed6-1acf-42e7-ba55-0cc9f04bddd8</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:SeriesCompensator rdf:ID="_df16b3dd-c905-4a6f-84ee-f067be86f5da">
+    <cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:SeriesCompensator.r>0</cim:SeriesCompensator.r>
+    <cim:SeriesCompensator.r0>0</cim:SeriesCompensator.r0>
+    <cim:SeriesCompensator.varistorPresent>true</cim:SeriesCompensator.varistorPresent>
+    <cim:SeriesCompensator.varistorRatedCurrent>500</cim:SeriesCompensator.varistorRatedCurrent>
+    <cim:SeriesCompensator.varistorVoltageThreshold>250</cim:SeriesCompensator.varistorVoltageThreshold>
+    <cim:SeriesCompensator.x>-31.83099</cim:SeriesCompensator.x>
+    <cim:SeriesCompensator.x0>-31.83099</cim:SeriesCompensator.x0>
+    <cim:IdentifiedObject.mRID>df16b3dd-c905-4a6f-84ee-f067be86f5da</cim:IdentifiedObject.mRID>
+  </cim:SeriesCompensator>
+  <cim:OperationalLimitSet rdf:ID="_653b4e65-a657-40fc-b987-c9e28104410f">
+    <cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7" />
+    <cim:IdentifiedObject.mRID>653b4e65-a657-40fc-b987-c9e28104410f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_9fb75b67-c505-4f24-8b92-5ac1a1a1fee1">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_653b4e65-a657-40fc-b987-c9e28104410f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>9fb75b67-c505-4f24-8b92-5ac1a1a1fee1</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_38c765fb-5707-404a-87f6-ace386edce11">
+    <cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_8171fc34-6891-40e0-92d1-da9f4ba69e26" />
+    <cim:IdentifiedObject.mRID>38c765fb-5707-404a-87f6-ace386edce11</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_c1b970ed-f1f6-432d-8d86-443988130e0d">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_38c765fb-5707-404a-87f6-ace386edce11" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>c1b970ed-f1f6-432d-8d86-443988130e0d</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:LinearShuntCompensator rdf:ID="_d771118f-36e9-4115-a128-cc3d9ce3e3da">
+    <cim:IdentifiedObject.name>BE_S1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>shunt with 4 sections</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE_S1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_4d50f86d-0d12-4ca3-9430-56bb05f9eee6" />
+    <cim:ShuntCompensator.grounded>true</cim:ShuntCompensator.grounded>
+    <cim:ShuntCompensator.maximumSections>1</cim:ShuntCompensator.maximumSections>
+    <cim:ShuntCompensator.nomU>110</cim:ShuntCompensator.nomU>
+    <cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+    <cim:LinearShuntCompensator.b0PerSection>0</cim:LinearShuntCompensator.b0PerSection>
+    <cim:LinearShuntCompensator.bPerSection>0.02479339</cim:LinearShuntCompensator.bPerSection>
+    <cim:LinearShuntCompensator.g0PerSection>0</cim:LinearShuntCompensator.g0PerSection>
+    <cim:LinearShuntCompensator.gPerSection>0</cim:LinearShuntCompensator.gPerSection>
+    <cim:IdentifiedObject.mRID>d771118f-36e9-4115-a128-cc3d9ce3e3da</cim:IdentifiedObject.mRID>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:ID="_4d50f86d-0d12-4ca3-9430-56bb05f9eee6">
+    <cim:IdentifiedObject.name>BE_S1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:IdentifiedObject.mRID>4d50f86d-0d12-4ca3-9430-56bb05f9eee6</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:NonlinearShuntCompensator rdf:ID="_002b0a40-3957-46db-b84a-30420083558f">
+    <cim:IdentifiedObject.name>BE_S2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>another shunt</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE_S2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_bee06911-8d5c-44c4-b2d2-5c22a461b5a0" />
+    <cim:ShuntCompensator.grounded>true</cim:ShuntCompensator.grounded>
+    <cim:ShuntCompensator.maximumSections>5</cim:ShuntCompensator.maximumSections>
+    <cim:ShuntCompensator.nomU>380</cim:ShuntCompensator.nomU>
+    <cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+    <cim:IdentifiedObject.mRID>002b0a40-3957-46db-b84a-30420083558f</cim:IdentifiedObject.mRID>
+  </cim:NonlinearShuntCompensator>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_48c4da87-08f6-408e-96e6-68fb5fd77d53">
+    <cim:NonlinearShuntCompensatorPoint.b>0.0003459834</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>1.09E-05</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>1</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_ffcbe3c9-5f5e-4de1-942c-c309e537b616">
+    <cim:NonlinearShuntCompensatorPoint.b>0.0001729917</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>2</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_8e4e1de4-71ba-4f36-9065-3d96c9702670">
+    <cim:NonlinearShuntCompensatorPoint.b>0.0001389889</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>3</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_a370cc7d-dad8-4b9e-8a36-0e202f6b028a">
+    <cim:NonlinearShuntCompensatorPoint.b>6.897507E-05</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>4</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_9347aeec-ab42-424e-a651-11ea7c3b6eb3">
+    <cim:NonlinearShuntCompensatorPoint.b>3.49723E-05</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>5</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:RegulatingControl rdf:ID="_bee06911-8d5c-44c4-b2d2-5c22a461b5a0">
+    <cim:IdentifiedObject.name>BE_S2</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+    <cim:IdentifiedObject.mRID>bee06911-8d5c-44c4-b2d2-5c22a461b5a0</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:StaticVarCompensator rdf:ID="_3c69652c-ff14-4550-9a87-b6fdaccbb5f4">
+    <cim:IdentifiedObject.name>SVC-1230797516</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_caf65447-3cfb-48d7-aaaa-cd9af3d34261" />
+    <cim:StaticVarCompensator.capacitiveRating>5062.5</cim:StaticVarCompensator.capacitiveRating>
+    <cim:StaticVarCompensator.inductiveRating>-5062.5</cim:StaticVarCompensator.inductiveRating>
+    <cim:StaticVarCompensator.slope>0.102</cim:StaticVarCompensator.slope>
+    <cim:IdentifiedObject.mRID>3c69652c-ff14-4550-9a87-b6fdaccbb5f4</cim:IdentifiedObject.mRID>
+  </cim:StaticVarCompensator>
+  <cim:RegulatingControl rdf:ID="_caf65447-3cfb-48d7-aaaa-cd9af3d34261">
+    <cim:IdentifiedObject.name>SVC-1230797516</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5" />
+    <cim:IdentifiedObject.mRID>caf65447-3cfb-48d7-aaaa-cd9af3d34261</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:ID="_550ebe0d-f2b2-48c1-991f-cebea43a21aa">
+    <cim:IdentifiedObject.name>BE-G2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-G2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_84bf5be8-eb59-4555-b131-fce4d2d7775d" />
+    <cim:RotatingMachine.ratedPowerFactor>0.85</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>300</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>21</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_5b7a4d43-09ec-4033-882d-64a76d557631" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>200</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-200</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.2</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>2</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.13</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.17</cim:SynchronousMachine.x2>
+    <cim:IdentifiedObject.mRID>550ebe0d-f2b2-48c1-991f-cebea43a21aa</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_5b7a4d43-09ec-4033-882d-64a76d557631">
+    <cim:IdentifiedObject.name>Gen-1229753024</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>200</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>50</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>255</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>5b7a4d43-09ec-4033-882d-64a76d557631</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_3a3b27be-b18b-4385-b557-6735d733baf0">
+    <cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-G1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_6ba406ce-78cf-4485-9b01-a34e584f1a8d" />
+    <cim:RotatingMachine.ratedPowerFactor>0.85</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>300</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>10.5</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_18993b11-2966-4bce-bab9-d86103f83b53" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>300</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-300</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>50</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.2</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>2</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generatorOrMotor" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.13</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.171</cim:SynchronousMachine.x2>
+    <cim:SynchronousMachine.InitialReactiveCapabilityCurve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+    <cim:IdentifiedObject.mRID>3a3b27be-b18b-4385-b557-6735d733baf0</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_18993b11-2966-4bce-bab9-d86103f83b53">
+    <cim:IdentifiedObject.name>Gen-1229753060</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>200</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>-100</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>255</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>18993b11-2966-4bce-bab9-d86103f83b53</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:ReactiveCapabilityCurve rdf:ID="_59ff1e53-0e1a-44c0-ada5-7a0b3a660170">
+    <cim:IdentifiedObject.name>BE-G1CapabilityCurveCapabilityCu</cim:IdentifiedObject.name>
+    <cim:Curve.curveStyle rdf:resource="http://iec.ch/TC57/CIM100#CurveStyle.straightLineYValues" />
+    <cim:Curve.xUnit rdf:resource="http://iec.ch/TC57/CIM100#UnitSymbol.W" />
+    <cim:Curve.y1Unit rdf:resource="http://iec.ch/TC57/CIM100#UnitSymbol.VAr" />
+    <cim:Curve.y2Unit rdf:resource="http://iec.ch/TC57/CIM100#UnitSymbol.VAr" />
+    <cim:IdentifiedObject.mRID>59ff1e53-0e1a-44c0-ada5-7a0b3a660170</cim:IdentifiedObject.mRID>
+  </cim:ReactiveCapabilityCurve>
+  <cim:CurveData rdf:ID="_5cef00db-5dda-4458-bc68-cc59804b1187">
+    <cim:CurveData.xvalue>0</cim:CurveData.xvalue>
+    <cim:CurveData.y1value>-300</cim:CurveData.y1value>
+    <cim:CurveData.y2value>300</cim:CurveData.y2value>
+    <cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+  </cim:CurveData>
+  <cim:CurveData rdf:ID="_52da6f7d-e9b6-4293-b1a3-d87a5f453a1c">
+    <cim:CurveData.xvalue>200</cim:CurveData.xvalue>
+    <cim:CurveData.y1value>-200</cim:CurveData.y1value>
+    <cim:CurveData.y2value>200</cim:CurveData.y2value>
+    <cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+  </cim:CurveData>
+  <cim:CurveData rdf:ID="_3a31cb5b-eac5-4717-acdb-48f357c6eefe">
+    <cim:CurveData.xvalue>-100</cim:CurveData.xvalue>
+    <cim:CurveData.y1value>-200</cim:CurveData.y1value>
+    <cim:CurveData.y2value>200</cim:CurveData.y2value>
+    <cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+  </cim:CurveData>
+  <cim:PowerTransformer rdf:ID="_b94318f6-6d24-4f56-96b9-df2531ad6543">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>This is T2 in the center</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>b94318f6-6d24-4f56-96b9-df2531ad6543</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_3c59d1b0-1ee9-4ca3-9086-4fe102b51b21">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_5a7b80f3-eeb3-4253-a792-5157c0946b15" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.8228</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.8228</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>11.13888</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>11.13888</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:IdentifiedObject.mRID>3c59d1b0-1ee9-4ca3-9086-4fe102b51b21</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_ba56158e-0c51-448d-999b-44cb0b3cebf5">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_0ac86078-8267-4fd9-b6c2-27984975ffcc" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>110</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:IdentifiedObject.mRID>ba56158e-0c51-448d-999b-44cb0b3cebf5</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PhaseTapChangerAsymmetrical rdf:ID="_36b83adb-3d45-4693-8967-96627b5f9ec9">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>25</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>13</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>10</cim:TapChanger.normalStep>
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_3c59d1b0-1ee9-4ca3-9086-4fe102b51b21" />
+    <cim:PhaseTapChangerNonLinear.voltageStepIncrement>1.25</cim:PhaseTapChangerNonLinear.voltageStepIncrement>
+    <cim:PhaseTapChangerNonLinear.xMax>11.88148</cim:PhaseTapChangerNonLinear.xMax>
+    <cim:PhaseTapChangerNonLinear.xMin>11.13888</cim:PhaseTapChangerNonLinear.xMin>
+    <cim:PhaseTapChangerAsymmetrical.windingConnectionAngle>30</cim:PhaseTapChangerAsymmetrical.windingConnectionAngle>
+    <cim:IdentifiedObject.mRID>36b83adb-3d45-4693-8967-96627b5f9ec9</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerAsymmetrical>
+  <cim:OperationalLimitSet rdf:ID="_88aa13e4-d3fe-4c47-9e47-39f8bb805e73">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_5a7b80f3-eeb3-4253-a792-5157c0946b15" />
+    <cim:IdentifiedObject.mRID>88aa13e4-d3fe-4c47-9e47-39f8bb805e73</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_0d73c833-c12b-4932-9fe3-f18ca522f331">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_88aa13e4-d3fe-4c47-9e47-39f8bb805e73" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1705.808</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>0d73c833-c12b-4932-9fe3-f18ca522f331</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_0ac86078-8267-4fd9-b6c2-27984975ffcc" />
+    <cim:IdentifiedObject.mRID>d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_d82cbf13-135c-407f-92b2-96d755a88932">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>3411.617</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>d82cbf13-135c-407f-92b2-96d755a88932</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>T1 that is after maintenance</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>a708c3bc-465d-4fe7-b6ef-6fa6408a62b0</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_bf76ac9d-0144-48f5-a24a-34ae15a455fb">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>2.707692</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>2.72</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>14.5189</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>14.5166</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:IdentifiedObject.mRID>bf76ac9d-0144-48f5-a24a-34ae15a455fb</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_e22f3c30-63f5-47bf-a8c4-fee2483d426c">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>110</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:IdentifiedObject.mRID>e22f3c30-63f5-47bf-a8c4-fee2483d426c</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PhaseTapChangerSymmetrical rdf:ID="_63454a73-f439-45bb-951a-e7b193986571">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>25</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>13</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>400</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>10</cim:TapChanger.normalStep>
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_bf76ac9d-0144-48f5-a24a-34ae15a455fb" />
+    <cim:PhaseTapChangerNonLinear.voltageStepIncrement>1.25</cim:PhaseTapChangerNonLinear.voltageStepIncrement>
+    <cim:PhaseTapChangerNonLinear.xMax>16.93872</cim:PhaseTapChangerNonLinear.xMax>
+    <cim:PhaseTapChangerNonLinear.xMin>14.5189</cim:PhaseTapChangerNonLinear.xMin>
+    <cim:IdentifiedObject.mRID>63454a73-f439-45bb-951a-e7b193986571</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerSymmetrical>
+  <cim:OperationalLimitSet rdf:ID="_0b7c4239-3c1b-438e-994d-f2a402ba743c">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+    <cim:IdentifiedObject.mRID>0b7c4239-3c1b-438e-994d-f2a402ba743c</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_5e35109b-9feb-4c06-a92c-b777783863c4">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0b7c4239-3c1b-438e-994d-f2a402ba743c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>938.1946</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>5e35109b-9feb-4c06-a92c-b777783863c4</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:IdentifiedObject.mRID>3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_d6da94f0-80dc-4163-82ce-2e19355196ab">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>3411.617</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>d6da94f0-80dc-4163-82ce-2e19355196ab</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_e482b89a-fa84-4ea9-8e70-a83d44790957">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>This is free description</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>e482b89a-fa84-4ea9-8e70-a83d44790957</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_f58281c5-862a-465e-97ec-d809be6e24ab">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:PowerTransformerEnd.b>-8.30339E-05</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>1.73295E-05</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.104711</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.104711</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>250</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>110.3438</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.843419</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.843419</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:IdentifiedObject.mRID>f58281c5-862a-465e-97ec-d809be6e24ab</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_35651e25-a77a-46a1-92f4-443d6acce90e">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>250</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>10.5</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:IdentifiedObject.mRID>35651e25-a77a-46a1-92f4-443d6acce90e</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:RatioTapChanger rdf:ID="_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>10.5</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>14</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.stepVoltageIncrement>0.8</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_35651e25-a77a-46a1-92f4-443d6acce90e" />
+    <cim:IdentifiedObject.mRID>83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChanger>
+  <cim:OperationalLimitSet rdf:ID="_40b75fae-2597-40df-98d2-8a0d83c238fd">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+    <cim:IdentifiedObject.mRID>40b75fae-2597-40df-98d2-8a0d83c238fd</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_48efd7e4-bd22-4521-8170-0ff15c14b9a1">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>13746.44</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>48efd7e4-bd22-4521-8170-0ff15c14b9a1</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_e40d809b-2f3f-4866-817d-7acec0fde34f">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d" />
+    <cim:IdentifiedObject.mRID>e40d809b-2f3f-4866-817d-7acec0fde34f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_fc604ec7-5977-4d5a-82bc-6bf7dee6ef8f">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1308.072</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>fc604ec7-5977-4d5a-82bc-6bf7dee6ef8f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_84ed55f4-61f5-4d9d-8755-bba7b877a246">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>new in 2015</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:IdentifiedObject.mRID>84ed55f4-61f5-4d9d-8755-bba7b877a246</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_5f68a129-d5d8-4b71-9743-9ca2572ba26b">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:PowerTransformerEnd.b>-2.4375E-06</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>-2.4375E-06</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.898462</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.898462</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>17.20413</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>17.23077</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:IdentifiedObject.mRID>5f68a129-d5d8-4b71-9743-9ca2572ba26b</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_e1f661c0-971d-4ce5-ad39-0ec427f288ab">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.323908</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.323908</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.949086</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.956923</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:IdentifiedObject.mRID>e1f661c0-971d-4ce5-ad39-0ec427f288ab</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_2e21d1ef-2287-434c-a767-1ca807cf2478">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>3</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.013332</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.013332</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>21</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0.059978</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0.061062</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:IdentifiedObject.mRID>2e21d1ef-2287-434c-a767-1ca807cf2478</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:RatioTapChanger rdf:ID="_fe25f43a-7341-446e-a71a-8ab7119ba806">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>17</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.stepVoltageIncrement>0.625</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_e1f661c0-971d-4ce5-ad39-0ec427f288ab" />
+    <cim:IdentifiedObject.mRID>fe25f43a-7341-446e-a71a-8ab7119ba806</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChanger>
+  <cim:OperationalLimitSet rdf:ID="_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1">
+    <cim:IdentifiedObject.name>Limits at Port 3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 3</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b" />
+    <cim:IdentifiedObject.mRID>f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_f660694a-682f-4e2e-b60c-1bab1a924b79">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>17870.37</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>f660694a-682f-4e2e-b60c-1bab1a924b79</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84" />
+    <cim:IdentifiedObject.mRID>b655ab41-8bc0-4bd3-a28c-cf9048e32b4a</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_61591ef6-b049-4188-b693-0a279b85e374">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>938.1946</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>61591ef6-b049-4188-b693-0a279b85e374</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_a2f11542-aeb8-4d7c-9594-25ac63e148bb">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+    <cim:IdentifiedObject.mRID>a2f11542-aeb8-4d7c-9594-25ac63e148bb</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2831d93a-f53c-44b8-aa34-54e7a04a34c4">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1705.808</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2831d93a-f53c-44b8-aa34-54e7a04a34c4</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:BaseVoltage rdf:ID="_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2">
+    <cim:IdentifiedObject.name>21.00 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>21.00</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>21</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_862a4658-6b03-4550-9de2-b5c413912b75">
+    <cim:IdentifiedObject.name>10.50 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>10.50</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>10.5</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>862a4658-6b03-4550-9de2-b5c413912b75</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_00b17311-075f-48f6-a79b-597f42af4694">
+    <cim:IdentifiedObject.name>110.00 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>110.00</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>110</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>00b17311-075f-48f6-a79b-597f42af4694</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:Terminal rdf:ID="_5a7b80f3-eeb3-4253-a792-5157c0946b15">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>5a7b80f3-eeb3-4253-a792-5157c0946b15</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_0ac86078-8267-4fd9-b6c2-27984975ffcc">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>0ac86078-8267-4fd9-b6c2-27984975ffcc</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_2ba1ad70-3533-402d-8686-f3bcce2c2e82">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>2ba1ad70-3533-402d-8686-f3bcce2c2e82</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b30ac237-4ce9-4869-8562-a07aaae1a7fa">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>b30ac237-4ce9-4869-8562-a07aaae1a7fa</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>3</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33" />
+    <cim:IdentifiedObject.mRID>e754f4c1-6aa0-43d2-98cb-ecf5ba12077b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_056b689f-1dab-48b3-8ac5-4eb11ca05d84">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>056b689f-1dab-48b3-8ac5-4eb11ca05d84</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>53fd6693-57e6-482e-8fbe-dcf3531a7ce0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>b9376bea-c75d-49f3-94ca-6a71fa0086a5</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>05a17350-55f5-4a00-9a50-8c0048a25495</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>a4d42d33-ae54-4fe9-ad59-f30da0dfb809</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33" />
+    <cim:IdentifiedObject.mRID>4bb5407b-b4a5-416c-80ad-1a778ada2b9b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>70d962fb-a492-4c36-8cad-b5c584df53bd</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>1ef0715a-d5a9-477b-b6e7-b635529ac140</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_d238885e-d9b6-4edc-8567-6a68c605ed67">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_87ea56f3-962a-427a-85d6-13b1f9295174" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>d238885e-d9b6-4edc-8567-6a68c605ed67</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_53072f42-f77b-47e2-bd9a-e097c910b173">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_24413233-26c3-4f7e-9f72-4461796938be" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>53072f42-f77b-47e2-bd9a-e097c910b173</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_57ae9251-c022-4c67-a8eb-611ad54c963c">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>57ae9251-c022-4c67-a8eb-611ad54c963c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3" />
+    <cim:IdentifiedObject.mRID>5b2c65b0-68ce-4530-85b7-385346a3b5e1</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>02a244ca-8bcb-4e25-8613-e948b8ba1f22</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>051d49ba-4360-4372-86bf-50eb8cf29778</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f9f29835-8a31-4310-9780-b1ad26f3cbb0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>c14d2036-72ec-4df3-b1b7-75d8afd9a1fe</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>77f04391-aa23-49b6-b3e9-6089130bb5d5</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>699545b9-82b9-4331-bc80-538d73b4ba56</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f3b56334-4638-49d3-a6a0-3f417422b8f5</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>231a4cf8-5069-4d53-96e4-e839f073f1ea</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:IdentifiedObject.mRID>1182d878-2eaa-4eec-91be-ce7b2b1e7f9a</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_2de997a1-c43e-4d39-9e55-dfd7cf97121d">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>2de997a1-c43e-4d39-9e55-dfd7cf97121d</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>4a7363a4-0b21-4f65-8bba-33e3a8f6bac3</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>22af3121-1a66-4546-bd80-4371f417c644</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b9539c41-d114-4280-8a54-8ecec398091e">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>b9539c41-d114-4280-8a54-8ecec398091e</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c41978db-794b-4bae-953e-60fc519e87dd">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_14b352cb-5574-40c5-bf83-0ed3574554a3" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>c41978db-794b-4bae-953e-60fc519e87dd</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cb459405-cc14-4215-a45c-416789205904" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>cbdf1842-74ed-4fce-a5d4-0296c82cbc92</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3" />
+    <cim:IdentifiedObject.mRID>13dcec71-4b02-4c0c-93a7-8e16db4aa0b7</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>8171fc34-6891-40e0-92d1-da9f4ba69e26</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>a036b765-1669-4f64-acd3-1e8fbd513312</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>67bb74f1-8620-4a32-9d7d-a44092d11d22</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:IdentifiedObject.mRID>beffa353-7d10-421d-9c08-036b744b1cee</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:OperationalLimitType rdf:ID="_3e6aa424-8f24-49a5-bbe0-0868441e25ae">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.patl" />
+    <cim:IdentifiedObject.mRID>3e6aa424-8f24-49a5-bbe0-0868441e25ae</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>true</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:OperationalLimitType rdf:ID="_5df721fe-c60b-4b91-8c92-3013fbdb6a70">
+    <cim:IdentifiedObject.name>Limit Type TATL</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>TATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.acceptableDuration>600</cim:OperationalLimitType.acceptableDuration>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.tatl" />
+    <cim:IdentifiedObject.mRID>5df721fe-c60b-4b91-8c92-3013fbdb6a70</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>false</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:ControlArea rdf:ID="_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7">
+    <cim:IdentifiedObject.name>BE</cim:IdentifiedObject.name>
+    <cim:ControlArea.type rdf:resource="http://iec.ch/TC57/CIM100#ControlAreaTypeKind.Interchange" />
+    <cim:ControlArea.EnergyArea rdf:resource="#_516c5401-f9f7-4cf8-89b5-853f9cd75f29" />
+    <cim:IdentifiedObject.mRID>50487bb8-be6d-42a8-9358-cc0bbfe6cfa7</cim:IdentifiedObject.mRID>
+  </cim:ControlArea>
+  <cim:TieFlow rdf:ID="_6c38eb9d-d412-444a-9fec-64cc4278ea40">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_1ef0715a-d5a9-477b-b6e7-b635529ac140" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>6c38eb9d-d412-444a-9fec-64cc4278ea40</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_90c53a07-7065-4faa-b12a-f80185d56fa5">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_57ae9251-c022-4c67-a8eb-611ad54c963c" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>90c53a07-7065-4faa-b12a-f80185d56fa5</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_aa336efd-8f54-49e6-8d9c-325e6e4d3184">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>aa336efd-8f54-49e6-8d9c-325e6e4d3184</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_6b5bc852-1dd3-49e2-89da-905b929a8cc3">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>6b5bc852-1dd3-49e2-89da-905b929a8cc3</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_29ab8015-51fe-431d-b1e2-7a147ffabac5">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_f3b56334-4638-49d3-a6a0-3f417422b8f5" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>29ab8015-51fe-431d-b1e2-7a147ffabac5</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:RegulatingControl rdf:ID="_84bf5be8-eb59-4555-b131-fce4d2d7775d">
+    <cim:IdentifiedObject.name>BE-G2</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b" />
+    <cim:IdentifiedObject.mRID>84bf5be8-eb59-4555-b131-fce4d2d7775d</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:ID="_6ba406ce-78cf-4485-9b01-a34e584f1a8d">
+    <cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:IdentifiedObject.mRID>6ba406ce-78cf-4485-9b01-a34e584f1a8d</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_GL_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_GL_001.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:064564b7-2663-411b-b617-55554e604510">
+    <md:Model.created>2021-03-25T23:16:28Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d" />
+  </md:FullModel>
+  <cim:CoordinateSystem rdf:ID="_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17">
+    <cim:IdentifiedObject.name>WGS84</cim:IdentifiedObject.name>
+    <cim:CoordinateSystem.crsUrn>urn:ogc:def:crs:EPSG::4326</cim:CoordinateSystem.crsUrn>
+    <cim:IdentifiedObject.mRID>5f5f3db1-b9f2-0a87-ca72-39fb7da2af17</cim:IdentifiedObject.mRID>
+  </cim:CoordinateSystem>
+  <cim:Location rdf:ID="_5733e014-95df-b4b4-3472-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_6</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:IdentifiedObject.mRID>5733e014-95df-b4b4-3472-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_234bb7b5-410e-4967-89d2-fbcd650fde32">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30113</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8035</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_8ae64308-69bc-4233-991d-4eab88ef00c5">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.34509</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.9169</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_88c387b8-b43f-4321-8a04-30d4131b3cc8">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.29565</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.0448</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_56108181-9ed5-4fa9-ac31-86ec9fac30da">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.38354</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.157</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ff0aae40-7be0-42eb-829e-0773c2658a05">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.25926</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3251</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_51ccb6f6-64e4-5fdd-c006-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_1</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:IdentifiedObject.mRID>51ccb6f6-64e4-5fdd-c006-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_40618e1c-e00d-44b2-a831-6eae0a31281b">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88798</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9127</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_51ccb6f6-64e4-5fdd-c006-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_c94850da-c5f9-453a-ba6c-024bc025bc1b">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84683</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.6121</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_51ccb6f6-64e4-5fdd-c006-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_f27cbfad-b445-1a56-a96d-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_7</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:IdentifiedObject.mRID>f27cbfad-b445-1a56-a96d-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_49768162-8b3e-404c-ad51-e48897d468e8">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88892</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9138</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_f27cbfad-b445-1a56-a96d-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_2d7c796f-3679-46ad-b4e0-f6144e46f4fa">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84772</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.6129</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_f27cbfad-b445-1a56-a96d-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_f1f4f0f1-ea0b-4954-902e-0e1bf55738f1">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.25926</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3251</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_f27cbfad-b445-1a56-a96d-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_33569661-1f7f-8318-8783-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_5</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:IdentifiedObject.mRID>33569661-1f7f-8318-8783-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_9ad48a2c-a9b8-4443-b84e-c371b9abe933">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30173</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_33569661-1f7f-8318-8783-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_b8e566a7-1618-401c-b448-86d1b4bb6166">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.69046</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8994</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_33569661-1f7f-8318-8783-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_3234d1f9-c3ca-4834-a446-e77370937869">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.08825</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3026</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_33569661-1f7f-8318-8783-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_a2cd4594-e708-4563-9ff7-5b3e90fa8281">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07058</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8731</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_33569661-1f7f-8318-8783-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_47478224-23fe-f47b-605c-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_4</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:IdentifiedObject.mRID>47478224-23fe-f47b-605c-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_fa51d03e-18e0-4cfc-a5e4-36e357cb9719">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30173</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_47478224-23fe-f47b-605c-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_86ef13e2-0a15-4431-908c-d9750c28a4ed">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.69046</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8994</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_47478224-23fe-f47b-605c-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_683718d3-8cce-4e70-901f-be45631ef069">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.08825</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3026</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_47478224-23fe-f47b-605c-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_a9d09a0a-321c-4762-8f2d-1d3de85fba11">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07186</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8756</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_47478224-23fe-f47b-605c-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_2</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:IdentifiedObject.mRID>73b023d3-4cf0-e1c5-56c4-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_d251e7fa-3401-4eab-ab25-ba3d882c5843">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30113</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8035</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_926d6929-9f0b-4c25-8ca6-9d6ae57ebd38">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.34509</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.9169</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_1234ebf1-60c5-44d6-a458-e17525f65b55">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.29565</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.0448</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_1beb4087-9d22-49d5-b292-b979162ebd3c">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.38354</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.157</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ad397578-69a5-418b-a3f9-0b2743076f7b">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.25926</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3251</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_05e9859c-01b9-12a7-3320-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_3</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:IdentifiedObject.mRID>05e9859c-01b9-12a7-3320-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_173034c8-dee1-4705-b41f-4e67c2472360">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30173</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_05e9859c-01b9-12a7-3320-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_f35c229f-84dd-4f11-821a-536c2b975bc8">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.69046</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8994</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_05e9859c-01b9-12a7-3320-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_4f245aa8-98ac-4ee0-a26b-04660c3d1b39">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.08825</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3026</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_05e9859c-01b9-12a7-3320-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ff7e39bc-0c8f-46e5-80b5-60a0b8aa9349">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07294</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8765</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_05e9859c-01b9-12a7-3320-39fb7da2af1e" />
+  </cim:PositionPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_SSH_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_SSH_001.xml
@@ -1,0 +1,440 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:1b092ff0-f8a0-49da-82d3-75eff5f1e820">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d" />
+  </md:FullModel>
+  <cim:Terminal rdf:about="#_5a7b80f3-eeb3-4253-a792-5157c0946b15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0ac86078-8267-4fd9-b6c2-27984975ffcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d238885e-d9b6-4edc-8567-6a68c605ed67">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53072f42-f77b-47e2-bd9a-e097c910b173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57ae9251-c022-4c67-a8eb-611ad54c963c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9539c41-d114-4280-8a54-8ecec398091e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c41978db-794b-4bae-953e-60fc519e87dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:RegulatingControl rdf:about="#_84bf5be8-eb59-4555-b131-fce4d2d7775d">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>21.987</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:about="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-118</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-18.7203</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_5b7a4d43-09ec-4033-882d-64a76d557631">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>1</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:RegulatingControl rdf:about="#_6ba406ce-78cf-4485-9b01-a34e584f1a8d">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>115.5</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:about="#_3a3b27be-b18b-4385-b557-6735d733baf0">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-90</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-100.256</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_18993b11-2966-4bce-bab9-d86103f83b53">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:LinearShuntCompensator rdf:about="#_d771118f-36e9-4115-a128-cc3d9ce3e3da">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_4d50f86d-0d12-4ca3-9430-56bb05f9eee6">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0.5</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>110</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:NonlinearShuntCompensator rdf:about="#_002b0a40-3957-46db-b84a-30420083558f">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+  </cim:NonlinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_bee06911-8d5c-44c4-b2d2-5c22a461b5a0">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0.5</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>380</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ConformLoad rdf:about="#_b1480a00-b427-4001-a26c-51954d2bb7e9">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>1</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:about="#_cb459405-cc14-4215-a45c-416789205904">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>200</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>90</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:about="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>200</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>50</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:StaticVarCompensator rdf:about="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:StaticVarCompensator.q>0</cim:StaticVarCompensator.q>
+  </cim:StaticVarCompensator>
+  <cim:RegulatingControl rdf:about="#_caf65447-3cfb-48d7-aaaa-cd9af3d34261">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>229.5</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:EquivalentInjection rdf:about="#_87ea56f3-962a-427a-85d6-13b1f9295174">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-83.18928</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>1.501529</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_24413233-26c3-4f7e-9f72-4461796938be">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-14.06748</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>63.95825</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-103.7413</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>11.31944</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-27.0286</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>120.7887</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_14b352cb-5574-40c5-bf83-0ed3574554a3">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-8.953211</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>67.2335</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:PhaseTapChangerAsymmetrical rdf:about="#_36b83adb-3d45-4693-8967-96627b5f9ec9">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>10</cim:TapChanger.step>
+  </cim:PhaseTapChangerAsymmetrical>
+  <cim:PhaseTapChangerSymmetrical rdf:about="#_63454a73-f439-45bb-951a-e7b193986571">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>10</cim:TapChanger.step>
+  </cim:PhaseTapChangerSymmetrical>
+  <cim:RatioTapChanger rdf:about="#_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>14</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_fe25f43a-7341-446e-a71a-8ab7119ba806">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>17</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:ControlArea rdf:about="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7">
+    <cim:ControlArea.netInterchange>236.9798</cim:ControlArea.netInterchange>
+    <cim:ControlArea.pTolerance>10</cim:ControlArea.pTolerance>
+  </cim:ControlArea>
+  <cim:CurrentLimit rdf:about="#_d1de5f7a-b11d-4c34-9628-1ce03b8f1989">
+    <cim:CurrentLimit.value>1312</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_6696b2a8-77fa-43a0-a019-f33287b03071">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_fc61a99c-b255-4f1e-96eb-16198b2fbfc3">
+    <cim:CurrentLimit.value>1312</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2c987138-9078-4f6a-b4f9-93d159b04fae">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_a2efb67d-28de-4243-aa59-8c297122b4f6">
+    <cim:CurrentLimit.value>1500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_718557d0-e400-47e7-ab87-0c466237672e">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_fbfb079a-f42a-49e4-a1cd-10a17b44e443">
+    <cim:CurrentLimit.value>1500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_9dd1c4cf-344a-4174-8000-430434090202">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_a1c57d7a-447a-4a1a-b69c-94653ca4756e">
+    <cim:CurrentLimit.value>1062</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_05715ad5-5667-41e9-8eec-b7d20dac0921">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_8a04fac9-7f86-47e7-b0d4-723b413113da">
+    <cim:CurrentLimit.value>1062</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_f772a663-0557-4de1-94ca-a0fc86ada89f">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_c27027b3-61e5-47ae-8f25-140808039152">
+    <cim:CurrentLimit.value>1876</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_a3b55712-7319-4725-aaef-d89be09e8e81">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_7f32e38e-73e1-4699-b00c-c9ce63f5faa4">
+    <cim:CurrentLimit.value>1876</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_cd1641e0-7dbd-4db2-8292-e87d65e2eeb5">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_e17d44b1-c678-40a3-a736-9f77781fb33e">
+    <cim:CurrentLimit.value>1226</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_770404e9-b224-4cda-b9bf-8b23d4fa7822">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2560b6d7-ee39-4f18-ba27-9e9ec505bc9e">
+    <cim:CurrentLimit.value>1226</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_ec82058b-5d1a-4f8d-a0e6-fa4c3940b273">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_e8b7722a-97b5-4831-b944-89c0a63a96fa">
+    <cim:CurrentLimit.value>1574</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_3ecb9d91-8fdc-4161-81a1-8c5cedd66844">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_4602330f-46c5-41d0-bbbe-4b207ff06dbd">
+    <cim:CurrentLimit.value>1574</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_7b7bb979-e984-4a1a-a977-6f78ddcbc9d3">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_008c7f00-df41-430c-b94c-37aa08c2e993">
+    <cim:CurrentLimit.value>1233.9</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_34d77ffb-666c-4651-9e25-956af0979088">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_e68e3e07-101e-42a7-9d85-1d4b7d284ca3">
+    <cim:CurrentLimit.value>1233.9</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_601df66c-7ba7-4ec8-8f8d-a30315f1a88f">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_9fb75b67-c505-4f24-8b92-5ac1a1a1fee1">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_c1b970ed-f1f6-432d-8d86-443988130e0d">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_0d73c833-c12b-4932-9fe3-f18ca522f331">
+    <cim:CurrentLimit.value>1705.808</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_d82cbf13-135c-407f-92b2-96d755a88932">
+    <cim:CurrentLimit.value>3411.617</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_5e35109b-9feb-4c06-a92c-b777783863c4">
+    <cim:CurrentLimit.value>938.1946</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_d6da94f0-80dc-4163-82ce-2e19355196ab">
+    <cim:CurrentLimit.value>3411.617</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_48efd7e4-bd22-4521-8170-0ff15c14b9a1">
+    <cim:CurrentLimit.value>13746.44</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_fc604ec7-5977-4d5a-82bc-6bf7dee6ef8f">
+    <cim:CurrentLimit.value>1308.072</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_f660694a-682f-4e2e-b60c-1bab1a924b79">
+    <cim:CurrentLimit.value>17870.37</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_61591ef6-b049-4188-b693-0a279b85e374">
+    <cim:CurrentLimit.value>938.1946</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2831d93a-f53c-44b8-aa34-54e7a04a34c4">
+    <cim:CurrentLimit.value>1705.808</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:Equipment rdf:about="#_5caf27ed-d2f8-458a-834a-6b3193a982e6">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_364c9ca2-0d1d-4363-8f46-e586f8f66a8c">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_ef45b632-3028-4afe-bc4c-a4fa323d83fe">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_fd649fe1-bdf5-4062-98ea-bbb66f50402d">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_17086487-56ba-4979-b8de-064025a6b4da">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_ed0c5d75-4a54-43c8-b782-b20d7431630b">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_78736387-5f60-4832-b3fe-d50daf81b0a6">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_df16b3dd-c905-4a6f-84ee-f067be86f5da">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_b94318f6-6d24-4f56-96b9-df2531ad6543">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_e482b89a-fa84-4ea9-8e70-a83d44790957">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_84ed55f4-61f5-4d9d-8755-bba7b877a246">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_SV_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_SV_001.xml
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:d8b89b1b-47a6-4a34-abab-29ebc0791711">
+    <md:Model.created>2021-04-15T21:56:31Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/StateVariables-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:95b0709c-bf22-4df8-a179-042c7038d62a" />
+  </md:FullModel>
+  <cim:SvPowerFlow rdf:ID="_f126425a-76b4-4b48-8809-2345918d67d1">
+    <cim:SvPowerFlow.p>0</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-330.75</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c" />
+  </cim:SvPowerFlow>
+  <cim:SvShuntCompensatorSections rdf:ID="_a63602d9-4825-4fbf-b0f7-ffb8af5d1a1f">
+    <cim:SvShuntCompensatorSections.sections>1</cim:SvShuntCompensatorSections.sections>
+    <cim:SvShuntCompensatorSections.ShuntCompensator rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da" />
+  </cim:SvShuntCompensatorSections>
+  <cim:SvShuntCompensatorSections rdf:ID="_44d90936-2c7a-4305-9a6e-9b9654a8beb6">
+    <cim:SvShuntCompensatorSections.sections>1</cim:SvShuntCompensatorSections.sections>
+    <cim:SvShuntCompensatorSections.ShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:SvShuntCompensatorSections>
+  <cim:SvPowerFlow rdf:ID="_c59226f2-3fab-4b0a-a41d-85ade4a80d0e">
+    <cim:SvPowerFlow.p>-27.0286</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>120.7887</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_b9539c41-d114-4280-8a54-8ecec398091e" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_60b2cd79-54ac-4987-886d-4969978ec985">
+    <cim:SvPowerFlow.p>-103.7413</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>11.31944</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_f68e2a9a-141e-474f-967a-fa2b87880ebf">
+    <cim:SvPowerFlow.p>1.871276</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-59.39729</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_22af3121-1a66-4546-bd80-4371f417c644" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_7b9487bf-2654-4f2b-805b-c841d3b4771a">
+    <cim:SvPowerFlow.p>-83.18928</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>1.501529</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_d238885e-d9b6-4edc-8567-6a68c605ed67" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_efd418ed-cd9f-4e0f-8050-8ac84c7bde5e">
+    <cim:SvPowerFlow.p>-81.35162</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>6.659446</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_70d962fb-a492-4c36-8cad-b5c584df53bd" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_8949d07c-e064-4a35-8bac-3ac3369a687e">
+    <cim:SvPowerFlow.p>83.18928</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-1.501529</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_1ef0715a-d5a9-477b-b6e7-b635529ac140" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_fa82fbde-1765-49c3-8c84-5566279fbcf1">
+    <cim:SvPowerFlow.p>-90</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>74.17992</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_beffa353-7d10-421d-9c08-036b744b1cee" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_58e9396f-6869-4329-9177-353fdde11640">
+    <cim:SvPowerFlow.p>-118</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-78.16264</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_05c49c94-abcf-4fcb-9edf-6c4fb7b697d1">
+    <cim:SvPowerFlow.p>-8.953211</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>67.2335</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_c41978db-794b-4bae-953e-60fc519e87dd" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_201b4477-d96d-4d04-99a6-79eacd2cf6ab">
+    <cim:SvPowerFlow.p>-14.06748</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>63.95825</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_53072f42-f77b-47e2-bd9a-e097c910b173" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_c8480054-d8fe-4c22-8434-a7527b831949">
+    <cim:SvPowerFlow.p>-19.81423</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>110.0211</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_051d49ba-4360-4372-86bf-50eb8cf29778" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_2558b059-4fff-4685-b59e-0100067523a4">
+    <cim:SvPowerFlow.p>-3.786605</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>38.5127</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_231a4cf8-5069-4d53-96e4-e839f073f1ea" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_24236d57-63d5-4709-a4f7-4efb5a4b29f4">
+    <cim:SvPowerFlow.p>8.953211</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-67.2335</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_b07837ab-6831-4cfa-90de-498e9335d6a2">
+    <cim:SvPowerFlow.p>-2.085326</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>62.96101</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_0b9c8ac8-8770-434d-8785-746fb6261213">
+    <cim:SvPowerFlow.p>-109.4835</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>183.1439</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_bf3159c3-b8dd-4565-8c55-8677bb2e5fa3">
+    <cim:SvPowerFlow.p>-116.2994</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>17.08473</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_699545b9-82b9-4331-bc80-538d73b4ba56" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_0e0f5da7-ad61-4439-896e-4f2e4ed7120d">
+    <cim:SvTapStep.position>10</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_63454a73-f439-45bb-951a-e7b193986571" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_02023ebd-baa6-4163-ba77-412bf7ecd303">
+    <cim:SvPowerFlow.p>200</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>50</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_a036b765-1669-4f64-acd3-1e8fbd513312" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_b26bbe55-2a8c-47db-8d12-adb1edf46916">
+    <cim:SvPowerFlow.p>120.2376</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-9.558035</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_77f04391-aa23-49b6-b3e9-6089130bb5d5" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_69891bcb-3234-4b1a-8029-459a79f7fd39">
+    <cim:SvPowerFlow.p>-53.59776</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>9.173759</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_05a17350-55f5-4a00-9a50-8c0048a25495" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_366e2cac-08e9-4c79-8e61-07f20e492805">
+    <cim:SvPowerFlow.p>200</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>90</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_e45edecd-8b7a-4976-b044-ee8595700727">
+    <cim:SvPowerFlow.p>27.0286</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-120.7887</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_79836947-12a0-42aa-8456-b8c1e1565b1d">
+    <cim:SvPowerFlow.p>-99.85394</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>24.87515</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_c6763484-5d89-45b0-a04f-506752565bb7">
+    <cim:SvPowerFlow.p>14.06748</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-63.95825</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f3b56334-4638-49d3-a6a0-3f417422b8f5" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_75c76717-e318-4258-9f7f-59507d4a973a">
+    <cim:SvPowerFlow.p>59.96792</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-5.537291</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_eccde42a-420a-4981-a29c-0d106fae57fe">
+    <cim:SvPowerFlow.p>103.7413</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-11.31944</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_57ae9251-c022-4c67-a8eb-611ad54c963c" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_6bb06f35-f1ab-495d-a536-1bbe8022d8f0">
+    <cim:SvPowerFlow.p>110.1824</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-179.3575</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_a0e7b7bf-8854-4a46-ba59-91eec77ef8c6">
+    <cim:SvPowerFlow.p>-86.36749</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>27.25996</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_94092f7b-4dad-49d2-b79f-34b17aca1562">
+    <cim:SvTapStep.position>17</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_fe25f43a-7341-446e-a71a-8ab7119ba806" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_7cbacf23-2cc8-4e28-8937-438c49fd6814">
+    <cim:SvPowerFlow.p>0.8637645</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>24.17813</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_5a7b80f3-eeb3-4253-a792-5157c0946b15" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_f14e5061-955f-494b-a7e0-42056fad17d6">
+    <cim:SvTapStep.position>14</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_bafd76a0-163e-4795-a72c-7c0493f98ef9">
+    <cim:SvPowerFlow.p>118</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>78.16264</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_7de37fe5-e143-46c8-8b01-28e28d2cdcf8">
+    <cim:SvPowerFlow.p>-0.8548296</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-24.05666</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_0ac86078-8267-4fd9-b6c2-27984975ffcc" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_d724035c-e136-4a3b-9072-04ff88954a48">
+    <cim:SvPowerFlow.p>-89.66164</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>81.66273</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_28361c6c-acb8-49e9-bef8-6c085cf86ed9">
+    <cim:SvTapStep.position>10</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_36b83adb-3d45-4693-8967-96627b5f9ec9" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_c91eb6af-9b79-45a2-9d46-4cde9ffdc636">
+    <cim:SvPowerFlow.p>-30.96664</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-100.4366</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_31e3d2b6-1615-402e-853b-83fea8e91633">
+    <cim:SvPowerFlow.p>90</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-74.17992</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_09d64a1c-556b-4ca7-9a51-287ac764bd44">
+    <cim:SvPowerFlow.p>99.85394</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-24.87515</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_201ff15d-10c2-48e2-bdaa-c07e8493c7ef">
+    <cim:SvPowerFlow.p>-99.85394</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>18.31695</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_8171fc34-6891-40e0-92d1-da9f4ba69e26" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_3dacc96f-add5-46bd-aeb7-8867ff2ccd34">
+    <cim:SvPowerFlow.p>0</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-9.88107</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_67bb74f1-8620-4a32-9d7d-a44092d11d22" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_75b55ed3-ee2e-4fb9-990a-f67dfb09f299">
+    <cim:SvPowerFlow.p>1</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>0</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_0af74e47-59f5-4099-b613-29c1f9148cae">
+    <cim:SvVoltage.angle>340.9585</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>115.5</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:SvVoltage>
+  <cim:TopologicalIsland rdf:ID="_c2aa21ca-1711-4946-adf1-0890e126e787">
+    <cim:IdentifiedObject.name>TopoIsland 1</cim:IdentifiedObject.name>
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+    <cim:TopologicalIsland.AngleRefTopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+    <cim:IdentifiedObject.mRID>c2aa21ca-1711-4946-adf1-0890e126e787</cim:IdentifiedObject.mRID>
+  </cim:TopologicalIsland>
+  <cim:SvVoltage rdf:ID="_d4133929-918a-46a2-81bd-dcaad9736542">
+    <cim:SvVoltage.angle>-15.51589</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>223.658</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_199ce97e-4751-4672-a641-87f17b12c2ff">
+    <cim:SvVoltage.angle>-19.1098</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>226.7108</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_fea095ab-b70c-4661-b94d-ea41fe6c56fb">
+    <cim:SvVoltage.angle>343.3294</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>10.3622</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_7ca681ed-2326-4f5f-a2a4-5a46b01c95d1">
+    <cim:SvVoltage.angle>-20.16267</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>224.6702</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_39c60fea-d51c-4bac-9c18-ac0340b1ffeb">
+    <cim:SvVoltage.angle>340.7323</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>21.987</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_b7387b87-1e2e-42b8-b035-3f9d604b23fc">
+    <cim:SvVoltage.angle>339.5023</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>414.3389</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:SvVoltage>
+  <cim:SvStatus rdf:ID="_94cff509-8290-4dfe-b59e-8380d52213ea">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_5caf27ed-d2f8-458a-834a-6b3193a982e6" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_0f7327aa-fd9c-40fb-913d-d9db8d819ab1">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_cce35bae-4623-4d74-bd66-b35930b50d4a">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_364c9ca2-0d1d-4363-8f46-e586f8f66a8c" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_61740bc5-c8b9-409e-b847-dd4a5b591cd5">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_ef45b632-3028-4afe-bc4c-a4fa323d83fe" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_bedbd659-3e33-4005-aee5-f5804d457f76">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_fd649fe1-bdf5-4062-98ea-bbb66f50402d" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_10fa943b-0451-4ecc-adae-20c605113987">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_87ea56f3-962a-427a-85d6-13b1f9295174" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_be4827ce-148b-4452-8417-a7d8811de11e">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_24413233-26c3-4f7e-9f72-4461796938be" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_639f3e51-aee1-49a4-ae3c-ccbecae233c6">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_233d47d1-ff5a-487f-a0f6-0c139874e7f0">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_4dab65b1-366c-4d78-a0b9-b2396ffa85e5">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_14b352cb-5574-40c5-bf83-0ed3574554a3" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_6c7905d1-d2a8-4de7-823a-13711df8104f">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_56b9bf81-079d-47b8-a180-cfa9f9113978">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_630f974e-b377-44b1-9327-2051beec6b55">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_da6e2b5a-4cd2-40eb-945c-6fbfc8162ffb">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_fca986a9-4273-436c-bd28-ffb74b3a6180">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_ade7f379-5fe2-43ae-86d5-1eb93faa5595">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_b08f548b-5ede-43c8-a01a-946f573aa7ef">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_5a415dbd-0df5-45f5-a465-679e27ae592b">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_8919d192-1970-4815-8a65-dc443f22a488">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_cb459405-cc14-4215-a45c-416789205904" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_42a00766-6635-467c-a975-a42fbe3694e9">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_cceb8d12-37f2-45f5-8b41-0b79056242ff">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_b6c62e02-b6e6-4611-8c1e-991f1ebebc65">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_215c093f-7931-4fa8-a025-6861712a9ac9">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_a45b51c4-6eb5-40c3-bd58-cfe7eaeb67ea">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_7c8d7652-3259-40c8-8ecb-352046d886cd">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_804ee38b-77f5-4132-bef8-4d499fe411e0">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_919645ab-77c6-4f43-aa36-0c977f790bed">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_ccd5b659-7a63-4b68-a669-9e67b6964af9">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_d73b7ebd-5aa1-4df9-9a3c-c25838d1013c">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_ccdb75ab-78ac-4c49-b68e-d11c1f753775">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+  </cim:SvStatus>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_TP_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210325T1530Z_1D_BE_TP_001.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:95b0709c-bf22-4df8-a179-042c7038d62a">
+    <md:Model.created>2021-04-15T21:56:31Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/Topology-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:1b092ff0-f8a0-49da-82d3-75eff5f1e820" />
+  </md:FullModel>
+  <cim:TopologicalNode rdf:ID="_99b219f3-4593-428b-a4da-124a54630178">
+    <cim:IdentifiedObject.name>BE_TR_BUS4</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>99b219f3-4593-428b-a4da-124a54630178</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_bf851342-832e-4ea2-b2ad-b09729b3af23">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_e44141af-f1dc-44d3-bfa4-b674e5c953d7">
+    <cim:IdentifiedObject.name>BE_TR_BUS2</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>e44141af-f1dc-44d3-bfa4-b674e5c953d7</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_f96d552a-618d-4d0c-a39a-2dea3c411dee">
+    <cim:IdentifiedObject.name>BE-Busbar_5</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>BGENT_72; this is old code</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-B_5</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:IdentifiedObject.mRID>f96d552a-618d-4d0c-a39a-2dea3c411dee</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_5c74cb26-ce2f-40c6-951d-89091eb781b6">
+    <cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>BBRUS151; BGENT_51</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-B_6</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:IdentifiedObject.mRID>5c74cb26-ce2f-40c6-951d-89091eb781b6</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_1695eb20-9044-4133-a3fd-2147f55f170d">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_f70f6bad-eb8d-4b8f-8431-4ab93581514e">
+    <cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>BBRUS_21; this is UCTE code</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-B_2</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>f70f6bad-eb8d-4b8f-8431-4ab93581514e</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_ae99bd74-26b1-443a-b1a5-656320283a36">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e">
+    <cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>BGENT_71; This is the old UCTE code from UCTE DEF</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-B_4</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:IdentifiedObject.mRID>a81d08ed-f51d-4538-8d1e-fb2d0dbd128e</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_23b65c6b-2351-4673-89e9-1895c7291543">
+    <cim:IdentifiedObject.name>Series Compensator</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>23b65c6b-2351-4673-89e9-1895c7291543</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:about="#_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:Terminal.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5a7b80f3-eeb3-4253-a792-5157c0946b15">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0ac86078-8267-4fd9-b6c2-27984975ffcc">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:Terminal.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:Terminal.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:Terminal.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:Terminal.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:Terminal>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210420T1730Z_1D_BE_DY_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BE-MAS/20210420T1730Z_1D_BE_DY_001.xml
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:8e91166f-12ce-4a20-b0bf-7be301171d0b">
+    <md:Model.created>2021-04-20T10:56:20Z</md:Model.created>
+    <md:Model.scenarioTime>2021-04-20T17:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/Dynamics-EU/1.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d" />
+  </md:FullModel>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_4f810658-da42-4bbf-b8ee-1c38019d7068">
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:RotatingMachineDynamics.damping>0.01</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>5</cim:RotatingMachineDynamics.inertia>
+    <cim:SynchronousMachineDetailed.saturationFactorQAxis>0.02</cim:SynchronousMachineDetailed.saturationFactorQAxis>
+    <cim:SynchronousMachineDetailed.saturationFactor120QAxis>0.12</cim:SynchronousMachineDetailed.saturationFactor120QAxis>
+    <cim:RotatingMachineDynamics.saturationFactor>0.02</cim:RotatingMachineDynamics.saturationFactor>
+    <cim:RotatingMachineDynamics.saturationFactor120>0.12</cim:RotatingMachineDynamics.saturationFactor120>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.15</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.roundRotor" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>8</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.03</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.07</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>1</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.23</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.81</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.3</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.25</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>1.76</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.65</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>4f810658-da42-4bbf-b8ee-1c38019d7068</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_8aa9d8c1-8711-40cf-8c77-509c4240562c">
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:RotatingMachineDynamics.damping>0</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>4.25</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.16</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDetailed.saturationFactorQAxis>0.02</cim:SynchronousMachineDetailed.saturationFactorQAxis>
+    <cim:SynchronousMachineDetailed.saturationFactor120QAxis>0.12</cim:SynchronousMachineDetailed.saturationFactor120QAxis>
+    <cim:RotatingMachineDynamics.saturationFactor>0.02</cim:RotatingMachineDynamics.saturationFactor>
+    <cim:RotatingMachineDynamics.saturationFactor120>0.12</cim:RotatingMachineDynamics.saturationFactor120>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.roundRotor" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>6.4</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.12</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.12</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>6.4</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.2</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.97</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.29</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.2</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>1.97</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.29</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>8aa9d8c1-8711-40cf-8c77-509c4240562c</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:VCompIEEEType1 rdf:ID="_3de814e0-4057-4359-8415-91f9cfc6954a">
+    <cim:IdentifiedObject.name>BE-G1-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_f7d4412c-6567-4759-aa48-4c881dd79902" />
+    <cim:VCompIEEEType1.rc>0</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.xc>0</cim:VCompIEEEType1.xc>
+    <cim:VCompIEEEType1.tr>0</cim:VCompIEEEType1.tr>
+    <cim:IdentifiedObject.mRID>3de814e0-4057-4359-8415-91f9cfc6954a</cim:IdentifiedObject.mRID>
+  </cim:VCompIEEEType1>
+  <cim:ExcIEEEAC4A rdf:ID="_f7d4412c-6567-4759-aa48-4c881dd79902">
+    <cim:IdentifiedObject.name>BE-G1-ExcAC4A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_8aa9d8c1-8711-40cf-8c77-509c4240562c" />
+    <cim:ExcIEEEAC4A.ka>200</cim:ExcIEEEAC4A.ka>
+    <cim:ExcIEEEAC4A.kc>0.05</cim:ExcIEEEAC4A.kc>
+    <cim:ExcIEEEAC4A.ta>0.07</cim:ExcIEEEAC4A.ta>
+    <cim:ExcIEEEAC4A.tb>8.5</cim:ExcIEEEAC4A.tb>
+    <cim:ExcIEEEAC4A.tc>1.8</cim:ExcIEEEAC4A.tc>
+    <cim:ExcIEEEAC4A.vimax>0.1</cim:ExcIEEEAC4A.vimax>
+    <cim:ExcIEEEAC4A.vimin>-0.1</cim:ExcIEEEAC4A.vimin>
+    <cim:ExcIEEEAC4A.vrmax>5</cim:ExcIEEEAC4A.vrmax>
+    <cim:ExcIEEEAC4A.vrmin>-4.65</cim:ExcIEEEAC4A.vrmin>
+    <cim:IdentifiedObject.mRID>f7d4412c-6567-4759-aa48-4c881dd79902</cim:IdentifiedObject.mRID>
+  </cim:ExcIEEEAC4A>
+  <cim:PssIEEE2B rdf:ID="_13267fa6-b3f0-4e23-8b4c-857d35eeed6f">
+    <cim:IdentifiedObject.name>BE-G1-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_f7d4412c-6567-4759-aa48-4c881dd79902" />
+    <cim:PssIEEE2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.rotorAngularFrequencyDeviation" />
+    <cim:PssIEEE2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.generatorElectricalPower" />
+    <cim:PssIEEE2B.ks1>16</cim:PssIEEE2B.ks1>
+    <cim:PssIEEE2B.ks2>0.31</cim:PssIEEE2B.ks2>
+    <cim:PssIEEE2B.ks3>1</cim:PssIEEE2B.ks3>
+    <cim:PssIEEE2B.m>5</cim:PssIEEE2B.m>
+    <cim:PssIEEE2B.n>1</cim:PssIEEE2B.n>
+    <cim:PssIEEE2B.t1>0.2</cim:PssIEEE2B.t1>
+    <cim:PssIEEE2B.t10>0</cim:PssIEEE2B.t10>
+    <cim:PssIEEE2B.t11>0</cim:PssIEEE2B.t11>
+    <cim:PssIEEE2B.t2>0.02</cim:PssIEEE2B.t2>
+    <cim:PssIEEE2B.t3>0.45</cim:PssIEEE2B.t3>
+    <cim:PssIEEE2B.t4>0.02</cim:PssIEEE2B.t4>
+    <cim:PssIEEE2B.t6>0</cim:PssIEEE2B.t6>
+    <cim:PssIEEE2B.t7>2</cim:PssIEEE2B.t7>
+    <cim:PssIEEE2B.t8>0.2</cim:PssIEEE2B.t8>
+    <cim:PssIEEE2B.t9>0.1</cim:PssIEEE2B.t9>
+    <cim:PssIEEE2B.tw1>2</cim:PssIEEE2B.tw1>
+    <cim:PssIEEE2B.tw2>2</cim:PssIEEE2B.tw2>
+    <cim:PssIEEE2B.tw3>2</cim:PssIEEE2B.tw3>
+    <cim:PssIEEE2B.tw4>0</cim:PssIEEE2B.tw4>
+    <cim:PssIEEE2B.vsi1max>999</cim:PssIEEE2B.vsi1max>
+    <cim:PssIEEE2B.vsi1min>-999</cim:PssIEEE2B.vsi1min>
+    <cim:PssIEEE2B.vsi2max>999</cim:PssIEEE2B.vsi2max>
+    <cim:PssIEEE2B.vsi2min>-999</cim:PssIEEE2B.vsi2min>
+    <cim:PssIEEE2B.vstmax>0.1</cim:PssIEEE2B.vstmax>
+    <cim:PssIEEE2B.vstmin>-0.1</cim:PssIEEE2B.vstmin>
+    <cim:IdentifiedObject.mRID>13267fa6-b3f0-4e23-8b4c-857d35eeed6f</cim:IdentifiedObject.mRID>
+  </cim:PssIEEE2B>
+  <cim:GovSteam1 rdf:ID="_d0ae3542-271e-4f50-8272-53bf553df6c2">
+    <cim:IdentifiedObject.name>BE-G1-TurbIEEEEG1</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_8aa9d8c1-8711-40cf-8c77-509c4240562c" />
+    <cim:GovSteam1.db2>0</cim:GovSteam1.db2>
+    <cim:GovSteam1.db1>0</cim:GovSteam1.db1>
+    <cim:GovSteam1.eps>0</cim:GovSteam1.eps>
+    <cim:GovSteam1.uo>1</cim:GovSteam1.uo>
+    <cim:GovSteam1.gv1>0</cim:GovSteam1.gv1>
+    <cim:GovSteam1.gv2>0.25</cim:GovSteam1.gv2>
+    <cim:GovSteam1.gv3>0.5</cim:GovSteam1.gv3>
+    <cim:GovSteam1.gv4>0.75</cim:GovSteam1.gv4>
+    <cim:GovSteam1.gv5>1</cim:GovSteam1.gv5>
+    <cim:GovSteam1.gv6>1.25</cim:GovSteam1.gv6>
+    <cim:GovSteam1.k>25</cim:GovSteam1.k>
+    <cim:GovSteam1.k1>0.25</cim:GovSteam1.k1>
+    <cim:GovSteam1.k2>0</cim:GovSteam1.k2>
+    <cim:GovSteam1.k3>0.6</cim:GovSteam1.k3>
+    <cim:GovSteam1.k4>0</cim:GovSteam1.k4>
+    <cim:GovSteam1.k5>0.15</cim:GovSteam1.k5>
+    <cim:GovSteam1.k6>0</cim:GovSteam1.k6>
+    <cim:GovSteam1.k7>0</cim:GovSteam1.k7>
+    <cim:GovSteam1.k8>0</cim:GovSteam1.k8>
+    <cim:GovSteam1.mwbase>255</cim:GovSteam1.mwbase>
+    <cim:GovSteam1.pgv1>0</cim:GovSteam1.pgv1>
+    <cim:GovSteam1.pgv2>0.25</cim:GovSteam1.pgv2>
+    <cim:GovSteam1.pgv3>0.5</cim:GovSteam1.pgv3>
+    <cim:GovSteam1.pgv4>0.75</cim:GovSteam1.pgv4>
+    <cim:GovSteam1.pgv5>1</cim:GovSteam1.pgv5>
+    <cim:GovSteam1.pgv6>1.25</cim:GovSteam1.pgv6>
+    <cim:GovSteam1.pmax>1.05</cim:GovSteam1.pmax>
+    <cim:GovSteam1.pmin>0</cim:GovSteam1.pmin>
+    <cim:GovSteam1.sdb1>true</cim:GovSteam1.sdb1>
+    <cim:GovSteam1.sdb2>true</cim:GovSteam1.sdb2>
+    <cim:GovSteam1.t1>5</cim:GovSteam1.t1>
+    <cim:GovSteam1.t2>1.5</cim:GovSteam1.t2>
+    <cim:GovSteam1.t3>0.3</cim:GovSteam1.t3>
+    <cim:GovSteam1.t4>0.15</cim:GovSteam1.t4>
+    <cim:GovSteam1.t5>2</cim:GovSteam1.t5>
+    <cim:GovSteam1.t6>0.1</cim:GovSteam1.t6>
+    <cim:GovSteam1.t7>0</cim:GovSteam1.t7>
+    <cim:GovSteam1.uc>-1.05</cim:GovSteam1.uc>
+    <cim:GovSteam1.valve>true</cim:GovSteam1.valve>
+    <cim:IdentifiedObject.mRID>d0ae3542-271e-4f50-8272-53bf553df6c2</cim:IdentifiedObject.mRID>
+  </cim:GovSteam1>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20171002T0930Z_ENTSO-E_EQ_BD_2.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20171002T0930Z_ENTSO-E_EQ_BD_2.xml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:eu="http://iec.ch/TC57/CIM100-European#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:536f9bf1-3f8f-a546-87e3-7af2272f29b7">
+    <md:Model.scenarioTime>2030-01-25T19:00:00Z</md:Model.scenarioTime>
+    <md:Model.created>2021-01-25T19:00:00Z</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/EquipmentBoundary-EU/3.0</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://entsoe.eu/boundary</md:Model.modelingAuthoritySet>
+    <md:Model.version>5</md:Model.version>
+  </md:FullModel>
+  <cim:BaseVoltage rdf:ID="_a7f1d8de-d658-428a-821b-3a5ae5965fd1">
+    <cim:IdentifiedObject.description>Base Voltage 220 kV</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>220 kV</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>220</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>220</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>a7f1d8de-d658-428a-821b-3a5ae5965fd1</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_63893f24-5b4e-407c-9a1e-4ff71121f33c">
+    <cim:IdentifiedObject.description>Base Voltage 225 kV</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>225 kV</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>225</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>225</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>63893f24-5b4e-407c-9a1e-4ff71121f33c</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6">
+    <cim:IdentifiedObject.description>Base Voltage 380 kV</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>380 kV</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>380</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>380</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>35cf638d-9a9d-4ae5-ae90-2f01ef898cb6</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_597e44dc-2a6e-4c62-82f3-f82cc46e0e14">
+    <cim:IdentifiedObject.description>Base Voltage 400 kV</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>400 kV</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>400</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>400</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>597e44dc-2a6e-4c62-82f3-f82cc46e0e14</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:ConnectivityNode rdf:ID="_b675a570-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_AL11</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XCA_AL11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-ES-PT-10004U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:IdentifiedObject.mRID>b675a570-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_b67c8340-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_GY11</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XWI_GY11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-HU-00002U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:IdentifiedObject.mRID>b67c8340-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_b67cf870-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_MA11</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XKA_MA11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-SI-00001T</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:IdentifiedObject.mRID>b67cf870-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_b66f15c0-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_ST23</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XZE_ST23</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00016Z</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:IdentifiedObject.mRID>b66f15c0-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_b6978550-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>Border_ST24</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>XZE_ST24</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00017X</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:IdentifiedObject.mRID>b6978550-cb6e-11e1-bcee-406c8f32ef58</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:EnergySchedulingType rdf:ID="_24C12434-E42B-497f-928F-119C6AE92079">
+    <cim:IdentifiedObject.name>Biomass</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Biomass</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>EST-Biomass</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>24C12434-E42B-497f-928F-119C6AE92079</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_FB6F43D6-E71E-423a-8CEB-084BC504FD1A">
+    <cim:IdentifiedObject.name>Co-generation</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Co-generation</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>CoGen</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>FB6F43D6-E71E-423a-8CEB-084BC504FD1A</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_1CDFB476-4E01-4488-B5A2-FDDEA0488C59">
+    <cim:IdentifiedObject.name>Geothermal</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Geothermal</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>Geotherm</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>1CDFB476-4E01-4488-B5A2-FDDEA0488C59</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_2C897906-9B7F-4508-B132-74EA3EE1D3B0">
+    <cim:IdentifiedObject.name>Marine</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Marine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>ES-Marine</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>2C897906-9B7F-4508-B132-74EA3EE1D3B0</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_A43C7A90-B4C7-460c-A607-942EFA3EFB79">
+    <cim:IdentifiedObject.name>Other renewable</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Other renewable</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>OtherRenew</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>A43C7A90-B4C7-460c-A607-942EFA3EFB79</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:EnergySchedulingType rdf:ID="_1C405140-0F45-4534-9C90-F38F4905362C">
+    <cim:IdentifiedObject.name>Waste</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Generation type Waste</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>EST-Waste</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>1C405140-0F45-4534-9C90-F38F4905362C</cim:IdentifiedObject.mRID>
+  </cim:EnergySchedulingType>
+  <cim:GeographicalRegion rdf:ID="_fb980bdf-ced5-4f87-8264-998e95e065a5">
+    <cim:IdentifiedObject.description>Economic and political union of member states located primarily in Europe</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>EU</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-EU-EU-000001</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>EU</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>fb980bdf-ced5-4f87-8264-998e95e065a5</cim:IdentifiedObject.mRID>
+  </cim:GeographicalRegion>
+  <cim:Line rdf:ID="_eac31e3d-fdf5-4656-b10e-66481bfcfec5">
+    <cim:IdentifiedObject.name>TieLine_XCA_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XCA_AL11</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XCA_AL11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10314U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>eac31e3d-fdf5-4656-b10e-66481bfcfec5</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_54a2e470-ef70-443f-ae81-bcf2d117caa2">
+    <cim:IdentifiedObject.name>TieLine_XKA_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XKA_MA11</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XKA_MA11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10114U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>54a2e470-ef70-443f-ae81-bcf2d117caa2</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_bd25e87a-c626-4dd7-a846-7fba517fbb8f">
+    <cim:IdentifiedObject.name>TieLine_XWI_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XWI_GY11</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XWI_GY11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10014U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>bd25e87a-c626-4dd7-a846-7fba517fbb8f</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1">
+    <cim:IdentifiedObject.name>TieLine_XZE_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XZE_ST23</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST23</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10234U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae2">
+    <cim:IdentifiedObject.name>TieLine_HVDC-NL</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>HVDC TieLine at NL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>HVDC_NL</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10344U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae2</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:Line rdf:ID="_54a2e470-ef70-443f-ae81-bcf2d117caa3">
+    <cim:IdentifiedObject.name>TieLine_XZE_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TieLine at XZE_ST24</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST24</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-BE-NL-10274U</eu:IdentifiedObject.energyIdentCodeEic>
+    <cim:Line.Region rdf:resource="#_fbcc6679-6da5-4cfd-b50c-8ce23f450c78" />
+    <cim:IdentifiedObject.mRID>54a2e470-ef70-443f-ae81-bcf2d117caa2</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:SubGeographicalRegion rdf:ID="_fbcc6679-6da5-4cfd-b50c-8ce23f450c78">
+    <cim:IdentifiedObject.name>ENTSO-E</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_fb980bdf-ced5-4f87-8264-998e95e065a5" />
+    <cim:IdentifiedObject.description>ENTSO-E region</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>ENTSO-E</eu:IdentifiedObject.shortName>
+    <cim:IdentifiedObject.mRID>fbcc6679-6da5-4cfd-b50c-8ce23f450c78</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <eu:BoundaryPoint rdf:ID="_8fe8c999-a939-5d43-b857-02dd312f2dea">
+    <cim:IdentifiedObject.name>Border_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XCA_AL11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-ES-PT-10004U</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>ES</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Cartelle</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>REE</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>PT</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Alto Lindoso</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>REN</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>8fe8c999-a939-5d43-b857-02dd312f2dea</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+  <eu:BoundaryPoint rdf:ID="_af1d901f-98de-574f-abc3-6c3025e7a685">
+    <cim:IdentifiedObject.name>Border_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XWI_GY11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-HU-00002U</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>AT</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Wien</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>APG</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>HU</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Győr</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>MAVIR</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>af1d901f-98de-574f-abc3-6c3025e7a685</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+  <eu:BoundaryPoint rdf:ID="_7976cd48-d51c-8e4b-9595-56299cb5b4f8">
+    <cim:IdentifiedObject.name>Border_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XKA_MA11</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-SI-00001T</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>AT</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Kainachtal</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>APG</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>SI</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Maribor</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>ELES</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>7976cd48-d51c-8e4b-9595-56299cb5b4f8</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+  <eu:BoundaryPoint rdf:ID="_c65325ed-92a7-384a-834b-99c1ceea32ef">
+    <cim:IdentifiedObject.name>Border_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST23</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00016Z</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>AT</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Zell/Ziller</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>APG</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>DE</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Strass</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>TIWAG-Netz</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>c65325ed-92a7-384a-834b-99c1ceea32ef</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+  <eu:BoundaryPoint rdf:ID="_fd0e36b7-817f-4547-9e0f-a07011aecd48">
+    <cim:IdentifiedObject.name>Border_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST24</eu:IdentifiedObject.shortName>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00017X</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:BoundaryPoint.fromEndIsoCode>AT</eu:BoundaryPoint.fromEndIsoCode>
+    <eu:BoundaryPoint.fromEndName>Zell/Ziller</eu:BoundaryPoint.fromEndName>
+    <eu:BoundaryPoint.fromEndNameTso>APG</eu:BoundaryPoint.fromEndNameTso>
+    <eu:BoundaryPoint.toEndIsoCode>DE</eu:BoundaryPoint.toEndIsoCode>
+    <eu:BoundaryPoint.toEndName>Strass</eu:BoundaryPoint.toEndName>
+    <eu:BoundaryPoint.toEndNameTso>TIWAG-Netz</eu:BoundaryPoint.toEndNameTso>
+    <eu:BoundaryPoint.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>fd0e36b7-817f-4547-9e0f-a07011aecd48</cim:IdentifiedObject.mRID>
+  </eu:BoundaryPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_ASSEMBLED_DL_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_ASSEMBLED_DL_001.xml
@@ -1,0 +1,1896 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:8336a39a-071e-41a5-9787-b26d99ca9177">
+    <md:Model.created>2021-03-25T23:16:28Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d" />
+    <md:Model.DependentOn rdf:resource="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61" />
+  </md:FullModel>
+  <cim:Diagram rdf:ID="_634dea3f-e2a6-36d0-d25c-39fb7da2af7d">
+    <cim:IdentifiedObject.name>Assembled</cim:IdentifiedObject.name>
+    <cim:Diagram.orientation rdf:resource="http://iec.ch/TC57/CIM100#OrientationKind.negative" />
+    <cim:IdentifiedObject.mRID>634dea3f-e2a6-36d0-d25c-39fb7da2af7d</cim:IdentifiedObject.mRID>
+  </cim:Diagram>
+  <cim:DiagramObject rdf:ID="_3f5fcd49-4e27-5c8c-7af0-39fb7da2af7e">
+    <cim:IdentifiedObject.name>G-Link-354409015</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>3f5fcd49-4e27-5c8c-7af0-39fb7da2af7e</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_5723b2d3-92bc-fc7c-0fb4-39fb7da2af80">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>682.625</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>113.7708</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3f5fcd49-4e27-5c8c-7af0-39fb7da2af7e" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b115f07e-73d2-6b47-0540-39fb7da2af80">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>663.3358</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>113.7708</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3f5fcd49-4e27-5c8c-7af0-39fb7da2af7e" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_01ac35a4-a39d-9f35-5d61-39fb7da2af80">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>663.3358</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>114.0391</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3f5fcd49-4e27-5c8c-7af0-39fb7da2af7e" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_2a77bc2c-b490-d16e-4b03-39fb7da2af80">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>114.0391</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3f5fcd49-4e27-5c8c-7af0-39fb7da2af7e" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_467d3d1e-f96f-acb5-c8b8-39fb7da2af80">
+    <cim:IdentifiedObject.name>G-Link-354408573</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_5a7b80f3-eeb3-4253-a792-5157c0946b15" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>467d3d1e-f96f-acb5-c8b8-39fb7da2af80</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_4ef3d9b5-fbea-2b52-8437-39fb7da2af80">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>240</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_467d3d1e-f96f-acb5-c8b8-39fb7da2af80" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_886d8253-d84c-bcac-ba41-39fb7da2af80">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>254.9966</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_467d3d1e-f96f-acb5-c8b8-39fb7da2af80" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_4f182a88-8564-4e9d-51e3-39fb7da2af80">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>254.9966</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_467d3d1e-f96f-acb5-c8b8-39fb7da2af80" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_5a65c0ab-e081-9ad4-27d8-39fb7da2af80">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>269.875</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_467d3d1e-f96f-acb5-c8b8-39fb7da2af80" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e7470557-0f67-c8e9-e796-39fb7da2af80">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>e7470557-0f67-c8e9-e796-39fb7da2af80</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d1b175bf-63b3-853f-ccf7-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>140</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e7470557-0f67-c8e9-e796-39fb7da2af80" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_1fdb8090-87d6-e088-ba02-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>124</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e7470557-0f67-c8e9-e796-39fb7da2af80" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_57e6bfd4-dd22-64a7-d1c5-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>57e6bfd4-dd22-64a7-d1c5-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d5075c67-8d4a-2fe4-9968-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>100</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>210</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_57e6bfd4-dd22-64a7-d1c5-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_2541ded4-a785-4ca1-a91a-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>100</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_57e6bfd4-dd22-64a7-d1c5-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_f2161998-0632-ac5d-7e98-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>f2161998-0632-ac5d-7e98-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_6427f636-8155-ed05-67ae-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>176.5</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f2161998-0632-ac5d-7e98-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_e992a024-524c-abbf-dac7-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>84.5</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f2161998-0632-ac5d-7e98-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_019ef9d5-4c45-f74d-5132-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>019ef9d5-4c45-f74d-5132-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_328944f0-8c1b-63c5-06aa-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>88</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_019ef9d5-4c45-f74d-5132-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_9b446293-e52e-d4d8-be14-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>104</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_019ef9d5-4c45-f74d-5132-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e18b4ed3-593d-5edb-d42d-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>e18b4ed3-593d-5edb-d42d-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_66d5d1fc-8ce6-4414-634f-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>198</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e18b4ed3-593d-5edb-d42d-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_15a961bc-cd2f-e196-96ba-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e18b4ed3-593d-5edb-d42d-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_58c4516e-0bf9-bd01-5499-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>58c4516e-0bf9-bd01-5499-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_522738e4-2cbb-6c4c-6481-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>250.2</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_58c4516e-0bf9-bd01-5499-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_cdf5e805-07b4-1621-1f32-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>240</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_58c4516e-0bf9-bd01-5499-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_2f14d750-5f1c-c7f0-828f-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>2f14d750-5f1c-c7f0-828f-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_7e860bcb-6cda-0eb2-d322-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>240</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>155</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2f14d750-5f1c-c7f0-828f-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b5f7cee3-1799-81bd-85f2-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>240</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>142</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2f14d750-5f1c-c7f0-828f-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_099f9e11-34a6-f1b5-e1de-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>099f9e11-34a6-f1b5-e1de-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_30a11095-e5b2-a093-9bcb-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>644</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>81.3</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_099f9e11-34a6-f1b5-e1de-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_ec427d5c-4156-107d-6c9e-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>644</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>263.2603</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_099f9e11-34a6-f1b5-e1de-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_0bbca635-cbcb-4638-0d60-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>0bbca635-cbcb-4638-0d60-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ddaebeb6-237c-7e17-454e-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>738</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>260</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0bbca635-cbcb-4638-0d60-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_19b0a739-94a6-e9c1-4add-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>738</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>175.2</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0bbca635-cbcb-4638-0d60-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_3333a803-f5b3-105f-15de-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>3333a803-f5b3-105f-15de-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_4d20c2e7-241e-2775-96a1-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>368</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>252</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3333a803-f5b3-105f-15de-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_7744910c-d819-88f3-9904-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>368</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>234</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3333a803-f5b3-105f-15de-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_9b802cf4-9855-cb9a-03ed-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>9b802cf4-9855-cb9a-03ed-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_7acdb729-54a1-afc8-47b7-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>270</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>246</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9b802cf4-9855-cb9a-03ed-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_0ea2b08f-a909-7a85-ce58-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>270</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>172</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9b802cf4-9855-cb9a-03ed-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_317503ed-2414-da1c-24ed-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>317503ed-2414-da1c-24ed-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_97f9e6d7-f439-e623-084b-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>152</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_317503ed-2414-da1c-24ed-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_1976dddd-6cdc-ac87-3f47-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>170</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_317503ed-2414-da1c-24ed-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_3da63568-6c5e-54dc-11e9-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>3da63568-6c5e-54dc-11e9-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_2885c658-7875-2814-4fbd-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>322</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>78</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3da63568-6c5e-54dc-11e9-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_f2838ebc-b036-c571-09b5-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>322</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3da63568-6c5e-54dc-11e9-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_b2e504c0-348d-7fad-5e09-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>b2e504c0-348d-7fad-5e09-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_5a9fdb01-cb12-5d97-04b3-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>180</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>238</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b2e504c0-348d-7fad-5e09-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_57ea18d2-3066-9e8e-1687-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>180</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>76</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b2e504c0-348d-7fad-5e09-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_a40e4afc-2b15-a171-f011-39fb7da2af81">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>a40e4afc-2b15-a171-f011-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_e1b86e08-4af5-d797-13dd-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>336</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>188</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a40e4afc-2b15-a171-f011-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_a418e340-da11-194b-1cfb-39fb7da2af81">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>336</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>258</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a40e4afc-2b15-a171-f011-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_7996889d-b7e0-b3bd-055d-39fb7da2af81">
+    <cim:IdentifiedObject.name>GR-L-1230804819-795098234</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>7996889d-b7e0-b3bd-055d-39fb7da2af81</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_8a2d14bd-4d3f-3ebc-7508-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>330</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>259.8</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7996889d-b7e0-b3bd-055d-39fb7da2af81" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_1c24a6b6-106d-5f14-2a6b-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-1519229870</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_beffa353-7d10-421d-9c08-036b744b1cee" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>1c24a6b6-106d-5f14-2a6b-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_edd4970f-468b-f45d-ae2c-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>84</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1c24a6b6-106d-5f14-2a6b-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_9fe6926c-bc70-356a-9292-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>100</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1c24a6b6-106d-5f14-2a6b-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_06860db8-e1c6-e18f-4e4d-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XCA_AL11-1413600188</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_24413233-26c3-4f7e-9f72-4461796938be" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>06860db8-e1c6-e18f-4e4d-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_996dbec2-799f-a623-337e-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>422.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_06860db8-e1c6-e18f-4e4d-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_35618b32-037a-0171-912a-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XZE_ST24-78955718</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>35618b32-037a-0171-912a-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_87dd38f7-88c0-55d8-3427-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>424.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_35618b32-037a-0171-912a-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_d49995f0-556b-74c3-59fe-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-633459252</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_53072f42-f77b-47e2-bd9a-e097c910b173" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>d49995f0-556b-74c3-59fe-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_77c077ca-1ed8-c0be-cd04-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>426</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d49995f0-556b-74c3-59fe-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_7d2575f2-c0cc-0a4a-304a-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138.1</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d49995f0-556b-74c3-59fe-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_0c0392c2-6ba8-dc84-f2e2-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-BE-Load_1-1132341825</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_cb459405-cc14-4215-a45c-416789205904" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>0c0392c2-6ba8-dc84-f2e2-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_996055ab-0823-fe37-e722-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>160.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>132</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0c0392c2-6ba8-dc84-f2e2-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_fa169583-ce02-9c1b-27c3-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-52575670</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>fa169583-ce02-9c1b-27c3-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_c42520c7-211d-4873-8084-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>330</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>256</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_fa169583-ce02-9c1b-27c3-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_05200b68-d8c2-7101-10cc-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>336</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>256</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_fa169583-ce02-9c1b-27c3-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_63ae4d75-b66c-0faa-b7b5-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-BE-TR2_2-1357561524</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>63ae4d75-b66c-0faa-b7b5-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_16539120-faeb-1bff-7c1e-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>230</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_63ae4d75-b66c-0faa-b7b5-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_1aa864ff-bdea-4937-db50-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-BE-TR3_1-2077564634</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>1aa864ff-bdea-4937-db50-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_220e7ffb-e8e9-3de1-ea55-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>293</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>156</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1aa864ff-bdea-4937-db50-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e2bb743e-aba7-e510-d8ca-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-NL-Load_3-631391046</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b1e03a8f-6a11-4454-af58-4a4a680e857f" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>e2bb743e-aba7-e510-d8ca-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d41c7132-24ad-51d2-2215-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>659.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>88</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e2bb743e-aba7-e510-d8ca-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_3a7c07a4-981d-01d7-8816-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-1962060451</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>3a7c07a4-981d-01d7-8816-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_cd450b7b-970a-36fb-7609-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>164</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>132</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3a7c07a4-981d-01d7-8816-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_cf7a1a67-2750-4b5e-4a03-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>180</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>132</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3a7c07a4-981d-01d7-8816-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_8694b1f7-ba70-1bf6-707b-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-1994603755</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>8694b1f7-ba70-1bf6-707b-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_5deb4f44-39e2-e004-209c-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>655.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>88</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8694b1f7-ba70-1bf6-707b-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_93dc6570-c544-1973-2a90-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>88</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8694b1f7-ba70-1bf6-707b-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_521430de-90d7-0417-a0dd-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-BE-G1-330853274</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>521430de-90d7-0417-a0dd-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_eb921de7-eb57-6203-6a47-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>78.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_521430de-90d7-0417-a0dd-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_fc229451-1303-82d9-aabc-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-254699869</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>fc229451-1303-82d9-aabc-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_c62c7f26-287a-641d-8488-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>428</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_fc229451-1303-82d9-aabc-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_4f06d024-4c28-5627-596a-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>247.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_fc229451-1303-82d9-aabc-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_130a8dfd-959e-e7e4-d4cf-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-1712449918</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f970233f-b573-49d9-9fc3-3a2a59ed3bbb" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>130a8dfd-959e-e7e4-d4cf-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_48c914fe-133a-4e26-2d42-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>444</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_130a8dfd-959e-e7e4-d4cf-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_8406f686-1e88-5b18-1b4e-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_130a8dfd-959e-e7e4-d4cf-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_58a55440-3afa-4369-3dae-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-SVC-1230797516-321439582</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>58a55440-3afa-4369-3dae-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_e1693570-2c41-6ead-c9fd-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.4688</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>261.8542</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_58a55440-3afa-4369-3dae-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_d77f1c30-229e-7304-d55b-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-1522016781</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>d77f1c30-229e-7304-d55b-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d4a9f5b7-ad1b-4bb3-32f6-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>573.9</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>134.4</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d77f1c30-229e-7304-d55b-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b7db517a-a79c-d2db-8f35-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>134.6</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d77f1c30-229e-7304-d55b-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5f069b7a-3de0-9631-eddb-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XZE_ST23-1448023129</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_87ea56f3-962a-427a-85d6-13b1f9295174" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>5f069b7a-3de0-9631-eddb-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_0fa99f63-fe7a-c4ab-e2aa-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>426.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5f069b7a-3de0-9631-eddb-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_53eb83ca-b82b-9d4e-fbfa-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-NL_TR2_3-1833298703</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-89.2</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>53eb83ca-b82b-9d4e-fbfa-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ba02593c-6d97-329c-b858-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>692.624</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>113.9105</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_53eb83ca-b82b-9d4e-fbfa-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_6e33646a-c005-a677-a091-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-590160729</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b9539c41-d114-4280-8a54-8ecec398091e" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>6e33646a-c005-a677-a091-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_6e477fec-98e3-2700-d2b7-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>426</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>100</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6e33646a-c005-a677-a091-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_953b64b2-cbc2-023a-300e-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>99.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6e33646a-c005-a677-a091-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_1f82307b-224c-5b52-8477-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-1163897995</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_d238885e-d9b6-4edc-8567-6a68c605ed67" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>1f82307b-224c-5b52-8477-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_006bcb41-d71f-4044-f73c-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>430</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1f82307b-224c-5b52-8477-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_bf243b1f-42fe-6d4e-c49a-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>213.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1f82307b-224c-5b52-8477-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_f493dd76-d32f-d501-eba1-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XCA_AL11-385950181</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_83bea592-913e-4473-8d17-969968ff83a2" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>f493dd76-d32f-d501-eba1-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_cee288ab-dbc7-129c-cb49-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>447.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f493dd76-d32f-d501-eba1-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_98c2cd9c-0736-8fab-c7a3-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-1006053890</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>98c2cd9c-0736-8fab-c7a3-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_3ac963bd-958c-89ca-3901-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>284</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>164</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_98c2cd9c-0736-8fab-c7a3-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_1e7353c3-6e03-ba1b-cee9-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>284</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>182</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_98c2cd9c-0736-8fab-c7a3-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_e6f6a917-35cf-953f-f70c-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>270</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>182</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_98c2cd9c-0736-8fab-c7a3-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_527833a7-b84b-8661-4285-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XKA_MA11-182978626</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_cab82e1c-1435-447b-bba0-74b592539eac" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>527833a7-b84b-8661-4285-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d0c45bab-49f6-cf24-358c-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>447.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_527833a7-b84b-8661-4285-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_85439b66-c718-55b1-56aa-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-NL-S1-23474354</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_fbfed7e3-3dec-4829-a286-029e73535685" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>85439b66-c718-55b1-56aa-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_a682842f-c5cd-96b9-63ed-39fb7da2af84">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>581.7</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>134.4</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_85439b66-c718-55b1-56aa-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_7451f968-de50-1a23-2527-39fb7da2af84">
+    <cim:IdentifiedObject.name>GR-L-82826021</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_39d27c17-1e5b-4edc-a7ec-65a2d56542df" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>7451f968-de50-1a23-2527-39fb7da2af84</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_a4c82c37-fe46-7cce-226e-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>444</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7451f968-de50-1a23-2527-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_9b80407c-3e24-fd2d-7a84-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138.1</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7451f968-de50-1a23-2527-39fb7da2af84" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5df00684-9350-95be-df85-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-444386168</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a036b765-1669-4f64-acd3-1e8fbd513312" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>5df00684-9350-95be-df85-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_0405717b-cab6-9c6a-9e6d-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>256</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>196</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5df00684-9350-95be-df85-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_c399f2e0-7d18-f59f-2f20-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>270</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>196</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5df00684-9350-95be-df85-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_390b0090-fd77-d447-d30e-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-1259515836</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_67bb74f1-8620-4a32-9d7d-a44092d11d22" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>390b0090-fd77-d447-d30e-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_6aae2033-a8f8-ec0e-febd-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.4688</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>251.3542</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_390b0090-fd77-d447-d30e-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_51e98db7-65c0-7723-fde5-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>252</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_390b0090-fd77-d447-d30e-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_37cb9d70-0f47-0251-6073-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-Load_2-664013061</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>37cb9d70-0f47-0251-6073-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_55df265f-edeb-cab1-3d99-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>252.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>196</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_37cb9d70-0f47-0251-6073-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_68b8b7d0-b858-4b32-69b1-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-108027093</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_26e50b4b-9a19-420d-98ce-bc4f11971cd7" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>68b8b7d0-b858-4b32-69b1-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_8676d398-bc98-aec4-a929-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>444</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_68b8b7d0-b858-4b32-69b1-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_a030f55c-ddcc-879e-a29e-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>247.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_68b8b7d0-b858-4b32-69b1-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_a1f5fa4a-252b-3a25-dac0-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XWI_GY11-1033807006</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>a1f5fa4a-252b-3a25-dac0-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_7576b08c-cc3b-819b-225e-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>422.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>100</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_a1f5fa4a-252b-3a25-dac0-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_9d9ce49c-954f-930c-fe32-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XZE_ST24-835537239</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_820d95d7-26d4-4311-8b1f-026f8605b86d" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>9d9ce49c-954f-930c-fe32-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_83a1635d-68fd-7768-5fe7-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>447.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9d9ce49c-954f-930c-fe32-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e52f38e1-6db7-40f8-5831-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-1691614453</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_c41978db-794b-4bae-953e-60fc519e87dd" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>e52f38e1-6db7-40f8-5831-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_8c06fa58-46d0-ebe9-5521-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>428</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e52f38e1-6db7-40f8-5831-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_52481060-5519-cc42-ac62-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e52f38e1-6db7-40f8-5831-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_360f54e8-158e-16ff-0bfb-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE_S2-252010594</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>360f54e8-158e-16ff-0bfb-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_0cbd23eb-77cc-4a7d-550d-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>301.7</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_360f54e8-158e-16ff-0bfb-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_17045431-5186-7322-809b-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL_TR2_2-25822384</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-89.8</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>17045431-5186-7322-809b-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_46670dce-a45d-258d-3991-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>688</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_17045431-5186-7322-809b-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_47f63ddd-965b-d6fd-e0d7-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-TR2_1-1902947644</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-89.5</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>47f63ddd-965b-d6fd-e0d7-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_f66c97b3-f234-a252-228d-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>604</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116.1</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_47f63ddd-965b-d6fd-e0d7-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_ca9165d3-17dd-6a20-865a-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-1633734589</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>ca9165d3-17dd-6a20-865a-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_617f40ce-3bed-cd21-1713-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>177.5</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ca9165d3-17dd-6a20-865a-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_1e9d4198-f256-a5c6-e8d7-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>180</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ca9165d3-17dd-6a20-865a-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e47c3a1d-aa70-88a7-0f40-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-958549789</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>e47c3a1d-aa70-88a7-0f40-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_c751f5df-12c3-9dee-75ca-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>594</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e47c3a1d-aa70-88a7-0f40-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_fd996f6b-b06d-41c7-58a8-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e47c3a1d-aa70-88a7-0f40-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_837a7d94-c576-34c6-d8d7-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-1192632359</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>837a7d94-c576-34c6-d8d7-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_65cd40f8-d0cd-7efa-a104-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>613.9996</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116.1873</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_837a7d94-c576-34c6-d8d7-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_04c5d7a1-74b3-ade9-74f7-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_837a7d94-c576-34c6-d8d7-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_504175f2-4ba9-2078-dbd8-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-1997329201</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_22af3121-1a66-4546-bd80-4371f417c644" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>504175f2-4ba9-2078-dbd8-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_5ed80e16-9ef4-fbc3-10ad-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>309.5</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_504175f2-4ba9-2078-dbd8-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_6c23a742-b5f5-d7f4-93e0-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>322</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_504175f2-4ba9-2078-dbd8-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5b42c603-e8ce-b062-4139-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-Inj-XKA_MA11-1735199274</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_14b352cb-5574-40c5-bf83-0ed3574554a3" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>5b42c603-e8ce-b062-4139-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ceb77dd4-a72e-fe0d-3d2d-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>424.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5b42c603-e8ce-b062-4139-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_1163f3fd-2c34-9374-da3b-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE_S1-265097752</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>1163f3fd-2c34-9374-da3b-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_fc343fed-0754-7f51-7f00-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>169.7</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>86</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1163f3fd-2c34-9374-da3b-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e649a5a2-5270-f047-0550-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-476899861</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>e649a5a2-5270-f047-0550-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d42ad328-2931-7591-01fd-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>757.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e649a5a2-5270-f047-0550-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_55ac5eda-2fba-b7e6-a37a-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e649a5a2-5270-f047-0550-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_4d428912-7981-161b-a501-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-TR2_3-266970206</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>4d428912-7981-161b-a501-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d2f9acb2-ce9f-3847-6152-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>136</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4d428912-7981-161b-a501-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_3e3a5430-e16e-7428-ffc0-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-1414387645</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>3e3a5430-e16e-7428-ffc0-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_65b3ff95-3503-75f1-9bde-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>228</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>152</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3e3a5430-e16e-7428-ffc0-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_c63722a6-2359-c49e-caa0-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>240</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>152</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3e3a5430-e16e-7428-ffc0-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_789399cf-2f9b-0e28-fae2-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-501948729</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>789399cf-2f9b-0e28-fae2-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_b899bd9e-37b1-d579-f155-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>126</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_789399cf-2f9b-0e28-fae2-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_0a48e5a9-f6d0-ed2f-99ed-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>100</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_789399cf-2f9b-0e28-fae2-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_9a2479b6-0ee9-e1a5-09a4-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-G2-569000708</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>9a2479b6-0ee9-e1a5-09a4-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_37c3e56e-f3eb-fac2-1006-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>222.2</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>152</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9a2479b6-0ee9-e1a5-09a4-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_c6517348-5a20-082a-de47-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-G3-1272157758</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>c6517348-5a20-082a-de47-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_db50ac78-65ad-e07d-9adc-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>763.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c6517348-5a20-082a-de47-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_87a1a7a2-7692-e053-30f4-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XZE_ST23-435758727</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_12baa3f3-23b1-44e0-956f-d331e1527f37" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>87a1a7a2-7692-e053-30f4-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_2b49681c-cbf3-28e0-f2ec-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>445.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_87a1a7a2-7692-e053-30f4-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_126b9b98-0957-8c1d-6167-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-412002467</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>126b9b98-0957-8c1d-6167-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_72a8f292-dafd-5174-057e-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>757.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>204</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_126b9b98-0957-8c1d-6167-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_ba69bc7a-b807-b4c9-4f94-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>204</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_126b9b98-0957-8c1d-6167-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_9ba97fe9-1a9b-62e6-785d-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-1648984860</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_8171fc34-6891-40e0-92d1-da9f4ba69e26" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>9ba97fe9-1a9b-62e6-785d-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d221845e-c0e1-25c8-68ec-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>343.9583</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244.7396</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9ba97fe9-1a9b-62e6-785d-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_e1992b11-c20a-3e44-80f1-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9ba97fe9-1a9b-62e6-785d-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_ab7515c4-6ca1-5747-fd53-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-SER-RLC-1230822986-763959145</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>270</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>ab7515c4-6ca1-5747-fd53-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_6375d4c5-3d9d-6eac-04cf-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>353.9583</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244.7396</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ab7515c4-6ca1-5747-fd53-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_f48a3c56-8e3e-aca3-88f6-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-805648696</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>f48a3c56-8e3e-aca3-88f6-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_9f8f13f0-b45b-2852-ac65-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>363.9583</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244.7396</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f48a3c56-8e3e-aca3-88f6-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d9828ece-61de-8695-b9be-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>367.7708</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f48a3c56-8e3e-aca3-88f6-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_cbb01f94-c042-6779-07fb-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-1977885975</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_24dd035c-0a8c-4351-aeb2-08d6622b42ae" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>cbb01f94-c042-6779-07fb-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ebd13d1e-6195-9287-8f56-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>442</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_cbb01f94-c042-6779-07fb-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b6a282db-e16d-3ebd-8f51-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>213.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_cbb01f94-c042-6779-07fb-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_8c0282f9-7de1-41bb-ca78-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-G2-1540646227</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_2844585c-0d35-488d-a449-685bcd57afbf" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>8c0282f9-7de1-41bb-ca78-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_92e7cf07-ceb9-d7f5-4df2-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>763.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>204</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8c0282f9-7de1-41bb-ca78-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_222ab4d4-8a49-06f3-ec97-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Load_1-704664914</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_69add5b4-70bd-4360-8a93-286256c0d38b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>222ab4d4-8a49-06f3-ec97-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_a3e71adc-c125-9f88-ae45-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>583.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>148</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_222ab4d4-8a49-06f3-ec97-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_62ee083b-e703-4e52-6aa1-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-Line_6-2084691096</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>62ee083b-e703-4e52-6aa1-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_e6c622c4-d206-2e2a-f34a-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>269.875</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>234.1563</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_62ee083b-e703-4e52-6aa1-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_428f0fb1-c0be-3ed9-22a3-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>234.1563</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_62ee083b-e703-4e52-6aa1-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_160b8549-e559-e056-4128-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-Line_7-1366516707</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>160b8549-e559-e056-4128-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_79c29367-071b-e53d-2480-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_160b8549-e559-e056-4128-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_464e1913-d0b8-214a-58dd-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>367.7708</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>243.4167</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_160b8549-e559-e056-4128-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e336f788-fbfd-0176-4249-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Line_5-1375941741</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>e336f788-fbfd-0176-4249-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_21d7911a-5867-ce40-5e9a-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>567.7958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>93.92693</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e336f788-fbfd-0176-4249-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_60128542-487c-1ea9-e960-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>94</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e336f788-fbfd-0176-4249-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_327060bc-1576-7ee2-fdd3-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-G1-145382758</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>327060bc-1576-7ee2-fdd3-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_48eda790-8a10-f0b4-c6e2-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>765.3542</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>191.8229</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_327060bc-1576-7ee2-fdd3-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_fc9bd44d-54d6-eca6-0ba7-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-Line_3-1247633054</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>fc9bd44d-54d6-eca6-0ba7-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_b1e3d469-1b4e-6d9d-a10c-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.9979</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>129.6474</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_fc9bd44d-54d6-eca6-0ba7-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_15656005-c67b-694b-3a34-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>130</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_fc9bd44d-54d6-eca6-0ba7-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_d7ac5983-b49d-5ce2-f8e1-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-TR2_1-1574014072</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>d7ac5983-b49d-5ce2-f8e1-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_76e22286-764f-aece-21e2-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>250</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d7ac5983-b49d-5ce2-f8e1-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_529bc239-186c-5ef9-ac0d-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-751811171</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_faab7959-f9bf-421b-bc3f-d364e0c1388b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>529bc239-186c-5ef9-ac0d-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_5376db90-d6c3-6331-64ff-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>759.3542</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>191.8229</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_529bc239-186c-5ef9-ac0d-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_cefd9130-5b83-92c8-9ebd-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>191.8229</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_529bc239-186c-5ef9-ac0d-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_9f3fc709-7799-dc2a-fbc5-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-Line_1-1392653407</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>9f3fc709-7799-dc2a-fbc5-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_9437d9f5-cdda-82b1-3795-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>204</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9f3fc709-7799-dc2a-fbc5-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_51aa231e-d95b-d03a-3aec-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>203.7292</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9f3fc709-7799-dc2a-fbc5-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_8ce7df60-0510-5f4c-bcaf-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Line_1-1770209197</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>8ce7df60-0510-5f4c-bcaf-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_227e24e4-c8d4-50f3-94e0-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>567.7958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>129.6451</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8ce7df60-0510-5f4c-bcaf-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_9c00f1f1-390c-6635-5079-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>130</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8ce7df60-0510-5f4c-bcaf-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_1cd51f72-e422-f42f-164b-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-1326432400</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f461fd2d-1e41-4a3e-8213-7cc33c77a089" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>1cd51f72-e422-f42f-164b-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_a811d60f-20fd-cbea-23c0-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>580</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>148</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1cd51f72-e422-f42f-164b-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_3c99aee2-9fbd-9ee2-e372-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>147.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1cd51f72-e422-f42f-164b-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5073a386-d357-79b8-a068-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XWI_GY11-486907852</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b0442899-8dbe-48c1-a1fa-adb2a5929273" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>5073a386-d357-79b8-a068-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ae750e42-a57d-ff10-5be5-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>447.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>100</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5073a386-d357-79b8-a068-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_4cbecbba-54c6-3ce8-7659-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-956945829</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f48d48c7-e9f6-460c-898f-cc68a96efdeb" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>4cbecbba-54c6-3ce8-7659-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_20da0040-7348-2c8d-a89f-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>444</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>100</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4cbecbba-54c6-3ce8-7659-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_7c6613b4-7c92-2934-c0ee-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>99.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4cbecbba-54c6-3ce8-7659-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_9f578172-e608-ca43-3663-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Line_4-1027009775</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>9f578172-e608-ca43-3663-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_55296348-b213-82d6-4e5f-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214.3137</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9f578172-e608-ca43-3663-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_2e1fce36-34d5-9202-1c1a-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.2473</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9f578172-e608-ca43-3663-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_4556aeff-1a4a-fd71-11be-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Line_3-1522111161</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>4556aeff-1a4a-fd71-11be-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_41be9d97-77b1-a375-f4d1-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>243.4174</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4556aeff-1a4a-fd71-11be-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b98022f9-a976-e043-e9af-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4556aeff-1a4a-fd71-11be-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_b668f530-d16f-498c-fc96-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-Line_4-687714713</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>b668f530-d16f-498c-fc96-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_cf9b749e-72e1-157d-0cfb-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>322</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>158</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b668f530-d16f-498c-fc96-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d1c62a28-f5af-0e75-6f1b-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>158</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b668f530-d16f-498c-fc96-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_d9d4abdd-1ed5-376b-225f-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-L-2070108204</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_6dad1a97-6874-4206-a5a5-837e495325f8" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>d9d4abdd-1ed5-376b-225f-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_4bd7f5c7-c39f-3fab-0250-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>580</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d9d4abdd-1ed5-376b-225f-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_6ab57ddc-a1e4-c604-9b36-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_d9d4abdd-1ed5-376b-225f-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_7fee9664-b00b-5cc0-91ed-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Line_2-1694985016</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>7fee9664-b00b-5cc0-91ed-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_58edb266-d2d2-0884-ba9e-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>567.7958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>157.4271</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7fee9664-b00b-5cc0-91ed-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_0584cf64-a60e-f75b-5b46-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>157.4271</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_7fee9664-b00b-5cc0-91ed-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_4a309c3b-78a7-8ca8-9e59-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-BE-Line_2-1618371762</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>4a309c3b-78a7-8ca8-9e59-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_aa0d28be-f0f6-2cd2-abb3-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>269.875</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4a309c3b-78a7-8ca8-9e59-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_745e24bd-cc4f-5935-e2eb-39fb7da2af85">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>335.7563</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_4a309c3b-78a7-8ca8-9e59-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_bff6eeab-84d4-9448-ae75-39fb7da2af85">
+    <cim:IdentifiedObject.name>GR-NL-Load_2-199595741</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_25ab1b5b-6803-47e2-805a-ab7b2072e034" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>bff6eeab-84d4-9448-ae75-39fb7da2af85</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d0bac36c-2a7a-38d9-33fc-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>583.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_bff6eeab-84d4-9448-ae75-39fb7da2af85" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_eeadbd0c-bd85-8d39-a0ea-39fb7da2af86">
+    <cim:IdentifiedObject.name>GR-BE-Line_5-1020037632</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>eeadbd0c-bd85-8d39-a0ea-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_85676028-e0a0-e738-0e10-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.9979</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>96.57291</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_eeadbd0c-bd85-8d39-a0ea-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_1779987a-88e6-3253-8f0f-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>96.57291</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_eeadbd0c-bd85-8d39-a0ea-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_67d1141f-e4e8-58f6-b501-39fb7da2af86">
+    <cim:IdentifiedObject.name>G-Link-354408541</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>67d1141f-e4e8-58f6-b501-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_a3513b00-0f25-51e2-72d8-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>260</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_67d1141f-e4e8-58f6-b501-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_3f0f479e-7ef4-5e35-5940-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>290.931</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_67d1141f-e4e8-58f6-b501-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_4d42e81b-42c6-4147-a0f0-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>290.931</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>109.8021</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_67d1141f-e4e8-58f6-b501-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_dc4f929a-45a0-b20b-2787-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.9979</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>109.8021</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_67d1141f-e4e8-58f6-b501-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5a037b6f-92a5-4dea-741c-39fb7da2af86">
+    <cim:IdentifiedObject.name>G-Link-354408554</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>5a037b6f-92a5-4dea-741c-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_92f11df7-bcf4-133e-ce61-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>284</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>156</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5a037b6f-92a5-4dea-741c-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_11a49f25-bf45-7a88-aecb-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>283.2062</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>156</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5a037b6f-92a5-4dea-741c-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_9afdd41c-f5bf-0460-5930-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>283.2062</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>150.8125</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5a037b6f-92a5-4dea-741c-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_80572fad-fd79-cb6e-19c9-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>321.9979</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>150.8125</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5a037b6f-92a5-4dea-741c-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_69737775-5a6c-5ac7-1953-39fb7da2af86">
+    <cim:IdentifiedObject.name>G-Link-354409027</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_70b326a3-5913-494f-b8f8-8e366253b597" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>69737775-5a6c-5ac7-1953-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_7de2675e-0bcb-3d22-e8ab-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>702.623</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>114.0501</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_69737775-5a6c-5ac7-1953-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d7e4c3aa-24fc-ec4b-0c6b-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>720.7014</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>114.0501</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_69737775-5a6c-5ac7-1953-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d1c8c3ca-de4b-0a4a-a23c-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>720.7014</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>181.2396</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_69737775-5a6c-5ac7-1953-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_830fbf2b-6cab-2169-88e2-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>181.2396</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_69737775-5a6c-5ac7-1953-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_1ff716d4-9ec2-de73-6bbc-39fb7da2af86">
+    <cim:IdentifiedObject.name>G-Link-354408595</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_0ac86078-8267-4fd9-b6c2-27984975ffcc" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>1ff716d4-9ec2-de73-6bbc-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_e301ee9c-7711-27a5-8ed8-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>220</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1ff716d4-9ec2-de73-6bbc-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_2aaab0ba-0c46-7181-21e0-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>200.1557</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1ff716d4-9ec2-de73-6bbc-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d1f12eae-045c-e157-f33e-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>200.1557</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1ff716d4-9ec2-de73-6bbc-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_e23b6077-a193-7e0e-4d4f-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>179.9167</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1ff716d4-9ec2-de73-6bbc-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_51fa4360-9e0a-f493-e002-39fb7da2af86">
+    <cim:IdentifiedObject.name>G-Link-354409049</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_421c7930-64c3-435d-afb8-2bb73b333e34" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>51fa4360-9e0a-f493-e002-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_9b411908-c6e1-8b36-d45f-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>678.0001</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.9651</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_51fa4360-9e0a-f493-e002-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_e3144927-a476-9ad8-ad60-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>661.1736</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.9651</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_51fa4360-9e0a-f493-e002-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_002eccf8-92d5-b530-09de-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>661.1736</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>206.375</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_51fa4360-9e0a-f493-e002-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_05984376-8a58-dc5b-6d0e-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>206.375</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_51fa4360-9e0a-f493-e002-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_bb421b7f-ac60-6476-5e51-39fb7da2af86">
+    <cim:IdentifiedObject.name>G-Link-354408484</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>bb421b7f-ac60-6476-5e51-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_1ba502fa-d511-6a57-1e03-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>302</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>148</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_bb421b7f-ac60-6476-5e51-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_c2354787-38f9-5103-b914-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>302.7938</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>148</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_bb421b7f-ac60-6476-5e51-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_162cdf42-f3a9-661e-46f5-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>302.7938</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>145.5208</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_bb421b7f-ac60-6476-5e51-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_c8c06078-855d-cfeb-2408-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>239.9771</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>145.5208</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_bb421b7f-ac60-6476-5e51-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_0c305168-ac23-44c5-f406-39fb7da2af86">
+    <cim:IdentifiedObject.name>G-Link-354409038</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_31bf04d0-7e34-465b-95a4-0604700325cf" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>0c305168-ac23-44c5-f406-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_7776814c-b380-e5fc-5082-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>697.9999</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216.0349</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0c305168-ac23-44c5-f406-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_dae23884-aa02-0680-abd7-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>717.9335</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216.0349</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0c305168-ac23-44c5-f406-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_4cfd59e8-28c8-56d5-3410-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>717.9335</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0c305168-ac23-44c5-f406-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_af75a3d2-6615-4b4b-8cc5-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0c305168-ac23-44c5-f406-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_9578ce66-d8aa-97b1-e45e-39fb7da2af86">
+    <cim:IdentifiedObject.name>G-Link-354408421</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>9578ce66-d8aa-97b1-e45e-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_24f111a2-cddb-b9e7-c4c2-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>240</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9578ce66-d8aa-97b1-e45e-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_f0133ec5-9e1f-307e-fb00-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>210.0364</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>110</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9578ce66-d8aa-97b1-e45e-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_6d8162bf-7825-9e68-d986-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>210.0364</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>109.9902</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9578ce66-d8aa-97b1-e45e-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d7846905-d3a7-fa7d-8e9d-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>179.9167</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>109.9902</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_9578ce66-d8aa-97b1-e45e-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_30273e63-d259-660a-e2e3-39fb7da2af86">
+    <cim:IdentifiedObject.name>G-Link-354408513</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d" />
+    <cim:DiagramObject.Diagram rdf:resource="#_634dea3f-e2a6-36d0-d25c-39fb7da2af7d" />
+    <cim:IdentifiedObject.mRID>30273e63-d259-660a-e2e3-39fb7da2af86</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_33630e48-ffd3-6539-0f45-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>146</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_30273e63-d259-660a-e2e3-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d8d7d85a-f865-1831-c8cf-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>162.7188</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>190</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_30273e63-d259-660a-e2e3-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_3f106b7f-3e76-21bb-336f-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>162.7188</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>189.1771</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_30273e63-d259-660a-e2e3-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_473263fd-3cf0-87cf-4117-39fb7da2af86">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>179.9167</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>189.1771</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_30273e63-d259-660a-e2e3-39fb7da2af86" />
+  </cim:DiagramObjectPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_ASSEMBLED_SV_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_ASSEMBLED_SV_001.xml
@@ -1,0 +1,685 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:99122158-12b8-48e1-a094-003f7f05edcb">
+    <md:Model.created>2021-03-25T23:16:28Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/StateVariables-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.DependentOn rdf:resource="urn:uuid:31a153c3-8ac9-4cb2-85d6-011ab522a133" />
+  </md:FullModel>
+  <cim:SvPowerFlow rdf:ID="_fd1ba2f7-3632-40c3-94a8-47249a69ed04">
+    <cim:SvPowerFlow.p>487.9077</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>231.3542</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_721de4d4-4271-4ef6-8f8e-22b29bc213c3">
+    <cim:SvVoltage.angle>-9.052585</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>223.2214</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_ebd2d2fd-3cfc-466d-a542-104ce0e8fd4d" />
+  </cim:SvVoltage>
+  <cim:TopologicalIsland rdf:ID="_48c763a1-4adf-43ee-a27e-2543b29549b6">
+    <cim:IdentifiedObject.name>TopoIsland 1</cim:IdentifiedObject.name>
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_ebd2d2fd-3cfc-466d-a542-104ce0e8fd4d" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_eff86931-991c-4f6f-b5d6-75dad40e0a12" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_1a4d0f02-6adb-4fa2-a828-b0366497ae5a" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_88f1e099-9930-4ad2-a477-f301e35ca9a4" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_994d58d1-48c9-477d-8ba4-ec143e714ba1" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+    <cim:TopologicalIsland.AngleRefTopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+    <cim:IdentifiedObject.mRID>48c763a1-4adf-43ee-a27e-2543b29549b6</cim:IdentifiedObject.mRID>
+  </cim:TopologicalIsland>
+  <cim:SvPowerFlow rdf:ID="_a190a49c-30f6-413a-98f2-d44b7f1ac76d">
+    <cim:SvPowerFlow.p>-27.0286</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>120.7887</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_b9539c41-d114-4280-8a54-8ecec398091e" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_394b77ce-a67f-4b12-abc7-9ae049d46a80">
+    <cim:SvPowerFlow.p>10</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>10</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_6dad1a97-6874-4206-a5a5-837e495325f8" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_2c32bc8a-da0b-429e-81c4-447b770b99ae">
+    <cim:SvPowerFlow.p>200</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>90</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_fa1d9590-75d3-4e35-b17f-ee17e7274c5a">
+    <cim:SvPowerFlow.p>99.85394</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-24.87515</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_15dc7836-abc4-48a4-a4f6-523ad1a5e77d">
+    <cim:SvPowerFlow.p>14.06748</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-63.95825</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_39d27c17-1e5b-4edc-a7ec-65a2d56542df" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_d6ee7368-1d2e-4c05-9aa3-846fad523240">
+    <cim:SvPowerFlow.p>90</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>280</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f461fd2d-1e41-4a3e-8213-7cc33c77a089" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_0c71fa38-18d3-480d-89aa-da44f3b55679">
+    <cim:SvPowerFlow.p>-168.0146</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>52.38079</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_7a3e94f1-f0b7-4dfb-af94-d2e7f72fdf24">
+    <cim:SvVoltage.angle>340.9585</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>115.5</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_1e12d575-9809-4d69-a58b-74d712bb040d">
+    <cim:SvPowerFlow.p>-118</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-78.16264</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_c4411a5a-760f-4bf3-903b-e08440376715">
+    <cim:SvPowerFlow.p>-103.7413</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>11.31944</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_d026525b-9784-4bb3-86d5-21cbe150be5f">
+    <cim:SvPowerFlow.p>-8.953211</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>67.2335</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_c41978db-794b-4bae-953e-60fc519e87dd" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_309de4fa-6041-41b0-9c2d-aad4fc933025">
+    <cim:SvPowerFlow.p>-3.786605</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>38.5127</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_231a4cf8-5069-4d53-96e4-e839f073f1ea" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_5d8f1e0d-31d0-43a5-b709-8b850137f392">
+    <cim:SvPowerFlow.p>-89.66164</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>81.66273</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_69f01012-4ce8-4177-9a61-b169fd44fa85">
+    <cim:SvPowerFlow.p>-27.0286</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>120.7887</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_ae588863-b154-451d-978a-7ab08ac50fb6" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_65b96b5d-ac82-422c-bca4-41c2e7680f18">
+    <cim:SvPowerFlow.p>-83.18928</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>1.501529</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_d238885e-d9b6-4edc-8567-6a68c605ed67" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_d90b115d-7c94-477a-aac5-58f2d321d685">
+    <cim:SvTapStep.position>17</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_ee649b97-d2ec-47e1-976f-0f4d9f50fa11" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_594eb33c-ddcd-48af-9810-85ea4744d200">
+    <cim:SvPowerFlow.p>19.19087</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-87.50481</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_67c6c4e7-1343-4c08-a9c9-d0f54fabbffb">
+    <cim:SvPowerFlow.p>120.2376</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-9.558035</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_77f04391-aa23-49b6-b3e9-6089130bb5d5" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_eaeae9e0-c2c0-4a91-ba6f-317146aabbaf">
+    <cim:SvPowerFlow.p>-150</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-83.296</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_d32c84c9-3277-4579-9c51-c28d5eb6a027">
+    <cim:SvPowerFlow.p>-103.7413</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>11.31944</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_6aecb9ba-5835-4b70-89bc-96d687e45779" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_cad73c42-881a-42ca-b748-82dd662118d5">
+    <cim:SvVoltage.angle>340.7323</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>21.987</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_2b28238d-9c83-4126-a367-db9eaf97b8b9">
+    <cim:SvPowerFlow.p>83.18928</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-1.501529</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_24dd035c-0a8c-4351-aeb2-08d6622b42ae" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_e6dc512b-2b44-4d4c-9e3e-e5e77751c8ef">
+    <cim:SvPowerFlow.p>-559.3295</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-88.78947</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_faab7959-f9bf-421b-bc3f-d364e0c1388b" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_9408a842-1d22-49ef-abd2-d3cfa8b087b8">
+    <cim:SvVoltage.angle>339.568</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>412.6039</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_eff86931-991c-4f6f-b5d6-75dad40e0a12" />
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_ae469b5f-b0cf-4afa-a12d-aa705bbbb326">
+    <cim:SvPowerFlow.p>0.8637645</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>24.17813</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_5a7b80f3-eeb3-4253-a792-5157c0946b15" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_5ea068c0-a8a5-4c33-824c-99c53b967cf3">
+    <cim:SvPowerFlow.p>59.96792</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-5.537291</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_2e38f630-c33f-48fe-921c-7a4595baa6e5">
+    <cim:SvPowerFlow.p>-140</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-77.743</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_12f86d10-96bb-40d2-9d16-569701f35aa4">
+    <cim:SvPowerFlow.p>0</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-52.79673</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_fe1fda63-1986-4389-adca-b1ab4e8b0fee">
+    <cim:SvPowerFlow.p>200</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>50</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_a036b765-1669-4f64-acd3-1e8fbd513312" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_cf29c76d-daaf-4f4c-b4c7-8a8c46089fbd">
+    <cim:SvVoltage.angle>339.5112</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>414.0277</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_1a4d0f02-6adb-4fa2-a828-b0366497ae5a" />
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_e891db2f-4503-47a2-9ad0-f42b4e2f19ea">
+    <cim:SvPowerFlow.p>-438.7081</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-11.90898</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_421c7930-64c3-435d-afb8-2bb73b333e34" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_346ea71d-f57e-40d9-b082-a51fad6a3b80">
+    <cim:SvPowerFlow.p>1.871276</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-59.39729</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_22af3121-1a66-4546-bd80-4371f417c644" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_c0e9fcff-1e81-4f4b-9c9a-e8c19f3598fc">
+    <cim:SvPowerFlow.p>-14.06748</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>63.95825</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_53072f42-f77b-47e2-bd9a-e097c910b173" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_68f796a5-df47-4808-a834-33786e706aeb">
+    <cim:SvPowerFlow.p>110.1824</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-179.3575</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_4f677d64-9172-452e-9329-851a3a27b74d">
+    <cim:SvVoltage.angle>-2.702116</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>224.3178</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_cdb5031b-6ab5-4ab8-a0fc-b4b285f8b212">
+    <cim:SvVoltage.angle>339.6498</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>410.7063</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_dccec5a2-13e0-4227-a1f3-5ead1c507f49">
+    <cim:SvPowerFlow.p>168.3565</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-46.45348</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_cb73a0dc-c910-4288-a930-eda39925c607">
+    <cim:SvPowerFlow.p>84.71166</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>3.317878</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_653bc4b8-518b-4adc-9d68-012fb641fb1d" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_9357e2e3-3416-4336-8713-3dc4483430ee">
+    <cim:SvPowerFlow.p>-53.59776</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>9.173759</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_05a17350-55f5-4a00-9a50-8c0048a25495" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_67afaff5-ce61-4a3e-bb06-d9d78aa8cb91">
+    <cim:SvPowerFlow.p>-19.81423</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>110.0211</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_051d49ba-4360-4372-86bf-50eb8cf29778" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_f4b530e1-0230-486a-a09f-dc31156d1836">
+    <cim:SvPowerFlow.p>27.0286</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-120.7887</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_8ae4c04f-e562-4f4a-aa30-dd8ca4f53758">
+    <cim:SvPowerFlow.p>-90</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>74.17992</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_beffa353-7d10-421d-9c08-036b744b1cee" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_d4afc6f9-11ad-47a2-b9f6-783cfc6f874b">
+    <cim:SvPowerFlow.p>0</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-9.88107</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_67bb74f1-8620-4a32-9d7d-a44092d11d22" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_95bb1d25-89ea-48c6-a5e2-98a73ecda360">
+    <cim:SvVoltage.angle>339.5023</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>414.3389</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_bf4d0111-51f6-4c69-934e-8ffaefe6ff15">
+    <cim:SvVoltage.angle>-11.03524</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>223.2396</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_88f1e099-9930-4ad2-a477-f301e35ca9a4" />
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_d3198d52-4730-4dd4-a91c-95e4c8cb66ed">
+    <cim:SvVoltage.angle>-20.16267</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>224.6702</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:SvVoltage>
+  <cim:SvShuntCompensatorSections rdf:ID="_37bf68b6-c7da-4119-9081-e11c22987f51">
+    <cim:SvShuntCompensatorSections.sections>1</cim:SvShuntCompensatorSections.sections>
+    <cim:SvShuntCompensatorSections.ShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:SvShuntCompensatorSections>
+  <cim:SvPowerFlow rdf:ID="_6e0b5794-acee-472e-b578-0e42d639931c">
+    <cim:SvPowerFlow.p>409.4445</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>209.9772</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_70b326a3-5913-494f-b8f8-8e366253b597" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_3826b191-bc7b-43e8-be60-f2720c85f572">
+    <cim:SvTapStep.position>5</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_44b4277a-0f4b-43a8-ad93-6f7d6ef02061" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_df359307-4034-4879-b636-048fde40252e">
+    <cim:SvPowerFlow.p>106.0121</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>2.926857</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_de3d72a1-2b00-4014-9218-504fa7fa28d0">
+    <cim:SvPowerFlow.p>14.06748</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-63.95825</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f3b56334-4638-49d3-a6a0-3f417422b8f5" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_5b7f6556-edeb-4471-b31a-78dba00fd635">
+    <cim:SvPowerFlow.p>439.885</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>39.85126</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_31bf04d0-7e34-465b-95a4-0604700325cf" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_89c31467-784e-46f3-8d8e-9dee64063b06">
+    <cim:SvPowerFlow.p>-81.35162</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>6.659446</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_70d962fb-a492-4c36-8cad-b5c584df53bd" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_e783e2c1-8497-4f89-b2ed-36eb2ea161db">
+    <cim:SvPowerFlow.p>-14.06748</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>63.95825</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_f61ade39-684e-4f8b-8a19-5106098d632f">
+    <cim:SvPowerFlow.p>-30.96664</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-100.4366</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_21ed3462-d65d-4225-929d-f70129e0a16a">
+    <cim:SvVoltage.angle>-15.51589</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>223.658</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:SvVoltage>
+  <cim:SvTapStep rdf:ID="_67b45903-a403-43f4-8508-c37e134d2ba7">
+    <cim:SvTapStep.position>14</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_7d61f2c1-7988-4912-ab6f-8824d2922e74">
+    <cim:SvPowerFlow.p>15.82242</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-70.92072</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_c557146e-dfc4-4020-9738-d592b188338b" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_2f43fb7c-c271-4e4c-94ec-3655a394fb47">
+    <cim:SvVoltage.angle>343.3294</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>10.3622</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_313ddf4f-6c14-4b80-9133-41a6fc81dc4e">
+    <cim:SvPowerFlow.p>-408.2798</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-179.2365</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_3c68ee89-7a4f-4aeb-8c95-9356398d204c">
+    <cim:SvVoltage.angle>339.5562</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>412.8738</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_994d58d1-48c9-477d-8ba4-ec143e714ba1" />
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_906e1707-dbc0-48e8-b415-c12fb3f03bd2">
+    <cim:SvPowerFlow.p>103.7413</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-11.31944</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_26e50b4b-9a19-420d-98ce-bc4f11971cd7" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_0706ad95-1746-49fe-8809-6a8467fd105e">
+    <cim:SvVoltage.angle>0</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>16.0335</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_2a2b7b8e-77d3-498c-abc4-f0f194fda7bc">
+    <cim:SvPowerFlow.p>-83.18928</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>1.501529</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_57979d14-d1d8-4311-ae53-aa8890423885" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_c77cdd6d-df2a-4bff-b98b-2ff44b91501b">
+    <cim:SvPowerFlow.p>-116.2994</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>17.08473</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_699545b9-82b9-4331-bc80-538d73b4ba56" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_9c05901e-1086-40f6-a731-caddf3517dec">
+    <cim:SvPowerFlow.p>83.18928</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-1.501529</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_1ef0715a-d5a9-477b-b6e7-b635529ac140" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_6c723cf0-99a3-4895-9808-c82dd76f0420">
+    <cim:SvPowerFlow.p>-109.4835</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>183.1439</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_e08f8876-223e-420b-8974-db9625fe89f8">
+    <cim:SvPowerFlow.p>1</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>0</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_7b1c5d7f-6c9d-4087-b546-9aee96c48779">
+    <cim:SvPowerFlow.p>-99.85394</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>18.31695</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_8171fc34-6891-40e0-92d1-da9f4ba69e26" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_f9ce8c28-c09b-42a0-a74c-6b9ee74d79f4">
+    <cim:SvPowerFlow.p>-99.85394</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>24.87515</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_3c534b4c-1490-4347-9612-3129d8a9d053">
+    <cim:SvTapStep.position>17</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_fe25f43a-7341-446e-a71a-8ab7119ba806" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_b3e0a636-37b9-4b50-b11a-c6e36e4dedc7">
+    <cim:SvPowerFlow.p>-2.085326</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>62.96101</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe" />
+  </cim:SvPowerFlow>
+  <cim:SvShuntCompensatorSections rdf:ID="_3b6bb720-f415-484f-a57f-346efaad832e">
+    <cim:SvShuntCompensatorSections.sections>1</cim:SvShuntCompensatorSections.sections>
+    <cim:SvShuntCompensatorSections.ShuntCompensator rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da" />
+  </cim:SvShuntCompensatorSections>
+  <cim:SvTapStep rdf:ID="_7619ac99-2255-493e-b306-26549066ef39">
+    <cim:SvTapStep.position>10</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_63454a73-f439-45bb-951a-e7b193986571" />
+  </cim:SvTapStep>
+  <cim:SvTapStep rdf:ID="_471f788f-74a8-4c39-b7a9-67275e4d43b1">
+    <cim:SvTapStep.position>8</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_341327c4-9224-40bf-bc33-7a3bb0bae680" />
+  </cim:SvTapStep>
+  <cim:SvTapStep rdf:ID="_a329c400-1ef7-468c-94a4-cdd389bc0190">
+    <cim:SvTapStep.position>10</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_36b83adb-3d45-4693-8967-96627b5f9ec9" />
+  </cim:SvTapStep>
+  <cim:SvVoltage rdf:ID="_b254f31b-e687-4fcf-98dc-88cdbc250d9b">
+    <cim:SvVoltage.angle>-19.1098</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>226.7108</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+  </cim:SvVoltage>
+  <cim:SvPowerFlow rdf:ID="_b73a0df9-5aa1-428d-8bd6-72d821e68e27">
+    <cim:SvPowerFlow.p>-0.8548296</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-24.05666</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_0ac86078-8267-4fd9-b6c2-27984975ffcc" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_b6d7bd62-567c-47cf-a23d-dbce0a245061">
+    <cim:SvPowerFlow.p>8.953211</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-67.2335</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_97d0d402-5f31-4621-9809-738afbabf933">
+    <cim:SvPowerFlow.p>0</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-330.75</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_ae22d364-40f5-4175-9d2d-32bf2ccb4a6c">
+    <cim:SvPowerFlow.p>-86.36749</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>27.25996</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_5bb4e051-1107-4d30-94fd-a57667652ecc">
+    <cim:SvPowerFlow.p>118</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>78.16264</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_fed10dd1-d6cb-47af-a5c7-3e2919ce7b9e">
+    <cim:SvPowerFlow.p>8.953211</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-67.2335</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f970233f-b573-49d9-9fc3-3a2a59ed3bbb" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_cefca669-270e-4e51-b953-5c94f58fe587">
+    <cim:SvPowerFlow.p>33.00131</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-131.1585</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_757d4f50-707b-47a0-891c-cbaefd649631" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_dfe5ad8e-daa3-48e5-8571-9d197832245a">
+    <cim:SvPowerFlow.p>27.0286</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-120.7887</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f48d48c7-e9f6-460c-898f-cc68a96efdeb" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_df477d1c-0b69-47ce-a5c1-0e182d6d201b">
+    <cim:SvPowerFlow.p>103.7413</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-11.31944</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_57ae9251-c022-4c67-a8eb-611ad54c963c" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_b3e1a065-79f6-414a-b8c2-358718cf1ed9">
+    <cim:SvPowerFlow.p>-8.953211</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>67.2335</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_8f308117-8bbd-4798-b145-4e78f7d049e7" />
+  </cim:SvPowerFlow>
+  <cim:SvShuntCompensatorSections rdf:ID="_a9278767-deb2-4654-9462-62b0ae591356">
+    <cim:SvShuntCompensatorSections.sections>1</cim:SvShuntCompensatorSections.sections>
+    <cim:SvShuntCompensatorSections.ShuntCompensator rdf:resource="#_fbfed7e3-3dec-4829-a286-029e73535685" />
+  </cim:SvShuntCompensatorSections>
+  <cim:SvPowerFlow rdf:ID="_54012246-068d-4784-9259-3901ce765a9f">
+    <cim:SvPowerFlow.p>90</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-74.17992</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+  </cim:SvPowerFlow>
+  <cim:SvStatus rdf:ID="_cef71b97-c2f4-4506-9203-db4de5a4ffdd">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_a31c8ce9-78c4-4653-bd9d-917e1652bd40">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_53da4025-9d51-4eaf-b0d2-ce27fbe740d2" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_f41a8067-a9db-4bec-9c68-8c717a37ba44">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b0442899-8dbe-48c1-a1fa-adb2a5929273" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_fe40702d-e384-438c-b6fb-80b521f3cb36">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_12baa3f3-23b1-44e0-956f-d331e1527f37" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_4620a52d-b8f8-4cb9-b388-dbbc2fb27197">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_83bea592-913e-4473-8d17-969968ff83a2" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_9632e1da-2475-4b11-ac9b-fc0c50c51537">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_820d95d7-26d4-4311-8b1f-026f8605b86d" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_eca9dce7-8104-4154-8f42-a3d96d1b889e">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_cab82e1c-1435-447b-bba0-74b592539eac" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_ce475b24-5084-4b7d-9c54-f138d4893d3f">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_c7f610d4-3bb1-4171-8b38-94e896b2a218">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_4b7a5761-c2b4-4484-99cb-0cc15db6c319">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_287c93cb-75ed-43a4-9f39-370de104d7de">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_4b75ab3a-fedb-4d37-8f53-932672d70908">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_6087f292-05f0-48b0-a972-f585d0215bac">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_25ab1b5b-6803-47e2-805a-ab7b2072e034" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_7f97d5ad-2db4-4e4d-a9c7-e64e502f965c">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_69add5b4-70bd-4360-8a93-286256c0d38b" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_4b55fd8e-738f-40ff-86dc-94d5bdb05ab0">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b1e03a8f-6a11-4454-af58-4a4a680e857f" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_83de2674-4b29-4402-ac33-4155ee9c12e2">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_fbfed7e3-3dec-4829-a286-029e73535685" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_a063e35d-6f4c-45db-acaf-20cbc05cd0c8">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_d403a271-40a4-4876-9d46-ae94f169ddde">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_f8f88691-c99b-4e08-89fe-10dc510d6c86">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_2844585c-0d35-488d-a449-685bcd57afbf" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_d3b523e0-cb84-4b09-bbf5-faea70ab32d0">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_b6592a7b-8d7e-44e5-9c87-bacf5b62d9aa">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_81cc8d9b-dce7-44ac-b839-ee8d429a27bd">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_b9e0964b-9d36-4463-b787-c9071052f7d9">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_5caf27ed-d2f8-458a-834a-6b3193a982e6" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_616ef874-a9b8-4408-8556-ecd555555840">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_ecb95969-6ba4-497b-ab4a-6ff58575db1b">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_364c9ca2-0d1d-4363-8f46-e586f8f66a8c" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_038ddada-1982-4561-88c7-a45b21e827d0">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_ef45b632-3028-4afe-bc4c-a4fa323d83fe" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_ee90b265-8ca1-4a79-839a-1790f0ea531c">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_fd649fe1-bdf5-4062-98ea-bbb66f50402d" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_36dd8115-5928-491d-8a9e-c6ada7fda454">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_87ea56f3-962a-427a-85d6-13b1f9295174" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_722e1d30-7a9c-4b25-82f8-3c819bffebfd">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_24413233-26c3-4f7e-9f72-4461796938be" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_dc69c693-45a5-4fe7-93a8-01950fe1a8e9">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_4e6250e0-2f54-481b-9afa-b875d1e0533e">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_50725cbb-c1e8-4568-9dde-43e6659f0db1">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_14b352cb-5574-40c5-bf83-0ed3574554a3" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_322fe079-cc8c-4422-aefc-6b52b3146a9d">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_3d941019-bded-45fe-96da-77e09f11e087">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_b869e8c4-0be8-4921-9a31-5e696e16d323">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_1aeb87ce-e752-497c-b6b6-bc2eae1a1036">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_906a87b5-3184-4d27-aa16-e6a947a778cf">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_d2d95691-e3b6-4057-b2b3-f70c6010170b">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_5ead0e3d-da12-4c24-94b8-243a2525c5a9">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_620e657a-3c65-4d2c-9d53-4cab48dd6495">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_1dea2915-da48-45b7-8855-ea0f9373ffc7">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_cb459405-cc14-4215-a45c-416789205904" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_1052c5fe-b164-4e03-8444-9ed3b8036880">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_40f6fe80-671b-423f-b546-2b88d509f842">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_1e9ac70b-6954-47c1-bc9b-7b303eb84aa1">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_549b05df-e22a-4c94-974e-0113ea5c1327">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_d84158d2-6f64-4e64-8fe7-375d2677bef9">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_4b2637b9-3cea-401d-b20e-f0766ebb43aa">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_1805f4e6-d146-49ed-952b-b4cf86d68a1a">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_69166263-d269-4e11-bd14-5a4aeb2141e7">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_00790418-46f2-43ab-8d4f-e4d158fb0d5e">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_29e037cd-e22e-4184-b950-5e90ae00801d">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_79a76ecb-f057-43bb-94e1-a2a3f09fab18">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+  </cim:SvStatus>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_ASSEMBLED_TP_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_ASSEMBLED_TP_001.xml
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:31a153c3-8ac9-4cb2-85d6-011ab522a133">
+    <md:Model.created>2021-03-25T23:16:28Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/Topology-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:1b092ff0-f8a0-49da-82d3-75eff5f1e820" />
+    <md:Model.DependentOn rdf:resource="urn:uuid:e888e6dc-c686-4957-b1ec-4be41760339e" />
+  </md:FullModel>
+  <cim:TopologicalNode rdf:ID="_99b219f3-4593-428b-a4da-124a54630178">
+    <cim:IdentifiedObject.name>BE_TR_BUS4</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>99b219f3-4593-428b-a4da-124a54630178</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_bf851342-832e-4ea2-b2ad-b09729b3af23">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_e44141af-f1dc-44d3-bfa4-b674e5c953d7">
+    <cim:IdentifiedObject.name>BE_TR_BUS2</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>e44141af-f1dc-44d3-bfa4-b674e5c953d7</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_f96d552a-618d-4d0c-a39a-2dea3c411dee">
+    <cim:IdentifiedObject.name>BE-Busbar_5</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>BGENT_72; this is old code</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-B_5</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:IdentifiedObject.mRID>f96d552a-618d-4d0c-a39a-2dea3c411dee</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_afddd60d-f7e6-419a-a5c2-be28d29beaf9">
+    <cim:IdentifiedObject.name>NL-Busbar_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>NAMST_21; this is the old code</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-B_2</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_d77b61ef-61aa-4b22-95f6-b56ca080788d" />
+    <cim:IdentifiedObject.mRID>afddd60d-f7e6-419a-a5c2-be28d29beaf9</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_5c74cb26-ce2f-40c6-951d-89091eb781b6">
+    <cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>BBRUS151; BGENT_51</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-B_6</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:IdentifiedObject.mRID>5c74cb26-ce2f-40c6-951d-89091eb781b6</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_1695eb20-9044-4133-a3fd-2147f55f170d">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_81b0e447-181e-4aec-8921-f1dd7813bebc">
+    <cim:IdentifiedObject.name>N1230992195</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>NAMST_11; old UCTE Name</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-_B_1</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:IdentifiedObject.mRID>81b0e447-181e-4aec-8921-f1dd7813bebc</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_90f78705-5ef4-479a-8d5a-70efc554e0ba">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_1a4d0f02-6adb-4fa2-a828-b0366497ae5a">
+    <cim:IdentifiedObject.name>TN_Border_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XKA_MA11</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:IdentifiedObject.mRID>1a4d0f02-6adb-4fa2-a828-b0366497ae5a</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_1a4d0f02-6adb-4fa2-a828-b0366497ae5a" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_eff86931-991c-4f6f-b5d6-75dad40e0a12">
+    <cim:IdentifiedObject.name>TN_Border_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XWI_GY11</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:IdentifiedObject.mRID>eff86931-991c-4f6f-b5d6-75dad40e0a12</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_eff86931-991c-4f6f-b5d6-75dad40e0a12" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_ebd2d2fd-3cfc-466d-a542-104ce0e8fd4d">
+    <cim:IdentifiedObject.name>TN_Border_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST23</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:IdentifiedObject.mRID>ebd2d2fd-3cfc-466d-a542-104ce0e8fd4d</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_ebd2d2fd-3cfc-466d-a542-104ce0e8fd4d" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_994d58d1-48c9-477d-8ba4-ec143e714ba1">
+    <cim:IdentifiedObject.name>TN_Border_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 400 kV; OHL (2)</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XCA_AL11</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:IdentifiedObject.mRID>994d58d1-48c9-477d-8ba4-ec143e714ba1</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_b675a570-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_994d58d1-48c9-477d-8ba4-ec143e714ba1" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_6bdc33de-d027-49b7-b98f-3b3d87716615">
+    <cim:IdentifiedObject.name>N1230822413</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_abb2348a-aa10-446f-9f5d-49f93f211535" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:IdentifiedObject.mRID>6bdc33de-d027-49b7-b98f-3b3d87716615</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_124b9180-9112-4b8a-a651-9c1bb9a031da">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_88f1e099-9930-4ad2-a477-f301e35ca9a4">
+    <cim:IdentifiedObject.name>TN_Border_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>RG CE; 220 kV; OHL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>XZE_ST24</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:IdentifiedObject.mRID>88f1e099-9930-4ad2-a477-f301e35ca9a4</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_b6978550-cb6e-11e1-bcee-406c8f32ef58">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_88f1e099-9930-4ad2-a477-f301e35ca9a4" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_f70f6bad-eb8d-4b8f-8431-4ab93581514e">
+    <cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>BBRUS_21; this is UCTE code</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-B_2</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>f70f6bad-eb8d-4b8f-8431-4ab93581514e</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_ae99bd74-26b1-443a-b1a5-656320283a36">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e">
+    <cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>BGENT_71; This is the old UCTE code from UCTE DEF</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-B_4</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:IdentifiedObject.mRID>a81d08ed-f51d-4538-8d1e-fb2d0dbd128e</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_23b65c6b-2351-4673-89e9-1895c7291543">
+    <cim:IdentifiedObject.name>Series Compensator</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>23b65c6b-2351-4673-89e9-1895c7291543</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:about="#_50f00b94-fe0f-48fd-887e-f0d4d59eee87">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f199d49-0093-4b51-b357-70371424d174">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_421c7930-64c3-435d-afb8-2bb73b333e34">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31bf04d0-7e34-465b-95a4-0604700325cf">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_757d4f50-707b-47a0-891c-cbaefd649631">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae588863-b154-451d-978a-7ab08ac50fb6">
+    <cim:Terminal.TopologicalNode rdf:resource="#_eff86931-991c-4f6f-b5d6-75dad40e0a12" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f308117-8bbd-4798-b145-4e78f7d049e7">
+    <cim:Terminal.TopologicalNode rdf:resource="#_1a4d0f02-6adb-4fa2-a828-b0366497ae5a" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c557146e-dfc4-4020-9738-d592b188338b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e3e0c496-5837-4f0f-a596-cc421940f73f">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dad1a97-6874-4206-a5a5-837e495325f8">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f48d48c7-e9f6-460c-898f-cc68a96efdeb">
+    <cim:Terminal.TopologicalNode rdf:resource="#_eff86931-991c-4f6f-b5d6-75dad40e0a12" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57979d14-d1d8-4311-ae53-aa8890423885">
+    <cim:Terminal.TopologicalNode rdf:resource="#_ebd2d2fd-3cfc-466d-a542-104ce0e8fd4d" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_653bc4b8-518b-4adc-9d68-012fb641fb1d">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d">
+    <cim:Terminal.TopologicalNode rdf:resource="#_994d58d1-48c9-477d-8ba4-ec143e714ba1" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24dd035c-0a8c-4351-aeb2-08d6622b42ae">
+    <cim:Terminal.TopologicalNode rdf:resource="#_ebd2d2fd-3cfc-466d-a542-104ce0e8fd4d" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39d27c17-1e5b-4edc-a7ec-65a2d56542df">
+    <cim:Terminal.TopologicalNode rdf:resource="#_994d58d1-48c9-477d-8ba4-ec143e714ba1" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6aecb9ba-5835-4b70-89bc-96d687e45779">
+    <cim:Terminal.TopologicalNode rdf:resource="#_88f1e099-9930-4ad2-a477-f301e35ca9a4" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26e50b4b-9a19-420d-98ce-bc4f11971cd7">
+    <cim:Terminal.TopologicalNode rdf:resource="#_88f1e099-9930-4ad2-a477-f301e35ca9a4" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f461fd2d-1e41-4a3e-8213-7cc33c77a089">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f970233f-b573-49d9-9fc3-3a2a59ed3bbb">
+    <cim:Terminal.TopologicalNode rdf:resource="#_1a4d0f02-6adb-4fa2-a828-b0366497ae5a" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_faab7959-f9bf-421b-bc3f-d364e0c1388b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70b326a3-5913-494f-b8f8-8e366253b597">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:Terminal.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5a7b80f3-eeb3-4253-a792-5157c0946b15">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0ac86078-8267-4fd9-b6c2-27984975ffcc">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f96d552a-618d-4d0c-a39a-2dea3c411dee" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+    <cim:Terminal.TopologicalNode rdf:resource="#_ebd2d2fd-3cfc-466d-a542-104ce0e8fd4d" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d238885e-d9b6-4edc-8567-6a68c605ed67">
+    <cim:Terminal.TopologicalNode rdf:resource="#_ebd2d2fd-3cfc-466d-a542-104ce0e8fd4d" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53072f42-f77b-47e2-bd9a-e097c910b173">
+    <cim:Terminal.TopologicalNode rdf:resource="#_994d58d1-48c9-477d-8ba4-ec143e714ba1" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57ae9251-c022-4c67-a8eb-611ad54c963c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_88f1e099-9930-4ad2-a477-f301e35ca9a4" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:Terminal.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+    <cim:Terminal.TopologicalNode rdf:resource="#_eff86931-991c-4f6f-b5d6-75dad40e0a12" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+    <cim:Terminal.TopologicalNode rdf:resource="#_1a4d0f02-6adb-4fa2-a828-b0366497ae5a" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+    <cim:Terminal.TopologicalNode rdf:resource="#_994d58d1-48c9-477d-8ba4-ec143e714ba1" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:Terminal.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+    <cim:Terminal.TopologicalNode rdf:resource="#_88f1e099-9930-4ad2-a477-f301e35ca9a4" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:Terminal.TopologicalNode rdf:resource="#_e44141af-f1dc-44d3-bfa4-b674e5c953d7" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9539c41-d114-4280-8a54-8ecec398091e">
+    <cim:Terminal.TopologicalNode rdf:resource="#_eff86931-991c-4f6f-b5d6-75dad40e0a12" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c41978db-794b-4bae-953e-60fc519e87dd">
+    <cim:Terminal.TopologicalNode rdf:resource="#_1a4d0f02-6adb-4fa2-a828-b0366497ae5a" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:Terminal.TopologicalNode rdf:resource="#_5c74cb26-ce2f-40c6-951d-89091eb781b6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:Terminal.TopologicalNode rdf:resource="#_23b65c6b-2351-4673-89e9-1895c7291543" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:Terminal.TopologicalNode rdf:resource="#_99b219f3-4593-428b-a4da-124a54630178" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:Terminal.TopologicalNode rdf:resource="#_f70f6bad-eb8d-4b8f-8431-4ab93581514e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:Terminal.TopologicalNode rdf:resource="#_a81d08ed-f51d-4538-8d1e-fb2d0dbd128e" />
+  </cim:Terminal>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_BE_EQ_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_BE_EQ_001.xml
@@ -1,0 +1,1806 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:536f9bf1-3f8f-a546-87e3-7af2272f29b7" />
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/3.0</md:Model.profile>
+  </md:FullModel>
+  <cim:LoadArea rdf:ID="_516c5401-f9f7-4cf8-89b5-853f9cd75f29">
+    <cim:IdentifiedObject.name>BE LoadArea</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>516c5401-f9f7-4cf8-89b5-853f9cd75f29</cim:IdentifiedObject.mRID>
+  </cim:LoadArea>
+  <cim:SubLoadArea rdf:ID="_0051c797-996b-42b8-86b7-3176e9b52cd3">
+    <cim:IdentifiedObject.name>ELIA-Anvers SubLoadArea</cim:IdentifiedObject.name>
+    <cim:SubLoadArea.LoadArea rdf:resource="#_516c5401-f9f7-4cf8-89b5-853f9cd75f29" />
+    <cim:IdentifiedObject.mRID>0051c797-996b-42b8-86b7-3176e9b52cd3</cim:IdentifiedObject.mRID>
+  </cim:SubLoadArea>
+  <cim:SubLoadArea rdf:ID="_f217eb1a-92c4-4e9e-ad95-8ac8e527f0fc">
+    <cim:IdentifiedObject.name>ELIA-Brussels SubLoadArea</cim:IdentifiedObject.name>
+    <cim:SubLoadArea.LoadArea rdf:resource="#_516c5401-f9f7-4cf8-89b5-853f9cd75f29" />
+    <cim:IdentifiedObject.mRID>f217eb1a-92c4-4e9e-ad95-8ac8e527f0fc</cim:IdentifiedObject.mRID>
+  </cim:SubLoadArea>
+  <cim:GeographicalRegion rdf:ID="_7bf89875-1476-4d1a-a56d-a2965cce3575">
+    <cim:IdentifiedObject.name>BE</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>7bf89875-1476-4d1a-a56d-a2965cce3575</cim:IdentifiedObject.mRID>
+  </cim:GeographicalRegion>
+  <cim:SubGeographicalRegion rdf:ID="_61378219-a236-4070-bbec-4e30a6ac848d">
+    <cim:IdentifiedObject.name>ELIA-Brussels</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_7bf89875-1476-4d1a-a56d-a2965cce3575" />
+    <cim:IdentifiedObject.mRID>61378219-a236-4070-bbec-4e30a6ac848d</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_37e14a0f-5e34-4647-a062-8bfd9305fa9d">
+    <cim:IdentifiedObject.name>PP_Brussels</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PP_Brussels</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>37e14a0f-5e34-4647-a062-8bfd9305fa9d</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+  <cim:SubGeographicalRegion rdf:ID="_02047c0b-b5a4-4e0d-bae6-fc5437a55e74">
+    <cim:IdentifiedObject.name>ELIA-Anvers</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_7bf89875-1476-4d1a-a56d-a2965cce3575" />
+    <cim:IdentifiedObject.mRID>02047c0b-b5a4-4e0d-bae6-fc5437a55e74</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_87f7002b-056f-4a6a-a872-1744eea757e3">
+    <cim:IdentifiedObject.name>Anvers</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>Anvers</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_02047c0b-b5a4-4e0d-bae6-fc5437a55e74" />
+    <cim:IdentifiedObject.mRID>87f7002b-056f-4a6a-a872-1744eea757e3</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+  <cim:VoltageLevel rdf:ID="_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c">
+    <cim:IdentifiedObject.name>225.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>247.5</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>202.5</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:IdentifiedObject.mRID>b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_bf851342-832e-4ea2-b2ad-b09729b3af23">
+    <cim:IdentifiedObject.name>BE-Busbar_3</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_3</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>bf851342-832e-4ea2-b2ad-b09729b3af23</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_5caf27ed-d2f8-458a-834a-6b3193a982e6">
+    <cim:IdentifiedObject.name>BE-Busbar_3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>5caf27ed-d2f8-458a-834a-6b3193a982e6</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:IdentifiedObject.name>BE-Busbar_3_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5caf27ed-d2f8-458a-834a-6b3193a982e6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_469df5f7-058f-4451-a998-57a48e8a56fe">
+    <cim:IdentifiedObject.name>380.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>418</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>342</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:IdentifiedObject.mRID>469df5f7-058f-4451-a998-57a48e8a56fe</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_4836f99b-c6e9-4ee8-a956-b1e3da882d46">
+    <cim:IdentifiedObject.name>BE-Busbar_1</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_1</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>4836f99b-c6e9-4ee8-a956-b1e3da882d46</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c">
+    <cim:IdentifiedObject.name>BE-Busbar_1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:IdentifiedObject.name>BE-Busbar_1_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>fa9e0f4d-8a2f-45e1-9e36-3611600d1c94</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_929ba893-c9dc-44d7-b1fd-30834bd3ab85">
+    <cim:IdentifiedObject.name>21.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>23.1</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>18.9</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2" />
+    <cim:IdentifiedObject.mRID>929ba893-c9dc-44d7-b1fd-30834bd3ab85</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33">
+    <cim:IdentifiedObject.name>BE-Busbar_5</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_5</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:IdentifiedObject.mRID>f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:VoltageLevel rdf:ID="_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0">
+    <cim:IdentifiedObject.name>110.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>121</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>99</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:IdentifiedObject.mRID>8bbd7e74-ae20-4dce-8780-c20f8e18c2e0</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_1695eb20-9044-4133-a3fd-2147f55f170d">
+    <cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_6</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:IdentifiedObject.mRID>1695eb20-9044-4133-a3fd-2147f55f170d</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_364c9ca2-0d1d-4363-8f46-e586f8f66a8c">
+    <cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:BusbarSection.ipMax>5000</cim:BusbarSection.ipMax>
+    <cim:IdentifiedObject.mRID>364c9ca2-0d1d-4363-8f46-e586f8f66a8c</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:IdentifiedObject.name>BE-Busbar_6_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_364c9ca2-0d1d-4363-8f46-e586f8f66a8c" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>a1b46f53-86f1-497e-bf57-c3b6268bcd6c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_69ef0dbd-da79-4eef-a02f-690cb8a28361">
+    <cim:IdentifiedObject.name>225.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>247.5</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>202.5</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_87f7002b-056f-4a6a-a872-1744eea757e3" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:IdentifiedObject.mRID>69ef0dbd-da79-4eef-a02f-690cb8a28361</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_ae99bd74-26b1-443a-b1a5-656320283a36">
+    <cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_2</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>ae99bd74-26b1-443a-b1a5-656320283a36</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_ef45b632-3028-4afe-bc4c-a4fa323d83fe">
+    <cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>ef45b632-3028-4afe-bc4c-a4fa323d83fe</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:IdentifiedObject.name>BE-Busbar_2_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ef45b632-3028-4afe-bc4c-a4fa323d83fe" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>800ada75-8c8c-4568-aec5-20f799e45f3c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386">
+    <cim:IdentifiedObject.name>10.5</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>11.55</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>9.45</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75" />
+    <cim:IdentifiedObject.mRID>4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c">
+    <cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_4</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:IdentifiedObject.mRID>0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_fd649fe1-bdf5-4062-98ea-bbb66f50402d">
+    <cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:IdentifiedObject.mRID>fd649fe1-bdf5-4062-98ea-bbb66f50402d</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:IdentifiedObject.name>BE-Busbar_4_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fd649fe1-bdf5-4062-98ea-bbb66f50402d" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:IdentifiedObject.mRID>65b8c937-9b25-4b9e-addf-602dbc1337f9</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_af14c8ab-eb51-42be-89cb-abbcf37e20a3">
+    <cim:IdentifiedObject.name>Series Compensator</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>af14c8ab-eb51-42be-89cb-abbcf37e20a3</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:EquivalentInjection rdf:ID="_87ea56f3-962a-427a-85d6-13b1f9295174">
+    <cim:IdentifiedObject.name>BE-Inj-XZE_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Equipment.EquipmentContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>87ea56f3-962a-427a-85d6-13b1f9295174</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_24413233-26c3-4f7e-9f72-4461796938be">
+    <cim:IdentifiedObject.name>BE-Inj-XCA_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XCA_AL1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>24413233-26c3-4f7e-9f72-4461796938be</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_f7f61a91-eca2-4492-8bd7-9ec2b28fc837">
+    <cim:IdentifiedObject.name>BE-Inj-XZE_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>f7f61a91-eca2-4492-8bd7-9ec2b28fc837</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf">
+    <cim:IdentifiedObject.name>BE-Inj-XWI_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XWI_GY1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_14b352cb-5574-40c5-bf83-0ed3574554a3">
+    <cim:IdentifiedObject.name>BE-Inj-XKA_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XKA_MA1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>14b352cb-5574-40c5-bf83-0ed3574554a3</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:Line rdf:ID="_cc4b99a5-e20d-407c-9d8e-a682b9723613">
+    <cim:IdentifiedObject.name>container of BE-Line_6</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>cc4b99a5-e20d-407c-9d8e-a682b9723613</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:ACLineSegment rdf:ID="_ffbabc27-1ccd-4fdc-b037-e341706c8d29">
+    <cim:IdentifiedObject.name>BE-Line_6</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TYNDP project BE-4; map reference 567</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_6</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>true</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cc4b99a5-e20d-407c-9d8e-a682b9723613" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:Conductor.length>100</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0.0001476549</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.00119E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0.00012</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0.00012</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>5.203</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>15</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>71</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>213</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>ffbabc27-1ccd-4fdc-b037-e341706c8d29</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_6 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_05a17350-55f5-4a00-9a50-8c0048a25495" />
+    <cim:IdentifiedObject.mRID>cb5b5011-9f6c-4af2-93f9-26ae7e30c8db</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_d1de5f7a-b11d-4c34-9628-1ce03b8f1989">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1312</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>d1de5f7a-b11d-4c34-9628-1ce03b8f1989</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_6696b2a8-77fa-43a0-a019-f33287b03071">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>6696b2a8-77fa-43a0-a019-f33287b03071</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_30cbcb48-f02e-4791-83ab-486d7688874c">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_6 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809" />
+    <cim:IdentifiedObject.mRID>30cbcb48-f02e-4791-83ab-486d7688874c</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_fc61a99c-b255-4f1e-96eb-16198b2fbfc3">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1312</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>fc61a99c-b255-4f1e-96eb-16198b2fbfc3</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2c987138-9078-4f6a-b4f9-93d159b04fae">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2c987138-9078-4f6a-b4f9-93d159b04fae</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_17086487-56ba-4979-b8de-064025a6b4da">
+    <cim:IdentifiedObject.name>BE-Line_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000061</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>22</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>2.62637E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>8.2938E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>3.08E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>3.08E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>2.2</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>6.6</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>68.2</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>204.6</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>17086487-56ba-4979-b8de-064025a6b4da</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_a5b37323-8f73-449a-8931-f73193d95587">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_70d962fb-a492-4c36-8cad-b5c584df53bd" />
+    <cim:IdentifiedObject.mRID>a5b37323-8f73-449a-8931-f73193d95587</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_a2efb67d-28de-4243-aa59-8c297122b4f6">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>a2efb67d-28de-4243-aa59-8c297122b4f6</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_718557d0-e400-47e7-ab87-0c466237672e">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>718557d0-e400-47e7-ab87-0c466237672e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_aef3c15e-c567-476a-83ad-3fe46c817fb2">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_1ef0715a-d5a9-477b-b6e7-b635529ac140" />
+    <cim:IdentifiedObject.mRID>aef3c15e-c567-476a-83ad-3fe46c817fb2</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_fbfb079a-f42a-49e4-a1cd-10a17b44e443">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>fbfb079a-f42a-49e4-a1cd-10a17b44e443</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_9dd1c4cf-344a-4174-8000-430434090202">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>9dd1c4cf-344a-4174-8000-430434090202</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4">
+    <cim:IdentifiedObject.name>BE-Line_7</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000061</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_7</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>23</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>2.89027E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.1677E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>5.75E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>5.75E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>4.6</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>13.8</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>69</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>207</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_56c9ef56-9268-47e6-bed2-044324c03830">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_7 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_57ae9251-c022-4c67-a8eb-611ad54c963c" />
+    <cim:IdentifiedObject.mRID>56c9ef56-9268-47e6-bed2-044324c03830</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_a1c57d7a-447a-4a1a-b69c-94653ca4756e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1062</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>a1c57d7a-447a-4a1a-b69c-94653ca4756e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_05715ad5-5667-41e9-8eec-b7d20dac0921">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>05715ad5-5667-41e9-8eec-b7d20dac0921</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_00672e1a-599a-44f3-aeaa-5a3c99c29ba1">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_7 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1" />
+    <cim:IdentifiedObject.mRID>00672e1a-599a-44f3-aeaa-5a3c99c29ba1</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_8a04fac9-7f86-47e7-b0d4-723b413113da">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1062</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>8a04fac9-7f86-47e7-b0d4-723b413113da</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_f772a663-0557-4de1-94ca-a0fc86ada89f">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>f772a663-0557-4de1-94ca-a0fc86ada89f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_b18cd1aa-7808-49b9-a7cf-605eaf07b006">
+    <cim:IdentifiedObject.name>BE-Line_5</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_5</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:Conductor.length>35</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>3.40863E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>6.59734E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>4.2E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>4.2E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.42</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>1.26</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>6.3</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>18.9</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>b18cd1aa-7808-49b9-a7cf-605eaf07b006</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_b639998f-3a5c-496d-96fd-759131b6c307">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_5 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22" />
+    <cim:IdentifiedObject.mRID>b639998f-3a5c-496d-96fd-759131b6c307</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_c27027b3-61e5-47ae-8f25-140808039152">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>c27027b3-61e5-47ae-8f25-140808039152</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_a3b55712-7319-4725-aaef-d89be09e8e81">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>a3b55712-7319-4725-aaef-d89be09e8e81</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_4af71c73-fd57-45d2-aa83-f1b52fcc3bee">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_5 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_051d49ba-4360-4372-86bf-50eb8cf29778" />
+    <cim:IdentifiedObject.mRID>4af71c73-fd57-45d2-aa83-f1b52fcc3bee</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_7f32e38e-73e1-4699-b00c-c9ce63f5faa4">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>7f32e38e-73e1-4699-b00c-c9ce63f5faa4</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_cd1641e0-7dbd-4db2-8292-e87d65e2eeb5">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>cd1641e0-7dbd-4db2-8292-e87d65e2eeb5</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_ed0c5d75-4a54-43c8-b782-b20d7431630b">
+    <cim:IdentifiedObject.name>BE-Line_4</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>to be connected to the boundary set</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_4</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:Conductor.length>40</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>6.28319E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.51956E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>4E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>4E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.24</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>0.72</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>2</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>6</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>ed0c5d75-4a54-43c8-b782-b20d7431630b</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_b93ba071-c1d4-4c7a-960d-48dcd5d7c389">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_4 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0" />
+    <cim:IdentifiedObject.mRID>b93ba071-c1d4-4c7a-960d-48dcd5d7c389</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e17d44b1-c678-40a3-a736-9f77781fb33e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1226</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>e17d44b1-c678-40a3-a736-9f77781fb33e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_770404e9-b224-4cda-b9bf-8b23d4fa7822">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>770404e9-b224-4cda-b9bf-8b23d4fa7822</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_67fa7320-7477-47e9-89ff-e3a407644aef">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_4 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe" />
+    <cim:IdentifiedObject.mRID>67fa7320-7477-47e9-89ff-e3a407644aef</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2560b6d7-ee39-4f18-ba27-9e9ec505bc9e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1226</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2560b6d7-ee39-4f18-ba27-9e9ec505bc9e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_ec82058b-5d1a-4f8d-a0e6-fa4c3940b273">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>ec82058b-5d1a-4f8d-a0e6-fa4c3940b273</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:Line rdf:ID="_b5d6ed2b-c961-4521-8aef-b943d7dc6c15">
+    <cim:IdentifiedObject.name>container of BE-Line_2</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>b5d6ed2b-c961-4521-8aef-b943d7dc6c15</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:ACLineSegment rdf:ID="_b58bf21a-096a-4dae-9a01-3f03b60c24c7">
+    <cim:IdentifiedObject.name>BE-Line_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00010A</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00010A</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>true</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b5d6ed2b-c961-4521-8aef-b943d7dc6c15" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:Conductor.length>45</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>6.64447E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>4.24115E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>6.75E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>6.75E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.935</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.195</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>34.2</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>102.6</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>b58bf21a-096a-4dae-9a01-3f03b60c24c7</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_7168dee1-15a7-4444-839f-feef071e956d">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_77f04391-aa23-49b6-b3e9-6089130bb5d5" />
+    <cim:IdentifiedObject.mRID>7168dee1-15a7-4444-839f-feef071e956d</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e8b7722a-97b5-4831-b944-89c0a63a96fa">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>e8b7722a-97b5-4831-b944-89c0a63a96fa</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_3ecb9d91-8fdc-4161-81a1-8c5cedd66844">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>3ecb9d91-8fdc-4161-81a1-8c5cedd66844</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_ecc2f619-5716-4af0-9d76-0631a3832e4f">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_699545b9-82b9-4331-bc80-538d73b4ba56" />
+    <cim:IdentifiedObject.mRID>ecc2f619-5716-4af0-9d76-0631a3832e4f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_4602330f-46c5-41d0-bbbe-4b207ff06dbd">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>4602330f-46c5-41d0-bbbe-4b207ff06dbd</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_7b7bb979-e984-4a1a-a977-6f78ddcbc9d3">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>7b7bb979-e984-4a1a-a977-6f78ddcbc9d3</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_78736387-5f60-4832-b3fe-d50daf81b0a6">
+    <cim:IdentifiedObject.name>BE-Line_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00008Y</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00008Y</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:Conductor.length>30</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>2.92168E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0.000149854</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>6E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>6E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.05</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.15</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>12</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>36</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>78736387-5f60-4832-b3fe-d50daf81b0a6</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_0acd95d7-aff7-41f6-aa8a-863c42f4bc36">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_f3b56334-4638-49d3-a6a0-3f417422b8f5" />
+    <cim:IdentifiedObject.mRID>0acd95d7-aff7-41f6-aa8a-863c42f4bc36</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_008c7f00-df41-430c-b94c-37aa08c2e993">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>008c7f00-df41-430c-b94c-37aa08c2e993</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_34d77ffb-666c-4651-9e25-956af0979088">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>34d77ffb-666c-4651-9e25-956af0979088</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_99941f7a-11bb-4a7b-928b-ef8145db7799">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_231a4cf8-5069-4d53-96e4-e839f073f1ea" />
+    <cim:IdentifiedObject.mRID>99941f7a-11bb-4a7b-928b-ef8145db7799</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e68e3e07-101e-42a7-9d85-1d4b7d284ca3">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>e68e3e07-101e-42a7-9d85-1d4b7d284ca3</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_601df66c-7ba7-4ec8-8f8d-a30315f1a88f">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_5df721fe-c60b-4b91-8c92-3013fbdb6a70" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>601df66c-7ba7-4ec8-8f8d-a30315f1a88f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ConformLoad rdf:ID="_b1480a00-b427-4001-a26c-51954d2bb7e9">
+    <cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>L-1230804819</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:EnergyConsumer.LoadResponse rdf:resource="#_8e3e7a69-a64a-43a8-906e-82cc63edfcd3" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_62b480de-1bcd-4771-b24d-e2ca1dac5610" />
+    <cim:IdentifiedObject.mRID>b1480a00-b427-4001-a26c-51954d2bb7e9</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoadGroup rdf:ID="_62b480de-1bcd-4771-b24d-e2ca1dac5610">
+    <cim:IdentifiedObject.name>ELIA-AnversconfLoadGr</cim:IdentifiedObject.name>
+    <cim:LoadGroup.SubLoadArea rdf:resource="#_0051c797-996b-42b8-86b7-3176e9b52cd3" />
+    <cim:IdentifiedObject.mRID>62b480de-1bcd-4771-b24d-e2ca1dac5610</cim:IdentifiedObject.mRID>
+  </cim:ConformLoadGroup>
+  <cim:LoadResponseCharacteristic rdf:ID="_8e3e7a69-a64a-43a8-906e-82cc63edfcd3">
+    <cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+    <cim:LoadResponseCharacteristic.exponentModel>false</cim:LoadResponseCharacteristic.exponentModel>
+    <cim:LoadResponseCharacteristic.pConstantCurrent>0</cim:LoadResponseCharacteristic.pConstantCurrent>
+    <cim:LoadResponseCharacteristic.pConstantImpedance>0</cim:LoadResponseCharacteristic.pConstantImpedance>
+    <cim:LoadResponseCharacteristic.pConstantPower>1</cim:LoadResponseCharacteristic.pConstantPower>
+    <cim:LoadResponseCharacteristic.qConstantCurrent>0</cim:LoadResponseCharacteristic.qConstantCurrent>
+    <cim:LoadResponseCharacteristic.qConstantImpedance>0</cim:LoadResponseCharacteristic.qConstantImpedance>
+    <cim:LoadResponseCharacteristic.qConstantPower>1</cim:LoadResponseCharacteristic.qConstantPower>
+    <cim:IdentifiedObject.mRID>8e3e7a69-a64a-43a8-906e-82cc63edfcd3</cim:IdentifiedObject.mRID>
+  </cim:LoadResponseCharacteristic>
+  <cim:ConformLoad rdf:ID="_cb459405-cc14-4215-a45c-416789205904">
+    <cim:IdentifiedObject.name>BE-Load_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Electrabel</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_12ee1483-1cbf-47c6-8d8a-772053bb6ff2" />
+    <cim:IdentifiedObject.mRID>cb459405-cc14-4215-a45c-416789205904</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoadGroup rdf:ID="_12ee1483-1cbf-47c6-8d8a-772053bb6ff2">
+    <cim:IdentifiedObject.name>ELIA-BrusselsconfLoadGr</cim:IdentifiedObject.name>
+    <cim:LoadGroup.SubLoadArea rdf:resource="#_f217eb1a-92c4-4e9e-ad95-8ac8e527f0fc" />
+    <cim:IdentifiedObject.mRID>12ee1483-1cbf-47c6-8d8a-772053bb6ff2</cim:IdentifiedObject.mRID>
+  </cim:ConformLoadGroup>
+  <cim:ConformLoad rdf:ID="_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8">
+    <cim:IdentifiedObject.name>BE-Load_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>EVN</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_12ee1483-1cbf-47c6-8d8a-772053bb6ff2" />
+    <cim:IdentifiedObject.mRID>1c6beed6-1acf-42e7-ba55-0cc9f04bddd8</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:SeriesCompensator rdf:ID="_df16b3dd-c905-4a6f-84ee-f067be86f5da">
+    <cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:SeriesCompensator.r>0</cim:SeriesCompensator.r>
+    <cim:SeriesCompensator.r0>0</cim:SeriesCompensator.r0>
+    <cim:SeriesCompensator.varistorPresent>true</cim:SeriesCompensator.varistorPresent>
+    <cim:SeriesCompensator.varistorRatedCurrent>500</cim:SeriesCompensator.varistorRatedCurrent>
+    <cim:SeriesCompensator.varistorVoltageThreshold>250</cim:SeriesCompensator.varistorVoltageThreshold>
+    <cim:SeriesCompensator.x>-31.83099</cim:SeriesCompensator.x>
+    <cim:SeriesCompensator.x0>-31.83099</cim:SeriesCompensator.x0>
+    <cim:IdentifiedObject.mRID>df16b3dd-c905-4a6f-84ee-f067be86f5da</cim:IdentifiedObject.mRID>
+  </cim:SeriesCompensator>
+  <cim:OperationalLimitSet rdf:ID="_653b4e65-a657-40fc-b987-c9e28104410f">
+    <cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7" />
+    <cim:IdentifiedObject.mRID>653b4e65-a657-40fc-b987-c9e28104410f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_9fb75b67-c505-4f24-8b92-5ac1a1a1fee1">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_653b4e65-a657-40fc-b987-c9e28104410f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>9fb75b67-c505-4f24-8b92-5ac1a1a1fee1</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_38c765fb-5707-404a-87f6-ace386edce11">
+    <cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_8171fc34-6891-40e0-92d1-da9f4ba69e26" />
+    <cim:IdentifiedObject.mRID>38c765fb-5707-404a-87f6-ace386edce11</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_c1b970ed-f1f6-432d-8d86-443988130e0d">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_38c765fb-5707-404a-87f6-ace386edce11" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>c1b970ed-f1f6-432d-8d86-443988130e0d</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:LinearShuntCompensator rdf:ID="_d771118f-36e9-4115-a128-cc3d9ce3e3da">
+    <cim:IdentifiedObject.name>BE_S1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>shunt with 4 sections</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE_S1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_4d50f86d-0d12-4ca3-9430-56bb05f9eee6" />
+    <cim:ShuntCompensator.grounded>true</cim:ShuntCompensator.grounded>
+    <cim:ShuntCompensator.maximumSections>1</cim:ShuntCompensator.maximumSections>
+    <cim:ShuntCompensator.nomU>110</cim:ShuntCompensator.nomU>
+    <cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+    <cim:LinearShuntCompensator.b0PerSection>0</cim:LinearShuntCompensator.b0PerSection>
+    <cim:LinearShuntCompensator.bPerSection>0.02479339</cim:LinearShuntCompensator.bPerSection>
+    <cim:LinearShuntCompensator.g0PerSection>0</cim:LinearShuntCompensator.g0PerSection>
+    <cim:LinearShuntCompensator.gPerSection>0</cim:LinearShuntCompensator.gPerSection>
+    <cim:IdentifiedObject.mRID>d771118f-36e9-4115-a128-cc3d9ce3e3da</cim:IdentifiedObject.mRID>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:ID="_4d50f86d-0d12-4ca3-9430-56bb05f9eee6">
+    <cim:IdentifiedObject.name>BE_S1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:IdentifiedObject.mRID>4d50f86d-0d12-4ca3-9430-56bb05f9eee6</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:NonlinearShuntCompensator rdf:ID="_002b0a40-3957-46db-b84a-30420083558f">
+    <cim:IdentifiedObject.name>BE_S2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>another shunt</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE_S2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_bee06911-8d5c-44c4-b2d2-5c22a461b5a0" />
+    <cim:ShuntCompensator.grounded>true</cim:ShuntCompensator.grounded>
+    <cim:ShuntCompensator.maximumSections>5</cim:ShuntCompensator.maximumSections>
+    <cim:ShuntCompensator.nomU>380</cim:ShuntCompensator.nomU>
+    <cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+    <cim:IdentifiedObject.mRID>002b0a40-3957-46db-b84a-30420083558f</cim:IdentifiedObject.mRID>
+  </cim:NonlinearShuntCompensator>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_48c4da87-08f6-408e-96e6-68fb5fd77d53">
+    <cim:NonlinearShuntCompensatorPoint.b>0.0003459834</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>1.09E-05</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>1.09E-05</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>1</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_ffcbe3c9-5f5e-4de1-942c-c309e537b616">
+    <cim:NonlinearShuntCompensatorPoint.b>0.0001729917</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>2</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_8e4e1de4-71ba-4f36-9065-3d96c9702670">
+    <cim:NonlinearShuntCompensatorPoint.b>0.0001389889</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>3</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_a370cc7d-dad8-4b9e-8a36-0e202f6b028a">
+    <cim:NonlinearShuntCompensatorPoint.b>6.897507E-05</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>4</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_9347aeec-ab42-424e-a651-11ea7c3b6eb3">
+    <cim:NonlinearShuntCompensatorPoint.b>3.49723E-05</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>5</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:RegulatingControl rdf:ID="_bee06911-8d5c-44c4-b2d2-5c22a461b5a0">
+    <cim:IdentifiedObject.name>BE_S2</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+    <cim:IdentifiedObject.mRID>bee06911-8d5c-44c4-b2d2-5c22a461b5a0</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:StaticVarCompensator rdf:ID="_3c69652c-ff14-4550-9a87-b6fdaccbb5f4">
+    <cim:IdentifiedObject.name>SVC-1230797516</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_caf65447-3cfb-48d7-aaaa-cd9af3d34261" />
+    <cim:StaticVarCompensator.capacitiveRating>5062.5</cim:StaticVarCompensator.capacitiveRating>
+    <cim:StaticVarCompensator.inductiveRating>-5062.5</cim:StaticVarCompensator.inductiveRating>
+    <cim:StaticVarCompensator.slope>0.102</cim:StaticVarCompensator.slope>
+    <cim:IdentifiedObject.mRID>3c69652c-ff14-4550-9a87-b6fdaccbb5f4</cim:IdentifiedObject.mRID>
+  </cim:StaticVarCompensator>
+  <cim:RegulatingControl rdf:ID="_caf65447-3cfb-48d7-aaaa-cd9af3d34261">
+    <cim:IdentifiedObject.name>SVC-1230797516</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5" />
+    <cim:IdentifiedObject.mRID>caf65447-3cfb-48d7-aaaa-cd9af3d34261</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:ID="_550ebe0d-f2b2-48c1-991f-cebea43a21aa">
+    <cim:IdentifiedObject.name>BE-G2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-G2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_84bf5be8-eb59-4555-b131-fce4d2d7775d" />
+    <cim:RotatingMachine.ratedPowerFactor>0.85</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>300</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>21</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_5b7a4d43-09ec-4033-882d-64a76d557631" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>200</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-200</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.2</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>2</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.13</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.17</cim:SynchronousMachine.x2>
+    <cim:IdentifiedObject.mRID>550ebe0d-f2b2-48c1-991f-cebea43a21aa</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_5b7a4d43-09ec-4033-882d-64a76d557631">
+    <cim:IdentifiedObject.name>Gen-1229753024</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>200</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>50</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>255</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>5b7a4d43-09ec-4033-882d-64a76d557631</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_3a3b27be-b18b-4385-b557-6735d733baf0">
+    <cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-G1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_6ba406ce-78cf-4485-9b01-a34e584f1a8d" />
+    <cim:RotatingMachine.ratedPowerFactor>0.85</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>300</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>10.5</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_18993b11-2966-4bce-bab9-d86103f83b53" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>300</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-300</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>50</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.2</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>2</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generatorOrMotor" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.13</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.171</cim:SynchronousMachine.x2>
+    <cim:SynchronousMachine.InitialReactiveCapabilityCurve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+    <cim:IdentifiedObject.mRID>3a3b27be-b18b-4385-b557-6735d733baf0</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_18993b11-2966-4bce-bab9-d86103f83b53">
+    <cim:IdentifiedObject.name>Gen-1229753060</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>200</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>-100</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>255</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>18993b11-2966-4bce-bab9-d86103f83b53</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:ReactiveCapabilityCurve rdf:ID="_59ff1e53-0e1a-44c0-ada5-7a0b3a660170">
+    <cim:IdentifiedObject.name>BE-G1CapabilityCurveCapabilityCu</cim:IdentifiedObject.name>
+    <cim:Curve.curveStyle rdf:resource="http://iec.ch/TC57/CIM100#CurveStyle.straightLineYValues" />
+    <cim:Curve.xUnit rdf:resource="http://iec.ch/TC57/CIM100#UnitSymbol.W" />
+    <cim:Curve.y1Unit rdf:resource="http://iec.ch/TC57/CIM100#UnitSymbol.VAr" />
+    <cim:Curve.y2Unit rdf:resource="http://iec.ch/TC57/CIM100#UnitSymbol.VAr" />
+    <cim:IdentifiedObject.mRID>59ff1e53-0e1a-44c0-ada5-7a0b3a660170</cim:IdentifiedObject.mRID>
+  </cim:ReactiveCapabilityCurve>
+  <cim:CurveData rdf:ID="_5cef00db-5dda-4458-bc68-cc59804b1187">
+    <cim:CurveData.xvalue>0</cim:CurveData.xvalue>
+    <cim:CurveData.y1value>-300</cim:CurveData.y1value>
+    <cim:CurveData.y2value>300</cim:CurveData.y2value>
+    <cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+  </cim:CurveData>
+  <cim:CurveData rdf:ID="_52da6f7d-e9b6-4293-b1a3-d87a5f453a1c">
+    <cim:CurveData.xvalue>200</cim:CurveData.xvalue>
+    <cim:CurveData.y1value>-200</cim:CurveData.y1value>
+    <cim:CurveData.y2value>200</cim:CurveData.y2value>
+    <cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+  </cim:CurveData>
+  <cim:CurveData rdf:ID="_3a31cb5b-eac5-4717-acdb-48f357c6eefe">
+    <cim:CurveData.xvalue>-100</cim:CurveData.xvalue>
+    <cim:CurveData.y1value>-200</cim:CurveData.y1value>
+    <cim:CurveData.y2value>200</cim:CurveData.y2value>
+    <cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+  </cim:CurveData>
+  <cim:PowerTransformer rdf:ID="_b94318f6-6d24-4f56-96b9-df2531ad6543">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>This is T2 in the center</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>b94318f6-6d24-4f56-96b9-df2531ad6543</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_3c59d1b0-1ee9-4ca3-9086-4fe102b51b21">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_5a7b80f3-eeb3-4253-a792-5157c0946b15" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.8228</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.8228</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>11.13888</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>11.13888</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:IdentifiedObject.mRID>3c59d1b0-1ee9-4ca3-9086-4fe102b51b21</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_ba56158e-0c51-448d-999b-44cb0b3cebf5">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_0ac86078-8267-4fd9-b6c2-27984975ffcc" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>110</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:IdentifiedObject.mRID>ba56158e-0c51-448d-999b-44cb0b3cebf5</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PhaseTapChangerAsymmetrical rdf:ID="_36b83adb-3d45-4693-8967-96627b5f9ec9">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>25</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>13</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>10</cim:TapChanger.normalStep>
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_3c59d1b0-1ee9-4ca3-9086-4fe102b51b21" />
+    <cim:PhaseTapChangerNonLinear.voltageStepIncrement>1.25</cim:PhaseTapChangerNonLinear.voltageStepIncrement>
+    <cim:PhaseTapChangerNonLinear.xMax>11.88148</cim:PhaseTapChangerNonLinear.xMax>
+    <cim:PhaseTapChangerNonLinear.xMin>11.13888</cim:PhaseTapChangerNonLinear.xMin>
+    <cim:PhaseTapChangerAsymmetrical.windingConnectionAngle>30</cim:PhaseTapChangerAsymmetrical.windingConnectionAngle>
+    <cim:IdentifiedObject.mRID>36b83adb-3d45-4693-8967-96627b5f9ec9</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerAsymmetrical>
+  <cim:OperationalLimitSet rdf:ID="_88aa13e4-d3fe-4c47-9e47-39f8bb805e73">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_5a7b80f3-eeb3-4253-a792-5157c0946b15" />
+    <cim:IdentifiedObject.mRID>88aa13e4-d3fe-4c47-9e47-39f8bb805e73</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_0d73c833-c12b-4932-9fe3-f18ca522f331">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_88aa13e4-d3fe-4c47-9e47-39f8bb805e73" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1705.808</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>0d73c833-c12b-4932-9fe3-f18ca522f331</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_0ac86078-8267-4fd9-b6c2-27984975ffcc" />
+    <cim:IdentifiedObject.mRID>d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_d82cbf13-135c-407f-92b2-96d755a88932">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>3411.617</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>d82cbf13-135c-407f-92b2-96d755a88932</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>T1 that is after maintenance</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>a708c3bc-465d-4fe7-b6ef-6fa6408a62b0</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_bf76ac9d-0144-48f5-a24a-34ae15a455fb">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>2.707692</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>2.72</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>14.5189</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>14.5166</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:IdentifiedObject.mRID>bf76ac9d-0144-48f5-a24a-34ae15a455fb</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_e22f3c30-63f5-47bf-a8c4-fee2483d426c">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>110</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:IdentifiedObject.mRID>e22f3c30-63f5-47bf-a8c4-fee2483d426c</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PhaseTapChangerSymmetrical rdf:ID="_63454a73-f439-45bb-951a-e7b193986571">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>25</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>13</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>400</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>10</cim:TapChanger.normalStep>
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_bf76ac9d-0144-48f5-a24a-34ae15a455fb" />
+    <cim:PhaseTapChangerNonLinear.voltageStepIncrement>1.25</cim:PhaseTapChangerNonLinear.voltageStepIncrement>
+    <cim:PhaseTapChangerNonLinear.xMax>16.93872</cim:PhaseTapChangerNonLinear.xMax>
+    <cim:PhaseTapChangerNonLinear.xMin>14.5189</cim:PhaseTapChangerNonLinear.xMin>
+    <cim:IdentifiedObject.mRID>63454a73-f439-45bb-951a-e7b193986571</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerSymmetrical>
+  <cim:OperationalLimitSet rdf:ID="_0b7c4239-3c1b-438e-994d-f2a402ba743c">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82" />
+    <cim:IdentifiedObject.mRID>0b7c4239-3c1b-438e-994d-f2a402ba743c</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_5e35109b-9feb-4c06-a92c-b777783863c4">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0b7c4239-3c1b-438e-994d-f2a402ba743c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>938.1946</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>5e35109b-9feb-4c06-a92c-b777783863c4</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:IdentifiedObject.mRID>3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_d6da94f0-80dc-4163-82ce-2e19355196ab">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>3411.617</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>d6da94f0-80dc-4163-82ce-2e19355196ab</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_e482b89a-fa84-4ea9-8e70-a83d44790957">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>This is free description</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>e482b89a-fa84-4ea9-8e70-a83d44790957</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_f58281c5-862a-465e-97ec-d809be6e24ab">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:PowerTransformerEnd.b>-8.30339E-05</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>1.73295E-05</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.104711</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.104711</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>250</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>110.3438</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.843419</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.843419</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:IdentifiedObject.mRID>f58281c5-862a-465e-97ec-d809be6e24ab</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_35651e25-a77a-46a1-92f4-443d6acce90e">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>250</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>10.5</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:IdentifiedObject.mRID>35651e25-a77a-46a1-92f4-443d6acce90e</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:RatioTapChanger rdf:ID="_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>10.5</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>14</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.stepVoltageIncrement>0.8</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_35651e25-a77a-46a1-92f4-443d6acce90e" />
+    <cim:IdentifiedObject.mRID>83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChanger>
+  <cim:OperationalLimitSet rdf:ID="_40b75fae-2597-40df-98d2-8a0d83c238fd">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+    <cim:IdentifiedObject.mRID>40b75fae-2597-40df-98d2-8a0d83c238fd</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_48efd7e4-bd22-4521-8170-0ff15c14b9a1">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>13746.44</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>48efd7e4-bd22-4521-8170-0ff15c14b9a1</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_e40d809b-2f3f-4866-817d-7acec0fde34f">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d" />
+    <cim:IdentifiedObject.mRID>e40d809b-2f3f-4866-817d-7acec0fde34f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_fc604ec7-5977-4d5a-82bc-6bf7dee6ef8f">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1308.072</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>fc604ec7-5977-4d5a-82bc-6bf7dee6ef8f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_84ed55f4-61f5-4d9d-8755-bba7b877a246">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>new in 2015</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:IdentifiedObject.mRID>84ed55f4-61f5-4d9d-8755-bba7b877a246</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_5f68a129-d5d8-4b71-9743-9ca2572ba26b">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:PowerTransformerEnd.b>-2.4375E-06</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>-2.4375E-06</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.898462</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.898462</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>17.20413</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>17.23077</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:IdentifiedObject.mRID>5f68a129-d5d8-4b71-9743-9ca2572ba26b</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_e1f661c0-971d-4ce5-ad39-0ec427f288ab">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.323908</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.323908</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.949086</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.956923</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:IdentifiedObject.mRID>e1f661c0-971d-4ce5-ad39-0ec427f288ab</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_2e21d1ef-2287-434c-a767-1ca807cf2478">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>3</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.013332</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.013332</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>21</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0.059978</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0.061062</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:IdentifiedObject.mRID>2e21d1ef-2287-434c-a767-1ca807cf2478</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:RatioTapChanger rdf:ID="_fe25f43a-7341-446e-a71a-8ab7119ba806">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>17</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.stepVoltageIncrement>0.625</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_e1f661c0-971d-4ce5-ad39-0ec427f288ab" />
+    <cim:IdentifiedObject.mRID>fe25f43a-7341-446e-a71a-8ab7119ba806</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChanger>
+  <cim:OperationalLimitSet rdf:ID="_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1">
+    <cim:IdentifiedObject.name>Limits at Port 3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 3</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b" />
+    <cim:IdentifiedObject.mRID>f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_f660694a-682f-4e2e-b60c-1bab1a924b79">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>17870.37</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>f660694a-682f-4e2e-b60c-1bab1a924b79</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84" />
+    <cim:IdentifiedObject.mRID>b655ab41-8bc0-4bd3-a28c-cf9048e32b4a</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_61591ef6-b049-4188-b693-0a279b85e374">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>938.1946</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>61591ef6-b049-4188-b693-0a279b85e374</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_a2f11542-aeb8-4d7c-9594-25ac63e148bb">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+    <cim:IdentifiedObject.mRID>a2f11542-aeb8-4d7c-9594-25ac63e148bb</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2831d93a-f53c-44b8-aa34-54e7a04a34c4">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1705.808</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2831d93a-f53c-44b8-aa34-54e7a04a34c4</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:BaseVoltage rdf:ID="_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2">
+    <cim:IdentifiedObject.name>21.00 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>21.00</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>21</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_862a4658-6b03-4550-9de2-b5c413912b75">
+    <cim:IdentifiedObject.name>10.50 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>10.50</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>10.5</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>862a4658-6b03-4550-9de2-b5c413912b75</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_00b17311-075f-48f6-a79b-597f42af4694">
+    <cim:IdentifiedObject.name>110.00 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>110.00</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>110</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>00b17311-075f-48f6-a79b-597f42af4694</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:Terminal rdf:ID="_5a7b80f3-eeb3-4253-a792-5157c0946b15">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>5a7b80f3-eeb3-4253-a792-5157c0946b15</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_0ac86078-8267-4fd9-b6c2-27984975ffcc">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>0ac86078-8267-4fd9-b6c2-27984975ffcc</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_2ba1ad70-3533-402d-8686-f3bcce2c2e82">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>2ba1ad70-3533-402d-8686-f3bcce2c2e82</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b30ac237-4ce9-4869-8562-a07aaae1a7fa">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>b30ac237-4ce9-4869-8562-a07aaae1a7fa</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>3</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33" />
+    <cim:IdentifiedObject.mRID>e754f4c1-6aa0-43d2-98cb-ecf5ba12077b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_056b689f-1dab-48b3-8ac5-4eb11ca05d84">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>056b689f-1dab-48b3-8ac5-4eb11ca05d84</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>53fd6693-57e6-482e-8fbe-dcf3531a7ce0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>b9376bea-c75d-49f3-94ca-6a71fa0086a5</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>05a17350-55f5-4a00-9a50-8c0048a25495</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>a4d42d33-ae54-4fe9-ad59-f30da0dfb809</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33" />
+    <cim:IdentifiedObject.mRID>4bb5407b-b4a5-416c-80ad-1a778ada2b9b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>70d962fb-a492-4c36-8cad-b5c584df53bd</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>1ef0715a-d5a9-477b-b6e7-b635529ac140</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_d238885e-d9b6-4edc-8567-6a68c605ed67">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_87ea56f3-962a-427a-85d6-13b1f9295174" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>d238885e-d9b6-4edc-8567-6a68c605ed67</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_53072f42-f77b-47e2-bd9a-e097c910b173">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_24413233-26c3-4f7e-9f72-4461796938be" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>53072f42-f77b-47e2-bd9a-e097c910b173</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_57ae9251-c022-4c67-a8eb-611ad54c963c">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>57ae9251-c022-4c67-a8eb-611ad54c963c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3" />
+    <cim:IdentifiedObject.mRID>5b2c65b0-68ce-4530-85b7-385346a3b5e1</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>02a244ca-8bcb-4e25-8613-e948b8ba1f22</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>051d49ba-4360-4372-86bf-50eb8cf29778</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f9f29835-8a31-4310-9780-b1ad26f3cbb0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>c14d2036-72ec-4df3-b1b7-75d8afd9a1fe</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>77f04391-aa23-49b6-b3e9-6089130bb5d5</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>699545b9-82b9-4331-bc80-538d73b4ba56</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f3b56334-4638-49d3-a6a0-3f417422b8f5</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>231a4cf8-5069-4d53-96e4-e839f073f1ea</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:IdentifiedObject.mRID>1182d878-2eaa-4eec-91be-ce7b2b1e7f9a</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_2de997a1-c43e-4d39-9e55-dfd7cf97121d">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>2de997a1-c43e-4d39-9e55-dfd7cf97121d</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>4a7363a4-0b21-4f65-8bba-33e3a8f6bac3</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>22af3121-1a66-4546-bd80-4371f417c644</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b9539c41-d114-4280-8a54-8ecec398091e">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>b9539c41-d114-4280-8a54-8ecec398091e</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c41978db-794b-4bae-953e-60fc519e87dd">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_14b352cb-5574-40c5-bf83-0ed3574554a3" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>c41978db-794b-4bae-953e-60fc519e87dd</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cb459405-cc14-4215-a45c-416789205904" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>cbdf1842-74ed-4fce-a5d4-0296c82cbc92</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3" />
+    <cim:IdentifiedObject.mRID>13dcec71-4b02-4c0c-93a7-8e16db4aa0b7</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>8171fc34-6891-40e0-92d1-da9f4ba69e26</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>a036b765-1669-4f64-acd3-1e8fbd513312</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>67bb74f1-8620-4a32-9d7d-a44092d11d22</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:IdentifiedObject.mRID>beffa353-7d10-421d-9c08-036b744b1cee</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:OperationalLimitType rdf:ID="_3e6aa424-8f24-49a5-bbe0-0868441e25ae">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.patl" />
+    <cim:IdentifiedObject.mRID>3e6aa424-8f24-49a5-bbe0-0868441e25ae</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>true</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:OperationalLimitType rdf:ID="_5df721fe-c60b-4b91-8c92-3013fbdb6a70">
+    <cim:IdentifiedObject.name>Limit Type TATL</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>TATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.acceptableDuration>600</cim:OperationalLimitType.acceptableDuration>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.tatl" />
+    <cim:IdentifiedObject.mRID>5df721fe-c60b-4b91-8c92-3013fbdb6a70</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>false</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:ControlArea rdf:ID="_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7">
+    <cim:IdentifiedObject.name>BE</cim:IdentifiedObject.name>
+    <cim:ControlArea.type rdf:resource="http://iec.ch/TC57/CIM100#ControlAreaTypeKind.Interchange" />
+    <cim:ControlArea.EnergyArea rdf:resource="#_516c5401-f9f7-4cf8-89b5-853f9cd75f29" />
+    <cim:IdentifiedObject.mRID>50487bb8-be6d-42a8-9358-cc0bbfe6cfa7</cim:IdentifiedObject.mRID>
+  </cim:ControlArea>
+  <cim:TieFlow rdf:ID="_6c38eb9d-d412-444a-9fec-64cc4278ea40">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_1ef0715a-d5a9-477b-b6e7-b635529ac140" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>6c38eb9d-d412-444a-9fec-64cc4278ea40</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_90c53a07-7065-4faa-b12a-f80185d56fa5">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_57ae9251-c022-4c67-a8eb-611ad54c963c" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>90c53a07-7065-4faa-b12a-f80185d56fa5</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_aa336efd-8f54-49e6-8d9c-325e6e4d3184">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>aa336efd-8f54-49e6-8d9c-325e6e4d3184</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_6b5bc852-1dd3-49e2-89da-905b929a8cc3">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>6b5bc852-1dd3-49e2-89da-905b929a8cc3</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_29ab8015-51fe-431d-b1e2-7a147ffabac5">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_f3b56334-4638-49d3-a6a0-3f417422b8f5" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>29ab8015-51fe-431d-b1e2-7a147ffabac5</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:RegulatingControl rdf:ID="_84bf5be8-eb59-4555-b131-fce4d2d7775d">
+    <cim:IdentifiedObject.name>BE-G2</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b" />
+    <cim:IdentifiedObject.mRID>84bf5be8-eb59-4555-b131-fce4d2d7775d</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:ID="_6ba406ce-78cf-4485-9b01-a34e584f1a8d">
+    <cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa" />
+    <cim:IdentifiedObject.mRID>6ba406ce-78cf-4485-9b01-a34e584f1a8d</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_BE_GL_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_BE_GL_001.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:064564b7-2663-411b-b617-55554e604510">
+    <md:Model.created>2021-03-25T23:16:28Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d" />
+  </md:FullModel>
+  <cim:CoordinateSystem rdf:ID="_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17">
+    <cim:IdentifiedObject.name>WGS84</cim:IdentifiedObject.name>
+    <cim:CoordinateSystem.crsUrn>urn:ogc:def:crs:EPSG::4326</cim:CoordinateSystem.crsUrn>
+    <cim:IdentifiedObject.mRID>5f5f3db1-b9f2-0a87-ca72-39fb7da2af17</cim:IdentifiedObject.mRID>
+  </cim:CoordinateSystem>
+  <cim:Location rdf:ID="_5733e014-95df-b4b4-3472-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_6</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:IdentifiedObject.mRID>5733e014-95df-b4b4-3472-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_234bb7b5-410e-4967-89d2-fbcd650fde32">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30113</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8035</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_8ae64308-69bc-4233-991d-4eab88ef00c5">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.34509</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.9169</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_88c387b8-b43f-4321-8a04-30d4131b3cc8">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.29565</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.0448</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_56108181-9ed5-4fa9-ac31-86ec9fac30da">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.38354</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.157</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ff0aae40-7be0-42eb-829e-0773c2658a05">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.25926</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3251</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5733e014-95df-b4b4-3472-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_51ccb6f6-64e4-5fdd-c006-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_1</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:IdentifiedObject.mRID>51ccb6f6-64e4-5fdd-c006-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_40618e1c-e00d-44b2-a831-6eae0a31281b">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88798</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9127</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_51ccb6f6-64e4-5fdd-c006-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_c94850da-c5f9-453a-ba6c-024bc025bc1b">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84683</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.6121</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_51ccb6f6-64e4-5fdd-c006-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_f27cbfad-b445-1a56-a96d-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_7</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:IdentifiedObject.mRID>f27cbfad-b445-1a56-a96d-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_49768162-8b3e-404c-ad51-e48897d468e8">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88892</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9138</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_f27cbfad-b445-1a56-a96d-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_2d7c796f-3679-46ad-b4e0-f6144e46f4fa">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84772</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.6129</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_f27cbfad-b445-1a56-a96d-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_f1f4f0f1-ea0b-4954-902e-0e1bf55738f1">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.25926</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3251</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_f27cbfad-b445-1a56-a96d-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_33569661-1f7f-8318-8783-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_5</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:IdentifiedObject.mRID>33569661-1f7f-8318-8783-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_9ad48a2c-a9b8-4443-b84e-c371b9abe933">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30173</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_33569661-1f7f-8318-8783-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_b8e566a7-1618-401c-b448-86d1b4bb6166">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.69046</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8994</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_33569661-1f7f-8318-8783-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_3234d1f9-c3ca-4834-a446-e77370937869">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.08825</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3026</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_33569661-1f7f-8318-8783-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_a2cd4594-e708-4563-9ff7-5b3e90fa8281">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07058</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8731</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_33569661-1f7f-8318-8783-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_47478224-23fe-f47b-605c-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_4</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:IdentifiedObject.mRID>47478224-23fe-f47b-605c-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_fa51d03e-18e0-4cfc-a5e4-36e357cb9719">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30173</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_47478224-23fe-f47b-605c-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_86ef13e2-0a15-4431-908c-d9750c28a4ed">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.69046</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8994</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_47478224-23fe-f47b-605c-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_683718d3-8cce-4e70-901f-be45631ef069">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.08825</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3026</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_47478224-23fe-f47b-605c-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_a9d09a0a-321c-4762-8f2d-1d3de85fba11">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07186</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8756</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_47478224-23fe-f47b-605c-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_2</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:IdentifiedObject.mRID>73b023d3-4cf0-e1c5-56c4-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_d251e7fa-3401-4eab-ab25-ba3d882c5843">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30113</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8035</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_926d6929-9f0b-4c25-8ca6-9d6ae57ebd38">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.34509</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.9169</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_1234ebf1-60c5-44d6-a458-e17525f65b55">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.29565</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.0448</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_1beb4087-9d22-49d5-b292-b979162ebd3c">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.38354</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.157</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ad397578-69a5-418b-a3f9-0b2743076f7b">
+    <cim:PositionPoint.sequenceNumber>5</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.25926</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3251</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_73b023d3-4cf0-e1c5-56c4-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_05e9859c-01b9-12a7-3320-39fb7da2af1e">
+    <cim:IdentifiedObject.name>BE-Line_3</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_5f5f3db1-b9f2-0a87-ca72-39fb7da2af17" />
+    <cim:Location.PowerSystemResources rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:IdentifiedObject.mRID>05e9859c-01b9-12a7-3320-39fb7da2af1e</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_173034c8-dee1-4705-b41f-4e67c2472360">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.30173</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.803</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_05e9859c-01b9-12a7-3320-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_f35c229f-84dd-4f11-821a-536c2b975bc8">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.69046</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>50.8994</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_05e9859c-01b9-12a7-3320-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_4f245aa8-98ac-4ee0-a26b-04660c3d1b39">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.08825</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.3026</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_05e9859c-01b9-12a7-3320-39fb7da2af1e" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ff7e39bc-0c8f-46e5-80b5-60a0b8aa9349">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07294</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8765</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_05e9859c-01b9-12a7-3320-39fb7da2af1e" />
+  </cim:PositionPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_BE_SSH_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_BE_SSH_001.xml
@@ -1,0 +1,440 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:1b092ff0-f8a0-49da-82d3-75eff5f1e820">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d" />
+  </md:FullModel>
+  <cim:Terminal rdf:about="#_5a7b80f3-eeb3-4253-a792-5157c0946b15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0ac86078-8267-4fd9-b6c2-27984975ffcc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ba1ad70-3533-402d-8686-f3bcce2c2e82">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b30ac237-4ce9-4869-8562-a07aaae1a7fa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e754f4c1-6aa0-43d2-98cb-ecf5ba12077b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_056b689f-1dab-48b3-8ac5-4eb11ca05d84">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d238885e-d9b6-4edc-8567-6a68c605ed67">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53072f42-f77b-47e2-bd9a-e097c910b173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57ae9251-c022-4c67-a8eb-611ad54c963c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2de997a1-c43e-4d39-9e55-dfd7cf97121d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9539c41-d114-4280-8a54-8ecec398091e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c41978db-794b-4bae-953e-60fc519e87dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:RegulatingControl rdf:about="#_84bf5be8-eb59-4555-b131-fce4d2d7775d">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>21.987</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:about="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-118</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-18.7203</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_5b7a4d43-09ec-4033-882d-64a76d557631">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:RegulatingControl rdf:about="#_6ba406ce-78cf-4485-9b01-a34e584f1a8d">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>115.5</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:about="#_3a3b27be-b18b-4385-b557-6735d733baf0">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-90</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-100.256</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_18993b11-2966-4bce-bab9-d86103f83b53">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:LinearShuntCompensator rdf:about="#_d771118f-36e9-4115-a128-cc3d9ce3e3da">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_4d50f86d-0d12-4ca3-9430-56bb05f9eee6">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0.5</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>110</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:NonlinearShuntCompensator rdf:about="#_002b0a40-3957-46db-b84a-30420083558f">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+  </cim:NonlinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_bee06911-8d5c-44c4-b2d2-5c22a461b5a0">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0.5</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>380</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ConformLoad rdf:about="#_b1480a00-b427-4001-a26c-51954d2bb7e9">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>1</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:about="#_cb459405-cc14-4215-a45c-416789205904">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>200</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>90</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:about="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>200</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>50</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:StaticVarCompensator rdf:about="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:StaticVarCompensator.q>0</cim:StaticVarCompensator.q>
+  </cim:StaticVarCompensator>
+  <cim:RegulatingControl rdf:about="#_caf65447-3cfb-48d7-aaaa-cd9af3d34261">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>229.5</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:EquivalentInjection rdf:about="#_87ea56f3-962a-427a-85d6-13b1f9295174">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-83.18928</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>1.501529</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_24413233-26c3-4f7e-9f72-4461796938be">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-14.06748</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>63.95825</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-103.7413</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>11.31944</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-27.0286</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>120.7887</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_14b352cb-5574-40c5-bf83-0ed3574554a3">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>-8.953211</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>67.2335</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:PhaseTapChangerAsymmetrical rdf:about="#_36b83adb-3d45-4693-8967-96627b5f9ec9">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>10</cim:TapChanger.step>
+  </cim:PhaseTapChangerAsymmetrical>
+  <cim:PhaseTapChangerSymmetrical rdf:about="#_63454a73-f439-45bb-951a-e7b193986571">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>10</cim:TapChanger.step>
+  </cim:PhaseTapChangerSymmetrical>
+  <cim:RatioTapChanger rdf:about="#_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>14</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_fe25f43a-7341-446e-a71a-8ab7119ba806">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>17</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:ControlArea rdf:about="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7">
+    <cim:ControlArea.netInterchange>236.9798</cim:ControlArea.netInterchange>
+    <cim:ControlArea.pTolerance>10</cim:ControlArea.pTolerance>
+  </cim:ControlArea>
+  <cim:CurrentLimit rdf:about="#_d1de5f7a-b11d-4c34-9628-1ce03b8f1989">
+    <cim:CurrentLimit.value>1312</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_6696b2a8-77fa-43a0-a019-f33287b03071">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_fc61a99c-b255-4f1e-96eb-16198b2fbfc3">
+    <cim:CurrentLimit.value>1312</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2c987138-9078-4f6a-b4f9-93d159b04fae">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_a2efb67d-28de-4243-aa59-8c297122b4f6">
+    <cim:CurrentLimit.value>1500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_718557d0-e400-47e7-ab87-0c466237672e">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_fbfb079a-f42a-49e4-a1cd-10a17b44e443">
+    <cim:CurrentLimit.value>1500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_9dd1c4cf-344a-4174-8000-430434090202">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_a1c57d7a-447a-4a1a-b69c-94653ca4756e">
+    <cim:CurrentLimit.value>1062</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_05715ad5-5667-41e9-8eec-b7d20dac0921">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_8a04fac9-7f86-47e7-b0d4-723b413113da">
+    <cim:CurrentLimit.value>1062</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_f772a663-0557-4de1-94ca-a0fc86ada89f">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_c27027b3-61e5-47ae-8f25-140808039152">
+    <cim:CurrentLimit.value>1876</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_a3b55712-7319-4725-aaef-d89be09e8e81">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_7f32e38e-73e1-4699-b00c-c9ce63f5faa4">
+    <cim:CurrentLimit.value>1876</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_cd1641e0-7dbd-4db2-8292-e87d65e2eeb5">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_e17d44b1-c678-40a3-a736-9f77781fb33e">
+    <cim:CurrentLimit.value>1226</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_770404e9-b224-4cda-b9bf-8b23d4fa7822">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2560b6d7-ee39-4f18-ba27-9e9ec505bc9e">
+    <cim:CurrentLimit.value>1226</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_ec82058b-5d1a-4f8d-a0e6-fa4c3940b273">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_e8b7722a-97b5-4831-b944-89c0a63a96fa">
+    <cim:CurrentLimit.value>1574</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_3ecb9d91-8fdc-4161-81a1-8c5cedd66844">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_4602330f-46c5-41d0-bbbe-4b207ff06dbd">
+    <cim:CurrentLimit.value>1574</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_7b7bb979-e984-4a1a-a977-6f78ddcbc9d3">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_008c7f00-df41-430c-b94c-37aa08c2e993">
+    <cim:CurrentLimit.value>1233.9</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_34d77ffb-666c-4651-9e25-956af0979088">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_e68e3e07-101e-42a7-9d85-1d4b7d284ca3">
+    <cim:CurrentLimit.value>1233.9</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_601df66c-7ba7-4ec8-8f8d-a30315f1a88f">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_9fb75b67-c505-4f24-8b92-5ac1a1a1fee1">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_c1b970ed-f1f6-432d-8d86-443988130e0d">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_0d73c833-c12b-4932-9fe3-f18ca522f331">
+    <cim:CurrentLimit.value>1705.808</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_d82cbf13-135c-407f-92b2-96d755a88932">
+    <cim:CurrentLimit.value>3411.617</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_5e35109b-9feb-4c06-a92c-b777783863c4">
+    <cim:CurrentLimit.value>938.1946</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_d6da94f0-80dc-4163-82ce-2e19355196ab">
+    <cim:CurrentLimit.value>3411.617</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_48efd7e4-bd22-4521-8170-0ff15c14b9a1">
+    <cim:CurrentLimit.value>13746.44</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_fc604ec7-5977-4d5a-82bc-6bf7dee6ef8f">
+    <cim:CurrentLimit.value>1308.072</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_f660694a-682f-4e2e-b60c-1bab1a924b79">
+    <cim:CurrentLimit.value>17870.37</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_61591ef6-b049-4188-b693-0a279b85e374">
+    <cim:CurrentLimit.value>938.1946</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2831d93a-f53c-44b8-aa34-54e7a04a34c4">
+    <cim:CurrentLimit.value>1705.808</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:Equipment rdf:about="#_5caf27ed-d2f8-458a-834a-6b3193a982e6">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_364c9ca2-0d1d-4363-8f46-e586f8f66a8c">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_ef45b632-3028-4afe-bc4c-a4fa323d83fe">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_fd649fe1-bdf5-4062-98ea-bbb66f50402d">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_17086487-56ba-4979-b8de-064025a6b4da">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_ed0c5d75-4a54-43c8-b782-b20d7431630b">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_78736387-5f60-4832-b3fe-d50daf81b0a6">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_df16b3dd-c905-4a6f-84ee-f067be86f5da">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_b94318f6-6d24-4f56-96b9-df2531ad6543">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_e482b89a-fa84-4ea9-8e70-a83d44790957">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_84ed55f4-61f5-4d9d-8755-bba7b877a246">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_NL_EQ_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_NL_EQ_001.xml
@@ -1,0 +1,1874 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:536f9bf1-3f8f-a546-87e3-7af2272f29b7" />
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/3.0</md:Model.profile>
+  </md:FullModel>
+  <cim:LoadArea rdf:ID="_70c4656c-f7a0-4319-98bb-84fb5e2e9b37">
+    <cim:IdentifiedObject.name>NL LoadArea</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>70c4656c-f7a0-4319-98bb-84fb5e2e9b37</cim:IdentifiedObject.mRID>
+  </cim:LoadArea>
+  <cim:SubLoadArea rdf:ID="_c4e8eb3a-76b0-4192-91fe-c2f0a60af0df">
+    <cim:IdentifiedObject.name>TENNET TSO B.V. SubLoadArea</cim:IdentifiedObject.name>
+    <cim:SubLoadArea.LoadArea rdf:resource="#_70c4656c-f7a0-4319-98bb-84fb5e2e9b37" />
+    <cim:IdentifiedObject.mRID>c4e8eb3a-76b0-4192-91fe-c2f0a60af0df</cim:IdentifiedObject.mRID>
+  </cim:SubLoadArea>
+  <cim:GeographicalRegion rdf:ID="_efc79870-d704-485e-a37b-0cf2e8e7657b">
+    <cim:IdentifiedObject.name>NL</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>efc79870-d704-485e-a37b-0cf2e8e7657b</cim:IdentifiedObject.mRID>
+  </cim:GeographicalRegion>
+  <cim:SubGeographicalRegion rdf:ID="_e58fc3bf-8c9f-450d-b3f7-9a1d19bd3bb4">
+    <cim:IdentifiedObject.name>TENNET TSO B.V.</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_efc79870-d704-485e-a37b-0cf2e8e7657b" />
+    <cim:IdentifiedObject.mRID>e58fc3bf-8c9f-450d-b3f7-9a1d19bd3bb4</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_c49942d6-8b01-4b01-b5e8-f1180f84906c">
+    <cim:IdentifiedObject.name>PP_Amsterdam</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PP_Amsterdam</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_e58fc3bf-8c9f-450d-b3f7-9a1d19bd3bb4" />
+    <cim:IdentifiedObject.mRID>c49942d6-8b01-4b01-b5e8-f1180f84906c</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+  <cim:VoltageLevel rdf:ID="_d77b61ef-61aa-4b22-95f6-b56ca080788d">
+    <cim:IdentifiedObject.name>220.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>242</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>198</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:IdentifiedObject.mRID>d77b61ef-61aa-4b22-95f6-b56ca080788d</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_cae57656-3fc2-4f5e-9ab9-fa5b118a632a">
+    <cim:IdentifiedObject.name>NL-Busbar_2</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>NL-B_2</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_d77b61ef-61aa-4b22-95f6-b56ca080788d" />
+    <cim:IdentifiedObject.mRID>cae57656-3fc2-4f5e-9ab9-fa5b118a632a</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a">
+    <cim:IdentifiedObject.name>NL-Busbar_2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d77b61ef-61aa-4b22-95f6-b56ca080788d" />
+    <cim:IdentifiedObject.mRID>143aa0b1-2cd4-4e58-98d4-b0438bd5a39a</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_50f00b94-fe0f-48fd-887e-f0d4d59eee87">
+    <cim:IdentifiedObject.name>NL-Busbar_2_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>50f00b94-fe0f-48fd-887e-f0d4d59eee87</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3">
+    <cim:IdentifiedObject.name>400.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>440</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>360</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:IdentifiedObject.mRID>b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_90f78705-5ef4-479a-8d5a-70efc554e0ba">
+    <cim:IdentifiedObject.name>NL-_Busbar_1</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>NL-_B_1</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:IdentifiedObject.mRID>90f78705-5ef4-479a-8d5a-70efc554e0ba</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:VoltageLevel rdf:ID="_8d8a82ba-b5b0-4e94-861a-192af055f2b8">
+    <cim:IdentifiedObject.name>15.8</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>17.325</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>14.175</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_abb2348a-aa10-446f-9f5d-49f93f211535" />
+    <cim:IdentifiedObject.mRID>8d8a82ba-b5b0-4e94-861a-192af055f2b8</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_124b9180-9112-4b8a-a651-9c1bb9a031da">
+    <cim:IdentifiedObject.name>NL-Busbar_3</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>NL-B_3</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:IdentifiedObject.mRID>124b9180-9112-4b8a-a651-9c1bb9a031da</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_53da4025-9d51-4eaf-b0d2-ce27fbe740d2">
+    <cim:IdentifiedObject.name>NL-Busbar_3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:IdentifiedObject.mRID>53da4025-9d51-4eaf-b0d2-ce27fbe740d2</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_0f199d49-0093-4b51-b357-70371424d174">
+    <cim:IdentifiedObject.name>NL-Busbar_3_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_53da4025-9d51-4eaf-b0d2-ce27fbe740d2" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>0f199d49-0093-4b51-b357-70371424d174</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:EquivalentInjection rdf:ID="_b0442899-8dbe-48c1-a1fa-adb2a5929273">
+    <cim:IdentifiedObject.name>NL-Inj-XWI_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XWI_GY1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>b0442899-8dbe-48c1-a1fa-adb2a5929273</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_12baa3f3-23b1-44e0-956f-d331e1527f37">
+    <cim:IdentifiedObject.name>NL-Inj-XZE_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>12baa3f3-23b1-44e0-956f-d331e1527f37</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_83bea592-913e-4473-8d17-969968ff83a2">
+    <cim:IdentifiedObject.name>NL-Inj-XCA_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XCA_AL1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>83bea592-913e-4473-8d17-969968ff83a2</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_820d95d7-26d4-4311-8b1f-026f8605b86d">
+    <cim:IdentifiedObject.name>NL-Inj-XZE_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>820d95d7-26d4-4311-8b1f-026f8605b86d</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_cab82e1c-1435-447b-bba0-74b592539eac">
+    <cim:IdentifiedObject.name>NL-Inj-XKA_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XKA_MA1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>cab82e1c-1435-447b-bba0-74b592539eac</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:ACLineSegment rdf:ID="_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc">
+    <cim:IdentifiedObject.name>NL-Line_5</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000118</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>NL-L_5</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:Conductor.length>35</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0.01099557</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>6.48739E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>3.5E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>3.5E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.42</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>1.26</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>6.3</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>18.9</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_a2c3d48f-d768-4e1e-8841-6e9c4913f11f">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_5 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_757d4f50-707b-47a0-891c-cbaefd649631" />
+    <cim:IdentifiedObject.mRID>a2c3d48f-d768-4e1e-8841-6e9c4913f11f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_47545df1-566d-4a8d-86e8-882655c6e79e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2c3d48f-d768-4e1e-8841-6e9c4913f11f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>47545df1-566d-4a8d-86e8-882655c6e79e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_08ad0781-b65c-4f2e-b5ba-00d58bcf2e58">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2c3d48f-d768-4e1e-8841-6e9c4913f11f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>08ad0781-b65c-4f2e-b5ba-00d58bcf2e58</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_5 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_ae588863-b154-451d-978a-7ab08ac50fb6" />
+    <cim:IdentifiedObject.mRID>b4d8f5e2-7b7a-45eb-b65a-252843d6acf4</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_56105225-1754-40da-b6df-43fd7cfeb50a">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>56105225-1754-40da-b6df-43fd7cfeb50a</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_86764bf6-6472-4ebe-9d6b-bcceffe66dad">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>86764bf6-6472-4ebe-9d6b-bcceffe66dad</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_dad02278-bd25-476f-8f58-dbe44be72586">
+    <cim:IdentifiedObject.name>NL-Line_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>tie line BE-NL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:Conductor.length>40</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.51327E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>4E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>4E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>2.32</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>6.96</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>20.24</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>60.72</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>dad02278-bd25-476f-8f58-dbe44be72586</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_7cf4108d-d355-48f5-8556-d42c37a8e2c8">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_8f308117-8bbd-4798-b145-4e78f7d049e7" />
+    <cim:IdentifiedObject.mRID>7cf4108d-d355-48f5-8556-d42c37a8e2c8</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_7cfff021-02d4-4aa1-8fe7-b9af9c1fdc44">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7cf4108d-d355-48f5-8556-d42c37a8e2c8" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1371</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>7cfff021-02d4-4aa1-8fe7-b9af9c1fdc44</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_d7422ce6-a13d-41ca-8111-9462b2e789dc">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7cf4108d-d355-48f5-8556-d42c37a8e2c8" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>d7422ce6-a13d-41ca-8111-9462b2e789dc</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_13ee714f-6df4-4039-8519-5cf4e84ab20d">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_c557146e-dfc4-4020-9738-d592b188338b" />
+    <cim:IdentifiedObject.mRID>13ee714f-6df4-4039-8519-5cf4e84ab20d</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2b05a185-07f6-4e72-a2c3-d28425c7aefc">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_13ee714f-6df4-4039-8519-5cf4e84ab20d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1371</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2b05a185-07f6-4e72-a2c3-d28425c7aefc</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_6fd8188f-65a6-4473-b8f1-ffe6122ba6ab">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_13ee714f-6df4-4039-8519-5cf4e84ab20d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>6fd8188f-65a6-4473-b8f1-ffe6122ba6ab</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_8fdc7abd-3746-481a-a65e-3df56acd8b13">
+    <cim:IdentifiedObject.name>NL-Line_4</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>NL-L_4</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>22</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>4.35425E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>8.98495E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>2.42E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>2.42E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>2.2</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>6.6</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>66</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>198</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>8fdc7abd-3746-481a-a65e-3df56acd8b13</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_03943678-b63e-44d8-bc7d-9461da496268">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_4 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_57979d14-d1d8-4311-ae53-aa8890423885" />
+    <cim:IdentifiedObject.mRID>03943678-b63e-44d8-bc7d-9461da496268</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2f424b90-a264-4592-8854-9838596c9f78">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_03943678-b63e-44d8-bc7d-9461da496268" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2f424b90-a264-4592-8854-9838596c9f78</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_89ef40fb-5d77-45cb-8073-cc2d1d171dcd">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_03943678-b63e-44d8-bc7d-9461da496268" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>89ef40fb-5d77-45cb-8073-cc2d1d171dcd</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_37cc4210-71c0-4328-a86b-df0f65e76ef4">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_4 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_653bc4b8-518b-4adc-9d68-012fb641fb1d" />
+    <cim:IdentifiedObject.mRID>37cc4210-71c0-4328-a86b-df0f65e76ef4</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_b35893b0-22d4-4127-9351-9c46fba6059b">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_37cc4210-71c0-4328-a86b-df0f65e76ef4" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>b35893b0-22d4-4127-9351-9c46fba6059b</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b780341b-7b90-498f-ab63-9deb16eff206">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_37cc4210-71c0-4328-a86b-df0f65e76ef4" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>b780341b-7b90-498f-ab63-9deb16eff206</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_7f43f508-2496-4b64-9146-0a40406cbe49">
+    <cim:IdentifiedObject.name>NL-Line_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000118</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>NL-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:Conductor.length>30</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0.00015</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0.0001413717</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>3E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>3E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.02</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.06</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>12</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>36</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>7f43f508-2496-4b64-9146-0a40406cbe49</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_79a1fb3a-a66a-468c-8c78-c25714c73eba">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3" />
+    <cim:IdentifiedObject.mRID>79a1fb3a-a66a-468c-8c78-c25714c73eba</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_1b65a297-4735-499f-8fe8-f08ea01b291f">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_79a1fb3a-a66a-468c-8c78-c25714c73eba" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>1b65a297-4735-499f-8fe8-f08ea01b291f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_5bc43480-4543-4193-8b0e-7ba7bf5b3441">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_79a1fb3a-a66a-468c-8c78-c25714c73eba" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>5bc43480-4543-4193-8b0e-7ba7bf5b3441</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_125eeb58-1c45-41b2-a981-7d5993b40cda">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d" />
+    <cim:IdentifiedObject.mRID>125eeb58-1c45-41b2-a981-7d5993b40cda</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_26069582-0f76-47fb-8bc0-44c99fb08887">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_125eeb58-1c45-41b2-a981-7d5993b40cda" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>26069582-0f76-47fb-8bc0-44c99fb08887</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2783b836-4271-4252-96a7-588c3a1b1826">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_125eeb58-1c45-41b2-a981-7d5993b40cda" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2783b836-4271-4252-96a7-588c3a1b1826</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_a279a3dc-550b-426c-af3a-61b7be508dcc">
+    <cim:IdentifiedObject.name>NL-Line_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>NL-L_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>23</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>4.55217E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.02319E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>2.3E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>2.3E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>5.06</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>15.18</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>69</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>207</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>a279a3dc-550b-426c-af3a-61b7be508dcc</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_14e9e317-a168-44a2-82ef-7c76190108a2">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_6aecb9ba-5835-4b70-89bc-96d687e45779" />
+    <cim:IdentifiedObject.mRID>14e9e317-a168-44a2-82ef-7c76190108a2</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_03287f0c-5562-4533-be7f-2fb40e1888f5">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>2000</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>03287f0c-5562-4533-be7f-2fb40e1888f5</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_84c93dae-4254-4b24-b0ee-3fc4bdf1ea02">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>84c93dae-4254-4b24-b0ee-3fc4bdf1ea02</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_9a03e8ee-e832-43c8-b38e-0d43f8ef7355">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10" />
+    <cim:IdentifiedObject.mRID>9a03e8ee-e832-43c8-b38e-0d43f8ef7355</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_c743cfb3-8279-4721-9eee-12020dd89f64">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>2000</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>c743cfb3-8279-4721-9eee-12020dd89f64</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_8eb25188-24dd-4f6e-97d9-b7b03c49454e">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>8eb25188-24dd-4f6e-97d9-b7b03c49454e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ConformLoad rdf:ID="_25ab1b5b-6803-47e2-805a-ab7b2072e034">
+    <cim:IdentifiedObject.name>NL-Load_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Electrabel</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_113fa6bb-c406-44a1-b9b7-67c43efe8372" />
+    <cim:IdentifiedObject.mRID>25ab1b5b-6803-47e2-805a-ab7b2072e034</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoadGroup rdf:ID="_113fa6bb-c406-44a1-b9b7-67c43efe8372">
+    <cim:IdentifiedObject.name>TENNET TSO B.V.confLoadGr</cim:IdentifiedObject.name>
+    <cim:LoadGroup.SubLoadArea rdf:resource="#_c4e8eb3a-76b0-4192-91fe-c2f0a60af0df" />
+    <cim:IdentifiedObject.mRID>113fa6bb-c406-44a1-b9b7-67c43efe8372</cim:IdentifiedObject.mRID>
+  </cim:ConformLoadGroup>
+  <cim:ConformLoad rdf:ID="_69add5b4-70bd-4360-8a93-286256c0d38b">
+    <cim:IdentifiedObject.name>NL-Load_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Apple</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_113fa6bb-c406-44a1-b9b7-67c43efe8372" />
+    <cim:IdentifiedObject.mRID>69add5b4-70bd-4360-8a93-286256c0d38b</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:ID="_b1e03a8f-6a11-4454-af58-4a4a680e857f">
+    <cim:IdentifiedObject.name>NL-Load_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Siemens</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-L_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d77b61ef-61aa-4b22-95f6-b56ca080788d" />
+    <cim:EnergyConsumer.LoadResponse rdf:resource="#_7a797ed8-c370-47cf-83df-16c40f8fff69" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_113fa6bb-c406-44a1-b9b7-67c43efe8372" />
+    <cim:IdentifiedObject.mRID>b1e03a8f-6a11-4454-af58-4a4a680e857f</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:LoadResponseCharacteristic rdf:ID="_7a797ed8-c370-47cf-83df-16c40f8fff69">
+    <cim:IdentifiedObject.name>NL-Load_3</cim:IdentifiedObject.name>
+    <cim:LoadResponseCharacteristic.exponentModel>false</cim:LoadResponseCharacteristic.exponentModel>
+    <cim:LoadResponseCharacteristic.pConstantCurrent>0.2</cim:LoadResponseCharacteristic.pConstantCurrent>
+    <cim:LoadResponseCharacteristic.pConstantImpedance>0</cim:LoadResponseCharacteristic.pConstantImpedance>
+    <cim:LoadResponseCharacteristic.pConstantPower>0.8</cim:LoadResponseCharacteristic.pConstantPower>
+    <cim:LoadResponseCharacteristic.qConstantCurrent>0.3</cim:LoadResponseCharacteristic.qConstantCurrent>
+    <cim:LoadResponseCharacteristic.qConstantImpedance>0</cim:LoadResponseCharacteristic.qConstantImpedance>
+    <cim:LoadResponseCharacteristic.qConstantPower>0.7</cim:LoadResponseCharacteristic.qConstantPower>
+    <cim:IdentifiedObject.mRID>7a797ed8-c370-47cf-83df-16c40f8fff69</cim:IdentifiedObject.mRID>
+  </cim:LoadResponseCharacteristic>
+  <cim:LinearShuntCompensator rdf:ID="_fbfed7e3-3dec-4829-a286-029e73535685">
+    <cim:IdentifiedObject.name>NL-S1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>shunt</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-S1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_613dfeb3-0161-4cec-aaa9-ccddd885771b" />
+    <cim:ShuntCompensator.grounded>true</cim:ShuntCompensator.grounded>
+    <cim:ShuntCompensator.maximumSections>1</cim:ShuntCompensator.maximumSections>
+    <cim:ShuntCompensator.nomU>400</cim:ShuntCompensator.nomU>
+    <cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+    <cim:LinearShuntCompensator.b0PerSection>0</cim:LinearShuntCompensator.b0PerSection>
+    <cim:LinearShuntCompensator.bPerSection>0.000313</cim:LinearShuntCompensator.bPerSection>
+    <cim:LinearShuntCompensator.g0PerSection>0</cim:LinearShuntCompensator.g0PerSection>
+    <cim:LinearShuntCompensator.gPerSection>0</cim:LinearShuntCompensator.gPerSection>
+    <cim:IdentifiedObject.mRID>fbfed7e3-3dec-4829-a286-029e73535685</cim:IdentifiedObject.mRID>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:ID="_613dfeb3-0161-4cec-aaa9-ccddd885771b">
+    <cim:IdentifiedObject.name>NL-S1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_757d4f50-707b-47a0-891c-cbaefd649631" />
+    <cim:IdentifiedObject.mRID>613dfeb3-0161-4cec-aaa9-ccddd885771b</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:ID="_1dc9afba-23b5-41a0-8540-b479ed8baf4b">
+    <cim:IdentifiedObject.name>NL-G3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-G3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:RotatingMachine.ratedPowerFactor>0.9</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>250</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>15.75</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_b850063d-eae7-4675-bc98-4642d3076783" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>200</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>0</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.2</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>1.9</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.13</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.17</cim:SynchronousMachine.x2>
+    <cim:IdentifiedObject.mRID>1dc9afba-23b5-41a0-8540-b479ed8baf4b</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_b850063d-eae7-4675-bc98-4642d3076783">
+    <cim:IdentifiedObject.name>Gen-12908</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>250</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>130</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>225</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>b850063d-eae7-4675-bc98-4642d3076783</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_9c3b8f97-7972-477d-9dc8-87365cc0ad0e">
+    <cim:IdentifiedObject.name>NL-G1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-G1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_04f338d3-3c0d-433f-a77b-e36dd256f0f0" />
+    <cim:RotatingMachine.ratedPowerFactor>0.9</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>1100</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>15.75</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_049438a6-780a-44fe-a788-ebe385d98e25" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>600</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>0</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.21</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>1.9</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries2" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.11</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.18</cim:SynchronousMachine.x2>
+    <cim:IdentifiedObject.mRID>9c3b8f97-7972-477d-9dc8-87365cc0ad0e</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_049438a6-780a-44fe-a788-ebe385d98e25">
+    <cim:IdentifiedObject.name>Gen-12923</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>1000</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>300</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>990</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>049438a6-780a-44fe-a788-ebe385d98e25</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_2844585c-0d35-488d-a449-685bcd57afbf">
+    <cim:IdentifiedObject.name>NL-G2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-G2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:RotatingMachine.ratedPowerFactor>0.9</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>250</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>15.75</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_ca80ee09-3bed-4884-bc28-6dc89d067289" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>200</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>0</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.18</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>1.8</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries2" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.1</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.16</cim:SynchronousMachine.x2>
+    <cim:IdentifiedObject.mRID>2844585c-0d35-488d-a449-685bcd57afbf</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_ca80ee09-3bed-4884-bc28-6dc89d067289">
+    <cim:IdentifiedObject.name>Gen-12910</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>250</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>130</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>225</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>ca80ee09-3bed-4884-bc28-6dc89d067289</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:PowerTransformer rdf:ID="_2184f365-8cd5-4b5d-8a28-9d68603bb6a4">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>2184f365-8cd5-4b5d-8a28-9d68603bb6a4</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_0dbed103-fc51-4df4-a6fa-0dee4c57f3a3">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_421c7930-64c3-435d-afb8-2bb73b333e34" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:PowerTransformerEnd.b>-0.0001420227</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>1.81818E-05</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.069143</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.069143</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>1260</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.377333</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.377333</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:IdentifiedObject.mRID>0dbed103-fc51-4df4-a6fa-0dee4c57f3a3</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_41ca9e70-1cb4-4971-b8e6-a97a15580b89">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_31bf04d0-7e34-465b-95a4-0604700325cf" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_abb2348a-aa10-446f-9f5d-49f93f211535" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>1260</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>15.75</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:IdentifiedObject.mRID>41ca9e70-1cb4-4971-b8e6-a97a15580b89</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PhaseTapChangerTabular rdf:ID="_ee649b97-d2ec-47e1-976f-0f4d9f50fa11">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>0</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>17</cim:TapChanger.normalStep>
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_0dbed103-fc51-4df4-a6fa-0dee4c57f3a3" />
+    <cim:PhaseTapChangerTabular.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+    <cim:IdentifiedObject.mRID>ee649b97-d2ec-47e1-976f-0f4d9f50fa11</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerTabular>
+  <cim:PhaseTapChangerTable rdf:ID="_50c903e2-ecbb-41b8-9a1d-746543c9b63f">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>50c903e2-ecbb-41b8-9a1d-746543c9b63f</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerTable>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_cb816a07-f79f-4eed-a279-2ad2ca435f91">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9200159</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>0</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.07682406</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_0c329ca6-c05a-416b-a919-885fd4860566">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9250145</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>1</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.07163366</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_301ffe68-fcb9-455f-8c4e-7280943667a4">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.930013</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>2</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.06649923</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_0bc0a45a-f196-430e-b5ac-37c39188a7ce">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9350125</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>3</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.0614186</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_6b03ed33-44a4-4fe6-a806-a0e76733304a">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.940011</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>4</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.05639308</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_febed19f-d33a-44fb-add3-4b10dcfee64c">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9450097</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>5</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.05142054</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_675f4994-9544-4634-9dae-7b8b2abdfef0">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9500085</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>6</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.04650027</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_daec57cc-6f98-44af-8645-afcfec90aa5f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9550072</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>7</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.04163161</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_53bd73f5-902c-4497-80d8-3707c90b7dcc">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9600061</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>8</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.03681348</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_cbdffa42-3eea-46aa-8e90-1de1c205fc71">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9650059</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>9</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.03204435</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_f0f5143d-5e04-4fcd-bdb7-1d2d46c604ef">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9700048</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>10</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.02732521</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_0761805f-8d0c-4a83-aec6-d3bd978097d8">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9750037</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>11</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.02265452</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_80f45cfb-a123-4438-aa1d-88fd63ed8ee4">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9800025</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>12</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.01803153</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_03c2b90a-162e-44b4-901f-ad3bc40fb95f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9850017</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>13</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.01345523</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_9b32f407-183b-4ddc-b213-d0eccf796455">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9900017</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>14</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.008924291</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_6bd09407-16dd-4ecb-b504-2ddb1db3b3df">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9950009</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>15</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.004439676</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_74414256-fc15-42a0-85f5-8c231863c9c6">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>16</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_60b1dbda-df22-4212-b495-f19200ef6458">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.004999</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>17</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.004395567</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_5e6588fe-5d2c-4715-b746-a02b2710ad2d">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.009998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>18</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.008747523</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_2e3a7427-0dd9-498d-853f-3269e02105f6">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.014998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>19</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.01305754</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_39b3ec77-b0b6-4a15-bc2b-36e752af54c4">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.019998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>20</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.01732449</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_9679897d-56e5-4910-9263-5a9a50c7a8c4">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.024997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>21</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.02154983</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_9a754a67-532f-4917-a6dd-6436b22b9a17">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.029998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>22</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.02573574</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_1118a9c0-cf20-45eb-a539-561e76fde2e2">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.034997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>23</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.02987964</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_105bd87e-1212-482f-aa64-376f3b0024b5">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.039997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>24</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.03398448</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_e2befe6d-07e5-48d1-8315-577bc038a827">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.044997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>25</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.03804918</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_369c3ab7-cb8c-418d-bdf0-9aa88af7e238">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.049997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>26</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.04207603</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_93e330b4-16de-40e4-b084-6f20646fa161">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.054996</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>27</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.04606397</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_749f4bc4-bfdb-4bda-8124-21b97e76f9df">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.059995</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>28</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.05001429</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_06aa2535-8010-4424-a97c-3a48b0aafec5">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.064998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>29</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.05392985</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_7d8fe4bf-94a9-4e2b-a90f-1271bdd99325">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.069997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>30</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.05780642</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_d1b48f8e-2f5c-45e5-8446-79a6604d3c8a">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.074996</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>31</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.06164702</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_b3c7dd07-c19a-4532-b212-27775264884f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.079996</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>32</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.0654528</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_df448145-8fef-4e66-93c2-b7f00a4ef857">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.084998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>33</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.06922422</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:OperationalLimitSet rdf:ID="_e7c1b1c7-aaeb-470a-9cb5-93a3ec269179">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_421c7930-64c3-435d-afb8-2bb73b333e34" />
+    <cim:IdentifiedObject.mRID>e7c1b1c7-aaeb-470a-9cb5-93a3ec269179</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_6745e040-9fd4-4cc5-8bfd-902d0aed4ee6">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e7c1b1c7-aaeb-470a-9cb5-93a3ec269179" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>3306.644</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>6745e040-9fd4-4cc5-8bfd-902d0aed4ee6</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_261d13c4-1527-42a5-ad0d-a3b817971166">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_31bf04d0-7e34-465b-95a4-0604700325cf" />
+    <cim:IdentifiedObject.mRID>261d13c4-1527-42a5-ad0d-a3b817971166</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_12f7803a-c65b-4a14-8c0d-7e52becb5772">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_261d13c4-1527-42a5-ad0d-a3b817971166" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>46188.04</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>12f7803a-c65b-4a14-8c0d-7e52becb5772</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_e8a7eaec-51d6-4571-b3d9-c36d52073c33">
+    <cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>new transformer in 2015</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>e8a7eaec-51d6-4571-b3d9-c36d52073c33</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_c614f321-2c88-4fa3-b98a-8ec3cde73db4">
+    <cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:PowerTransformerEnd.b>-4.4445E-06</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>5.625E-07</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>1.35</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>1.35</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>320</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>27.96744</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>27.96744</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:IdentifiedObject.mRID>c614f321-2c88-4fa3-b98a-8ec3cde73db4</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_0dec3883-a2b6-4353-83cc-d4dd5df513a6">
+    <cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>320</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:IdentifiedObject.mRID>0dec3883-a2b6-4353-83cc-d4dd5df513a6</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PhaseTapChangerLinear rdf:ID="_341327c4-9224-40bf-bc33-7a3bb0bae680">
+    <cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>20</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>-20</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>0</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>400</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>8</cim:TapChanger.normalStep>
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_c614f321-2c88-4fa3-b98a-8ec3cde73db4" />
+    <cim:PhaseTapChangerLinear.stepPhaseShiftIncrement>-2</cim:PhaseTapChangerLinear.stepPhaseShiftIncrement>
+    <cim:PhaseTapChangerLinear.xMax>29.7154</cim:PhaseTapChangerLinear.xMax>
+    <cim:PhaseTapChangerLinear.xMin>27.96744</cim:PhaseTapChangerLinear.xMin>
+    <cim:IdentifiedObject.mRID>341327c4-9224-40bf-bc33-7a3bb0bae680</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerLinear>
+  <cim:OperationalLimitSet rdf:ID="_d47a27cc-9fad-40f2-a08c-37e545c268df">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-TR2_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0" />
+    <cim:IdentifiedObject.mRID>d47a27cc-9fad-40f2-a08c-37e545c268df</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_ef715edd-516e-4bfd-adc4-1c882852920e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d47a27cc-9fad-40f2-a08c-37e545c268df" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>839.7826</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>ef715edd-516e-4bfd-adc4-1c882852920e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_83f719ad-2083-44ea-9ebc-9f456c114bdb">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-TR2_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f" />
+    <cim:IdentifiedObject.mRID>83f719ad-2083-44ea-9ebc-9f456c114bdb</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e37ee101-2f68-4d55-b24f-c24c5faba8b5">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_83f719ad-2083-44ea-9ebc-9f456c114bdb" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>461.8804</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>e37ee101-2f68-4d55-b24f-c24c5faba8b5</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_80016742-31b3-432a-b00a-300667a1e572">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>out of service in 2020</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>80016742-31b3-432a-b00a-300667a1e572</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_f3600241-63dc-485b-aefb-4ec24028f8b3">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:PowerTransformerEnd.b>-0.0001420227</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>1.81818E-05</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.065302</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.069143</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>1260</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.377381</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.377333</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:IdentifiedObject.mRID>f3600241-63dc-485b-aefb-4ec24028f8b3</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_4df90339-ae02-4da1-8e1e-69ab068df065">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_70b326a3-5913-494f-b8f8-8e366253b597" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_abb2348a-aa10-446f-9f5d-49f93f211535" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>1260</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>15.75</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:IdentifiedObject.mRID>4df90339-ae02-4da1-8e1e-69ab068df065</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:RatioTapChanger rdf:ID="_44b4277a-0f4b-43a8-ad93-6f7d6ef02061">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>15</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>-15</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>0</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>5</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.stepVoltageIncrement>0.5500001</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_f3600241-63dc-485b-aefb-4ec24028f8b3" />
+    <cim:IdentifiedObject.mRID>44b4277a-0f4b-43a8-ad93-6f7d6ef02061</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChangerTable rdf:ID="_24533a0f-3c24-4253-863a-5b1449e5b2de">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>24533a0f-3c24-4253-863a-5b1449e5b2de</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChangerTable>
+  <cim:RatioTapChangerTablePoint rdf:ID="_069e3d31-b5b0-4136-ab22-d40779e369b2">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.92</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-15</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.680805</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_32fb1a15-6650-4559-a7d2-12e5b75daa4b">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.925</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-14</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.680916</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_b4029b1f-2727-4fa3-8275-da91787f8521">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.93</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-13</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681027</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_dbf8c02e-2079-40fc-a8aa-b68dfc6aa5fd">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.94</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-12</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681139</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_ceb1cd1e-bece-4ff2-90bf-fe3932ffd014">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.945</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-11</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681139</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_03c0a363-bbb1-4353-a4a6-f78ef8d8cc84">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.95</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-10</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.68125</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_66161dc4-42c4-4ad6-8e5d-b4bbb135bf03">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.955</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-9</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.68125</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_5d6db173-ce6d-4a8d-b830-7192d7060daa">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.96</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-8</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681361</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_641b55be-29e0-4abf-ac03-fd23e467e5c2">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.965</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-7</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681472</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_16ab43b0-1f68-48d2-8d2b-bb8bfaddd79f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.97</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-6</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681583</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_5dd946ee-deca-4766-948c-635e0fd47562">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.975</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-5</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681583</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_4cdd75fd-f620-4d26-b635-c7b97735fe67">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.98</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-4</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681694</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_36679ac7-f571-4528-b92a-47e95fbc22e9">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.985</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-3</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681805</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_bdf2881d-ccd0-4f7b-b239-e1e085572f94">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.99</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-2</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681916</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_52ac1197-1688-4214-ba55-9f0a0154420c">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.995</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-1</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682027</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_e3479531-ffab-4d87-bc6d-5669e1854a28">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>0</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682138</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_3d4e9276-68b5-4d28-9d9e-0dfb5b9860e8">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.005</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>1</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.68225</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_4480247c-9999-4fe5-98f7-29e822873d4b">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.01</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>2</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682361</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_fcd1200d-f49c-4958-b09c-eb36286f3ca3">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.0153</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>3</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682361</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_39408e1d-792e-4cfb-9610-2c8c031b7e6a">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.02</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>4</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682472</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_3777ebd7-2977-43ba-87aa-1d1f4dff32b2">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.025</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>5</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682583</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_e3b3aeff-3818-4dac-934c-33109122860f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.031</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>6</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682694</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_1613356f-6177-4959-b300-42b0c0e73059">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.037</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>7</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682805</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_3a705ef0-80e6-43b5-a9db-02ae130ab38f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.043</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>8</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682916</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_4c798580-bf82-43cc-aac6-3f7ef1683836">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.05</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>9</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682916</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_5a716e55-2365-454c-be9b-642853275533">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.055</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>10</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683027</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_eec323a6-074f-4e68-a2db-89a0689afd16">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.06</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>11</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683027</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_eec7d9c6-536e-4449-96df-f4c7d633682a">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.065</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>12</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683138</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_649a76ff-50bc-457f-b965-033814273e1d">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.072</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>13</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683138</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_1fee8078-51b8-49cf-a1cd-db18db2f840d">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.08</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>14</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683249</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_835c45c5-e710-4b11-858f-704066a43904">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.085</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>15</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683361</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:OperationalLimitSet rdf:ID="_cf3e5341-6736-4b34-b4da-e4af2073765b">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_70b326a3-5913-494f-b8f8-8e366253b597" />
+    <cim:IdentifiedObject.mRID>cf3e5341-6736-4b34-b4da-e4af2073765b</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_26ce5ed9-6557-473e-a710-b7720c2c8355">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf3e5341-6736-4b34-b4da-e4af2073765b" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>46188.04</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>26ce5ed9-6557-473e-a710-b7720c2c8355</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_fd472104-d68c-4536-ba4a-5fd9349c0a65">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea" />
+    <cim:IdentifiedObject.mRID>fd472104-d68c-4536-ba4a-5fd9349c0a65</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2ca6c9d7-1310-4487-a177-0c3f7b461194">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_fd472104-d68c-4536-ba4a-5fd9349c0a65" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>3306.644</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2ca6c9d7-1310-4487-a177-0c3f7b461194</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:BaseVoltage rdf:ID="_abb2348a-aa10-446f-9f5d-49f93f211535">
+    <cim:IdentifiedObject.name>15.75 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>15.75</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>15.75</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>abb2348a-aa10-446f-9f5d-49f93f211535</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:Terminal rdf:ID="_421c7930-64c3-435d-afb8-2bb73b333e34">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>421c7930-64c3-435d-afb8-2bb73b333e34</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_31bf04d0-7e34-465b-95a4-0604700325cf">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>31bf04d0-7e34-465b-95a4-0604700325cf</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_757d4f50-707b-47a0-891c-cbaefd649631">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>757d4f50-707b-47a0-891c-cbaefd649631</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_ae588863-b154-451d-978a-7ab08ac50fb6">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>ae588863-b154-451d-978a-7ab08ac50fb6</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_8f308117-8bbd-4798-b145-4e78f7d049e7">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>8f308117-8bbd-4798-b145-4e78f7d049e7</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c557146e-dfc4-4020-9738-d592b188338b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>c557146e-dfc4-4020-9738-d592b188338b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a015f692-3fc5-4ec3-8d1d-977c7b499e7c">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fbfed7e3-3dec-4829-a286-029e73535685" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>a015f692-3fc5-4ec3-8d1d-977c7b499e7c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>baa7aef1-afcd-4981-97c0-ccec7b5ad4e0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_e3e0c496-5837-4f0f-a596-cc421940f73f">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>e3e0c496-5837-4f0f-a596-cc421940f73f</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_6dad1a97-6874-4206-a5a5-837e495325f8">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_25ab1b5b-6803-47e2-805a-ab7b2072e034" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>6dad1a97-6874-4206-a5a5-837e495325f8</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f48d48c7-e9f6-460c-898f-cc68a96efdeb">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b0442899-8dbe-48c1-a1fa-adb2a5929273" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f48d48c7-e9f6-460c-898f-cc68a96efdeb</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_57979d14-d1d8-4311-ae53-aa8890423885">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>57979d14-d1d8-4311-ae53-aa8890423885</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_653bc4b8-518b-4adc-9d68-012fb641fb1d">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>653bc4b8-518b-4adc-9d68-012fb641fb1d</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>357e3e14-c38e-4a7e-9c95-b3dbe158f5f3</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>6b1cd30c-19ba-44e1-9447-d01db6b1ef9d</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_24dd035c-0a8c-4351-aeb2-08d6622b42ae">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_12baa3f3-23b1-44e0-956f-d331e1527f37" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>24dd035c-0a8c-4351-aeb2-08d6622b42ae</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_39d27c17-1e5b-4edc-a7ec-65a2d56542df">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_83bea592-913e-4473-8d17-969968ff83a2" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>39d27c17-1e5b-4edc-a7ec-65a2d56542df</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f04ecab5-1a12-4cc0-ba56-b157ebf11a42">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>f04ecab5-1a12-4cc0-ba56-b157ebf11a42</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_6aecb9ba-5835-4b70-89bc-96d687e45779">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>6aecb9ba-5835-4b70-89bc-96d687e45779</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5dfee914-a4fd-4bde-a5b4-c4caa6378d10">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>5dfee914-a4fd-4bde-a5b4-c4caa6378d10</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_26e50b4b-9a19-420d-98ce-bc4f11971cd7">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_820d95d7-26d4-4311-8b1f-026f8605b86d" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>26e50b4b-9a19-420d-98ce-bc4f11971cd7</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f461fd2d-1e41-4a3e-8213-7cc33c77a089">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_69add5b4-70bd-4360-8a93-286256c0d38b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>f461fd2d-1e41-4a3e-8213-7cc33c77a089</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f970233f-b573-49d9-9fc3-3a2a59ed3bbb">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cab82e1c-1435-447b-bba0-74b592539eac" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f970233f-b573-49d9-9fc3-3a2a59ed3bbb</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b1e03a8f-6a11-4454-af58-4a4a680e857f" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_faab7959-f9bf-421b-bc3f-d364e0c1388b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>faab7959-f9bf-421b-bc3f-d364e0c1388b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_ae4b7cbe-349a-41c8-ace2-25ec26f14a64">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2844585c-0d35-488d-a449-685bcd57afbf" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>ae4b7cbe-349a-41c8-ace2-25ec26f14a64</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_70b326a3-5913-494f-b8f8-8e366253b597">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>70b326a3-5913-494f-b8f8-8e366253b597</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c9b27b4e-d492-4c3c-b147-67addbb9d3ea">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>c9b27b4e-d492-4c3c-b147-67addbb9d3ea</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:OperationalLimitType rdf:ID="_1aee0921-7cbe-481c-9078-daf66ab2a950">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.patl" />
+    <cim:IdentifiedObject.mRID>1aee0921-7cbe-481c-9078-daf66ab2a950</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>true</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:OperationalLimitType rdf:ID="_bf2a4896-2e92-465b-b5f9-b033993a31c8">
+    <cim:IdentifiedObject.name>Limit Type TATL</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>TATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.acceptableDuration>600</cim:OperationalLimitType.acceptableDuration>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.tatl" />
+    <cim:IdentifiedObject.mRID>bf2a4896-2e92-465b-b5f9-b033993a31c8</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>false</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:ControlArea rdf:ID="_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a">
+    <cim:IdentifiedObject.name>NL</cim:IdentifiedObject.name>
+    <cim:ControlArea.type rdf:resource="http://iec.ch/TC57/CIM100#ControlAreaTypeKind.Interchange" />
+    <cim:ControlArea.EnergyArea rdf:resource="#_70c4656c-f7a0-4319-98bb-84fb5e2e9b37" />
+    <cim:IdentifiedObject.mRID>31b2fe09-63f6-44f6-9b4f-01dbe7e4944a</cim:IdentifiedObject.mRID>
+  </cim:ControlArea>
+  <cim:TieFlow rdf:ID="_14f1c9bd-93d8-4238-9e26-aacc53fe8855">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_ae588863-b154-451d-978a-7ab08ac50fb6" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>14f1c9bd-93d8-4238-9e26-aacc53fe8855</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_4ed170fe-2571-4044-9bfa-7345e70a69d2">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_8f308117-8bbd-4798-b145-4e78f7d049e7" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>4ed170fe-2571-4044-9bfa-7345e70a69d2</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_945d6e95-1b83-47c5-a0e9-277d434c2d12">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_57979d14-d1d8-4311-ae53-aa8890423885" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>945d6e95-1b83-47c5-a0e9-277d434c2d12</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_4669c2b7-89d0-46d1-9bbb-37e989d581cd">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>4669c2b7-89d0-46d1-9bbb-37e989d581cd</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_f9ffc8ea-37f2-404a-9bd3-f3fa15476d4c">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_6aecb9ba-5835-4b70-89bc-96d687e45779" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>f9ffc8ea-37f2-404a-9bd3-f3fa15476d4c</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:RegulatingControl rdf:ID="_04f338d3-3c0d-433f-a77b-e36dd256f0f0">
+    <cim:IdentifiedObject.name>NL-G1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_faab7959-f9bf-421b-bc3f-d364e0c1388b" />
+    <cim:IdentifiedObject.mRID>04f338d3-3c0d-433f-a77b-e36dd256f0f0</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_NL_GL_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_NL_GL_001.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:76be4572-58c0-40c0-ae26-e65add81593d">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61" />
+  </md:FullModel>
+  <cim:CoordinateSystem rdf:ID="_38876874-fcfc-a4d9-9d16-39fb7da2ad74">
+    <cim:IdentifiedObject.name>WGS84</cim:IdentifiedObject.name>
+    <cim:CoordinateSystem.crsUrn>urn:ogc:def:crs:EPSG::4326</cim:CoordinateSystem.crsUrn>
+    <cim:IdentifiedObject.mRID>38876874-fcfc-a4d9-9d16-39fb7da2ad74</cim:IdentifiedObject.mRID>
+  </cim:CoordinateSystem>
+  <cim:Location rdf:ID="_c84ce457-406b-a13c-ad76-39fb7da2ad7a">
+    <cim:IdentifiedObject.name>NL-Line_5</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+    <cim:IdentifiedObject.mRID>c84ce457-406b-a13c-ad76-39fb7da2ad7a</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_c3c79c7b-2420-4e1f-8409-a33f300a23d0">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84744</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4027</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_c84ce457-406b-a13c-ad76-39fb7da2ad7a" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_b352d929-4f26-4c14-a45c-668858a7d0b3">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.98125</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.2483</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_c84ce457-406b-a13c-ad76-39fb7da2ad7a" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_4a497a1b-495a-46b7-946e-f0ce456baea2">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.04709</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.0699</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_c84ce457-406b-a13c-ad76-39fb7da2ad7a" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_674c30e0-d3d4-4936-9e88-d1c0cb7cad7f">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07058</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8731</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_c84ce457-406b-a13c-ad76-39fb7da2ad7a" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_5350c085-4b5e-5909-1d55-39fb7da2ad7b">
+    <cim:IdentifiedObject.name>NL-Line_2</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+    <cim:IdentifiedObject.mRID>5350c085-4b5e-5909-1d55-39fb7da2ad7b</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_5a899c67-25ca-40db-8114-8da314040efc">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84744</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4027</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5350c085-4b5e-5909-1d55-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_e1c899b9-e683-4650-b975-e14b99f34339">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.98125</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.2483</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5350c085-4b5e-5909-1d55-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_61c447ed-2413-40fa-aca5-3a0758357cc0">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.04709</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.0699</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5350c085-4b5e-5909-1d55-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ce082601-0923-430b-9063-57df68931720">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07186</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8756</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5350c085-4b5e-5909-1d55-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_480fa612-9f7c-44fa-8522-39fb7da2ad7b">
+    <cim:IdentifiedObject.name>NL-Line_4</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+    <cim:IdentifiedObject.mRID>480fa612-9f7c-44fa-8522-39fb7da2ad7b</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_64e596c6-a8bf-4626-a955-4fa9e6c12ed1">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84845</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4023</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_480fa612-9f7c-44fa-8522-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_707917fa-86d5-41c6-84a0-ffc51a940000">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.79004</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.1571</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_480fa612-9f7c-44fa-8522-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ffb34d5a-4d38-4d9c-acf8-e5b25a9c0ffa">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88892</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9138</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_480fa612-9f7c-44fa-8522-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_daafb8a7-efae-4a7d-91f8-45647a8492a2">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88798</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9127</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_480fa612-9f7c-44fa-8522-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_e072869d-f08d-34f3-bf8f-39fb7da2ad7b">
+    <cim:IdentifiedObject.name>NL-Line_1</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+    <cim:IdentifiedObject.mRID>e072869d-f08d-34f3-bf8f-39fb7da2ad7b</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_acc3e8bc-2ff1-49dd-92bf-d4b78061cc8b">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84744</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4027</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_e072869d-f08d-34f3-bf8f-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ea627c7c-e27a-466d-95f9-a1c9b6a8c7cf">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.98125</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.2483</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_e072869d-f08d-34f3-bf8f-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_1c577e91-4823-4507-9462-138732ece375">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.04709</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.0699</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_e072869d-f08d-34f3-bf8f-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_7d673371-9850-4544-8881-1b47ee86edcb">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07294</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8765</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_e072869d-f08d-34f3-bf8f-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_a719fa3b-aec1-c681-8da9-39fb7da2ad7b">
+    <cim:IdentifiedObject.name>NL-Line_3</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+    <cim:IdentifiedObject.mRID>a719fa3b-aec1-c681-8da9-39fb7da2ad7b</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_e238474d-ba73-4414-b30c-beac239b2561">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84845</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4023</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_a719fa3b-aec1-c681-8da9-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_a6443772-92de-47de-8bf3-53804c3bc2cb">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.79004</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.1571</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_a719fa3b-aec1-c681-8da9-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_fd1b2b5f-73d5-4f65-8c5e-28774dfcd623">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88892</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9138</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_a719fa3b-aec1-c681-8da9-39fb7da2ad7b" />
+  </cim:PositionPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_NL_SSH_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210325T1530Z_1D_NL_SSH_001.xml
@@ -1,0 +1,320 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:e888e6dc-c686-4957-b1ec-4be41760339e">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61" />
+  </md:FullModel>
+  <cim:Terminal rdf:about="#_421c7930-64c3-435d-afb8-2bb73b333e34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31bf04d0-7e34-465b-95a4-0604700325cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_757d4f50-707b-47a0-891c-cbaefd649631">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae588863-b154-451d-978a-7ab08ac50fb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f308117-8bbd-4798-b145-4e78f7d049e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c557146e-dfc4-4020-9738-d592b188338b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e3e0c496-5837-4f0f-a596-cc421940f73f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dad1a97-6874-4206-a5a5-837e495325f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f48d48c7-e9f6-460c-898f-cc68a96efdeb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57979d14-d1d8-4311-ae53-aa8890423885">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_653bc4b8-518b-4adc-9d68-012fb641fb1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24dd035c-0a8c-4351-aeb2-08d6622b42ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39d27c17-1e5b-4edc-a7ec-65a2d56542df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6aecb9ba-5835-4b70-89bc-96d687e45779">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26e50b4b-9a19-420d-98ce-bc4f11971cd7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f461fd2d-1e41-4a3e-8213-7cc33c77a089">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f970233f-b573-49d9-9fc3-3a2a59ed3bbb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_faab7959-f9bf-421b-bc3f-d364e0c1388b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70b326a3-5913-494f-b8f8-8e366253b597">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_50f00b94-fe0f-48fd-887e-f0d4d59eee87">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f199d49-0093-4b51-b357-70371424d174">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:SynchronousMachine rdf:about="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-150</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-83.296</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_b850063d-eae7-4675-bc98-4642d3076783">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:RegulatingControl rdf:about="#_04f338d3-3c0d-433f-a77b-e36dd256f0f0">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>16.0335</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:about="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-600.4927</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-386.9225</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_049438a6-780a-44fe-a788-ebe385d98e25">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>1</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_2844585c-0d35-488d-a449-685bcd57afbf">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-140</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-77.743</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_ca80ee09-3bed-4884-bc28-6dc89d067289">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:LinearShuntCompensator rdf:about="#_fbfed7e3-3dec-4829-a286-029e73535685">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_613dfeb3-0161-4cec-aaa9-ccddd885771b">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0.5</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>400</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ConformLoad rdf:about="#_25ab1b5b-6803-47e2-805a-ab7b2072e034">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:about="#_69add5b4-70bd-4360-8a93-286256c0d38b">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>90</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>280</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:about="#_b1e03a8f-6a11-4454-af58-4a4a680e857f">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>486</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>230</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:EquivalentInjection rdf:about="#_b0442899-8dbe-48c1-a1fa-adb2a5929273">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>27.0286</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-120.7887</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_12baa3f3-23b1-44e0-956f-d331e1527f37">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>83.18928</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-1.501529</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_83bea592-913e-4473-8d17-969968ff83a2">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>14.06748</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-63.95825</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_820d95d7-26d4-4311-8b1f-026f8605b86d">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>103.7413</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-11.31944</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_cab82e1c-1435-447b-bba0-74b592539eac">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>8.953211</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-67.2335</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:PhaseTapChangerTabular rdf:about="#_ee649b97-d2ec-47e1-976f-0f4d9f50fa11">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>17</cim:TapChanger.step>
+  </cim:PhaseTapChangerTabular>
+  <cim:PhaseTapChangerLinear rdf:about="#_341327c4-9224-40bf-bc33-7a3bb0bae680">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>8</cim:TapChanger.step>
+  </cim:PhaseTapChangerLinear>
+  <cim:RatioTapChanger rdf:about="#_44b4277a-0f4b-43a8-ad93-6f7d6ef02061">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>5</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:ControlArea rdf:about="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a">
+    <cim:ControlArea.netInterchange>-236.9798</cim:ControlArea.netInterchange>
+    <cim:ControlArea.pTolerance>10</cim:ControlArea.pTolerance>
+  </cim:ControlArea>
+  <cim:CurrentLimit rdf:about="#_47545df1-566d-4a8d-86e8-882655c6e79e">
+    <cim:CurrentLimit.value>1876</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_08ad0781-b65c-4f2e-b5ba-00d58bcf2e58">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_56105225-1754-40da-b6df-43fd7cfeb50a">
+    <cim:CurrentLimit.value>1876</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_86764bf6-6472-4ebe-9d6b-bcceffe66dad">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_7cfff021-02d4-4aa1-8fe7-b9af9c1fdc44">
+    <cim:CurrentLimit.value>1371</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_d7422ce6-a13d-41ca-8111-9462b2e789dc">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2b05a185-07f6-4e72-a2c3-d28425c7aefc">
+    <cim:CurrentLimit.value>1371</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_6fd8188f-65a6-4473-b8f1-ffe6122ba6ab">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2f424b90-a264-4592-8854-9838596c9f78">
+    <cim:CurrentLimit.value>1574</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_89ef40fb-5d77-45cb-8073-cc2d1d171dcd">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_b35893b0-22d4-4127-9351-9c46fba6059b">
+    <cim:CurrentLimit.value>1574</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_b780341b-7b90-498f-ab63-9deb16eff206">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_1b65a297-4735-499f-8fe8-f08ea01b291f">
+    <cim:CurrentLimit.value>1233.9</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_5bc43480-4543-4193-8b0e-7ba7bf5b3441">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_26069582-0f76-47fb-8bc0-44c99fb08887">
+    <cim:CurrentLimit.value>1233.9</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2783b836-4271-4252-96a7-588c3a1b1826">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_03287f0c-5562-4533-be7f-2fb40e1888f5">
+    <cim:CurrentLimit.value>2000</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_84c93dae-4254-4b24-b0ee-3fc4bdf1ea02">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_c743cfb3-8279-4721-9eee-12020dd89f64">
+    <cim:CurrentLimit.value>2000</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_8eb25188-24dd-4f6e-97d9-b7b03c49454e">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_6745e040-9fd4-4cc5-8bfd-902d0aed4ee6">
+    <cim:CurrentLimit.value>3306.644</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_12f7803a-c65b-4a14-8c0d-7e52becb5772">
+    <cim:CurrentLimit.value>46188.04</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_ef715edd-516e-4bfd-adc4-1c882852920e">
+    <cim:CurrentLimit.value>839.7826</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_e37ee101-2f68-4d55-b24f-c24c5faba8b5">
+    <cim:CurrentLimit.value>461.8804</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_26ce5ed9-6557-473e-a710-b7720c2c8355">
+    <cim:CurrentLimit.value>46188.04</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2ca6c9d7-1310-4487-a177-0c3f7b461194">
+    <cim:CurrentLimit.value>3306.644</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:Equipment rdf:about="#_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_53da4025-9d51-4eaf-b0d2-ce27fbe740d2">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_dad02278-bd25-476f-8f58-dbe44be72586">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_8fdc7abd-3746-481a-a65e-3df56acd8b13">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_7f43f508-2496-4b64-9146-0a40406cbe49">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_a279a3dc-550b-426c-af3a-61b7be508dcc">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_80016742-31b3-432a-b00a-300667a1e572">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210420T1730Z_1D_BE_DY_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210420T1730Z_1D_BE_DY_001.xml
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:8e91166f-12ce-4a20-b0bf-7be301171d0b">
+    <md:Model.created>2021-04-20T10:56:20Z</md:Model.created>
+    <md:Model.scenarioTime>2021-04-20T17:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/Dynamics-EU/1.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d" />
+  </md:FullModel>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_4f810658-da42-4bbf-b8ee-1c38019d7068">
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:RotatingMachineDynamics.damping>0.01</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>5</cim:RotatingMachineDynamics.inertia>
+    <cim:SynchronousMachineDetailed.saturationFactorQAxis>0.02</cim:SynchronousMachineDetailed.saturationFactorQAxis>
+    <cim:SynchronousMachineDetailed.saturationFactor120QAxis>0.12</cim:SynchronousMachineDetailed.saturationFactor120QAxis>
+    <cim:RotatingMachineDynamics.saturationFactor>0.02</cim:RotatingMachineDynamics.saturationFactor>
+    <cim:RotatingMachineDynamics.saturationFactor120>0.12</cim:RotatingMachineDynamics.saturationFactor120>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.15</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.roundRotor" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>8</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.03</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.07</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>1</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.23</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.81</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.3</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.25</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>1.76</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.65</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>4f810658-da42-4bbf-b8ee-1c38019d7068</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_8aa9d8c1-8711-40cf-8c77-509c4240562c">
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:RotatingMachineDynamics.damping>0</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>4.25</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.16</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDetailed.saturationFactorQAxis>0.02</cim:SynchronousMachineDetailed.saturationFactorQAxis>
+    <cim:SynchronousMachineDetailed.saturationFactor120QAxis>0.12</cim:SynchronousMachineDetailed.saturationFactor120QAxis>
+    <cim:RotatingMachineDynamics.saturationFactor>0.02</cim:RotatingMachineDynamics.saturationFactor>
+    <cim:RotatingMachineDynamics.saturationFactor120>0.12</cim:RotatingMachineDynamics.saturationFactor120>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.roundRotor" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>6.4</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.12</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.12</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>6.4</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.2</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.97</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.29</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.2</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>1.97</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.29</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>8aa9d8c1-8711-40cf-8c77-509c4240562c</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:VCompIEEEType1 rdf:ID="_3de814e0-4057-4359-8415-91f9cfc6954a">
+    <cim:IdentifiedObject.name>BE-G1-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_f7d4412c-6567-4759-aa48-4c881dd79902" />
+    <cim:VCompIEEEType1.rc>0</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.xc>0</cim:VCompIEEEType1.xc>
+    <cim:VCompIEEEType1.tr>0</cim:VCompIEEEType1.tr>
+    <cim:IdentifiedObject.mRID>3de814e0-4057-4359-8415-91f9cfc6954a</cim:IdentifiedObject.mRID>
+  </cim:VCompIEEEType1>
+  <cim:ExcIEEEAC4A rdf:ID="_f7d4412c-6567-4759-aa48-4c881dd79902">
+    <cim:IdentifiedObject.name>BE-G1-ExcAC4A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_8aa9d8c1-8711-40cf-8c77-509c4240562c" />
+    <cim:ExcIEEEAC4A.ka>200</cim:ExcIEEEAC4A.ka>
+    <cim:ExcIEEEAC4A.kc>0.05</cim:ExcIEEEAC4A.kc>
+    <cim:ExcIEEEAC4A.ta>0.07</cim:ExcIEEEAC4A.ta>
+    <cim:ExcIEEEAC4A.tb>8.5</cim:ExcIEEEAC4A.tb>
+    <cim:ExcIEEEAC4A.tc>1.8</cim:ExcIEEEAC4A.tc>
+    <cim:ExcIEEEAC4A.vimax>0.1</cim:ExcIEEEAC4A.vimax>
+    <cim:ExcIEEEAC4A.vimin>-0.1</cim:ExcIEEEAC4A.vimin>
+    <cim:ExcIEEEAC4A.vrmax>5</cim:ExcIEEEAC4A.vrmax>
+    <cim:ExcIEEEAC4A.vrmin>-4.65</cim:ExcIEEEAC4A.vrmin>
+    <cim:IdentifiedObject.mRID>f7d4412c-6567-4759-aa48-4c881dd79902</cim:IdentifiedObject.mRID>
+  </cim:ExcIEEEAC4A>
+  <cim:PssIEEE2B rdf:ID="_13267fa6-b3f0-4e23-8b4c-857d35eeed6f">
+    <cim:IdentifiedObject.name>BE-G1-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_f7d4412c-6567-4759-aa48-4c881dd79902" />
+    <cim:PssIEEE2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.rotorAngularFrequencyDeviation" />
+    <cim:PssIEEE2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.generatorElectricalPower" />
+    <cim:PssIEEE2B.ks1>16</cim:PssIEEE2B.ks1>
+    <cim:PssIEEE2B.ks2>0.31</cim:PssIEEE2B.ks2>
+    <cim:PssIEEE2B.ks3>1</cim:PssIEEE2B.ks3>
+    <cim:PssIEEE2B.m>5</cim:PssIEEE2B.m>
+    <cim:PssIEEE2B.n>1</cim:PssIEEE2B.n>
+    <cim:PssIEEE2B.t1>0.2</cim:PssIEEE2B.t1>
+    <cim:PssIEEE2B.t10>0</cim:PssIEEE2B.t10>
+    <cim:PssIEEE2B.t11>0</cim:PssIEEE2B.t11>
+    <cim:PssIEEE2B.t2>0.02</cim:PssIEEE2B.t2>
+    <cim:PssIEEE2B.t3>0.45</cim:PssIEEE2B.t3>
+    <cim:PssIEEE2B.t4>0.02</cim:PssIEEE2B.t4>
+    <cim:PssIEEE2B.t6>0</cim:PssIEEE2B.t6>
+    <cim:PssIEEE2B.t7>2</cim:PssIEEE2B.t7>
+    <cim:PssIEEE2B.t8>0.2</cim:PssIEEE2B.t8>
+    <cim:PssIEEE2B.t9>0.1</cim:PssIEEE2B.t9>
+    <cim:PssIEEE2B.tw1>2</cim:PssIEEE2B.tw1>
+    <cim:PssIEEE2B.tw2>2</cim:PssIEEE2B.tw2>
+    <cim:PssIEEE2B.tw3>2</cim:PssIEEE2B.tw3>
+    <cim:PssIEEE2B.tw4>0</cim:PssIEEE2B.tw4>
+    <cim:PssIEEE2B.vsi1max>999</cim:PssIEEE2B.vsi1max>
+    <cim:PssIEEE2B.vsi1min>-999</cim:PssIEEE2B.vsi1min>
+    <cim:PssIEEE2B.vsi2max>999</cim:PssIEEE2B.vsi2max>
+    <cim:PssIEEE2B.vsi2min>-999</cim:PssIEEE2B.vsi2min>
+    <cim:PssIEEE2B.vstmax>0.1</cim:PssIEEE2B.vstmax>
+    <cim:PssIEEE2B.vstmin>-0.1</cim:PssIEEE2B.vstmin>
+    <cim:IdentifiedObject.mRID>13267fa6-b3f0-4e23-8b4c-857d35eeed6f</cim:IdentifiedObject.mRID>
+  </cim:PssIEEE2B>
+  <cim:GovSteam1 rdf:ID="_d0ae3542-271e-4f50-8272-53bf553df6c2">
+    <cim:IdentifiedObject.name>BE-G1-TurbIEEEEG1</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_8aa9d8c1-8711-40cf-8c77-509c4240562c" />
+    <cim:GovSteam1.db2>0</cim:GovSteam1.db2>
+    <cim:GovSteam1.db1>0</cim:GovSteam1.db1>
+    <cim:GovSteam1.eps>0</cim:GovSteam1.eps>
+    <cim:GovSteam1.uo>1</cim:GovSteam1.uo>
+    <cim:GovSteam1.gv1>0</cim:GovSteam1.gv1>
+    <cim:GovSteam1.gv2>0.25</cim:GovSteam1.gv2>
+    <cim:GovSteam1.gv3>0.5</cim:GovSteam1.gv3>
+    <cim:GovSteam1.gv4>0.75</cim:GovSteam1.gv4>
+    <cim:GovSteam1.gv5>1</cim:GovSteam1.gv5>
+    <cim:GovSteam1.gv6>1.25</cim:GovSteam1.gv6>
+    <cim:GovSteam1.k>25</cim:GovSteam1.k>
+    <cim:GovSteam1.k1>0.25</cim:GovSteam1.k1>
+    <cim:GovSteam1.k2>0</cim:GovSteam1.k2>
+    <cim:GovSteam1.k3>0.6</cim:GovSteam1.k3>
+    <cim:GovSteam1.k4>0</cim:GovSteam1.k4>
+    <cim:GovSteam1.k5>0.15</cim:GovSteam1.k5>
+    <cim:GovSteam1.k6>0</cim:GovSteam1.k6>
+    <cim:GovSteam1.k7>0</cim:GovSteam1.k7>
+    <cim:GovSteam1.k8>0</cim:GovSteam1.k8>
+    <cim:GovSteam1.mwbase>255</cim:GovSteam1.mwbase>
+    <cim:GovSteam1.pgv1>0</cim:GovSteam1.pgv1>
+    <cim:GovSteam1.pgv2>0.25</cim:GovSteam1.pgv2>
+    <cim:GovSteam1.pgv3>0.5</cim:GovSteam1.pgv3>
+    <cim:GovSteam1.pgv4>0.75</cim:GovSteam1.pgv4>
+    <cim:GovSteam1.pgv5>1</cim:GovSteam1.pgv5>
+    <cim:GovSteam1.pgv6>1.25</cim:GovSteam1.pgv6>
+    <cim:GovSteam1.pmax>1.05</cim:GovSteam1.pmax>
+    <cim:GovSteam1.pmin>0</cim:GovSteam1.pmin>
+    <cim:GovSteam1.sdb1>true</cim:GovSteam1.sdb1>
+    <cim:GovSteam1.sdb2>true</cim:GovSteam1.sdb2>
+    <cim:GovSteam1.t1>5</cim:GovSteam1.t1>
+    <cim:GovSteam1.t2>1.5</cim:GovSteam1.t2>
+    <cim:GovSteam1.t3>0.3</cim:GovSteam1.t3>
+    <cim:GovSteam1.t4>0.15</cim:GovSteam1.t4>
+    <cim:GovSteam1.t5>2</cim:GovSteam1.t5>
+    <cim:GovSteam1.t6>0.1</cim:GovSteam1.t6>
+    <cim:GovSteam1.t7>0</cim:GovSteam1.t7>
+    <cim:GovSteam1.uc>-1.05</cim:GovSteam1.uc>
+    <cim:GovSteam1.valve>true</cim:GovSteam1.valve>
+    <cim:IdentifiedObject.mRID>d0ae3542-271e-4f50-8272-53bf553df6c2</cim:IdentifiedObject.mRID>
+  </cim:GovSteam1>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210420T1730Z_1D_NL_DY_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged/20210420T1730Z_1D_NL_DY_001.xml
@@ -1,0 +1,369 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:00d66ea3-929d-444f-bf51-dfbbf01bc0af">
+    <md:Model.created>2021-04-20T10:56:20Z</md:Model.created>
+    <md:Model.scenarioTime>2021-04-20T17:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/Dynamics-EU/1.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61" />
+  </md:FullModel>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_f450a965-7cfb-4516-a2bf-618f05e84eed">
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:RotatingMachineDynamics.damping>1</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>4.4</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.23</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDetailed.saturationFactorQAxis>0.02</cim:SynchronousMachineDetailed.saturationFactorQAxis>
+    <cim:SynchronousMachineDetailed.saturationFactor120QAxis>0.12</cim:SynchronousMachineDetailed.saturationFactor120QAxis>
+    <cim:RotatingMachineDynamics.saturationFactor>0.02</cim:RotatingMachineDynamics.saturationFactor>
+    <cim:RotatingMachineDynamics.saturationFactor120>0.12</cim:RotatingMachineDynamics.saturationFactor120>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.roundRotor" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>9.6</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.08</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.0837</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>0.09</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.24</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.98</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.37</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.24</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>0.8</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.24</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>f450a965-7cfb-4516-a2bf-618f05e84eed</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_bd63d5d8-3d61-4233-a3e0-a66d512c1574">
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:RotatingMachineDynamics.damping>1</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>9.9</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.1934</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.salientPole" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>8.8</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.031</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.0354</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>0.04</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.318</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>2.35</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.452</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.318</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>2.24</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.318</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>bd63d5d8-3d61-4233-a3e0-a66d512c1574</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_e58068fe-5436-4a2a-aa72-da3377ea1355">
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:RotatingMachineDynamics.damping>1</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>4.4</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.23</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_2844585c-0d35-488d-a449-685bcd57afbf" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.salientPole" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>9.6</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.08</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.0837</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>0.09</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.24</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.98</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.37</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.24</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>0.8</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.24</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>e58068fe-5436-4a2a-aa72-da3377ea1355</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:ExcIEEEST1A rdf:ID="_3bd610c9-8ecd-4466-a5ea-c998749a38ea">
+    <cim:IdentifiedObject.name>NL-G2-Exc-ST1A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_e58068fe-5436-4a2a-aa72-da3377ea1355" />
+    <cim:ExcIEEEST1A.ilr>0</cim:ExcIEEEST1A.ilr>
+    <cim:ExcIEEEST1A.ka>190</cim:ExcIEEEST1A.ka>
+    <cim:ExcIEEEST1A.kc>0.08</cim:ExcIEEEST1A.kc>
+    <cim:ExcIEEEST1A.kf>0.02</cim:ExcIEEEST1A.kf>
+    <cim:ExcIEEEST1A.klr>0</cim:ExcIEEEST1A.klr>
+    <cim:ExcIEEEST1A.pssin>false</cim:ExcIEEEST1A.pssin>
+    <cim:ExcIEEEST1A.ta>0.1</cim:ExcIEEEST1A.ta>
+    <cim:ExcIEEEST1A.tb>10</cim:ExcIEEEST1A.tb>
+    <cim:ExcIEEEST1A.tb1>0.001</cim:ExcIEEEST1A.tb1>
+    <cim:ExcIEEEST1A.tc>1.5</cim:ExcIEEEST1A.tc>
+    <cim:ExcIEEEST1A.tc1>0.001</cim:ExcIEEEST1A.tc1>
+    <cim:ExcIEEEST1A.tf>0.8</cim:ExcIEEEST1A.tf>
+    <cim:ExcIEEEST1A.uelin rdf:resource="http://iec.ch/TC57/CIM100#ExcIEEEST1AUELselectorKind.ignoreUELsignal" />
+    <cim:ExcIEEEST1A.vamax>8</cim:ExcIEEEST1A.vamax>
+    <cim:ExcIEEEST1A.vamin>-8</cim:ExcIEEEST1A.vamin>
+    <cim:ExcIEEEST1A.vimax>0.2</cim:ExcIEEEST1A.vimax>
+    <cim:ExcIEEEST1A.vimin>-0.2</cim:ExcIEEEST1A.vimin>
+    <cim:ExcIEEEST1A.vrmax>7.8</cim:ExcIEEEST1A.vrmax>
+    <cim:ExcIEEEST1A.vrmin>-6.7</cim:ExcIEEEST1A.vrmin>
+    <cim:IdentifiedObject.mRID>3bd610c9-8ecd-4466-a5ea-c998749a38ea</cim:IdentifiedObject.mRID>
+  </cim:ExcIEEEST1A>
+  <cim:PssIEEE2B rdf:ID="_fd134308-7b1c-4272-b2cd-7989c13a5ca5">
+    <cim:IdentifiedObject.name>NL-G2-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_3bd610c9-8ecd-4466-a5ea-c998749a38ea" />
+    <cim:PssIEEE2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.rotorAngularFrequencyDeviation" />
+    <cim:PssIEEE2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.generatorElectricalPower" />
+    <cim:PssIEEE2B.ks1>10</cim:PssIEEE2B.ks1>
+    <cim:PssIEEE2B.ks2>0.31</cim:PssIEEE2B.ks2>
+    <cim:PssIEEE2B.ks3>1</cim:PssIEEE2B.ks3>
+    <cim:PssIEEE2B.m>5</cim:PssIEEE2B.m>
+    <cim:PssIEEE2B.n>1</cim:PssIEEE2B.n>
+    <cim:PssIEEE2B.t1>0.12</cim:PssIEEE2B.t1>
+    <cim:PssIEEE2B.t10>0</cim:PssIEEE2B.t10>
+    <cim:PssIEEE2B.t11>0</cim:PssIEEE2B.t11>
+    <cim:PssIEEE2B.t2>0.02</cim:PssIEEE2B.t2>
+    <cim:PssIEEE2B.t3>0.4</cim:PssIEEE2B.t3>
+    <cim:PssIEEE2B.t4>0.02</cim:PssIEEE2B.t4>
+    <cim:PssIEEE2B.t6>0</cim:PssIEEE2B.t6>
+    <cim:PssIEEE2B.t7>2</cim:PssIEEE2B.t7>
+    <cim:PssIEEE2B.t8>0.2</cim:PssIEEE2B.t8>
+    <cim:PssIEEE2B.t9>0.1</cim:PssIEEE2B.t9>
+    <cim:PssIEEE2B.tw1>2</cim:PssIEEE2B.tw1>
+    <cim:PssIEEE2B.tw2>2</cim:PssIEEE2B.tw2>
+    <cim:PssIEEE2B.tw3>2</cim:PssIEEE2B.tw3>
+    <cim:PssIEEE2B.tw4>0</cim:PssIEEE2B.tw4>
+    <cim:PssIEEE2B.vsi1max>999</cim:PssIEEE2B.vsi1max>
+    <cim:PssIEEE2B.vsi1min>-999</cim:PssIEEE2B.vsi1min>
+    <cim:PssIEEE2B.vsi2max>999</cim:PssIEEE2B.vsi2max>
+    <cim:PssIEEE2B.vsi2min>-999</cim:PssIEEE2B.vsi2min>
+    <cim:PssIEEE2B.vstmax>0.1</cim:PssIEEE2B.vstmax>
+    <cim:PssIEEE2B.vstmin>-0.1</cim:PssIEEE2B.vstmin>
+    <cim:IdentifiedObject.mRID>fd134308-7b1c-4272-b2cd-7989c13a5ca5</cim:IdentifiedObject.mRID>
+  </cim:PssIEEE2B>
+  <cim:VCompIEEEType1 rdf:ID="_50a79cc5-c98d-4b3b-b863-0b677d09eca3">
+    <cim:IdentifiedObject.name>NL-G2-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_3bd610c9-8ecd-4466-a5ea-c998749a38ea" />
+    <cim:VCompIEEEType1.rc>0</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.xc>0</cim:VCompIEEEType1.xc>
+    <cim:VCompIEEEType1.tr>0</cim:VCompIEEEType1.tr>
+    <cim:IdentifiedObject.mRID>50a79cc5-c98d-4b3b-b863-0b677d09eca3</cim:IdentifiedObject.mRID>
+  </cim:VCompIEEEType1>
+  <cim:VCompIEEEType1 rdf:ID="_38bfffb4-e20d-4259-9a25-92bc74ed1167">
+    <cim:IdentifiedObject.name>NL-G1-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_a29ea0a1-af24-4c9b-aa8f-5c97374996e2" />
+    <cim:VCompIEEEType1.rc>0</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.xc>0</cim:VCompIEEEType1.xc>
+    <cim:VCompIEEEType1.tr>0</cim:VCompIEEEType1.tr>
+    <cim:IdentifiedObject.mRID>38bfffb4-e20d-4259-9a25-92bc74ed1167</cim:IdentifiedObject.mRID>
+  </cim:VCompIEEEType1>
+  <cim:VCompIEEEType1 rdf:ID="_3105e155-0187-4c30-903b-41d4946c39bb">
+    <cim:IdentifiedObject.name>NL-G3-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_cf42c5ad-b3f9-4f9f-ae5e-6169cb07ae89" />
+    <cim:VCompIEEEType1.rc>0</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.xc>0</cim:VCompIEEEType1.xc>
+    <cim:VCompIEEEType1.tr>0</cim:VCompIEEEType1.tr>
+    <cim:IdentifiedObject.mRID>3105e155-0187-4c30-903b-41d4946c39bb</cim:IdentifiedObject.mRID>
+  </cim:VCompIEEEType1>
+  <cim:PssIEEE2B rdf:ID="_fd6074ce-e88d-4191-8dd7-d44114684d47">
+    <cim:IdentifiedObject.name>NL-G1-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_a29ea0a1-af24-4c9b-aa8f-5c97374996e2" />
+    <cim:PssIEEE2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.rotorAngularFrequencyDeviation" />
+    <cim:PssIEEE2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.generatorElectricalPower" />
+    <cim:PssIEEE2B.ks1>12</cim:PssIEEE2B.ks1>
+    <cim:PssIEEE2B.ks2>0.2</cim:PssIEEE2B.ks2>
+    <cim:PssIEEE2B.ks3>1</cim:PssIEEE2B.ks3>
+    <cim:PssIEEE2B.m>5</cim:PssIEEE2B.m>
+    <cim:PssIEEE2B.n>1</cim:PssIEEE2B.n>
+    <cim:PssIEEE2B.t1>0.12</cim:PssIEEE2B.t1>
+    <cim:PssIEEE2B.t10>0</cim:PssIEEE2B.t10>
+    <cim:PssIEEE2B.t11>0</cim:PssIEEE2B.t11>
+    <cim:PssIEEE2B.t2>0.02</cim:PssIEEE2B.t2>
+    <cim:PssIEEE2B.t3>0.3</cim:PssIEEE2B.t3>
+    <cim:PssIEEE2B.t4>0.02</cim:PssIEEE2B.t4>
+    <cim:PssIEEE2B.t6>0</cim:PssIEEE2B.t6>
+    <cim:PssIEEE2B.t7>2</cim:PssIEEE2B.t7>
+    <cim:PssIEEE2B.t8>0</cim:PssIEEE2B.t8>
+    <cim:PssIEEE2B.t9>0.1</cim:PssIEEE2B.t9>
+    <cim:PssIEEE2B.tw1>2</cim:PssIEEE2B.tw1>
+    <cim:PssIEEE2B.tw2>2</cim:PssIEEE2B.tw2>
+    <cim:PssIEEE2B.tw3>2</cim:PssIEEE2B.tw3>
+    <cim:PssIEEE2B.tw4>0</cim:PssIEEE2B.tw4>
+    <cim:PssIEEE2B.vsi1max>999</cim:PssIEEE2B.vsi1max>
+    <cim:PssIEEE2B.vsi1min>-999</cim:PssIEEE2B.vsi1min>
+    <cim:PssIEEE2B.vsi2max>999</cim:PssIEEE2B.vsi2max>
+    <cim:PssIEEE2B.vsi2min>-999</cim:PssIEEE2B.vsi2min>
+    <cim:PssIEEE2B.vstmax>0.1</cim:PssIEEE2B.vstmax>
+    <cim:PssIEEE2B.vstmin>-0.1</cim:PssIEEE2B.vstmin>
+    <cim:IdentifiedObject.mRID>fd6074ce-e88d-4191-8dd7-d44114684d47</cim:IdentifiedObject.mRID>
+  </cim:PssIEEE2B>
+  <cim:ExcIEEEAC1A rdf:ID="_a29ea0a1-af24-4c9b-aa8f-5c97374996e2">
+    <cim:IdentifiedObject.name>NL-G1-ExcAC1A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_bd63d5d8-3d61-4233-a3e0-a66d512c1574" />
+    <cim:ExcIEEEAC1A.ka>30</cim:ExcIEEEAC1A.ka>
+    <cim:ExcIEEEAC1A.kc>0.2</cim:ExcIEEEAC1A.kc>
+    <cim:ExcIEEEAC1A.kd>0.4</cim:ExcIEEEAC1A.kd>
+    <cim:ExcIEEEAC1A.ke>1</cim:ExcIEEEAC1A.ke>
+    <cim:ExcIEEEAC1A.kf>0.03</cim:ExcIEEEAC1A.kf>
+    <cim:ExcIEEEAC1A.seve1>0.03</cim:ExcIEEEAC1A.seve1>
+    <cim:ExcIEEEAC1A.seve2>0.1</cim:ExcIEEEAC1A.seve2>
+    <cim:ExcIEEEAC1A.ta>0.05</cim:ExcIEEEAC1A.ta>
+    <cim:ExcIEEEAC1A.tb>0.02</cim:ExcIEEEAC1A.tb>
+    <cim:ExcIEEEAC1A.tc>0.001</cim:ExcIEEEAC1A.tc>
+    <cim:ExcIEEEAC1A.te>0.4</cim:ExcIEEEAC1A.te>
+    <cim:ExcIEEEAC1A.tf>1</cim:ExcIEEEAC1A.tf>
+    <cim:ExcIEEEAC1A.vamax>10</cim:ExcIEEEAC1A.vamax>
+    <cim:ExcIEEEAC1A.vamin>-10</cim:ExcIEEEAC1A.vamin>
+    <cim:ExcIEEEAC1A.ve1>3.14</cim:ExcIEEEAC1A.ve1>
+    <cim:ExcIEEEAC1A.ve2>4.18</cim:ExcIEEEAC1A.ve2>
+    <cim:ExcIEEEAC1A.vrmax>10</cim:ExcIEEEAC1A.vrmax>
+    <cim:ExcIEEEAC1A.vrmin>-5</cim:ExcIEEEAC1A.vrmin>
+    <cim:IdentifiedObject.mRID>a29ea0a1-af24-4c9b-aa8f-5c97374996e2</cim:IdentifiedObject.mRID>
+  </cim:ExcIEEEAC1A>
+  <cim:ExcIEEEST1A rdf:ID="_cf42c5ad-b3f9-4f9f-ae5e-6169cb07ae89">
+    <cim:IdentifiedObject.name>NL-G3-Exc-ST1A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_f450a965-7cfb-4516-a2bf-618f05e84eed" />
+    <cim:ExcIEEEST1A.ilr>0</cim:ExcIEEEST1A.ilr>
+    <cim:ExcIEEEST1A.ka>220</cim:ExcIEEEST1A.ka>
+    <cim:ExcIEEEST1A.kc>0.08</cim:ExcIEEEST1A.kc>
+    <cim:ExcIEEEST1A.kf>0.02</cim:ExcIEEEST1A.kf>
+    <cim:ExcIEEEST1A.klr>0</cim:ExcIEEEST1A.klr>
+    <cim:ExcIEEEST1A.pssin>false</cim:ExcIEEEST1A.pssin>
+    <cim:ExcIEEEST1A.ta>0.1</cim:ExcIEEEST1A.ta>
+    <cim:ExcIEEEST1A.tb>10</cim:ExcIEEEST1A.tb>
+    <cim:ExcIEEEST1A.tb1>0.001</cim:ExcIEEEST1A.tb1>
+    <cim:ExcIEEEST1A.tc>1.5</cim:ExcIEEEST1A.tc>
+    <cim:ExcIEEEST1A.tc1>0.001</cim:ExcIEEEST1A.tc1>
+    <cim:ExcIEEEST1A.tf>0.8</cim:ExcIEEEST1A.tf>
+    <cim:ExcIEEEST1A.uelin rdf:resource="http://iec.ch/TC57/CIM100#ExcIEEEST1AUELselectorKind.ignoreUELsignal" />
+    <cim:ExcIEEEST1A.vamax>8</cim:ExcIEEEST1A.vamax>
+    <cim:ExcIEEEST1A.vamin>-8</cim:ExcIEEEST1A.vamin>
+    <cim:ExcIEEEST1A.vimax>0.2</cim:ExcIEEEST1A.vimax>
+    <cim:ExcIEEEST1A.vimin>-0.2</cim:ExcIEEEST1A.vimin>
+    <cim:ExcIEEEST1A.vrmax>7.8</cim:ExcIEEEST1A.vrmax>
+    <cim:ExcIEEEST1A.vrmin>-6.7</cim:ExcIEEEST1A.vrmin>
+    <cim:IdentifiedObject.mRID>cf42c5ad-b3f9-4f9f-ae5e-6169cb07ae89</cim:IdentifiedObject.mRID>
+  </cim:ExcIEEEST1A>
+  <cim:PssIEEE2B rdf:ID="_6b347d56-00c6-4916-be40-08c9b11c32b9">
+    <cim:IdentifiedObject.name>NL-G3-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_cf42c5ad-b3f9-4f9f-ae5e-6169cb07ae89" />
+    <cim:PssIEEE2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.rotorAngularFrequencyDeviation" />
+    <cim:PssIEEE2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.generatorElectricalPower" />
+    <cim:PssIEEE2B.ks1>10</cim:PssIEEE2B.ks1>
+    <cim:PssIEEE2B.ks2>0.31</cim:PssIEEE2B.ks2>
+    <cim:PssIEEE2B.ks3>1</cim:PssIEEE2B.ks3>
+    <cim:PssIEEE2B.m>5</cim:PssIEEE2B.m>
+    <cim:PssIEEE2B.n>1</cim:PssIEEE2B.n>
+    <cim:PssIEEE2B.t1>0.3</cim:PssIEEE2B.t1>
+    <cim:PssIEEE2B.t10>0</cim:PssIEEE2B.t10>
+    <cim:PssIEEE2B.t11>0</cim:PssIEEE2B.t11>
+    <cim:PssIEEE2B.t2>0.02</cim:PssIEEE2B.t2>
+    <cim:PssIEEE2B.t3>0.45</cim:PssIEEE2B.t3>
+    <cim:PssIEEE2B.t4>0.02</cim:PssIEEE2B.t4>
+    <cim:PssIEEE2B.t6>0</cim:PssIEEE2B.t6>
+    <cim:PssIEEE2B.t7>2</cim:PssIEEE2B.t7>
+    <cim:PssIEEE2B.t8>0.2</cim:PssIEEE2B.t8>
+    <cim:PssIEEE2B.t9>0.1</cim:PssIEEE2B.t9>
+    <cim:PssIEEE2B.tw1>2</cim:PssIEEE2B.tw1>
+    <cim:PssIEEE2B.tw2>2</cim:PssIEEE2B.tw2>
+    <cim:PssIEEE2B.tw3>2</cim:PssIEEE2B.tw3>
+    <cim:PssIEEE2B.tw4>0</cim:PssIEEE2B.tw4>
+    <cim:PssIEEE2B.vsi1max>999</cim:PssIEEE2B.vsi1max>
+    <cim:PssIEEE2B.vsi1min>-999</cim:PssIEEE2B.vsi1min>
+    <cim:PssIEEE2B.vsi2max>999</cim:PssIEEE2B.vsi2max>
+    <cim:PssIEEE2B.vsi2min>-999</cim:PssIEEE2B.vsi2min>
+    <cim:PssIEEE2B.vstmax>0.1</cim:PssIEEE2B.vstmax>
+    <cim:PssIEEE2B.vstmin>-0.1</cim:PssIEEE2B.vstmin>
+    <cim:IdentifiedObject.mRID>6b347d56-00c6-4916-be40-08c9b11c32b9</cim:IdentifiedObject.mRID>
+  </cim:PssIEEE2B>
+  <cim:GovHydro1 rdf:ID="_f12ead9a-0d9d-469e-9351-0f187bd2e523">
+    <cim:IdentifiedObject.name>NL-G2-Turb-GovHydro1</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_e58068fe-5436-4a2a-aa72-da3377ea1355" />
+    <cim:GovHydro1.at>1.2</cim:GovHydro1.at>
+    <cim:GovHydro1.dturb>0.3</cim:GovHydro1.dturb>
+    <cim:GovHydro1.gmax>0.75</cim:GovHydro1.gmax>
+    <cim:GovHydro1.gmin>0</cim:GovHydro1.gmin>
+    <cim:GovHydro1.hdam>1</cim:GovHydro1.hdam>
+    <cim:GovHydro1.mwbase>225</cim:GovHydro1.mwbase>
+    <cim:GovHydro1.qnl>0.08</cim:GovHydro1.qnl>
+    <cim:GovHydro1.rperm>0.05</cim:GovHydro1.rperm>
+    <cim:GovHydro1.rtemp>1.27</cim:GovHydro1.rtemp>
+    <cim:GovHydro1.tf>0.099</cim:GovHydro1.tf>
+    <cim:GovHydro1.tg>0.9</cim:GovHydro1.tg>
+    <cim:GovHydro1.tr>10.4</cim:GovHydro1.tr>
+    <cim:GovHydro1.tw>2.6</cim:GovHydro1.tw>
+    <cim:GovHydro1.velm>0.2</cim:GovHydro1.velm>
+    <cim:IdentifiedObject.mRID>f12ead9a-0d9d-469e-9351-0f187bd2e523</cim:IdentifiedObject.mRID>
+  </cim:GovHydro1>
+  <cim:GovHydro2 rdf:ID="_32fb9a75-5aa2-4ead-843b-8b8c0254683d">
+    <cim:IdentifiedObject.name>NL-G1-IEEEEG3</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_bd63d5d8-3d61-4233-a3e0-a66d512c1574" />
+    <cim:GovHydro2.aturb>-1</cim:GovHydro2.aturb>
+    <cim:GovHydro2.bturb>0.5</cim:GovHydro2.bturb>
+    <cim:GovHydro2.db2>0</cim:GovHydro2.db2>
+    <cim:GovHydro2.db1>0</cim:GovHydro2.db1>
+    <cim:GovHydro2.eps>0</cim:GovHydro2.eps>
+    <cim:GovHydro2.gv1>0</cim:GovHydro2.gv1>
+    <cim:GovHydro2.gv2>0.25</cim:GovHydro2.gv2>
+    <cim:GovHydro2.gv3>0.5</cim:GovHydro2.gv3>
+    <cim:GovHydro2.gv4>0.75</cim:GovHydro2.gv4>
+    <cim:GovHydro2.gv5>1</cim:GovHydro2.gv5>
+    <cim:GovHydro2.gv6>1.25</cim:GovHydro2.gv6>
+    <cim:GovHydro2.kturb>1</cim:GovHydro2.kturb>
+    <cim:GovHydro2.mwbase>990</cim:GovHydro2.mwbase>
+    <cim:GovHydro2.pgv1>0</cim:GovHydro2.pgv1>
+    <cim:GovHydro2.pgv2>0.25</cim:GovHydro2.pgv2>
+    <cim:GovHydro2.pgv3>0.5</cim:GovHydro2.pgv3>
+    <cim:GovHydro2.pgv4>0.75</cim:GovHydro2.pgv4>
+    <cim:GovHydro2.pgv5>1</cim:GovHydro2.pgv5>
+    <cim:GovHydro2.pgv6>1.25</cim:GovHydro2.pgv6>
+    <cim:GovHydro2.pmax>1</cim:GovHydro2.pmax>
+    <cim:GovHydro2.pmin>-1</cim:GovHydro2.pmin>
+    <cim:GovHydro2.rperm>0.05</cim:GovHydro2.rperm>
+    <cim:GovHydro2.rtemp>0.52</cim:GovHydro2.rtemp>
+    <cim:GovHydro2.tg>1</cim:GovHydro2.tg>
+    <cim:GovHydro2.tp>0.04</cim:GovHydro2.tp>
+    <cim:GovHydro2.tr>9.19</cim:GovHydro2.tr>
+    <cim:GovHydro2.tw>1.84</cim:GovHydro2.tw>
+    <cim:GovHydro2.uc>-0.2</cim:GovHydro2.uc>
+    <cim:GovHydro2.uo>0.2</cim:GovHydro2.uo>
+    <cim:IdentifiedObject.mRID>32fb9a75-5aa2-4ead-843b-8b8c0254683d</cim:IdentifiedObject.mRID>
+  </cim:GovHydro2>
+  <cim:GovHydro1 rdf:ID="_93e64753-4784-4bc0-8ba9-48eae88cce2f">
+    <cim:IdentifiedObject.name>NL-G3-GovHydro1</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_f450a965-7cfb-4516-a2bf-618f05e84eed" />
+    <cim:GovHydro1.at>1.2</cim:GovHydro1.at>
+    <cim:GovHydro1.dturb>0.3</cim:GovHydro1.dturb>
+    <cim:GovHydro1.gmax>0.75</cim:GovHydro1.gmax>
+    <cim:GovHydro1.gmin>0</cim:GovHydro1.gmin>
+    <cim:GovHydro1.hdam>1</cim:GovHydro1.hdam>
+    <cim:GovHydro1.mwbase>225</cim:GovHydro1.mwbase>
+    <cim:GovHydro1.qnl>0.08</cim:GovHydro1.qnl>
+    <cim:GovHydro1.rperm>0.05</cim:GovHydro1.rperm>
+    <cim:GovHydro1.rtemp>1.27</cim:GovHydro1.rtemp>
+    <cim:GovHydro1.tf>0.099</cim:GovHydro1.tf>
+    <cim:GovHydro1.tg>0.9</cim:GovHydro1.tg>
+    <cim:GovHydro1.tr>10.4</cim:GovHydro1.tr>
+    <cim:GovHydro1.tw>2.6</cim:GovHydro1.tw>
+    <cim:GovHydro1.velm>0.2</cim:GovHydro1.velm>
+    <cim:IdentifiedObject.mRID>93e64753-4784-4bc0-8ba9-48eae88cce2f</cim:IdentifiedObject.mRID>
+  </cim:GovHydro1>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_DL_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_DL_001.xml
@@ -1,0 +1,849 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:df1d6478-6fab-41b5-afa2-2013f393c13b">
+    <md:Model.created>2021-04-23T00:13:30Z</md:Model.created>
+    <md:Model.scenarioTime>2021-04-23T17:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/DiagramLayout-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61" />
+  </md:FullModel>
+  <cim:Diagram rdf:ID="_c4445d40-46c7-79e4-8e08-39fc0dd20916">
+    <cim:IdentifiedObject.name>NL</cim:IdentifiedObject.name>
+    <cim:Diagram.orientation rdf:resource="http://iec.ch/TC57/CIM100#OrientationKind.negative" />
+    <cim:IdentifiedObject.mRID>c4445d40-46c7-79e4-8e08-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:Diagram>
+  <cim:DiagramObject rdf:ID="_054c322e-ee5d-3865-3378-39fc0dd20916">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>054c322e-ee5d-3865-3378-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_906a6dd1-2911-dacb-ddbf-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>198</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_054c322e-ee5d-3865-3378-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_01b7a769-61bb-ab49-7a98-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_054c322e-ee5d-3865-3378-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_eea48f08-db1c-82bc-7e36-39fc0dd20916">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>eea48f08-db1c-82bc-7e36-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_801b11b5-0f12-ee20-914f-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>644</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>81.3</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_eea48f08-db1c-82bc-7e36-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_e8973193-9140-b3b9-c4ab-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>644</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>263.2603</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_eea48f08-db1c-82bc-7e36-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_03fd7cde-f0fe-8b96-5af8-39fc0dd20916">
+    <cim:IdentifiedObject.name>GR-NL-G2-2145269378</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_2844585c-0d35-488d-a449-685bcd57afbf" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>03fd7cde-f0fe-8b96-5af8-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_87ff1e6c-5242-6c2f-4ff1-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>763.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>204</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_03fd7cde-f0fe-8b96-5af8-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_6e2ec2a1-85d8-ad63-373a-39fc0dd20916">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>6e2ec2a1-85d8-ad63-373a-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_80e4cfc8-e725-cf6b-0d1c-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>140</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6e2ec2a1-85d8-ad63-373a-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_a66a0347-067a-7cfe-e4cc-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>124</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_6e2ec2a1-85d8-ad63-373a-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_ea26d030-6eb3-ccf8-f7d1-39fc0dd20916">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>ea26d030-6eb3-ccf8-f7d1-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_00cde329-7112-1083-2dff-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>250.2</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ea26d030-6eb3-ccf8-f7d1-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_0503259b-85c1-a59a-ad6a-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>240</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ea26d030-6eb3-ccf8-f7d1-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_3e0b956f-277f-0ef3-351f-39fc0dd20916">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>3e0b956f-277f-0ef3-351f-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ebe13578-c9b7-767b-673e-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>738</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>260</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3e0b956f-277f-0ef3-351f-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_f3bdfa19-d1cc-ddd0-41d4-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>738</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>175.2</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_3e0b956f-277f-0ef3-351f-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_93b2873e-21cc-29a5-af11-39fc0dd20916">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>93b2873e-21cc-29a5-af11-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_56b5b0b4-2d1f-631f-7c67-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>176.5</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_93b2873e-21cc-29a5-af11-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_eee7f1c4-44c0-65e9-7a90-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>84.5</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_93b2873e-21cc-29a5-af11-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_8d96bf69-0076-4ce5-8f31-39fc0dd20916">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>8d96bf69-0076-4ce5-8f31-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_dfbe60d4-4c85-ac63-1ee6-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>152</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8d96bf69-0076-4ce5-8f31-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_aaedb669-2361-bef9-bc66-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>170</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_8d96bf69-0076-4ce5-8f31-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e2fced6a-c2ab-b120-04dd-39fc0dd20916">
+    <cim:IdentifiedObject.name>GR-L-515371590</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>e2fced6a-c2ab-b120-04dd-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_28de42e2-e784-9c3b-91f3-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>757.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>204</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e2fced6a-c2ab-b120-04dd-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_c03e6e8c-fe57-db2f-6067-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>204</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e2fced6a-c2ab-b120-04dd-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_81b4b86c-6ee7-b2b1-b5e7-39fc0dd20916">
+    <cim:IdentifiedObject.name>none</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>81b4b86c-6ee7-b2b1-b5e7-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_f29b59d7-c63e-d64a-cc86-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>88</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_81b4b86c-6ee7-b2b1-b5e7-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_ab2baa50-a67a-93f1-16e8-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>104</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_81b4b86c-6ee7-b2b1-b5e7-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_1133b448-1950-50e4-068c-39fc0dd20916">
+    <cim:IdentifiedObject.name>GR-L-1662050064</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_6dad1a97-6874-4206-a5a5-837e495325f8" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>1133b448-1950-50e4-068c-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_91bed92a-b8f7-2a02-8ef0-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>580</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1133b448-1950-50e4-068c-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_d7c75c1c-7923-41fd-8032-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1133b448-1950-50e4-068c-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_ddd2b813-8755-9c00-2729-39fc0dd20916">
+    <cim:IdentifiedObject.name>GR-L-555535362</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f48d48c7-e9f6-460c-898f-cc68a96efdeb" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>ddd2b813-8755-9c00-2729-39fc0dd20916</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d4ad43ab-be35-0e06-ac08-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>444</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>100</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ddd2b813-8755-9c00-2729-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_5efd31c2-17c2-9d29-cefb-39fc0dd20916">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>99.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ddd2b813-8755-9c00-2729-39fc0dd20916" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_b7439380-87e7-416c-8c51-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Load_2-1412852621</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_25ab1b5b-6803-47e2-805a-ab7b2072e034" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>b7439380-87e7-416c-8c51-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_6dc1dde7-56b1-9fdd-01dd-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>583.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b7439380-87e7-416c-8c51-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_f2437fa7-d2d2-9824-533d-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XWI_GY11-246454759</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b0442899-8dbe-48c1-a1fa-adb2a5929273" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>f2437fa7-d2d2-9824-533d-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_cf5aeebe-ef12-a336-1ebc-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>447.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>100</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f2437fa7-d2d2-9824-533d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_b3c5ca66-91c2-4191-f226-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-1167564868</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f461fd2d-1e41-4a3e-8213-7cc33c77a089" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>b3c5ca66-91c2-4191-f226-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_fcbec959-6c67-755e-0b31-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>580</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>148</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b3c5ca66-91c2-4191-f226-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b656610d-c064-2dde-7a97-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>147.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b3c5ca66-91c2-4191-f226-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_dfa7b62c-6909-4edd-4307-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-95306126</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>dfa7b62c-6909-4edd-4307-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_1111d294-f4a7-c694-2e5c-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>655.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>88</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_dfa7b62c-6909-4edd-4307-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_a63c2e97-a6b4-2821-7aec-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>88</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_dfa7b62c-6909-4edd-4307-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_c6294e86-f6b9-4534-efa0-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XZE_ST23-1204585731</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_12baa3f3-23b1-44e0-956f-d331e1527f37" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>c6294e86-f6b9-4534-efa0-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ca4d8ca4-537a-a3d4-7ec3-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>445.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_c6294e86-f6b9-4534-efa0-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_1b78a880-daab-78ba-6204-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Load_1-1649810583</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_69add5b4-70bd-4360-8a93-286256c0d38b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>1b78a880-daab-78ba-6204-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_d782bc09-eb44-e1b4-f73b-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>583.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>148</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_1b78a880-daab-78ba-6204-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5064b9a6-e717-b798-6341-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-501399091</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>5064b9a6-e717-b798-6341-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_edc0e2cd-498f-98cb-2261-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>682.625</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>113.7708</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5064b9a6-e717-b798-6341-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_a627c1b9-33bb-b1da-c091-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>663.3358</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>113.7708</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5064b9a6-e717-b798-6341-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b56764b9-f9fc-1f6d-f1b4-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>663.3358</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>114.0391</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5064b9a6-e717-b798-6341-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_97f9b3bd-29d4-3afe-662c-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>114.0391</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5064b9a6-e717-b798-6341-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_fac3ef3c-c659-388a-7067-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XCA_AL11-294071078</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_83bea592-913e-4473-8d17-969968ff83a2" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>fac3ef3c-c659-388a-7067-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_72aaa60c-cc9f-c0df-fa7e-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>447.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_fac3ef3c-c659-388a-7067-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_e732e7da-a3ed-f6f9-8c3d-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-369246503</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_39d27c17-1e5b-4edc-a7ec-65a2d56542df" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>e732e7da-a3ed-f6f9-8c3d-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_f89fb799-5421-764f-4a9b-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>444</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e732e7da-a3ed-f6f9-8c3d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_5e68f659-38c0-7efc-282a-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>138.1</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_e732e7da-a3ed-f6f9-8c3d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_09034a65-66e4-d3b7-b313-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-1021375204</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_70b326a3-5913-494f-b8f8-8e366253b597" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>09034a65-66e4-d3b7-b313-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_4dc8221c-1f0a-be2c-e013-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>702.623</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>114.0501</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_09034a65-66e4-d3b7-b313-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_f0c19dcd-cdd3-967a-967f-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>720.7014</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>114.0501</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_09034a65-66e4-d3b7-b313-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_bd9c855f-d841-03be-fda4-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>720.7014</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>181.2396</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_09034a65-66e4-d3b7-b313-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_f1bf8586-cd42-7ee3-3349-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>181.2396</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_09034a65-66e4-d3b7-b313-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5357e27e-17d8-d76d-cd47-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Load_3-977005825</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_b1e03a8f-6a11-4454-af58-4a4a680e857f" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>5357e27e-17d8-d76d-cd47-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_e10cf16b-94f8-1f3c-1bc7-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>659.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>88</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5357e27e-17d8-d76d-cd47-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_141f7526-2f76-cfae-cab9-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL_TR2_3-301185911</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-89.2</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>141f7526-2f76-cfae-cab9-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_41627f14-145e-4c2e-c015-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>692.624</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>113.9105</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_141f7526-2f76-cfae-cab9-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_22c2cdda-8c7a-ba0e-dd30-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-G3-2138969859</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>22c2cdda-8c7a-ba0e-dd30-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_0831cd16-cd06-2d9e-c742-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>763.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_22c2cdda-8c7a-ba0e-dd30-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_2dd550f6-4a57-ba8e-5645-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-1994470626</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>2dd550f6-4a57-ba8e-5645-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_566cf5d0-2b9d-8ed4-b381-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>757.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2dd550f6-4a57-ba8e-5645-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_91e5ca0c-eae2-43a1-4f0b-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2dd550f6-4a57-ba8e-5645-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_2ed7581d-7d46-53c1-9b51-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-1237589049</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_24dd035c-0a8c-4351-aeb2-08d6622b42ae" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>2ed7581d-7d46-53c1-9b51-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_21da87f7-81b2-1837-3c1b-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>442</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2ed7581d-7d46-53c1-9b51-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_2c09e58e-b4aa-7f79-db03-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>213.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2ed7581d-7d46-53c1-9b51-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_fc672410-48a7-12c9-108d-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-783297209</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_faab7959-f9bf-421b-bc3f-d364e0c1388b" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>fc672410-48a7-12c9-108d-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_9d39b12e-ca0f-c520-59fb-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>759.3542</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>191.8229</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_fc672410-48a7-12c9-108d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_3f4f275c-9745-57ab-a5f4-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>191.8229</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_fc672410-48a7-12c9-108d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_291dfb83-9351-102f-4a57-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-S1-597510278</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_fbfed7e3-3dec-4829-a286-029e73535685" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>291dfb83-9351-102f-4a57-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_816954ef-5fe7-8d7b-22cf-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>581.7</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>134.4</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_291dfb83-9351-102f-4a57-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_ee7751b4-67fb-6143-da1d-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-354016970</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>ee7751b4-67fb-6143-da1d-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_ac3d4239-2978-532a-e424-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>573.9</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>134.4</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ee7751b4-67fb-6143-da1d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b08129fc-5753-2c40-2afc-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>134.6</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ee7751b4-67fb-6143-da1d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_ad033987-14ba-954a-cee5-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XZE_ST24-776682307</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_820d95d7-26d4-4311-8b1f-026f8605b86d" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>ad033987-14ba-954a-cee5-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_83ccae19-d0ae-a8cf-3f5c-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>447.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_ad033987-14ba-954a-cee5-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_93969455-4f8c-c96f-d210-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-1784331499</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_26e50b4b-9a19-420d-98ce-bc4f11971cd7" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>93969455-4f8c-c96f-d210-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_efef88ce-edff-80ee-2813-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>444</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>248</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_93969455-4f8c-c96f-d210-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_c5ada1da-6847-a234-2601-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>247.9</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_93969455-4f8c-c96f-d210-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_2e36cf89-e1a5-ac98-44fb-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-G1-1723743043</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>2e36cf89-e1a5-ac98-44fb-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_49feb11b-8712-7024-b4ac-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>765.3542</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>191.8229</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_2e36cf89-e1a5-ac98-44fb-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_b2aa5fc3-11ce-ce1f-b25e-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-1101624851</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_f970233f-b573-49d9-9fc3-3a2a59ed3bbb" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>b2aa5fc3-11ce-ce1f-b25e-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_b92a3d39-0a71-4c03-9cf3-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>444</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b2aa5fc3-11ce-ce1f-b25e-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_4d6c696f-4623-60df-b894-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>438</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b2aa5fc3-11ce-ce1f-b25e-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5722e896-ce81-05c8-7327-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Inj-XKA_MA11-875136959</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-90</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_cab82e1c-1435-447b-bba0-74b592539eac" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>5722e896-ce81-05c8-7327-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_9f12c391-f8b3-324d-bb17-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>447.8</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>166</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5722e896-ce81-05c8-7327-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_20552fa2-79d8-194d-887f-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL_TR2_2-1846944073</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-89.8</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>20552fa2-79d8-194d-887f-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_12172ce9-c829-1fd5-1ae4-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>688</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_20552fa2-79d8-194d-887f-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_126a2f5f-16b5-a678-adc1-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Line_1-1060868737</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>126a2f5f-16b5-a678-adc1-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_e9935589-902d-cf2c-7b57-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>567.7958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>129.6451</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_126a2f5f-16b5-a678-adc1-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_3d6afc51-69de-132e-56a6-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>130</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_126a2f5f-16b5-a678-adc1-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_0cf095d2-e8ef-1a2a-908a-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-1283714213</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>0cf095d2-e8ef-1a2a-908a-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_2c37c6bd-d9c8-5c16-b328-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>594</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0cf095d2-e8ef-1a2a-908a-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_65968f71-a1c7-8794-0864-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>568</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_0cf095d2-e8ef-1a2a-908a-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_f375ea76-1ff0-b98f-8ed1-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-TR2_1-716034994</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>-89.5</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>f375ea76-1ff0-b98f-8ed1-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_806dda36-b158-8336-ec8d-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>604</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116.1</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_f375ea76-1ff0-b98f-8ed1-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_b7101d05-8205-86dd-0a8f-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Line_4-991600420</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>b7101d05-8205-86dd-0a8f-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_509ebe3f-e670-094e-f34b-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>214.3137</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b7101d05-8205-86dd-0a8f-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_dd18323c-0651-bacb-22f0-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.2473</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_b7101d05-8205-86dd-0a8f-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_07dacec2-d781-51a8-949d-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Line_2-611933023</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>07dacec2-d781-51a8-949d-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_9367476c-7123-4da3-ddc7-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>567.7958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>157.4271</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_07dacec2-d781-51a8-949d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_71f42348-264e-b305-e35e-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>157.4271</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_07dacec2-d781-51a8-949d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_73b382bd-4530-aa1e-1c71-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-727304126</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_421c7930-64c3-435d-afb8-2bb73b333e34" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>73b382bd-4530-aa1e-1c71-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_2080db8f-29fd-5aca-6d42-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>678.0001</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.9651</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_73b382bd-4530-aa1e-1c71-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_b3d0f18f-977c-94a7-5b0a-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>661.1736</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.9651</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_73b382bd-4530-aa1e-1c71-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_8c1359bb-dc2b-1dc1-afeb-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>661.1736</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>206.375</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_73b382bd-4530-aa1e-1c71-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_5793b158-d715-7d8f-cdc6-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>206.375</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_73b382bd-4530-aa1e-1c71-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_5216fcbb-ae41-0432-149c-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Line_3-1037345008</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>5216fcbb-ae41-0432-149c-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_e739b383-0ed0-f242-5327-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>243.4174</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5216fcbb-ae41-0432-149c-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_86d12902-2a50-e5ee-a510-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>244</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_5216fcbb-ae41-0432-149c-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_614a1865-d3fc-dec1-37b7-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-1818655306</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>614a1865-d3fc-dec1-37b7-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_6401095c-1311-35d8-9df5-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>613.9996</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116.1873</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_614a1865-d3fc-dec1-37b7-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_4352c397-a972-b7a1-eccb-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>643.9958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>116</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_614a1865-d3fc-dec1-37b7-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_52088c0d-7ac2-de5b-001d-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-NL-Line_5-786913105</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>52088c0d-7ac2-de5b-001d-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_c2535903-e784-f7f6-5f5c-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>567.7958</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>93.92693</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_52088c0d-7ac2-de5b-001d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_9438334c-12c8-146f-eb0f-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>437.8854</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>94</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_52088c0d-7ac2-de5b-001d-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObject rdf:ID="_29b6ed59-98c2-c3a9-e4d3-39fc0dd20917">
+    <cim:IdentifiedObject.name>GR-L-1280564080</cim:IdentifiedObject.name>
+    <cim:DiagramObject.rotation>0</cim:DiagramObject.rotation>
+    <cim:DiagramObject.IdentifiedObject rdf:resource="#_31bf04d0-7e34-465b-95a4-0604700325cf" />
+    <cim:DiagramObject.Diagram rdf:resource="#_c4445d40-46c7-79e4-8e08-39fc0dd20916" />
+    <cim:IdentifiedObject.mRID>29b6ed59-98c2-c3a9-e4d3-39fc0dd20917</cim:IdentifiedObject.mRID>
+  </cim:DiagramObject>
+  <cim:DiagramObjectPoint rdf:ID="_5b76c7d2-6a98-d34a-fb54-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>1</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>697.9999</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216.0349</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_29b6ed59-98c2-c3a9-e4d3-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_0ce43782-5f82-2691-2a90-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>2</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>717.9335</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>216.0349</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_29b6ed59-98c2-c3a9-e4d3-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_76057ba9-f6e1-1cb7-d191-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>3</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>717.9335</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_29b6ed59-98c2-c3a9-e4d3-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+  <cim:DiagramObjectPoint rdf:ID="_43cafbe8-42bd-e120-5edb-39fc0dd20917">
+    <cim:DiagramObjectPoint.sequenceNumber>4</cim:DiagramObjectPoint.sequenceNumber>
+    <cim:DiagramObjectPoint.xPosition>737.9229</cim:DiagramObjectPoint.xPosition>
+    <cim:DiagramObjectPoint.yPosition>215.6354</cim:DiagramObjectPoint.yPosition>
+    <cim:DiagramObjectPoint.DiagramObject rdf:resource="#_29b6ed59-98c2-c3a9-e4d3-39fc0dd20917" />
+  </cim:DiagramObjectPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_EQ_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_EQ_001.xml
@@ -1,0 +1,1874 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:536f9bf1-3f8f-a546-87e3-7af2272f29b7" />
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/3.0</md:Model.profile>
+  </md:FullModel>
+  <cim:LoadArea rdf:ID="_70c4656c-f7a0-4319-98bb-84fb5e2e9b37">
+    <cim:IdentifiedObject.name>NL LoadArea</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>70c4656c-f7a0-4319-98bb-84fb5e2e9b37</cim:IdentifiedObject.mRID>
+  </cim:LoadArea>
+  <cim:SubLoadArea rdf:ID="_c4e8eb3a-76b0-4192-91fe-c2f0a60af0df">
+    <cim:IdentifiedObject.name>TENNET TSO B.V. SubLoadArea</cim:IdentifiedObject.name>
+    <cim:SubLoadArea.LoadArea rdf:resource="#_70c4656c-f7a0-4319-98bb-84fb5e2e9b37" />
+    <cim:IdentifiedObject.mRID>c4e8eb3a-76b0-4192-91fe-c2f0a60af0df</cim:IdentifiedObject.mRID>
+  </cim:SubLoadArea>
+  <cim:GeographicalRegion rdf:ID="_efc79870-d704-485e-a37b-0cf2e8e7657b">
+    <cim:IdentifiedObject.name>NL</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>efc79870-d704-485e-a37b-0cf2e8e7657b</cim:IdentifiedObject.mRID>
+  </cim:GeographicalRegion>
+  <cim:SubGeographicalRegion rdf:ID="_e58fc3bf-8c9f-450d-b3f7-9a1d19bd3bb4">
+    <cim:IdentifiedObject.name>TENNET TSO B.V.</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_efc79870-d704-485e-a37b-0cf2e8e7657b" />
+    <cim:IdentifiedObject.mRID>e58fc3bf-8c9f-450d-b3f7-9a1d19bd3bb4</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_c49942d6-8b01-4b01-b5e8-f1180f84906c">
+    <cim:IdentifiedObject.name>PP_Amsterdam</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PP_Amsterdam</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_e58fc3bf-8c9f-450d-b3f7-9a1d19bd3bb4" />
+    <cim:IdentifiedObject.mRID>c49942d6-8b01-4b01-b5e8-f1180f84906c</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+  <cim:VoltageLevel rdf:ID="_d77b61ef-61aa-4b22-95f6-b56ca080788d">
+    <cim:IdentifiedObject.name>220.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>242</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>198</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:IdentifiedObject.mRID>d77b61ef-61aa-4b22-95f6-b56ca080788d</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_cae57656-3fc2-4f5e-9ab9-fa5b118a632a">
+    <cim:IdentifiedObject.name>NL-Busbar_2</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>NL-B_2</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_d77b61ef-61aa-4b22-95f6-b56ca080788d" />
+    <cim:IdentifiedObject.mRID>cae57656-3fc2-4f5e-9ab9-fa5b118a632a</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a">
+    <cim:IdentifiedObject.name>NL-Busbar_2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d77b61ef-61aa-4b22-95f6-b56ca080788d" />
+    <cim:IdentifiedObject.mRID>143aa0b1-2cd4-4e58-98d4-b0438bd5a39a</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_50f00b94-fe0f-48fd-887e-f0d4d59eee87">
+    <cim:IdentifiedObject.name>NL-Busbar_2_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>50f00b94-fe0f-48fd-887e-f0d4d59eee87</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3">
+    <cim:IdentifiedObject.name>400.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>440</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>360</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:IdentifiedObject.mRID>b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_90f78705-5ef4-479a-8d5a-70efc554e0ba">
+    <cim:IdentifiedObject.name>NL-_Busbar_1</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>NL-_B_1</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:IdentifiedObject.mRID>90f78705-5ef4-479a-8d5a-70efc554e0ba</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:VoltageLevel rdf:ID="_8d8a82ba-b5b0-4e94-861a-192af055f2b8">
+    <cim:IdentifiedObject.name>15.8</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>17.325</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>14.175</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_abb2348a-aa10-446f-9f5d-49f93f211535" />
+    <cim:IdentifiedObject.mRID>8d8a82ba-b5b0-4e94-861a-192af055f2b8</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_124b9180-9112-4b8a-a651-9c1bb9a031da">
+    <cim:IdentifiedObject.name>NL-Busbar_3</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>NL-B_3</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:IdentifiedObject.mRID>124b9180-9112-4b8a-a651-9c1bb9a031da</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_53da4025-9d51-4eaf-b0d2-ce27fbe740d2">
+    <cim:IdentifiedObject.name>NL-Busbar_3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:IdentifiedObject.mRID>53da4025-9d51-4eaf-b0d2-ce27fbe740d2</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_0f199d49-0093-4b51-b357-70371424d174">
+    <cim:IdentifiedObject.name>NL-Busbar_3_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_53da4025-9d51-4eaf-b0d2-ce27fbe740d2" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>0f199d49-0093-4b51-b357-70371424d174</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:EquivalentInjection rdf:ID="_b0442899-8dbe-48c1-a1fa-adb2a5929273">
+    <cim:IdentifiedObject.name>NL-Inj-XWI_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XWI_GY1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>b0442899-8dbe-48c1-a1fa-adb2a5929273</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_12baa3f3-23b1-44e0-956f-d331e1527f37">
+    <cim:IdentifiedObject.name>NL-Inj-XZE_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>12baa3f3-23b1-44e0-956f-d331e1527f37</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_83bea592-913e-4473-8d17-969968ff83a2">
+    <cim:IdentifiedObject.name>NL-Inj-XCA_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XCA_AL1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>83bea592-913e-4473-8d17-969968ff83a2</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_820d95d7-26d4-4311-8b1f-026f8605b86d">
+    <cim:IdentifiedObject.name>NL-Inj-XZE_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>820d95d7-26d4-4311-8b1f-026f8605b86d</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_cab82e1c-1435-447b-bba0-74b592539eac">
+    <cim:IdentifiedObject.name>NL-Inj-XKA_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-I-XKA_MA1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>cab82e1c-1435-447b-bba0-74b592539eac</cim:IdentifiedObject.mRID>
+  </cim:EquivalentInjection>
+  <cim:ACLineSegment rdf:ID="_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc">
+    <cim:IdentifiedObject.name>NL-Line_5</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000118</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>NL-L_5</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:Conductor.length>35</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0.01099557</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>6.48739E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>3.5E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>3.5E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.42</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>1.26</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>6.3</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>18.9</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_a2c3d48f-d768-4e1e-8841-6e9c4913f11f">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_5 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_757d4f50-707b-47a0-891c-cbaefd649631" />
+    <cim:IdentifiedObject.mRID>a2c3d48f-d768-4e1e-8841-6e9c4913f11f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_47545df1-566d-4a8d-86e8-882655c6e79e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2c3d48f-d768-4e1e-8841-6e9c4913f11f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>47545df1-566d-4a8d-86e8-882655c6e79e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_08ad0781-b65c-4f2e-b5ba-00d58bcf2e58">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2c3d48f-d768-4e1e-8841-6e9c4913f11f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>08ad0781-b65c-4f2e-b5ba-00d58bcf2e58</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_5 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_ae588863-b154-451d-978a-7ab08ac50fb6" />
+    <cim:IdentifiedObject.mRID>b4d8f5e2-7b7a-45eb-b65a-252843d6acf4</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_56105225-1754-40da-b6df-43fd7cfeb50a">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>56105225-1754-40da-b6df-43fd7cfeb50a</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_86764bf6-6472-4ebe-9d6b-bcceffe66dad">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>86764bf6-6472-4ebe-9d6b-bcceffe66dad</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_dad02278-bd25-476f-8f58-dbe44be72586">
+    <cim:IdentifiedObject.name>NL-Line_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>tie line BE-NL</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:Conductor.length>40</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.51327E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>4E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>4E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>2.32</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>6.96</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>20.24</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>60.72</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>dad02278-bd25-476f-8f58-dbe44be72586</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_7cf4108d-d355-48f5-8556-d42c37a8e2c8">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_8f308117-8bbd-4798-b145-4e78f7d049e7" />
+    <cim:IdentifiedObject.mRID>7cf4108d-d355-48f5-8556-d42c37a8e2c8</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_7cfff021-02d4-4aa1-8fe7-b9af9c1fdc44">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7cf4108d-d355-48f5-8556-d42c37a8e2c8" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1371</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>7cfff021-02d4-4aa1-8fe7-b9af9c1fdc44</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_d7422ce6-a13d-41ca-8111-9462b2e789dc">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7cf4108d-d355-48f5-8556-d42c37a8e2c8" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>d7422ce6-a13d-41ca-8111-9462b2e789dc</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_13ee714f-6df4-4039-8519-5cf4e84ab20d">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_c557146e-dfc4-4020-9738-d592b188338b" />
+    <cim:IdentifiedObject.mRID>13ee714f-6df4-4039-8519-5cf4e84ab20d</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2b05a185-07f6-4e72-a2c3-d28425c7aefc">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_13ee714f-6df4-4039-8519-5cf4e84ab20d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1371</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2b05a185-07f6-4e72-a2c3-d28425c7aefc</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_6fd8188f-65a6-4473-b8f1-ffe6122ba6ab">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_13ee714f-6df4-4039-8519-5cf4e84ab20d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>6fd8188f-65a6-4473-b8f1-ffe6122ba6ab</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_8fdc7abd-3746-481a-a65e-3df56acd8b13">
+    <cim:IdentifiedObject.name>NL-Line_4</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>NL-L_4</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>22</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>4.35425E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>8.98495E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>2.42E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>2.42E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>2.2</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>6.6</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>66</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>198</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>8fdc7abd-3746-481a-a65e-3df56acd8b13</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_03943678-b63e-44d8-bc7d-9461da496268">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_4 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_57979d14-d1d8-4311-ae53-aa8890423885" />
+    <cim:IdentifiedObject.mRID>03943678-b63e-44d8-bc7d-9461da496268</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2f424b90-a264-4592-8854-9838596c9f78">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_03943678-b63e-44d8-bc7d-9461da496268" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2f424b90-a264-4592-8854-9838596c9f78</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_89ef40fb-5d77-45cb-8073-cc2d1d171dcd">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_03943678-b63e-44d8-bc7d-9461da496268" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>89ef40fb-5d77-45cb-8073-cc2d1d171dcd</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_37cc4210-71c0-4328-a86b-df0f65e76ef4">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_4 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_653bc4b8-518b-4adc-9d68-012fb641fb1d" />
+    <cim:IdentifiedObject.mRID>37cc4210-71c0-4328-a86b-df0f65e76ef4</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_b35893b0-22d4-4127-9351-9c46fba6059b">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_37cc4210-71c0-4328-a86b-df0f65e76ef4" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>b35893b0-22d4-4127-9351-9c46fba6059b</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b780341b-7b90-498f-ab63-9deb16eff206">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_37cc4210-71c0-4328-a86b-df0f65e76ef4" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>b780341b-7b90-498f-ab63-9deb16eff206</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_7f43f508-2496-4b64-9146-0a40406cbe49">
+    <cim:IdentifiedObject.name>NL-Line_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000118</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>NL-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:Conductor.length>30</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0.00015</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0.0001413717</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>3E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>3E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.02</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.06</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>12</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>36</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>7f43f508-2496-4b64-9146-0a40406cbe49</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_79a1fb3a-a66a-468c-8c78-c25714c73eba">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3" />
+    <cim:IdentifiedObject.mRID>79a1fb3a-a66a-468c-8c78-c25714c73eba</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_1b65a297-4735-499f-8fe8-f08ea01b291f">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_79a1fb3a-a66a-468c-8c78-c25714c73eba" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>1b65a297-4735-499f-8fe8-f08ea01b291f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_5bc43480-4543-4193-8b0e-7ba7bf5b3441">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_79a1fb3a-a66a-468c-8c78-c25714c73eba" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>5bc43480-4543-4193-8b0e-7ba7bf5b3441</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_125eeb58-1c45-41b2-a981-7d5993b40cda">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d" />
+    <cim:IdentifiedObject.mRID>125eeb58-1c45-41b2-a981-7d5993b40cda</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_26069582-0f76-47fb-8bc0-44c99fb08887">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_125eeb58-1c45-41b2-a981-7d5993b40cda" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>26069582-0f76-47fb-8bc0-44c99fb08887</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2783b836-4271-4252-96a7-588c3a1b1826">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_125eeb58-1c45-41b2-a981-7d5993b40cda" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2783b836-4271-4252-96a7-588c3a1b1826</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_a279a3dc-550b-426c-af3a-61b7be508dcc">
+    <cim:IdentifiedObject.name>NL-Line_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>NL-L_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>23</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>4.55217E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.02319E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>2.3E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>2.3E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>5.06</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>15.18</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>69</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>207</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>a279a3dc-550b-426c-af3a-61b7be508dcc</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_14e9e317-a168-44a2-82ef-7c76190108a2">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_6aecb9ba-5835-4b70-89bc-96d687e45779" />
+    <cim:IdentifiedObject.mRID>14e9e317-a168-44a2-82ef-7c76190108a2</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_03287f0c-5562-4533-be7f-2fb40e1888f5">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>2000</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>03287f0c-5562-4533-be7f-2fb40e1888f5</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_84c93dae-4254-4b24-b0ee-3fc4bdf1ea02">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>84c93dae-4254-4b24-b0ee-3fc4bdf1ea02</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_9a03e8ee-e832-43c8-b38e-0d43f8ef7355">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10" />
+    <cim:IdentifiedObject.mRID>9a03e8ee-e832-43c8-b38e-0d43f8ef7355</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_c743cfb3-8279-4721-9eee-12020dd89f64">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>2000</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>c743cfb3-8279-4721-9eee-12020dd89f64</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_8eb25188-24dd-4f6e-97d9-b7b03c49454e">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_bf2a4896-2e92-465b-b5f9-b033993a31c8" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>8eb25188-24dd-4f6e-97d9-b7b03c49454e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ConformLoad rdf:ID="_25ab1b5b-6803-47e2-805a-ab7b2072e034">
+    <cim:IdentifiedObject.name>NL-Load_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Electrabel</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_113fa6bb-c406-44a1-b9b7-67c43efe8372" />
+    <cim:IdentifiedObject.mRID>25ab1b5b-6803-47e2-805a-ab7b2072e034</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoadGroup rdf:ID="_113fa6bb-c406-44a1-b9b7-67c43efe8372">
+    <cim:IdentifiedObject.name>TENNET TSO B.V.confLoadGr</cim:IdentifiedObject.name>
+    <cim:LoadGroup.SubLoadArea rdf:resource="#_c4e8eb3a-76b0-4192-91fe-c2f0a60af0df" />
+    <cim:IdentifiedObject.mRID>113fa6bb-c406-44a1-b9b7-67c43efe8372</cim:IdentifiedObject.mRID>
+  </cim:ConformLoadGroup>
+  <cim:ConformLoad rdf:ID="_69add5b4-70bd-4360-8a93-286256c0d38b">
+    <cim:IdentifiedObject.name>NL-Load_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Apple</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_113fa6bb-c406-44a1-b9b7-67c43efe8372" />
+    <cim:IdentifiedObject.mRID>69add5b4-70bd-4360-8a93-286256c0d38b</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:ID="_b1e03a8f-6a11-4454-af58-4a4a680e857f">
+    <cim:IdentifiedObject.name>NL-Load_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Siemens</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-L_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d77b61ef-61aa-4b22-95f6-b56ca080788d" />
+    <cim:EnergyConsumer.LoadResponse rdf:resource="#_7a797ed8-c370-47cf-83df-16c40f8fff69" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_113fa6bb-c406-44a1-b9b7-67c43efe8372" />
+    <cim:IdentifiedObject.mRID>b1e03a8f-6a11-4454-af58-4a4a680e857f</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:LoadResponseCharacteristic rdf:ID="_7a797ed8-c370-47cf-83df-16c40f8fff69">
+    <cim:IdentifiedObject.name>NL-Load_3</cim:IdentifiedObject.name>
+    <cim:LoadResponseCharacteristic.exponentModel>false</cim:LoadResponseCharacteristic.exponentModel>
+    <cim:LoadResponseCharacteristic.pConstantCurrent>0.2</cim:LoadResponseCharacteristic.pConstantCurrent>
+    <cim:LoadResponseCharacteristic.pConstantImpedance>0</cim:LoadResponseCharacteristic.pConstantImpedance>
+    <cim:LoadResponseCharacteristic.pConstantPower>0.8</cim:LoadResponseCharacteristic.pConstantPower>
+    <cim:LoadResponseCharacteristic.qConstantCurrent>0.3</cim:LoadResponseCharacteristic.qConstantCurrent>
+    <cim:LoadResponseCharacteristic.qConstantImpedance>0</cim:LoadResponseCharacteristic.qConstantImpedance>
+    <cim:LoadResponseCharacteristic.qConstantPower>0.7</cim:LoadResponseCharacteristic.qConstantPower>
+    <cim:IdentifiedObject.mRID>7a797ed8-c370-47cf-83df-16c40f8fff69</cim:IdentifiedObject.mRID>
+  </cim:LoadResponseCharacteristic>
+  <cim:LinearShuntCompensator rdf:ID="_fbfed7e3-3dec-4829-a286-029e73535685">
+    <cim:IdentifiedObject.name>NL-S1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>shunt</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-S1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_613dfeb3-0161-4cec-aaa9-ccddd885771b" />
+    <cim:ShuntCompensator.grounded>true</cim:ShuntCompensator.grounded>
+    <cim:ShuntCompensator.maximumSections>1</cim:ShuntCompensator.maximumSections>
+    <cim:ShuntCompensator.nomU>400</cim:ShuntCompensator.nomU>
+    <cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+    <cim:LinearShuntCompensator.b0PerSection>0</cim:LinearShuntCompensator.b0PerSection>
+    <cim:LinearShuntCompensator.bPerSection>0.000313</cim:LinearShuntCompensator.bPerSection>
+    <cim:LinearShuntCompensator.g0PerSection>0</cim:LinearShuntCompensator.g0PerSection>
+    <cim:LinearShuntCompensator.gPerSection>0</cim:LinearShuntCompensator.gPerSection>
+    <cim:IdentifiedObject.mRID>fbfed7e3-3dec-4829-a286-029e73535685</cim:IdentifiedObject.mRID>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:ID="_613dfeb3-0161-4cec-aaa9-ccddd885771b">
+    <cim:IdentifiedObject.name>NL-S1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_757d4f50-707b-47a0-891c-cbaefd649631" />
+    <cim:IdentifiedObject.mRID>613dfeb3-0161-4cec-aaa9-ccddd885771b</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:ID="_1dc9afba-23b5-41a0-8540-b479ed8baf4b">
+    <cim:IdentifiedObject.name>NL-G3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-G3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:RotatingMachine.ratedPowerFactor>0.9</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>250</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>15.75</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_b850063d-eae7-4675-bc98-4642d3076783" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>200</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>0</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.2</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>1.9</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.13</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.17</cim:SynchronousMachine.x2>
+    <cim:IdentifiedObject.mRID>1dc9afba-23b5-41a0-8540-b479ed8baf4b</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_b850063d-eae7-4675-bc98-4642d3076783">
+    <cim:IdentifiedObject.name>Gen-12908</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>250</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>130</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>225</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>b850063d-eae7-4675-bc98-4642d3076783</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_9c3b8f97-7972-477d-9dc8-87365cc0ad0e">
+    <cim:IdentifiedObject.name>NL-G1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-G1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_04f338d3-3c0d-433f-a77b-e36dd256f0f0" />
+    <cim:RotatingMachine.ratedPowerFactor>0.9</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>1100</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>15.75</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_049438a6-780a-44fe-a788-ebe385d98e25" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>600</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>0</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.21</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>1.9</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries2" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.11</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.18</cim:SynchronousMachine.x2>
+    <cim:IdentifiedObject.mRID>9c3b8f97-7972-477d-9dc8-87365cc0ad0e</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_049438a6-780a-44fe-a788-ebe385d98e25">
+    <cim:IdentifiedObject.name>Gen-12923</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>1000</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>300</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>990</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>049438a6-780a-44fe-a788-ebe385d98e25</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_2844585c-0d35-488d-a449-685bcd57afbf">
+    <cim:IdentifiedObject.name>NL-G2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-G2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:RotatingMachine.ratedPowerFactor>0.9</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>250</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>15.75</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_ca80ee09-3bed-4884-bc28-6dc89d067289" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>200</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>0</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.18</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>1.8</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries2" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.1</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.16</cim:SynchronousMachine.x2>
+    <cim:IdentifiedObject.mRID>2844585c-0d35-488d-a449-685bcd57afbf</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_ca80ee09-3bed-4884-bc28-6dc89d067289">
+    <cim:IdentifiedObject.name>Gen-12910</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>250</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>130</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>225</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>ca80ee09-3bed-4884-bc28-6dc89d067289</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:PowerTransformer rdf:ID="_2184f365-8cd5-4b5d-8a28-9d68603bb6a4">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>2184f365-8cd5-4b5d-8a28-9d68603bb6a4</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_0dbed103-fc51-4df4-a6fa-0dee4c57f3a3">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_421c7930-64c3-435d-afb8-2bb73b333e34" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:PowerTransformerEnd.b>-0.0001420227</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>1.81818E-05</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.069143</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.069143</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>1260</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.377333</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.377333</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:IdentifiedObject.mRID>0dbed103-fc51-4df4-a6fa-0dee4c57f3a3</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_41ca9e70-1cb4-4971-b8e6-a97a15580b89">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_31bf04d0-7e34-465b-95a4-0604700325cf" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_abb2348a-aa10-446f-9f5d-49f93f211535" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>1260</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>15.75</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:IdentifiedObject.mRID>41ca9e70-1cb4-4971-b8e6-a97a15580b89</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PhaseTapChangerTabular rdf:ID="_ee649b97-d2ec-47e1-976f-0f4d9f50fa11">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>0</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>17</cim:TapChanger.normalStep>
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_0dbed103-fc51-4df4-a6fa-0dee4c57f3a3" />
+    <cim:PhaseTapChangerTabular.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+    <cim:IdentifiedObject.mRID>ee649b97-d2ec-47e1-976f-0f4d9f50fa11</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerTabular>
+  <cim:PhaseTapChangerTable rdf:ID="_50c903e2-ecbb-41b8-9a1d-746543c9b63f">
+    <cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>50c903e2-ecbb-41b8-9a1d-746543c9b63f</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerTable>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_cb816a07-f79f-4eed-a279-2ad2ca435f91">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9200159</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>0</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.07682406</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_0c329ca6-c05a-416b-a919-885fd4860566">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9250145</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>1</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.07163366</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_301ffe68-fcb9-455f-8c4e-7280943667a4">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.930013</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>2</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.06649923</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_0bc0a45a-f196-430e-b5ac-37c39188a7ce">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9350125</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>3</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.0614186</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_6b03ed33-44a4-4fe6-a806-a0e76733304a">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.940011</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>4</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.05639308</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_febed19f-d33a-44fb-add3-4b10dcfee64c">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9450097</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>5</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.05142054</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_675f4994-9544-4634-9dae-7b8b2abdfef0">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9500085</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>6</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.04650027</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_daec57cc-6f98-44af-8645-afcfec90aa5f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9550072</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>7</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.04163161</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_53bd73f5-902c-4497-80d8-3707c90b7dcc">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9600061</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>8</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.03681348</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_cbdffa42-3eea-46aa-8e90-1de1c205fc71">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9650059</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>9</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.03204435</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_f0f5143d-5e04-4fcd-bdb7-1d2d46c604ef">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9700048</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>10</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.02732521</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_0761805f-8d0c-4a83-aec6-d3bd978097d8">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9750037</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>11</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.02265452</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_80f45cfb-a123-4438-aa1d-88fd63ed8ee4">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9800025</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>12</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.01803153</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_03c2b90a-162e-44b4-901f-ad3bc40fb95f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9850017</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>13</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.01345523</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_9b32f407-183b-4ddc-b213-d0eccf796455">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9900017</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>14</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.008924291</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_6bd09407-16dd-4ecb-b504-2ddb1db3b3df">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.9950009</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>15</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>-0.004439676</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_74414256-fc15-42a0-85f5-8c231863c9c6">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>16</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_60b1dbda-df22-4212-b495-f19200ef6458">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.004999</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>17</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.004395567</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_5e6588fe-5d2c-4715-b746-a02b2710ad2d">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.009998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>18</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.008747523</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_2e3a7427-0dd9-498d-853f-3269e02105f6">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.014998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>19</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.01305754</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_39b3ec77-b0b6-4a15-bc2b-36e752af54c4">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.019998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>20</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.01732449</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_9679897d-56e5-4910-9263-5a9a50c7a8c4">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.024997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>21</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.02154983</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_9a754a67-532f-4917-a6dd-6436b22b9a17">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.029998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>22</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.02573574</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_1118a9c0-cf20-45eb-a539-561e76fde2e2">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.034997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>23</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.02987964</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_105bd87e-1212-482f-aa64-376f3b0024b5">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.039997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>24</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.03398448</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_e2befe6d-07e5-48d1-8315-577bc038a827">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.044997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>25</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.03804918</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_369c3ab7-cb8c-418d-bdf0-9aa88af7e238">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.049997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>26</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.04207603</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_93e330b4-16de-40e4-b084-6f20646fa161">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.054996</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>27</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.04606397</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_749f4bc4-bfdb-4bda-8124-21b97e76f9df">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.059995</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>28</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.05001429</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_06aa2535-8010-4424-a97c-3a48b0aafec5">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.064998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>29</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.05392985</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_7d8fe4bf-94a9-4e2b-a90f-1271bdd99325">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.069997</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>30</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.05780642</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_d1b48f8e-2f5c-45e5-8446-79a6604d3c8a">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.074996</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>31</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.06164702</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_b3c7dd07-c19a-4532-b212-27775264884f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.079996</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>32</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.0654528</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:PhaseTapChangerTablePoint rdf:ID="_df448145-8fef-4e66-93c2-b7f00a4ef857">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.084998</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>33</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>0</cim:TapChangerTablePoint.x>
+    <cim:PhaseTapChangerTablePoint.angle>0.06922422</cim:PhaseTapChangerTablePoint.angle>
+    <cim:PhaseTapChangerTablePoint.PhaseTapChangerTable rdf:resource="#_50c903e2-ecbb-41b8-9a1d-746543c9b63f" />
+  </cim:PhaseTapChangerTablePoint>
+  <cim:OperationalLimitSet rdf:ID="_e7c1b1c7-aaeb-470a-9cb5-93a3ec269179">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_421c7930-64c3-435d-afb8-2bb73b333e34" />
+    <cim:IdentifiedObject.mRID>e7c1b1c7-aaeb-470a-9cb5-93a3ec269179</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_6745e040-9fd4-4cc5-8bfd-902d0aed4ee6">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e7c1b1c7-aaeb-470a-9cb5-93a3ec269179" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>3306.644</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>6745e040-9fd4-4cc5-8bfd-902d0aed4ee6</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_261d13c4-1527-42a5-ad0d-a3b817971166">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_31bf04d0-7e34-465b-95a4-0604700325cf" />
+    <cim:IdentifiedObject.mRID>261d13c4-1527-42a5-ad0d-a3b817971166</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_12f7803a-c65b-4a14-8c0d-7e52becb5772">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_261d13c4-1527-42a5-ad0d-a3b817971166" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>46188.04</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>12f7803a-c65b-4a14-8c0d-7e52becb5772</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_e8a7eaec-51d6-4571-b3d9-c36d52073c33">
+    <cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>new transformer in 2015</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>e8a7eaec-51d6-4571-b3d9-c36d52073c33</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_c614f321-2c88-4fa3-b98a-8ec3cde73db4">
+    <cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:PowerTransformerEnd.b>-4.4445E-06</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>5.625E-07</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>1.35</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>1.35</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>320</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>27.96744</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>27.96744</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:IdentifiedObject.mRID>c614f321-2c88-4fa3-b98a-8ec3cde73db4</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_0dec3883-a2b6-4353-83cc-d4dd5df513a6">
+    <cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>320</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:IdentifiedObject.mRID>0dec3883-a2b6-4353-83cc-d4dd5df513a6</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PhaseTapChangerLinear rdf:ID="_341327c4-9224-40bf-bc33-7a3bb0bae680">
+    <cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>20</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>-20</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>0</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>400</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>8</cim:TapChanger.normalStep>
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_c614f321-2c88-4fa3-b98a-8ec3cde73db4" />
+    <cim:PhaseTapChangerLinear.stepPhaseShiftIncrement>-2</cim:PhaseTapChangerLinear.stepPhaseShiftIncrement>
+    <cim:PhaseTapChangerLinear.xMax>29.7154</cim:PhaseTapChangerLinear.xMax>
+    <cim:PhaseTapChangerLinear.xMin>27.96744</cim:PhaseTapChangerLinear.xMin>
+    <cim:IdentifiedObject.mRID>341327c4-9224-40bf-bc33-7a3bb0bae680</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerLinear>
+  <cim:OperationalLimitSet rdf:ID="_d47a27cc-9fad-40f2-a08c-37e545c268df">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-TR2_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0" />
+    <cim:IdentifiedObject.mRID>d47a27cc-9fad-40f2-a08c-37e545c268df</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_ef715edd-516e-4bfd-adc4-1c882852920e">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d47a27cc-9fad-40f2-a08c-37e545c268df" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>839.7826</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>ef715edd-516e-4bfd-adc4-1c882852920e</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_83f719ad-2083-44ea-9ebc-9f456c114bdb">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL-TR2_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f" />
+    <cim:IdentifiedObject.mRID>83f719ad-2083-44ea-9ebc-9f456c114bdb</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e37ee101-2f68-4d55-b24f-c24c5faba8b5">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_83f719ad-2083-44ea-9ebc-9f456c114bdb" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>461.8804</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>e37ee101-2f68-4d55-b24f-c24c5faba8b5</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_80016742-31b3-432a-b00a-300667a1e572">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>out of service in 2020</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>80016742-31b3-432a-b00a-300667a1e572</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_f3600241-63dc-485b-aefb-4ec24028f8b3">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:PowerTransformerEnd.b>-0.0001420227</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>1.81818E-05</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.065302</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.069143</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>1260</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.377381</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.377333</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:IdentifiedObject.mRID>f3600241-63dc-485b-aefb-4ec24028f8b3</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_4df90339-ae02-4da1-8e1e-69ab068df065">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_70b326a3-5913-494f-b8f8-8e366253b597" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_abb2348a-aa10-446f-9f5d-49f93f211535" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>1260</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>15.75</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:IdentifiedObject.mRID>4df90339-ae02-4da1-8e1e-69ab068df065</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:RatioTapChanger rdf:ID="_44b4277a-0f4b-43a8-ad93-6f7d6ef02061">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>15</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>-15</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>0</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>5</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.stepVoltageIncrement>0.5500001</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_f3600241-63dc-485b-aefb-4ec24028f8b3" />
+    <cim:IdentifiedObject.mRID>44b4277a-0f4b-43a8-ad93-6f7d6ef02061</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChangerTable rdf:ID="_24533a0f-3c24-4253-863a-5b1449e5b2de">
+    <cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>24533a0f-3c24-4253-863a-5b1449e5b2de</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChangerTable>
+  <cim:RatioTapChangerTablePoint rdf:ID="_069e3d31-b5b0-4136-ab22-d40779e369b2">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.92</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-15</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.680805</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_32fb1a15-6650-4559-a7d2-12e5b75daa4b">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.925</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-14</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.680916</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_b4029b1f-2727-4fa3-8275-da91787f8521">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.93</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-13</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681027</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_dbf8c02e-2079-40fc-a8aa-b68dfc6aa5fd">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.94</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-12</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681139</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_ceb1cd1e-bece-4ff2-90bf-fe3932ffd014">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.945</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-11</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681139</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_03c0a363-bbb1-4353-a4a6-f78ef8d8cc84">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.95</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-10</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.68125</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_66161dc4-42c4-4ad6-8e5d-b4bbb135bf03">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.955</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-9</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.68125</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_5d6db173-ce6d-4a8d-b830-7192d7060daa">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.96</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-8</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681361</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_641b55be-29e0-4abf-ac03-fd23e467e5c2">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.965</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-7</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681472</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_16ab43b0-1f68-48d2-8d2b-bb8bfaddd79f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.97</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-6</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681583</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_5dd946ee-deca-4766-948c-635e0fd47562">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.975</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-5</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681583</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_4cdd75fd-f620-4d26-b635-c7b97735fe67">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.98</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-4</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681694</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_36679ac7-f571-4528-b92a-47e95fbc22e9">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.985</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-3</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681805</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_bdf2881d-ccd0-4f7b-b239-e1e085572f94">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.99</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-2</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.681916</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_52ac1197-1688-4214-ba55-9f0a0154420c">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>0.995</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>-1</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682027</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_e3479531-ffab-4d87-bc6d-5669e1854a28">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>0</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682138</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_3d4e9276-68b5-4d28-9d9e-0dfb5b9860e8">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.005</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>1</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.68225</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_4480247c-9999-4fe5-98f7-29e822873d4b">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.01</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>2</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682361</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_fcd1200d-f49c-4958-b09c-eb36286f3ca3">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.0153</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>3</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682361</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_39408e1d-792e-4cfb-9610-2c8c031b7e6a">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.02</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>4</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682472</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_3777ebd7-2977-43ba-87aa-1d1f4dff32b2">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.025</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>5</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682583</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_e3b3aeff-3818-4dac-934c-33109122860f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.031</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>6</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682694</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_1613356f-6177-4959-b300-42b0c0e73059">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.037</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>7</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682805</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_3a705ef0-80e6-43b5-a9db-02ae130ab38f">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.043</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>8</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682916</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_4c798580-bf82-43cc-aac6-3f7ef1683836">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.05</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>9</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.682916</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_5a716e55-2365-454c-be9b-642853275533">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.055</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>10</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683027</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_eec323a6-074f-4e68-a2db-89a0689afd16">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.06</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>11</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683027</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_eec7d9c6-536e-4449-96df-f4c7d633682a">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.065</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>12</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683138</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_649a76ff-50bc-457f-b965-033814273e1d">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.072</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>13</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683138</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_1fee8078-51b8-49cf-a1cd-db18db2f840d">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.08</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>14</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683249</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:RatioTapChangerTablePoint rdf:ID="_835c45c5-e710-4b11-858f-704066a43904">
+    <cim:TapChangerTablePoint.b>0</cim:TapChangerTablePoint.b>
+    <cim:TapChangerTablePoint.g>0</cim:TapChangerTablePoint.g>
+    <cim:TapChangerTablePoint.r>0.065302</cim:TapChangerTablePoint.r>
+    <cim:TapChangerTablePoint.ratio>1.085</cim:TapChangerTablePoint.ratio>
+    <cim:TapChangerTablePoint.step>15</cim:TapChangerTablePoint.step>
+    <cim:TapChangerTablePoint.x>5.683361</cim:TapChangerTablePoint.x>
+    <cim:RatioTapChangerTablePoint.RatioTapChangerTable rdf:resource="#_24533a0f-3c24-4253-863a-5b1449e5b2de" />
+  </cim:RatioTapChangerTablePoint>
+  <cim:OperationalLimitSet rdf:ID="_cf3e5341-6736-4b34-b4da-e4af2073765b">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_70b326a3-5913-494f-b8f8-8e366253b597" />
+    <cim:IdentifiedObject.mRID>cf3e5341-6736-4b34-b4da-e4af2073765b</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_26ce5ed9-6557-473e-a710-b7720c2c8355">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf3e5341-6736-4b34-b4da-e4af2073765b" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>46188.04</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>26ce5ed9-6557-473e-a710-b7720c2c8355</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_fd472104-d68c-4536-ba4a-5fd9349c0a65">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea" />
+    <cim:IdentifiedObject.mRID>fd472104-d68c-4536-ba4a-5fd9349c0a65</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2ca6c9d7-1310-4487-a177-0c3f7b461194">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_fd472104-d68c-4536-ba4a-5fd9349c0a65" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950" />
+    <cim:CurrentLimit.normalValue>3306.644</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2ca6c9d7-1310-4487-a177-0c3f7b461194</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:BaseVoltage rdf:ID="_abb2348a-aa10-446f-9f5d-49f93f211535">
+    <cim:IdentifiedObject.name>15.75 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>15.75</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>15.75</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>abb2348a-aa10-446f-9f5d-49f93f211535</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:Terminal rdf:ID="_421c7930-64c3-435d-afb8-2bb73b333e34">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>421c7930-64c3-435d-afb8-2bb73b333e34</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_31bf04d0-7e34-465b-95a4-0604700325cf">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>31bf04d0-7e34-465b-95a4-0604700325cf</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_757d4f50-707b-47a0-891c-cbaefd649631">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>757d4f50-707b-47a0-891c-cbaefd649631</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_ae588863-b154-451d-978a-7ab08ac50fb6">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>ae588863-b154-451d-978a-7ab08ac50fb6</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_8f308117-8bbd-4798-b145-4e78f7d049e7">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>8f308117-8bbd-4798-b145-4e78f7d049e7</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c557146e-dfc4-4020-9738-d592b188338b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>c557146e-dfc4-4020-9738-d592b188338b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a015f692-3fc5-4ec3-8d1d-977c7b499e7c">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fbfed7e3-3dec-4829-a286-029e73535685" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>a015f692-3fc5-4ec3-8d1d-977c7b499e7c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>baa7aef1-afcd-4981-97c0-ccec7b5ad4e0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_e3e0c496-5837-4f0f-a596-cc421940f73f">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>e3e0c496-5837-4f0f-a596-cc421940f73f</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_6dad1a97-6874-4206-a5a5-837e495325f8">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_25ab1b5b-6803-47e2-805a-ab7b2072e034" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>6dad1a97-6874-4206-a5a5-837e495325f8</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f48d48c7-e9f6-460c-898f-cc68a96efdeb">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b0442899-8dbe-48c1-a1fa-adb2a5929273" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f48d48c7-e9f6-460c-898f-cc68a96efdeb</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_57979d14-d1d8-4311-ae53-aa8890423885">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>57979d14-d1d8-4311-ae53-aa8890423885</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_653bc4b8-518b-4adc-9d68-012fb641fb1d">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>653bc4b8-518b-4adc-9d68-012fb641fb1d</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>357e3e14-c38e-4a7e-9c95-b3dbe158f5f3</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>6b1cd30c-19ba-44e1-9447-d01db6b1ef9d</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_24dd035c-0a8c-4351-aeb2-08d6622b42ae">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_12baa3f3-23b1-44e0-956f-d331e1527f37" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>24dd035c-0a8c-4351-aeb2-08d6622b42ae</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_39d27c17-1e5b-4edc-a7ec-65a2d56542df">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_83bea592-913e-4473-8d17-969968ff83a2" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>39d27c17-1e5b-4edc-a7ec-65a2d56542df</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f04ecab5-1a12-4cc0-ba56-b157ebf11a42">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>f04ecab5-1a12-4cc0-ba56-b157ebf11a42</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_6aecb9ba-5835-4b70-89bc-96d687e45779">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>6aecb9ba-5835-4b70-89bc-96d687e45779</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5dfee914-a4fd-4bde-a5b4-c4caa6378d10">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>5dfee914-a4fd-4bde-a5b4-c4caa6378d10</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_26e50b4b-9a19-420d-98ce-bc4f11971cd7">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_820d95d7-26d4-4311-8b1f-026f8605b86d" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>26e50b4b-9a19-420d-98ce-bc4f11971cd7</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f461fd2d-1e41-4a3e-8213-7cc33c77a089">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_69add5b4-70bd-4360-8a93-286256c0d38b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_90f78705-5ef4-479a-8d5a-70efc554e0ba" />
+    <cim:IdentifiedObject.mRID>f461fd2d-1e41-4a3e-8213-7cc33c77a089</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f970233f-b573-49d9-9fc3-3a2a59ed3bbb">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cab82e1c-1435-447b-bba0-74b592539eac" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f970233f-b573-49d9-9fc3-3a2a59ed3bbb</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b1e03a8f-6a11-4454-af58-4a4a680e857f" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_faab7959-f9bf-421b-bc3f-d364e0c1388b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>faab7959-f9bf-421b-bc3f-d364e0c1388b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_ae4b7cbe-349a-41c8-ace2-25ec26f14a64">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2844585c-0d35-488d-a449-685bcd57afbf" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>ae4b7cbe-349a-41c8-ace2-25ec26f14a64</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_70b326a3-5913-494f-b8f8-8e366253b597">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_124b9180-9112-4b8a-a651-9c1bb9a031da" />
+    <cim:IdentifiedObject.mRID>70b326a3-5913-494f-b8f8-8e366253b597</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c9b27b4e-d492-4c3c-b147-67addbb9d3ea">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a" />
+    <cim:IdentifiedObject.mRID>c9b27b4e-d492-4c3c-b147-67addbb9d3ea</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:OperationalLimitType rdf:ID="_1aee0921-7cbe-481c-9078-daf66ab2a950">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.patl" />
+    <cim:IdentifiedObject.mRID>1aee0921-7cbe-481c-9078-daf66ab2a950</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>true</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:OperationalLimitType rdf:ID="_bf2a4896-2e92-465b-b5f9-b033993a31c8">
+    <cim:IdentifiedObject.name>Limit Type TATL</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>TATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.acceptableDuration>600</cim:OperationalLimitType.acceptableDuration>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.tatl" />
+    <cim:IdentifiedObject.mRID>bf2a4896-2e92-465b-b5f9-b033993a31c8</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>false</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:ControlArea rdf:ID="_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a">
+    <cim:IdentifiedObject.name>NL</cim:IdentifiedObject.name>
+    <cim:ControlArea.type rdf:resource="http://iec.ch/TC57/CIM100#ControlAreaTypeKind.Interchange" />
+    <cim:ControlArea.EnergyArea rdf:resource="#_70c4656c-f7a0-4319-98bb-84fb5e2e9b37" />
+    <cim:IdentifiedObject.mRID>31b2fe09-63f6-44f6-9b4f-01dbe7e4944a</cim:IdentifiedObject.mRID>
+  </cim:ControlArea>
+  <cim:TieFlow rdf:ID="_14f1c9bd-93d8-4238-9e26-aacc53fe8855">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_ae588863-b154-451d-978a-7ab08ac50fb6" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>14f1c9bd-93d8-4238-9e26-aacc53fe8855</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_4ed170fe-2571-4044-9bfa-7345e70a69d2">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_8f308117-8bbd-4798-b145-4e78f7d049e7" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>4ed170fe-2571-4044-9bfa-7345e70a69d2</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_945d6e95-1b83-47c5-a0e9-277d434c2d12">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_57979d14-d1d8-4311-ae53-aa8890423885" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>945d6e95-1b83-47c5-a0e9-277d434c2d12</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_4669c2b7-89d0-46d1-9bbb-37e989d581cd">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>4669c2b7-89d0-46d1-9bbb-37e989d581cd</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_f9ffc8ea-37f2-404a-9bd3-f3fa15476d4c">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_6aecb9ba-5835-4b70-89bc-96d687e45779" />
+    <cim:TieFlow.ControlArea rdf:resource="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a" />
+    <cim:IdentifiedObject.mRID>f9ffc8ea-37f2-404a-9bd3-f3fa15476d4c</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:RegulatingControl rdf:ID="_04f338d3-3c0d-433f-a77b-e36dd256f0f0">
+    <cim:IdentifiedObject.name>NL-G1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_faab7959-f9bf-421b-bc3f-d364e0c1388b" />
+    <cim:IdentifiedObject.mRID>04f338d3-3c0d-433f-a77b-e36dd256f0f0</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_GL_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_GL_001.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:76be4572-58c0-40c0-ae26-e65add81593d">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/GeographicalLocation-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61" />
+  </md:FullModel>
+  <cim:CoordinateSystem rdf:ID="_38876874-fcfc-a4d9-9d16-39fb7da2ad74">
+    <cim:IdentifiedObject.name>WGS84</cim:IdentifiedObject.name>
+    <cim:CoordinateSystem.crsUrn>urn:ogc:def:crs:EPSG::4326</cim:CoordinateSystem.crsUrn>
+    <cim:IdentifiedObject.mRID>38876874-fcfc-a4d9-9d16-39fb7da2ad74</cim:IdentifiedObject.mRID>
+  </cim:CoordinateSystem>
+  <cim:Location rdf:ID="_c84ce457-406b-a13c-ad76-39fb7da2ad7a">
+    <cim:IdentifiedObject.name>NL-Line_5</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+    <cim:IdentifiedObject.mRID>c84ce457-406b-a13c-ad76-39fb7da2ad7a</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_c3c79c7b-2420-4e1f-8409-a33f300a23d0">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84744</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4027</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_c84ce457-406b-a13c-ad76-39fb7da2ad7a" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_b352d929-4f26-4c14-a45c-668858a7d0b3">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.98125</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.2483</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_c84ce457-406b-a13c-ad76-39fb7da2ad7a" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_4a497a1b-495a-46b7-946e-f0ce456baea2">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.04709</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.0699</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_c84ce457-406b-a13c-ad76-39fb7da2ad7a" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_674c30e0-d3d4-4936-9e88-d1c0cb7cad7f">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07058</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8731</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_c84ce457-406b-a13c-ad76-39fb7da2ad7a" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_5350c085-4b5e-5909-1d55-39fb7da2ad7b">
+    <cim:IdentifiedObject.name>NL-Line_2</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+    <cim:IdentifiedObject.mRID>5350c085-4b5e-5909-1d55-39fb7da2ad7b</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_5a899c67-25ca-40db-8114-8da314040efc">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84744</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4027</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5350c085-4b5e-5909-1d55-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_e1c899b9-e683-4650-b975-e14b99f34339">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.98125</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.2483</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5350c085-4b5e-5909-1d55-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_61c447ed-2413-40fa-aca5-3a0758357cc0">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.04709</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.0699</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5350c085-4b5e-5909-1d55-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ce082601-0923-430b-9063-57df68931720">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07186</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8756</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_5350c085-4b5e-5909-1d55-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_480fa612-9f7c-44fa-8522-39fb7da2ad7b">
+    <cim:IdentifiedObject.name>NL-Line_4</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+    <cim:IdentifiedObject.mRID>480fa612-9f7c-44fa-8522-39fb7da2ad7b</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_64e596c6-a8bf-4626-a955-4fa9e6c12ed1">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84845</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4023</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_480fa612-9f7c-44fa-8522-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_707917fa-86d5-41c6-84a0-ffc51a940000">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.79004</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.1571</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_480fa612-9f7c-44fa-8522-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ffb34d5a-4d38-4d9c-acf8-e5b25a9c0ffa">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88892</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9138</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_480fa612-9f7c-44fa-8522-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_daafb8a7-efae-4a7d-91f8-45647a8492a2">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88798</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9127</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_480fa612-9f7c-44fa-8522-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_e072869d-f08d-34f3-bf8f-39fb7da2ad7b">
+    <cim:IdentifiedObject.name>NL-Line_1</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+    <cim:IdentifiedObject.mRID>e072869d-f08d-34f3-bf8f-39fb7da2ad7b</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_acc3e8bc-2ff1-49dd-92bf-d4b78061cc8b">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84744</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4027</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_e072869d-f08d-34f3-bf8f-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_ea627c7c-e27a-466d-95f9-a1c9b6a8c7cf">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.98125</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.2483</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_e072869d-f08d-34f3-bf8f-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_1c577e91-4823-4507-9462-138732ece375">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.04709</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.0699</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_e072869d-f08d-34f3-bf8f-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_7d673371-9850-4544-8881-1b47ee86edcb">
+    <cim:PositionPoint.sequenceNumber>4</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>5.07294</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.8765</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_e072869d-f08d-34f3-bf8f-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:Location rdf:ID="_a719fa3b-aec1-c681-8da9-39fb7da2ad7b">
+    <cim:IdentifiedObject.name>NL-Line_3</cim:IdentifiedObject.name>
+    <cim:Location.CoordinateSystem rdf:resource="#_38876874-fcfc-a4d9-9d16-39fb7da2ad74" />
+    <cim:Location.PowerSystemResources rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+    <cim:IdentifiedObject.mRID>a719fa3b-aec1-c681-8da9-39fb7da2ad7b</cim:IdentifiedObject.mRID>
+  </cim:Location>
+  <cim:PositionPoint rdf:ID="_e238474d-ba73-4414-b30c-beac239b2561">
+    <cim:PositionPoint.sequenceNumber>1</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.84845</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.4023</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_a719fa3b-aec1-c681-8da9-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_a6443772-92de-47de-8bf3-53804c3bc2cb">
+    <cim:PositionPoint.sequenceNumber>2</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.79004</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>52.1571</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_a719fa3b-aec1-c681-8da9-39fb7da2ad7b" />
+  </cim:PositionPoint>
+  <cim:PositionPoint rdf:ID="_fd1b2b5f-73d5-4f65-8c5e-28774dfcd623">
+    <cim:PositionPoint.sequenceNumber>3</cim:PositionPoint.sequenceNumber>
+    <cim:PositionPoint.xPosition>4.88892</cim:PositionPoint.xPosition>
+    <cim:PositionPoint.yPosition>51.9138</cim:PositionPoint.yPosition>
+    <cim:PositionPoint.Location rdf:resource="#_a719fa3b-aec1-c681-8da9-39fb7da2ad7b" />
+  </cim:PositionPoint>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_SSH_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_SSH_001.xml
@@ -1,0 +1,320 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:e888e6dc-c686-4957-b1ec-4be41760339e">
+    <md:Model.created>2021-03-25T23:16:27Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/SteadyStateHypothesis-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61" />
+  </md:FullModel>
+  <cim:Terminal rdf:about="#_421c7930-64c3-435d-afb8-2bb73b333e34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31bf04d0-7e34-465b-95a4-0604700325cf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_757d4f50-707b-47a0-891c-cbaefd649631">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae588863-b154-451d-978a-7ab08ac50fb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f308117-8bbd-4798-b145-4e78f7d049e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c557146e-dfc4-4020-9738-d592b188338b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e3e0c496-5837-4f0f-a596-cc421940f73f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dad1a97-6874-4206-a5a5-837e495325f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f48d48c7-e9f6-460c-898f-cc68a96efdeb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57979d14-d1d8-4311-ae53-aa8890423885">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_653bc4b8-518b-4adc-9d68-012fb641fb1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24dd035c-0a8c-4351-aeb2-08d6622b42ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39d27c17-1e5b-4edc-a7ec-65a2d56542df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6aecb9ba-5835-4b70-89bc-96d687e45779">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26e50b4b-9a19-420d-98ce-bc4f11971cd7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f461fd2d-1e41-4a3e-8213-7cc33c77a089">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f970233f-b573-49d9-9fc3-3a2a59ed3bbb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_faab7959-f9bf-421b-bc3f-d364e0c1388b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70b326a3-5913-494f-b8f8-8e366253b597">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_50f00b94-fe0f-48fd-887e-f0d4d59eee87">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f199d49-0093-4b51-b357-70371424d174">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:SynchronousMachine rdf:about="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-150</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-83.296</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_b850063d-eae7-4675-bc98-4642d3076783">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:RegulatingControl rdf:about="#_04f338d3-3c0d-433f-a77b-e36dd256f0f0">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>16.0335</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:about="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-600.4927</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-386.9225</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_049438a6-780a-44fe-a788-ebe385d98e25">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>1</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_2844585c-0d35-488d-a449-685bcd57afbf">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-140</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-77.743</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineOperatingMode.generator" />
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_ca80ee09-3bed-4884-bc28-6dc89d067289">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:LinearShuntCompensator rdf:about="#_fbfed7e3-3dec-4829-a286-029e73535685">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:about="#_613dfeb3-0161-4cec-aaa9-ccddd885771b">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0.5</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>400</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/CIM100#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+  <cim:ConformLoad rdf:about="#_25ab1b5b-6803-47e2-805a-ab7b2072e034">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:about="#_69add5b4-70bd-4360-8a93-286256c0d38b">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>90</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>280</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:about="#_b1e03a8f-6a11-4454-af58-4a4a680e857f">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EnergyConsumer.p>486</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>230</cim:EnergyConsumer.q>
+  </cim:ConformLoad>
+  <cim:EquivalentInjection rdf:about="#_b0442899-8dbe-48c1-a1fa-adb2a5929273">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>27.0286</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-120.7887</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_12baa3f3-23b1-44e0-956f-d331e1527f37">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>83.18928</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-1.501529</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_83bea592-913e-4473-8d17-969968ff83a2">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>14.06748</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-63.95825</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_820d95d7-26d4-4311-8b1f-026f8605b86d">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>103.7413</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-11.31944</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_cab82e1c-1435-447b-bba0-74b592539eac">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+    <cim:EquivalentInjection.p>8.953211</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-67.2335</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:PhaseTapChangerTabular rdf:about="#_ee649b97-d2ec-47e1-976f-0f4d9f50fa11">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>17</cim:TapChanger.step>
+  </cim:PhaseTapChangerTabular>
+  <cim:PhaseTapChangerLinear rdf:about="#_341327c4-9224-40bf-bc33-7a3bb0bae680">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>8</cim:TapChanger.step>
+  </cim:PhaseTapChangerLinear>
+  <cim:RatioTapChanger rdf:about="#_44b4277a-0f4b-43a8-ad93-6f7d6ef02061">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>5</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:ControlArea rdf:about="#_31b2fe09-63f6-44f6-9b4f-01dbe7e4944a">
+    <cim:ControlArea.netInterchange>-236.9798</cim:ControlArea.netInterchange>
+    <cim:ControlArea.pTolerance>10</cim:ControlArea.pTolerance>
+  </cim:ControlArea>
+  <cim:CurrentLimit rdf:about="#_47545df1-566d-4a8d-86e8-882655c6e79e">
+    <cim:CurrentLimit.value>1876</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_08ad0781-b65c-4f2e-b5ba-00d58bcf2e58">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_56105225-1754-40da-b6df-43fd7cfeb50a">
+    <cim:CurrentLimit.value>1876</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_86764bf6-6472-4ebe-9d6b-bcceffe66dad">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_7cfff021-02d4-4aa1-8fe7-b9af9c1fdc44">
+    <cim:CurrentLimit.value>1371</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_d7422ce6-a13d-41ca-8111-9462b2e789dc">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2b05a185-07f6-4e72-a2c3-d28425c7aefc">
+    <cim:CurrentLimit.value>1371</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_6fd8188f-65a6-4473-b8f1-ffe6122ba6ab">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2f424b90-a264-4592-8854-9838596c9f78">
+    <cim:CurrentLimit.value>1574</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_89ef40fb-5d77-45cb-8073-cc2d1d171dcd">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_b35893b0-22d4-4127-9351-9c46fba6059b">
+    <cim:CurrentLimit.value>1574</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_b780341b-7b90-498f-ab63-9deb16eff206">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_1b65a297-4735-499f-8fe8-f08ea01b291f">
+    <cim:CurrentLimit.value>1233.9</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_5bc43480-4543-4193-8b0e-7ba7bf5b3441">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_26069582-0f76-47fb-8bc0-44c99fb08887">
+    <cim:CurrentLimit.value>1233.9</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2783b836-4271-4252-96a7-588c3a1b1826">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_03287f0c-5562-4533-be7f-2fb40e1888f5">
+    <cim:CurrentLimit.value>2000</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_84c93dae-4254-4b24-b0ee-3fc4bdf1ea02">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_c743cfb3-8279-4721-9eee-12020dd89f64">
+    <cim:CurrentLimit.value>2000</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_8eb25188-24dd-4f6e-97d9-b7b03c49454e">
+    <cim:CurrentLimit.value>500</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_6745e040-9fd4-4cc5-8bfd-902d0aed4ee6">
+    <cim:CurrentLimit.value>3306.644</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_12f7803a-c65b-4a14-8c0d-7e52becb5772">
+    <cim:CurrentLimit.value>46188.04</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_ef715edd-516e-4bfd-adc4-1c882852920e">
+    <cim:CurrentLimit.value>839.7826</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_e37ee101-2f68-4d55-b24f-c24c5faba8b5">
+    <cim:CurrentLimit.value>461.8804</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_26ce5ed9-6557-473e-a710-b7720c2c8355">
+    <cim:CurrentLimit.value>46188.04</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:about="#_2ca6c9d7-1310-4487-a177-0c3f7b461194">
+    <cim:CurrentLimit.value>3306.644</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:Equipment rdf:about="#_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_53da4025-9d51-4eaf-b0d2-ce27fbe740d2">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_dad02278-bd25-476f-8f58-dbe44be72586">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_8fdc7abd-3746-481a-a65e-3df56acd8b13">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_7f43f508-2496-4b64-9146-0a40406cbe49">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_a279a3dc-550b-426c-af3a-61b7be508dcc">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+  <cim:Equipment rdf:about="#_80016742-31b3-432a-b00a-300667a1e572">
+    <cim:Equipment.inService>true</cim:Equipment.inService>
+  </cim:Equipment>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_SV_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_SV_001.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:7addc722-a5b5-499d-8bbc-44cd00c37d1e">
+    <md:Model.created>2021-04-15T21:41:56Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/StateVariables-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:2cca999a-6837-4332-8f43-3e55a9dfa69b" />
+  </md:FullModel>
+  <cim:SvPowerFlow rdf:ID="_2c356540-8d9a-4d97-9123-aa94ba2c1576">
+    <cim:SvPowerFlow.p>8.953211</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-67.2335</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f970233f-b573-49d9-9fc3-3a2a59ed3bbb" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_346f193f-4c72-4724-9780-f530372ecd8a">
+    <cim:SvPowerFlow.p>19.19087</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-87.50481</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_b931fdba-9435-468e-9e5c-135b7f7d30de">
+    <cim:SvPowerFlow.p>27.0286</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-120.7887</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f48d48c7-e9f6-460c-898f-cc68a96efdeb" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_6c200135-9cff-4c61-97ff-51e18afd7dc4">
+    <cim:SvTapStep.position>8</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_341327c4-9224-40bf-bc33-7a3bb0bae680" />
+  </cim:SvTapStep>
+  <cim:SvShuntCompensatorSections rdf:ID="_1b7f518f-5e2f-45b0-bf83-da34393978a0">
+    <cim:SvShuntCompensatorSections.sections>1</cim:SvShuntCompensatorSections.sections>
+    <cim:SvShuntCompensatorSections.ShuntCompensator rdf:resource="#_fbfed7e3-3dec-4829-a286-029e73535685" />
+  </cim:SvShuntCompensatorSections>
+  <cim:SvPowerFlow rdf:ID="_53ab7d08-c37d-4284-b3a3-d32036f3c24b">
+    <cim:SvPowerFlow.p>103.7413</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-11.31944</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_26e50b4b-9a19-420d-98ce-bc4f11971cd7" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_24c2804e-00eb-481a-99ab-1d670ed58218">
+    <cim:SvPowerFlow.p>-140</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-77.743</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_0c3d7e99-9146-41b4-9ade-a9ae44f79f44">
+    <cim:SvPowerFlow.p>0</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-52.79673</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_eee4ef43-b918-4264-a3bf-2b624d5e55f6">
+    <cim:SvPowerFlow.p>-8.953211</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>67.2335</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_8f308117-8bbd-4798-b145-4e78f7d049e7" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_61faccd6-c108-47dd-8ea5-8f33ecd8fef6">
+    <cim:SvPowerFlow.p>90</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>280</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f461fd2d-1e41-4a3e-8213-7cc33c77a089" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_5ec939b0-4aac-423b-8728-f07cc8c02cf5">
+    <cim:SvPowerFlow.p>-83.18928</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>1.501529</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_57979d14-d1d8-4311-ae53-aa8890423885" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_759df043-e5e3-49c3-8db5-7bb3af7e6c41">
+    <cim:SvPowerFlow.p>439.885</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>39.85126</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_31bf04d0-7e34-465b-95a4-0604700325cf" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_542d5214-b329-4501-98e0-25f114561dcc">
+    <cim:SvPowerFlow.p>-438.7081</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-11.90898</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_421c7930-64c3-435d-afb8-2bb73b333e34" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_550a3a58-4b2c-42bf-af93-4d6c7cd98485">
+    <cim:SvPowerFlow.p>409.4445</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>209.9772</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_70b326a3-5913-494f-b8f8-8e366253b597" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_5b9761bb-36c3-471a-be2a-596abb1f9df7">
+    <cim:SvPowerFlow.p>10</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>10</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_6dad1a97-6874-4206-a5a5-837e495325f8" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_9e23db6a-cc32-47cb-88c8-bc33cbc73102">
+    <cim:SvPowerFlow.p>84.71166</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>3.317878</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_653bc4b8-518b-4adc-9d68-012fb641fb1d" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_69445870-8b92-4c2d-9bf8-2ef5f3e31ade">
+    <cim:SvPowerFlow.p>106.0121</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>2.926857</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_d1a56c26-ecc0-47ce-adfa-23d6d47ef1f6">
+    <cim:SvPowerFlow.p>-559.3295</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-88.78947</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_faab7959-f9bf-421b-bc3f-d364e0c1388b" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_6663fd96-3dbe-4f0f-82f8-c57f04f58664">
+    <cim:SvPowerFlow.p>487.9077</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>231.3542</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_896ba569-c4a9-4622-a25b-322269e1b416">
+    <cim:SvTapStep.position>17</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_ee649b97-d2ec-47e1-976f-0f4d9f50fa11" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_304811a6-f8b3-4b1d-b494-7c32ee91c4fe">
+    <cim:SvPowerFlow.p>-14.06748</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>63.95825</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_631ec9eb-3d57-4dd5-913a-a8fc658ca2d2">
+    <cim:SvPowerFlow.p>-27.0286</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>120.7887</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_ae588863-b154-451d-978a-7ab08ac50fb6" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_3fa902f5-6b3a-4beb-9b48-9cdff1512790">
+    <cim:SvPowerFlow.p>14.06748</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-63.95825</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_39d27c17-1e5b-4edc-a7ec-65a2d56542df" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_613a32cf-54f0-4cc4-ab18-37e8fcccffd8">
+    <cim:SvPowerFlow.p>83.18928</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-1.501529</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_24dd035c-0a8c-4351-aeb2-08d6622b42ae" />
+  </cim:SvPowerFlow>
+  <cim:SvTapStep rdf:ID="_81dbf9df-7ff8-4c6f-9d2d-be69eba66961">
+    <cim:SvTapStep.position>5</cim:SvTapStep.position>
+    <cim:SvTapStep.TapChanger rdf:resource="#_44b4277a-0f4b-43a8-ad93-6f7d6ef02061" />
+  </cim:SvTapStep>
+  <cim:SvPowerFlow rdf:ID="_441fa4c2-43d4-49af-b3e8-f5eafc73d6c8">
+    <cim:SvPowerFlow.p>-408.2798</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-179.2365</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_d28aa2bd-6474-42eb-8f90-535c684e4f5c">
+    <cim:SvPowerFlow.p>15.82242</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-70.92072</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_c557146e-dfc4-4020-9738-d592b188338b" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_e13a623b-828a-48e3-8efc-4cbbb287b052">
+    <cim:SvPowerFlow.p>168.3565</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-46.45348</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_8fae7e93-8c66-4f92-ae74-43cf9c2cfec9">
+    <cim:SvPowerFlow.p>33.00131</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-131.1585</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_757d4f50-707b-47a0-891c-cbaefd649631" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_ed4f8d68-56ae-45ea-b690-6789b8f51a96">
+    <cim:SvPowerFlow.p>-103.7413</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>11.31944</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_6aecb9ba-5835-4b70-89bc-96d687e45779" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_b89f78a4-d9e1-44b0-ade4-3beb9e8f38d1">
+    <cim:SvPowerFlow.p>-150</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>-83.296</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42" />
+  </cim:SvPowerFlow>
+  <cim:SvPowerFlow rdf:ID="_45ec549a-28b3-4c0b-b2cb-9398ca791598">
+    <cim:SvPowerFlow.p>-168.0146</cim:SvPowerFlow.p>
+    <cim:SvPowerFlow.q>52.38079</cim:SvPowerFlow.q>
+    <cim:SvPowerFlow.Terminal rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f" />
+  </cim:SvPowerFlow>
+  <cim:SvVoltage rdf:ID="_b5a392e1-852e-4118-b5ce-0e1b2f18f38a">
+    <cim:SvVoltage.angle>339.6498</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>410.7063</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:SvVoltage>
+  <cim:TopologicalIsland rdf:ID="_c88fe8fc-c2ce-4a44-b2b1-0bf5640e6113">
+    <cim:IdentifiedObject.name>TopoIsland 1</cim:IdentifiedObject.name>
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+    <cim:TopologicalIsland.TopologicalNodes rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+    <cim:TopologicalIsland.AngleRefTopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+    <cim:IdentifiedObject.mRID>c88fe8fc-c2ce-4a44-b2b1-0bf5640e6113</cim:IdentifiedObject.mRID>
+  </cim:TopologicalIsland>
+  <cim:SvVoltage rdf:ID="_a8ae77f3-b1ff-4dd9-8e11-0c056df5625f">
+    <cim:SvVoltage.angle>0</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>16.0335</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:SvVoltage>
+  <cim:SvVoltage rdf:ID="_41c46676-2466-461d-b018-3ef37cc0e1b2">
+    <cim:SvVoltage.angle>-2.702116</cim:SvVoltage.angle>
+    <cim:SvVoltage.v>224.3178</cim:SvVoltage.v>
+    <cim:SvVoltage.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:SvVoltage>
+  <cim:SvStatus rdf:ID="_1000c71e-ee56-43b3-80d2-620cfb2e799d">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_d97f2ecf-6c51-4c34-afba-7896ab5c7a5f">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_53da4025-9d51-4eaf-b0d2-ce27fbe740d2" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_bda4bf9d-0cf0-4ead-8c9a-d34dc2a4a537">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b0442899-8dbe-48c1-a1fa-adb2a5929273" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_d17803b0-9ab8-4a5d-8223-84036c89203a">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_12baa3f3-23b1-44e0-956f-d331e1527f37" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_f5883a69-e866-46a3-91d7-14a0237106e6">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_83bea592-913e-4473-8d17-969968ff83a2" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_f7e900c4-7fb9-4ca3-9ff2-eb7e9bedd678">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_820d95d7-26d4-4311-8b1f-026f8605b86d" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_2ae8a406-d8e2-452a-9331-b39063607967">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_cab82e1c-1435-447b-bba0-74b592539eac" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_f1e1615b-d4ab-4234-b042-5d2ba1f92c73">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_42fefa05-d932-452a-b077-606fa50b63aa">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_e15b371e-4c42-4649-afc3-0535eacd0e6c">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_d94bec74-176d-4a17-b35a-45d34b1d104b">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_f4d61164-ec4a-4be5-831c-50531ad031f8">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_5af6ddc0-e07e-4813-89a7-de4b3e721896">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_25ab1b5b-6803-47e2-805a-ab7b2072e034" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_fc492253-21cf-4da8-8f7b-44735b5210f9">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_69add5b4-70bd-4360-8a93-286256c0d38b" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_44800809-ffee-404f-8fcc-ab1edb50f1b8">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_b1e03a8f-6a11-4454-af58-4a4a680e857f" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_c4827630-5093-4e9a-8425-9f712507d724">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_fbfed7e3-3dec-4829-a286-029e73535685" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_c7dc1b56-e616-4217-a42e-b00601a991e5">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_cb12c47a-1e13-4712-95f1-0a3eb575ae13">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_5be850ec-7368-4398-bded-b332a23a8566">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_2844585c-0d35-488d-a449-685bcd57afbf" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_e6c9812f-b21d-4c03-99b5-3e5cb01de0e4">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_5039b23d-1299-4f5e-ae90-97825e147b7b">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33" />
+  </cim:SvStatus>
+  <cim:SvStatus rdf:ID="_91cafc5b-8af3-4311-b4fc-285787395674">
+    <cim:SvStatus.inService>true</cim:SvStatus.inService>
+    <cim:SvStatus.ConductingEquipment rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572" />
+  </cim:SvStatus>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_TP_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210325T1530Z_1D_NL_TP_001.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:2cca999a-6837-4332-8f43-3e55a9dfa69b">
+    <md:Model.created>2021-04-15T21:41:56Z</md:Model.created>
+    <md:Model.scenarioTime>2021-03-25T15:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/Topology-EU/3.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:e888e6dc-c686-4957-b1ec-4be41760339e" />
+  </md:FullModel>
+  <cim:TopologicalNode rdf:ID="_afddd60d-f7e6-419a-a5c2-be28d29beaf9">
+    <cim:IdentifiedObject.name>NL-Busbar_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>NAMST_21; this is the old code</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-B_2</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_d77b61ef-61aa-4b22-95f6-b56ca080788d" />
+    <cim:IdentifiedObject.mRID>afddd60d-f7e6-419a-a5c2-be28d29beaf9</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_cae57656-3fc2-4f5e-9ab9-fa5b118a632a">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_81b0e447-181e-4aec-8921-f1dd7813bebc">
+    <cim:IdentifiedObject.name>N1230992195</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>NAMST_11; old UCTE Name</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>NL-_B_1</eu:IdentifiedObject.shortName>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_b7998ae6-0cc6-4dfe-8fec-0b549b07b6c3" />
+    <cim:IdentifiedObject.mRID>81b0e447-181e-4aec-8921-f1dd7813bebc</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_90f78705-5ef4-479a-8d5a-70efc554e0ba">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:ConnectivityNode>
+  <cim:TopologicalNode rdf:ID="_6bdc33de-d027-49b7-b98f-3b3d87716615">
+    <cim:IdentifiedObject.name>N1230822413</cim:IdentifiedObject.name>
+    <cim:TopologicalNode.BaseVoltage rdf:resource="#_abb2348a-aa10-446f-9f5d-49f93f211535" />
+    <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8" />
+    <cim:IdentifiedObject.mRID>6bdc33de-d027-49b7-b98f-3b3d87716615</cim:IdentifiedObject.mRID>
+  </cim:TopologicalNode>
+  <cim:ConnectivityNode rdf:about="#_124b9180-9112-4b8a-a651-9c1bb9a031da">
+    <cim:ConnectivityNode.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:about="#_50f00b94-fe0f-48fd-887e-f0d4d59eee87">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f199d49-0093-4b51-b357-70371424d174">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_421c7930-64c3-435d-afb8-2bb73b333e34">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_31bf04d0-7e34-465b-95a4-0604700325cf">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_757d4f50-707b-47a0-891c-cbaefd649631">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c557146e-dfc4-4020-9738-d592b188338b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e3e0c496-5837-4f0f-a596-cc421940f73f">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dad1a97-6874-4206-a5a5-837e495325f8">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_653bc4b8-518b-4adc-9d68-012fb641fb1d">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f461fd2d-1e41-4a3e-8213-7cc33c77a089">
+    <cim:Terminal.TopologicalNode rdf:resource="#_81b0e447-181e-4aec-8921-f1dd7813bebc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_faab7959-f9bf-421b-bc3f-d364e0c1388b">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70b326a3-5913-494f-b8f8-8e366253b597">
+    <cim:Terminal.TopologicalNode rdf:resource="#_6bdc33de-d027-49b7-b98f-3b3d87716615" />
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c9b27b4e-d492-4c3c-b147-67addbb9d3ea">
+    <cim:Terminal.TopologicalNode rdf:resource="#_afddd60d-f7e6-419a-a5c2-be28d29beaf9" />
+  </cim:Terminal>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210420T1730Z_1D_NL_DY_001.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-NL-MAS/20210420T1730Z_1D_NL_DY_001.xml
@@ -1,0 +1,369 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:00d66ea3-929d-444f-bf51-dfbbf01bc0af">
+    <md:Model.created>2021-04-20T10:56:20Z</md:Model.created>
+    <md:Model.scenarioTime>2021-04-20T17:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/Dynamics-EU/1.0</md:Model.profile>
+    <md:Model.version>001</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61" />
+  </md:FullModel>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_f450a965-7cfb-4516-a2bf-618f05e84eed">
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:RotatingMachineDynamics.damping>1</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>4.4</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.23</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDetailed.saturationFactorQAxis>0.02</cim:SynchronousMachineDetailed.saturationFactorQAxis>
+    <cim:SynchronousMachineDetailed.saturationFactor120QAxis>0.12</cim:SynchronousMachineDetailed.saturationFactor120QAxis>
+    <cim:RotatingMachineDynamics.saturationFactor>0.02</cim:RotatingMachineDynamics.saturationFactor>
+    <cim:RotatingMachineDynamics.saturationFactor120>0.12</cim:RotatingMachineDynamics.saturationFactor120>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.roundRotor" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>9.6</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.08</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.0837</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>0.09</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.24</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.98</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.37</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.24</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>0.8</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.24</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>f450a965-7cfb-4516-a2bf-618f05e84eed</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_bd63d5d8-3d61-4233-a3e0-a66d512c1574">
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:RotatingMachineDynamics.damping>1</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>9.9</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.1934</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.salientPole" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>8.8</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.031</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.0354</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>0.04</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.318</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>2.35</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.452</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.318</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>2.24</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.318</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>bd63d5d8-3d61-4233-a3e0-a66d512c1574</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:SynchronousMachineTimeConstantReactance rdf:ID="_e58068fe-5436-4a2a-aa72-da3377ea1355">
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:IdentifiedObject.name>sm</cim:IdentifiedObject.name>
+    <cim:RotatingMachineDynamics.damping>1</cim:RotatingMachineDynamics.damping>
+    <cim:RotatingMachineDynamics.inertia>4.4</cim:RotatingMachineDynamics.inertia>
+    <cim:RotatingMachineDynamics.statorLeakageReactance>0.23</cim:RotatingMachineDynamics.statorLeakageReactance>
+    <cim:RotatingMachineDynamics.statorResistance>0</cim:RotatingMachineDynamics.statorResistance>
+    <cim:SynchronousMachineDynamics.SynchronousMachine rdf:resource="#_2844585c-0d35-488d-a449-685bcd57afbf" />
+    <cim:SynchronousMachineTimeConstantReactance.modelType rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineModelKind.subtransient" />
+    <cim:SynchronousMachineTimeConstantReactance.rotorType rdf:resource="http://iec.ch/TC57/CIM100#RotorKind.salientPole" />
+    <cim:SynchronousMachineTimeConstantReactance.tpdo>9.6</cim:SynchronousMachineTimeConstantReactance.tpdo>
+    <cim:SynchronousMachineTimeConstantReactance.tc>0</cim:SynchronousMachineTimeConstantReactance.tc>
+    <cim:SynchronousMachineTimeConstantReactance.tppdo>0.08</cim:SynchronousMachineTimeConstantReactance.tppdo>
+    <cim:SynchronousMachineTimeConstantReactance.tppqo>0.0837</cim:SynchronousMachineTimeConstantReactance.tppqo>
+    <cim:SynchronousMachineTimeConstantReactance.tpqo>0.09</cim:SynchronousMachineTimeConstantReactance.tpqo>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>0.24</cim:SynchronousMachineTimeConstantReactance.xDirectSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectSync>1.98</cim:SynchronousMachineTimeConstantReactance.xDirectSync>
+    <cim:SynchronousMachineTimeConstantReactance.xDirectTrans>0.37</cim:SynchronousMachineTimeConstantReactance.xDirectTrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>0.24</cim:SynchronousMachineTimeConstantReactance.xQuadSubtrans>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadSync>0.8</cim:SynchronousMachineTimeConstantReactance.xQuadSync>
+    <cim:SynchronousMachineTimeConstantReactance.xQuadTrans>0.24</cim:SynchronousMachineTimeConstantReactance.xQuadTrans>
+    <cim:SynchronousMachineDetailed.efdBaseRatio>1</cim:SynchronousMachineDetailed.efdBaseRatio>
+    <cim:SynchronousMachineDetailed.ifdBaseType rdf:resource="http://iec.ch/TC57/CIM100#IfdBaseKind.ifag" />
+    <cim:SynchronousMachineTimeConstantReactance.ks>0</cim:SynchronousMachineTimeConstantReactance.ks>
+    <cim:IdentifiedObject.mRID>e58068fe-5436-4a2a-aa72-da3377ea1355</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachineTimeConstantReactance>
+  <cim:ExcIEEEST1A rdf:ID="_3bd610c9-8ecd-4466-a5ea-c998749a38ea">
+    <cim:IdentifiedObject.name>NL-G2-Exc-ST1A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_e58068fe-5436-4a2a-aa72-da3377ea1355" />
+    <cim:ExcIEEEST1A.ilr>0</cim:ExcIEEEST1A.ilr>
+    <cim:ExcIEEEST1A.ka>190</cim:ExcIEEEST1A.ka>
+    <cim:ExcIEEEST1A.kc>0.08</cim:ExcIEEEST1A.kc>
+    <cim:ExcIEEEST1A.kf>0.02</cim:ExcIEEEST1A.kf>
+    <cim:ExcIEEEST1A.klr>0</cim:ExcIEEEST1A.klr>
+    <cim:ExcIEEEST1A.pssin>false</cim:ExcIEEEST1A.pssin>
+    <cim:ExcIEEEST1A.ta>0.1</cim:ExcIEEEST1A.ta>
+    <cim:ExcIEEEST1A.tb>10</cim:ExcIEEEST1A.tb>
+    <cim:ExcIEEEST1A.tb1>0.001</cim:ExcIEEEST1A.tb1>
+    <cim:ExcIEEEST1A.tc>1.5</cim:ExcIEEEST1A.tc>
+    <cim:ExcIEEEST1A.tc1>0.001</cim:ExcIEEEST1A.tc1>
+    <cim:ExcIEEEST1A.tf>0.8</cim:ExcIEEEST1A.tf>
+    <cim:ExcIEEEST1A.uelin rdf:resource="http://iec.ch/TC57/CIM100#ExcIEEEST1AUELselectorKind.ignoreUELsignal" />
+    <cim:ExcIEEEST1A.vamax>8</cim:ExcIEEEST1A.vamax>
+    <cim:ExcIEEEST1A.vamin>-8</cim:ExcIEEEST1A.vamin>
+    <cim:ExcIEEEST1A.vimax>0.2</cim:ExcIEEEST1A.vimax>
+    <cim:ExcIEEEST1A.vimin>-0.2</cim:ExcIEEEST1A.vimin>
+    <cim:ExcIEEEST1A.vrmax>7.8</cim:ExcIEEEST1A.vrmax>
+    <cim:ExcIEEEST1A.vrmin>-6.7</cim:ExcIEEEST1A.vrmin>
+    <cim:IdentifiedObject.mRID>3bd610c9-8ecd-4466-a5ea-c998749a38ea</cim:IdentifiedObject.mRID>
+  </cim:ExcIEEEST1A>
+  <cim:PssIEEE2B rdf:ID="_fd134308-7b1c-4272-b2cd-7989c13a5ca5">
+    <cim:IdentifiedObject.name>NL-G2-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_3bd610c9-8ecd-4466-a5ea-c998749a38ea" />
+    <cim:PssIEEE2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.rotorAngularFrequencyDeviation" />
+    <cim:PssIEEE2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.generatorElectricalPower" />
+    <cim:PssIEEE2B.ks1>10</cim:PssIEEE2B.ks1>
+    <cim:PssIEEE2B.ks2>0.31</cim:PssIEEE2B.ks2>
+    <cim:PssIEEE2B.ks3>1</cim:PssIEEE2B.ks3>
+    <cim:PssIEEE2B.m>5</cim:PssIEEE2B.m>
+    <cim:PssIEEE2B.n>1</cim:PssIEEE2B.n>
+    <cim:PssIEEE2B.t1>0.12</cim:PssIEEE2B.t1>
+    <cim:PssIEEE2B.t10>0</cim:PssIEEE2B.t10>
+    <cim:PssIEEE2B.t11>0</cim:PssIEEE2B.t11>
+    <cim:PssIEEE2B.t2>0.02</cim:PssIEEE2B.t2>
+    <cim:PssIEEE2B.t3>0.4</cim:PssIEEE2B.t3>
+    <cim:PssIEEE2B.t4>0.02</cim:PssIEEE2B.t4>
+    <cim:PssIEEE2B.t6>0</cim:PssIEEE2B.t6>
+    <cim:PssIEEE2B.t7>2</cim:PssIEEE2B.t7>
+    <cim:PssIEEE2B.t8>0.2</cim:PssIEEE2B.t8>
+    <cim:PssIEEE2B.t9>0.1</cim:PssIEEE2B.t9>
+    <cim:PssIEEE2B.tw1>2</cim:PssIEEE2B.tw1>
+    <cim:PssIEEE2B.tw2>2</cim:PssIEEE2B.tw2>
+    <cim:PssIEEE2B.tw3>2</cim:PssIEEE2B.tw3>
+    <cim:PssIEEE2B.tw4>0</cim:PssIEEE2B.tw4>
+    <cim:PssIEEE2B.vsi1max>999</cim:PssIEEE2B.vsi1max>
+    <cim:PssIEEE2B.vsi1min>-999</cim:PssIEEE2B.vsi1min>
+    <cim:PssIEEE2B.vsi2max>999</cim:PssIEEE2B.vsi2max>
+    <cim:PssIEEE2B.vsi2min>-999</cim:PssIEEE2B.vsi2min>
+    <cim:PssIEEE2B.vstmax>0.1</cim:PssIEEE2B.vstmax>
+    <cim:PssIEEE2B.vstmin>-0.1</cim:PssIEEE2B.vstmin>
+    <cim:IdentifiedObject.mRID>fd134308-7b1c-4272-b2cd-7989c13a5ca5</cim:IdentifiedObject.mRID>
+  </cim:PssIEEE2B>
+  <cim:VCompIEEEType1 rdf:ID="_50a79cc5-c98d-4b3b-b863-0b677d09eca3">
+    <cim:IdentifiedObject.name>NL-G2-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_3bd610c9-8ecd-4466-a5ea-c998749a38ea" />
+    <cim:VCompIEEEType1.rc>0</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.xc>0</cim:VCompIEEEType1.xc>
+    <cim:VCompIEEEType1.tr>0</cim:VCompIEEEType1.tr>
+    <cim:IdentifiedObject.mRID>50a79cc5-c98d-4b3b-b863-0b677d09eca3</cim:IdentifiedObject.mRID>
+  </cim:VCompIEEEType1>
+  <cim:VCompIEEEType1 rdf:ID="_38bfffb4-e20d-4259-9a25-92bc74ed1167">
+    <cim:IdentifiedObject.name>NL-G1-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_a29ea0a1-af24-4c9b-aa8f-5c97374996e2" />
+    <cim:VCompIEEEType1.rc>0</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.xc>0</cim:VCompIEEEType1.xc>
+    <cim:VCompIEEEType1.tr>0</cim:VCompIEEEType1.tr>
+    <cim:IdentifiedObject.mRID>38bfffb4-e20d-4259-9a25-92bc74ed1167</cim:IdentifiedObject.mRID>
+  </cim:VCompIEEEType1>
+  <cim:VCompIEEEType1 rdf:ID="_3105e155-0187-4c30-903b-41d4946c39bb">
+    <cim:IdentifiedObject.name>NL-G3-Vcomp</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:VoltageCompensatorDynamics.ExcitationSystemDynamics rdf:resource="#_cf42c5ad-b3f9-4f9f-ae5e-6169cb07ae89" />
+    <cim:VCompIEEEType1.rc>0</cim:VCompIEEEType1.rc>
+    <cim:VCompIEEEType1.xc>0</cim:VCompIEEEType1.xc>
+    <cim:VCompIEEEType1.tr>0</cim:VCompIEEEType1.tr>
+    <cim:IdentifiedObject.mRID>3105e155-0187-4c30-903b-41d4946c39bb</cim:IdentifiedObject.mRID>
+  </cim:VCompIEEEType1>
+  <cim:PssIEEE2B rdf:ID="_fd6074ce-e88d-4191-8dd7-d44114684d47">
+    <cim:IdentifiedObject.name>NL-G1-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_a29ea0a1-af24-4c9b-aa8f-5c97374996e2" />
+    <cim:PssIEEE2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.rotorAngularFrequencyDeviation" />
+    <cim:PssIEEE2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.generatorElectricalPower" />
+    <cim:PssIEEE2B.ks1>12</cim:PssIEEE2B.ks1>
+    <cim:PssIEEE2B.ks2>0.2</cim:PssIEEE2B.ks2>
+    <cim:PssIEEE2B.ks3>1</cim:PssIEEE2B.ks3>
+    <cim:PssIEEE2B.m>5</cim:PssIEEE2B.m>
+    <cim:PssIEEE2B.n>1</cim:PssIEEE2B.n>
+    <cim:PssIEEE2B.t1>0.12</cim:PssIEEE2B.t1>
+    <cim:PssIEEE2B.t10>0</cim:PssIEEE2B.t10>
+    <cim:PssIEEE2B.t11>0</cim:PssIEEE2B.t11>
+    <cim:PssIEEE2B.t2>0.02</cim:PssIEEE2B.t2>
+    <cim:PssIEEE2B.t3>0.3</cim:PssIEEE2B.t3>
+    <cim:PssIEEE2B.t4>0.02</cim:PssIEEE2B.t4>
+    <cim:PssIEEE2B.t6>0</cim:PssIEEE2B.t6>
+    <cim:PssIEEE2B.t7>2</cim:PssIEEE2B.t7>
+    <cim:PssIEEE2B.t8>0</cim:PssIEEE2B.t8>
+    <cim:PssIEEE2B.t9>0.1</cim:PssIEEE2B.t9>
+    <cim:PssIEEE2B.tw1>2</cim:PssIEEE2B.tw1>
+    <cim:PssIEEE2B.tw2>2</cim:PssIEEE2B.tw2>
+    <cim:PssIEEE2B.tw3>2</cim:PssIEEE2B.tw3>
+    <cim:PssIEEE2B.tw4>0</cim:PssIEEE2B.tw4>
+    <cim:PssIEEE2B.vsi1max>999</cim:PssIEEE2B.vsi1max>
+    <cim:PssIEEE2B.vsi1min>-999</cim:PssIEEE2B.vsi1min>
+    <cim:PssIEEE2B.vsi2max>999</cim:PssIEEE2B.vsi2max>
+    <cim:PssIEEE2B.vsi2min>-999</cim:PssIEEE2B.vsi2min>
+    <cim:PssIEEE2B.vstmax>0.1</cim:PssIEEE2B.vstmax>
+    <cim:PssIEEE2B.vstmin>-0.1</cim:PssIEEE2B.vstmin>
+    <cim:IdentifiedObject.mRID>fd6074ce-e88d-4191-8dd7-d44114684d47</cim:IdentifiedObject.mRID>
+  </cim:PssIEEE2B>
+  <cim:ExcIEEEAC1A rdf:ID="_a29ea0a1-af24-4c9b-aa8f-5c97374996e2">
+    <cim:IdentifiedObject.name>NL-G1-ExcAC1A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_bd63d5d8-3d61-4233-a3e0-a66d512c1574" />
+    <cim:ExcIEEEAC1A.ka>30</cim:ExcIEEEAC1A.ka>
+    <cim:ExcIEEEAC1A.kc>0.2</cim:ExcIEEEAC1A.kc>
+    <cim:ExcIEEEAC1A.kd>0.4</cim:ExcIEEEAC1A.kd>
+    <cim:ExcIEEEAC1A.ke>1</cim:ExcIEEEAC1A.ke>
+    <cim:ExcIEEEAC1A.kf>0.03</cim:ExcIEEEAC1A.kf>
+    <cim:ExcIEEEAC1A.seve1>0.03</cim:ExcIEEEAC1A.seve1>
+    <cim:ExcIEEEAC1A.seve2>0.1</cim:ExcIEEEAC1A.seve2>
+    <cim:ExcIEEEAC1A.ta>0.05</cim:ExcIEEEAC1A.ta>
+    <cim:ExcIEEEAC1A.tb>0.02</cim:ExcIEEEAC1A.tb>
+    <cim:ExcIEEEAC1A.tc>0.001</cim:ExcIEEEAC1A.tc>
+    <cim:ExcIEEEAC1A.te>0.4</cim:ExcIEEEAC1A.te>
+    <cim:ExcIEEEAC1A.tf>1</cim:ExcIEEEAC1A.tf>
+    <cim:ExcIEEEAC1A.vamax>10</cim:ExcIEEEAC1A.vamax>
+    <cim:ExcIEEEAC1A.vamin>-10</cim:ExcIEEEAC1A.vamin>
+    <cim:ExcIEEEAC1A.ve1>3.14</cim:ExcIEEEAC1A.ve1>
+    <cim:ExcIEEEAC1A.ve2>4.18</cim:ExcIEEEAC1A.ve2>
+    <cim:ExcIEEEAC1A.vrmax>10</cim:ExcIEEEAC1A.vrmax>
+    <cim:ExcIEEEAC1A.vrmin>-5</cim:ExcIEEEAC1A.vrmin>
+    <cim:IdentifiedObject.mRID>a29ea0a1-af24-4c9b-aa8f-5c97374996e2</cim:IdentifiedObject.mRID>
+  </cim:ExcIEEEAC1A>
+  <cim:ExcIEEEST1A rdf:ID="_cf42c5ad-b3f9-4f9f-ae5e-6169cb07ae89">
+    <cim:IdentifiedObject.name>NL-G3-Exc-ST1A</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:ExcitationSystemDynamics.SynchronousMachineDynamics rdf:resource="#_f450a965-7cfb-4516-a2bf-618f05e84eed" />
+    <cim:ExcIEEEST1A.ilr>0</cim:ExcIEEEST1A.ilr>
+    <cim:ExcIEEEST1A.ka>220</cim:ExcIEEEST1A.ka>
+    <cim:ExcIEEEST1A.kc>0.08</cim:ExcIEEEST1A.kc>
+    <cim:ExcIEEEST1A.kf>0.02</cim:ExcIEEEST1A.kf>
+    <cim:ExcIEEEST1A.klr>0</cim:ExcIEEEST1A.klr>
+    <cim:ExcIEEEST1A.pssin>false</cim:ExcIEEEST1A.pssin>
+    <cim:ExcIEEEST1A.ta>0.1</cim:ExcIEEEST1A.ta>
+    <cim:ExcIEEEST1A.tb>10</cim:ExcIEEEST1A.tb>
+    <cim:ExcIEEEST1A.tb1>0.001</cim:ExcIEEEST1A.tb1>
+    <cim:ExcIEEEST1A.tc>1.5</cim:ExcIEEEST1A.tc>
+    <cim:ExcIEEEST1A.tc1>0.001</cim:ExcIEEEST1A.tc1>
+    <cim:ExcIEEEST1A.tf>0.8</cim:ExcIEEEST1A.tf>
+    <cim:ExcIEEEST1A.uelin rdf:resource="http://iec.ch/TC57/CIM100#ExcIEEEST1AUELselectorKind.ignoreUELsignal" />
+    <cim:ExcIEEEST1A.vamax>8</cim:ExcIEEEST1A.vamax>
+    <cim:ExcIEEEST1A.vamin>-8</cim:ExcIEEEST1A.vamin>
+    <cim:ExcIEEEST1A.vimax>0.2</cim:ExcIEEEST1A.vimax>
+    <cim:ExcIEEEST1A.vimin>-0.2</cim:ExcIEEEST1A.vimin>
+    <cim:ExcIEEEST1A.vrmax>7.8</cim:ExcIEEEST1A.vrmax>
+    <cim:ExcIEEEST1A.vrmin>-6.7</cim:ExcIEEEST1A.vrmin>
+    <cim:IdentifiedObject.mRID>cf42c5ad-b3f9-4f9f-ae5e-6169cb07ae89</cim:IdentifiedObject.mRID>
+  </cim:ExcIEEEST1A>
+  <cim:PssIEEE2B rdf:ID="_6b347d56-00c6-4916-be40-08c9b11c32b9">
+    <cim:IdentifiedObject.name>NL-G3-PSSB</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:PowerSystemStabilizerDynamics.ExcitationSystemDynamics rdf:resource="#_cf42c5ad-b3f9-4f9f-ae5e-6169cb07ae89" />
+    <cim:PssIEEE2B.inputSignal1Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.rotorAngularFrequencyDeviation" />
+    <cim:PssIEEE2B.inputSignal2Type rdf:resource="http://iec.ch/TC57/CIM100#InputSignalKind.generatorElectricalPower" />
+    <cim:PssIEEE2B.ks1>10</cim:PssIEEE2B.ks1>
+    <cim:PssIEEE2B.ks2>0.31</cim:PssIEEE2B.ks2>
+    <cim:PssIEEE2B.ks3>1</cim:PssIEEE2B.ks3>
+    <cim:PssIEEE2B.m>5</cim:PssIEEE2B.m>
+    <cim:PssIEEE2B.n>1</cim:PssIEEE2B.n>
+    <cim:PssIEEE2B.t1>0.3</cim:PssIEEE2B.t1>
+    <cim:PssIEEE2B.t10>0</cim:PssIEEE2B.t10>
+    <cim:PssIEEE2B.t11>0</cim:PssIEEE2B.t11>
+    <cim:PssIEEE2B.t2>0.02</cim:PssIEEE2B.t2>
+    <cim:PssIEEE2B.t3>0.45</cim:PssIEEE2B.t3>
+    <cim:PssIEEE2B.t4>0.02</cim:PssIEEE2B.t4>
+    <cim:PssIEEE2B.t6>0</cim:PssIEEE2B.t6>
+    <cim:PssIEEE2B.t7>2</cim:PssIEEE2B.t7>
+    <cim:PssIEEE2B.t8>0.2</cim:PssIEEE2B.t8>
+    <cim:PssIEEE2B.t9>0.1</cim:PssIEEE2B.t9>
+    <cim:PssIEEE2B.tw1>2</cim:PssIEEE2B.tw1>
+    <cim:PssIEEE2B.tw2>2</cim:PssIEEE2B.tw2>
+    <cim:PssIEEE2B.tw3>2</cim:PssIEEE2B.tw3>
+    <cim:PssIEEE2B.tw4>0</cim:PssIEEE2B.tw4>
+    <cim:PssIEEE2B.vsi1max>999</cim:PssIEEE2B.vsi1max>
+    <cim:PssIEEE2B.vsi1min>-999</cim:PssIEEE2B.vsi1min>
+    <cim:PssIEEE2B.vsi2max>999</cim:PssIEEE2B.vsi2max>
+    <cim:PssIEEE2B.vsi2min>-999</cim:PssIEEE2B.vsi2min>
+    <cim:PssIEEE2B.vstmax>0.1</cim:PssIEEE2B.vstmax>
+    <cim:PssIEEE2B.vstmin>-0.1</cim:PssIEEE2B.vstmin>
+    <cim:IdentifiedObject.mRID>6b347d56-00c6-4916-be40-08c9b11c32b9</cim:IdentifiedObject.mRID>
+  </cim:PssIEEE2B>
+  <cim:GovHydro1 rdf:ID="_f12ead9a-0d9d-469e-9351-0f187bd2e523">
+    <cim:IdentifiedObject.name>NL-G2-Turb-GovHydro1</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_e58068fe-5436-4a2a-aa72-da3377ea1355" />
+    <cim:GovHydro1.at>1.2</cim:GovHydro1.at>
+    <cim:GovHydro1.dturb>0.3</cim:GovHydro1.dturb>
+    <cim:GovHydro1.gmax>0.75</cim:GovHydro1.gmax>
+    <cim:GovHydro1.gmin>0</cim:GovHydro1.gmin>
+    <cim:GovHydro1.hdam>1</cim:GovHydro1.hdam>
+    <cim:GovHydro1.mwbase>225</cim:GovHydro1.mwbase>
+    <cim:GovHydro1.qnl>0.08</cim:GovHydro1.qnl>
+    <cim:GovHydro1.rperm>0.05</cim:GovHydro1.rperm>
+    <cim:GovHydro1.rtemp>1.27</cim:GovHydro1.rtemp>
+    <cim:GovHydro1.tf>0.099</cim:GovHydro1.tf>
+    <cim:GovHydro1.tg>0.9</cim:GovHydro1.tg>
+    <cim:GovHydro1.tr>10.4</cim:GovHydro1.tr>
+    <cim:GovHydro1.tw>2.6</cim:GovHydro1.tw>
+    <cim:GovHydro1.velm>0.2</cim:GovHydro1.velm>
+    <cim:IdentifiedObject.mRID>f12ead9a-0d9d-469e-9351-0f187bd2e523</cim:IdentifiedObject.mRID>
+  </cim:GovHydro1>
+  <cim:GovHydro2 rdf:ID="_32fb9a75-5aa2-4ead-843b-8b8c0254683d">
+    <cim:IdentifiedObject.name>NL-G1-IEEEEG3</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_bd63d5d8-3d61-4233-a3e0-a66d512c1574" />
+    <cim:GovHydro2.aturb>-1</cim:GovHydro2.aturb>
+    <cim:GovHydro2.bturb>0.5</cim:GovHydro2.bturb>
+    <cim:GovHydro2.db2>0</cim:GovHydro2.db2>
+    <cim:GovHydro2.db1>0</cim:GovHydro2.db1>
+    <cim:GovHydro2.eps>0</cim:GovHydro2.eps>
+    <cim:GovHydro2.gv1>0</cim:GovHydro2.gv1>
+    <cim:GovHydro2.gv2>0.25</cim:GovHydro2.gv2>
+    <cim:GovHydro2.gv3>0.5</cim:GovHydro2.gv3>
+    <cim:GovHydro2.gv4>0.75</cim:GovHydro2.gv4>
+    <cim:GovHydro2.gv5>1</cim:GovHydro2.gv5>
+    <cim:GovHydro2.gv6>1.25</cim:GovHydro2.gv6>
+    <cim:GovHydro2.kturb>1</cim:GovHydro2.kturb>
+    <cim:GovHydro2.mwbase>990</cim:GovHydro2.mwbase>
+    <cim:GovHydro2.pgv1>0</cim:GovHydro2.pgv1>
+    <cim:GovHydro2.pgv2>0.25</cim:GovHydro2.pgv2>
+    <cim:GovHydro2.pgv3>0.5</cim:GovHydro2.pgv3>
+    <cim:GovHydro2.pgv4>0.75</cim:GovHydro2.pgv4>
+    <cim:GovHydro2.pgv5>1</cim:GovHydro2.pgv5>
+    <cim:GovHydro2.pgv6>1.25</cim:GovHydro2.pgv6>
+    <cim:GovHydro2.pmax>1</cim:GovHydro2.pmax>
+    <cim:GovHydro2.pmin>-1</cim:GovHydro2.pmin>
+    <cim:GovHydro2.rperm>0.05</cim:GovHydro2.rperm>
+    <cim:GovHydro2.rtemp>0.52</cim:GovHydro2.rtemp>
+    <cim:GovHydro2.tg>1</cim:GovHydro2.tg>
+    <cim:GovHydro2.tp>0.04</cim:GovHydro2.tp>
+    <cim:GovHydro2.tr>9.19</cim:GovHydro2.tr>
+    <cim:GovHydro2.tw>1.84</cim:GovHydro2.tw>
+    <cim:GovHydro2.uc>-0.2</cim:GovHydro2.uc>
+    <cim:GovHydro2.uo>0.2</cim:GovHydro2.uo>
+    <cim:IdentifiedObject.mRID>32fb9a75-5aa2-4ead-843b-8b8c0254683d</cim:IdentifiedObject.mRID>
+  </cim:GovHydro2>
+  <cim:GovHydro1 rdf:ID="_93e64753-4784-4bc0-8ba9-48eae88cce2f">
+    <cim:IdentifiedObject.name>NL-G3-GovHydro1</cim:IdentifiedObject.name>
+    <cim:DynamicsFunctionBlock.enabled>true</cim:DynamicsFunctionBlock.enabled>
+    <cim:TurbineGovernorDynamics.SynchronousMachineDynamics rdf:resource="#_f450a965-7cfb-4516-a2bf-618f05e84eed" />
+    <cim:GovHydro1.at>1.2</cim:GovHydro1.at>
+    <cim:GovHydro1.dturb>0.3</cim:GovHydro1.dturb>
+    <cim:GovHydro1.gmax>0.75</cim:GovHydro1.gmax>
+    <cim:GovHydro1.gmin>0</cim:GovHydro1.gmin>
+    <cim:GovHydro1.hdam>1</cim:GovHydro1.hdam>
+    <cim:GovHydro1.mwbase>225</cim:GovHydro1.mwbase>
+    <cim:GovHydro1.qnl>0.08</cim:GovHydro1.qnl>
+    <cim:GovHydro1.rperm>0.05</cim:GovHydro1.rperm>
+    <cim:GovHydro1.rtemp>1.27</cim:GovHydro1.rtemp>
+    <cim:GovHydro1.tf>0.099</cim:GovHydro1.tf>
+    <cim:GovHydro1.tg>0.9</cim:GovHydro1.tg>
+    <cim:GovHydro1.tr>10.4</cim:GovHydro1.tr>
+    <cim:GovHydro1.tw>2.6</cim:GovHydro1.tw>
+    <cim:GovHydro1.velm>0.2</cim:GovHydro1.velm>
+    <cim:IdentifiedObject.mRID>93e64753-4784-4bc0-8ba9-48eae88cce2f</cim:IdentifiedObject.mRID>
+  </cim:GovHydro1>
+</rdf:RDF>

--- a/cgmes/cgmes-conversion/pom.xml
+++ b/cgmes/cgmes-conversion/pom.xml
@@ -34,13 +34,6 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/cgmes/cgmes-conversion/pom.xml
+++ b/cgmes/cgmes-conversion/pom.xml
@@ -34,6 +34,13 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity3ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity3ConversionTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.test.conformity;
+
+import com.powsybl.cgmes.conformity.CgmesConformity3Catalog;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.TieLine;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+public class CgmesConformity3ConversionTest {
+    @Test
+    public void microGridBaseCaseBEMergedWithNL() {
+        Network be = Network.read(CgmesConformity3Catalog.microGridBaseCaseBE().dataSource());
+        assertNotEquals("unknown", be.getId());
+        int nSubBE = be.getSubstationCount();
+        int nDlBE = be.getDanglingLineCount();
+        Network nl = Network.read(CgmesConformity3Catalog.microGridBaseCaseNL().dataSource());
+        assertNotEquals("unknown", nl.getId());
+        int nSubNL = nl.getSubstationCount();
+        int nDlNL = nl.getDanglingLineCount();
+        // Both networks have the same number of dangling lines
+        assertEquals(nDlBE, nDlNL);
+        be.merge(nl);
+        int nSub = be.getSubstationCount();
+        assertEquals(nSubBE + nSubNL, nSub);
+        long nTl = be.getLineStream().filter(l -> l instanceof TieLine).count();
+        // All dangling lines must have been converted to tie lines
+        assertEquals(nDlBE, nTl);
+    }
+}

--- a/cgmes/cgmes-model/src/main/resources/CIM100.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM100.sparql
@@ -8,7 +8,7 @@
 # include: CIM16.sparql
 
 # query: boundaryNodes
-# All pairs (Connectiviy Node, Topological Node) from a graph that has a modelProfile EquipmentBoundary-
+# All pairs (Connectiviy Node, Topological Node) from a graph that has a modeProfile EquipmentBoundary-
 # We expect all Connectivity Nodes have 1 and only one corresponding TopologicalNode
 prefix md: <http://iec.ch/TC57/61970-552/ModelDescription/1#>
 SELECT *
@@ -32,6 +32,19 @@ OPTIONAL { GRAPH ?grapBDTP {
     ?TopologicalNode cim:IdentifiedObject.name ?topologicalNodeName
 }}
 }
+
+# query: modelIds
+prefix md: <http://iec.ch/TC57/61970-552/ModelDescription/1#>
+SELECT *
+{ GRAPH ?graph {
+    # We will return all model identifiers for FullModel objects of profile EquipmentCore
+    ?FullModel
+        a md:FullModel ;
+        md:Model.modelingAuthoritySet ?modelingAuthoritySet ;
+        md:Model.profile ?profile .
+    FILTER (regex(?profile, "CoreEquipment", "i")
+        && !regex(?profile, "EquipmentBoundary", "i"))
+}}
 
 # query: synchronousMachines
 SELECT *


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The network identifier is not read correctly for CGMES 3 (CIM100) files. The Network identifier is read as the `FullModel` `mRID` of the EQ instance file.

**What is the new behavior (if this is a feature change)?**
The network identifier is read correctly for CGMES 3 files. The profile name that identifies the EQ instance file has been updated for the CGMES 3 in the corresponding SPARQL query. 

