### PR TITLE
Add side integer to SensitivityFunctionType, SensitivityVariableType 

### DIFF
--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFunctionType.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFunctionType.java
@@ -10,32 +10,42 @@ import java.util.OptionalInt;
 
 /**
  * Supported function types related to the equipment to monitor. Use:
- * - BRANCH_ACTIVE_POWER_1 and BRANCH_ACTIVE_POWER_2 if you want to monitor the active power in MW of a network branch (lines,
+ * <ul>
+ *     <li>{@link #BRANCH_ACTIVE_POWER_1} and {@link #BRANCH_ACTIVE_POWER_2} if you want to monitor the active power in MW of a network branch (lines,
  * two windings transformer, dangling lines, etc.). Use 1 for side 1 and 2 for side 2. In case of a three windings transformer,
- * use BRANCH_ACTIVE_POWER_3 to monitor the active power in MW of the leg 3 (network side).
- * - BRANCH_CURRENT_1 and BRANCH_CURRENT_2 if you want to monitor the current in A of a network branch (lines,
+ * use {@link #BRANCH_ACTIVE_POWER_3} to monitor the active power in MW of the leg 3 (network side).</li>
+ *     <li>{@link #BRANCH_CURRENT_1} and {@link #BRANCH_CURRENT_2} if you want to monitor the current in A of a network branch (lines,
  * two windings transformer, dangling lines, etc.). Use 1 for side 1 and use 2 for side 2. In case of a three windings transformer,
- * use BRANCH_CURRENT_3 to monitor the current in A of the leg 3 (network side).
- * - BUS_VOLTAGE if you want to monitor the voltage in KV of a specific network bus.
- *
+ * use {@link #BRANCH_CURRENT_3} to monitor the current in A of the leg 3 (network side).</li>
+ *     <li>{@link #BUS_VOLTAGE} if you want to monitor the voltage in KV of a specific network bus.</li>
+ * </ul>
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public enum SensitivityFunctionType {
     /**
+     * in MW
      * @deprecated Use {@link #BRANCH_ACTIVE_POWER_1} instead.
      */
-    @Deprecated BRANCH_ACTIVE_POWER, // MW
+    @Deprecated BRANCH_ACTIVE_POWER,
     /**
+     * in A
      * @deprecated Use {@link #BRANCH_CURRENT_1} instead.
      */
-    @Deprecated BRANCH_CURRENT, // A
-    BRANCH_ACTIVE_POWER_1(1), // MW
-    BRANCH_CURRENT_1(1), // A
-    BRANCH_ACTIVE_POWER_2(2), // MW
-    BRANCH_CURRENT_2(2), // A
-    BRANCH_ACTIVE_POWER_3(3), // MW
-    BRANCH_CURRENT_3(3), // A
-    BUS_VOLTAGE; // KV
+    @Deprecated BRANCH_CURRENT,
+    /** in MW */
+    BRANCH_ACTIVE_POWER_1(1),
+    /** in A */
+    BRANCH_CURRENT_1(1),
+    /** in MW */
+    BRANCH_ACTIVE_POWER_2(2),
+    /** in A */
+    BRANCH_CURRENT_2(2),
+    /** in MW */
+    BRANCH_ACTIVE_POWER_3(3),
+    /** in A */
+    BRANCH_CURRENT_3(3),
+    /** in kV */
+    BUS_VOLTAGE;
 
     private final Integer side;
 

--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFunctionType.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFunctionType.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.sensitivity;
 
+import java.util.OptionalInt;
+
 /**
  * Supported function types related to the equipment to monitor. Use:
  * - BRANCH_ACTIVE_POWER_1 and BRANCH_ACTIVE_POWER_2 if you want to monitor the active power in MW of a network branch (lines,
@@ -13,7 +15,7 @@ package com.powsybl.sensitivity;
  * use BRANCH_ACTIVE_POWER_3 to monitor the active power in MW of the leg 3 (network side).
  * - BRANCH_CURRENT_1 and BRANCH_CURRENT_2 if you want to monitor the current in A of a network branch (lines,
  * two windings transformer, dangling lines, etc.). Use 1 for side 1 and use 2 for side 2. In case of a three windings transformer,
- *  use BRANCH_CURRENT_3 to monitor the current in A of the leg 3 (network side).
+ * use BRANCH_CURRENT_3 to monitor the current in A of the leg 3 (network side).
  * - BUS_VOLTAGE if you want to monitor the voltage in KV of a specific network bus.
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -27,11 +29,25 @@ public enum SensitivityFunctionType {
      * @deprecated Use {@link #BRANCH_CURRENT_1} instead.
      */
     @Deprecated BRANCH_CURRENT, // A
-    BRANCH_ACTIVE_POWER_1, // MW
-    BRANCH_CURRENT_1, // A
-    BRANCH_ACTIVE_POWER_2, // MW
-    BRANCH_CURRENT_2, // A
-    BRANCH_ACTIVE_POWER_3, // MW
-    BRANCH_CURRENT_3, // A
-    BUS_VOLTAGE // KV
+    BRANCH_ACTIVE_POWER_1(1), // MW
+    BRANCH_CURRENT_1(1), // A
+    BRANCH_ACTIVE_POWER_2(2), // MW
+    BRANCH_CURRENT_2(2), // A
+    BRANCH_ACTIVE_POWER_3(3), // MW
+    BRANCH_CURRENT_3(3), // A
+    BUS_VOLTAGE; // KV
+
+    private final Integer side;
+
+    SensitivityFunctionType() {
+        this.side = null;
+    }
+
+    SensitivityFunctionType(int side) {
+        this.side = side;
+    }
+
+    public OptionalInt getSide() {
+        return side == null ? OptionalInt.empty() : OptionalInt.of(side);
+    }
 }

--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityVariableType.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityVariableType.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.sensitivity;
 
+import java.util.OptionalInt;
+
 /**
  * A variable represents a change on a equipment or on a group of equipments. The supported variable types are:
  * - Use INJECTION_ACTIVE_POWER to model a change on the production of a generator or on a group of generators, on
@@ -26,7 +28,21 @@ public enum SensitivityVariableType {
     TRANSFORMER_PHASE, // °
     BUS_TARGET_VOLTAGE, // KV
     HVDC_LINE_ACTIVE_POWER, // MW
-    TRANSFORMER_PHASE_1, // °
-    TRANSFORMER_PHASE_2, // °
-    TRANSFORMER_PHASE_3 // °
+    TRANSFORMER_PHASE_1(1), // °
+    TRANSFORMER_PHASE_2(2), // °
+    TRANSFORMER_PHASE_3(3); // °
+
+    private final Integer side;
+
+    SensitivityVariableType() {
+        this.side = null;
+    }
+
+    SensitivityVariableType(int side) {
+        this.side = side;
+    }
+
+    public OptionalInt getSide() {
+        return side == null ? OptionalInt.empty() : OptionalInt.of(side);
+    }
 }

--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityVariableType.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityVariableType.java
@@ -10,27 +10,35 @@ import java.util.OptionalInt;
 
 /**
  * A variable represents a change on a equipment or on a group of equipments. The supported variable types are:
- * - Use INJECTION_ACTIVE_POWER to model a change on the production of a generator or on a group of generators, on
+ * <ul>
+ *     <li>Use {@link #INJECTION_ACTIVE_POWER} to model a change on the production of a generator or on a group of generators, on
  * the consumption of a load or on a group of loads or on GLSK (for Generation and Load Shift keys) that describes a
- * linear combination of power injection shifts on generators and loads. The variable increase is in MW.
- * - Use TRANSFORMER_PHASE to model the change of the tap position of a phase tap changer of a two windings transformer
- * or a three windings transformer that contains only one phase tap changer. The increase is in degree.
- * - Use BUS_TARGET_VOLTAGE to model an increase of the voltage target of a generator, a static var compensator, a two
- * or three windings transformer, a shunt compensator or a VSC converter station. The increase is in KV.
- * - Use HVDC_LINE_ACTIVE_POWER to model the change of the active power set point of an HVDC line. The increase is in MW.
- * - Use TRANSFORMER_PHASE_1, TRANSFORMER_PHASE_2 or TRANSFORMER_PHASE_3 to model the change of the tap position of a phase
- * tap changer of a three windings transformer that contains several phase tap changers.
- *
+ * linear combination of power injection shifts on generators and loads. The variable increase is in MW.</li>
+ *     <li>Use {@link #TRANSFORMER_PHASE} to model the change of the tap position of a phase tap changer of a two windings transformer
+ * or a three windings transformer that contains only one phase tap changer. The increase is in degree.</li>
+ *     <li>Use {@link #BUS_TARGET_VOLTAGE} to model an increase of the voltage target of a generator, a static var compensator, a two
+ * or three windings transformer, a shunt compensator or a VSC converter station. The increase is in KV.</li>
+ *     <li>Use {@link #HVDC_LINE_ACTIVE_POWER} to model the change of the active power set point of an HVDC line. The increase is in MW.</li>
+ *     <li>Use {@link #TRANSFORMER_PHASE_1}, {@link #TRANSFORMER_PHASE_2} or {@link #TRANSFORMER_PHASE_3} to model the change of the tap position of a phase
+ * tap changer of a three windings transformer that contains several phase tap changers.</li>
+ * </ul>
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public enum SensitivityVariableType {
-    INJECTION_ACTIVE_POWER, // MW
-    TRANSFORMER_PHASE, // °
-    BUS_TARGET_VOLTAGE, // KV
-    HVDC_LINE_ACTIVE_POWER, // MW
-    TRANSFORMER_PHASE_1(1), // °
-    TRANSFORMER_PHASE_2(2), // °
-    TRANSFORMER_PHASE_3(3); // °
+    /** increase in MW */
+    INJECTION_ACTIVE_POWER,
+    /** increase in degrees */
+    TRANSFORMER_PHASE,
+    /** increase in kV */
+    BUS_TARGET_VOLTAGE,
+    /** increase in MW */
+    HVDC_LINE_ACTIVE_POWER,
+    /** increase in degrees */
+    TRANSFORMER_PHASE_1(1),
+    /** increase in degrees */
+    TRANSFORMER_PHASE_2(2),
+    /** increase in degrees */
+    TRANSFORMER_PHASE_3(3);
 
     private final Integer side;
 

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisResultTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityAnalysisResultTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.*;
 public class SensitivityAnalysisResultTest extends AbstractConverterTest {
 
     @Test
-    public void test() {
+    public void testSide1() {
         SensitivityFactor factor1 = new SensitivityFactor(SensitivityFunctionType.BRANCH_ACTIVE_POWER_1, "l",
                                                           SensitivityVariableType.INJECTION_ACTIVE_POWER, "g",
                                                           false, ContingencyContext.all());
@@ -44,7 +44,8 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
                 false, ContingencyContext.none());
 
         List<SensitivityFactor> factors = List.of(factor1, factor2, factor3, factor4, factor5);
-        List<Contingency> contingencies = List.of(new Contingency("NHV1_NHV2_2", new BranchContingency("NHV1_NHV2_2")), new Contingency("NHV2_NHV3"));
+        factors.forEach(f -> assertEquals(1, f.getFunctionType().getSide().orElse(0)));
+
         SensitivityValue value1 = new SensitivityValue(0, 0, 1d, 2d);
         SensitivityValue value2 = new SensitivityValue(1, -1, 3d, 4d);
         SensitivityValue value3 = new SensitivityValue(2, 0, 1d, 2d);
@@ -103,6 +104,8 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
                 false, ContingencyContext.none());
 
         List<SensitivityFactor> factors = List.of(factor1, factor2, factor3, factor4, factor5);
+        factors.forEach(f -> assertEquals(2, f.getFunctionType().getSide().orElse(0)));
+
         List<Contingency> contingencies = List.of(new Contingency("NHV1_NHV2_2", new BranchContingency("NHV1_NHV2_2")));
         SensitivityValue value1 = new SensitivityValue(0, 0, 1d, 2d);
         SensitivityValue value2 = new SensitivityValue(1, -1, 3d, 4d);
@@ -156,6 +159,8 @@ public class SensitivityAnalysisResultTest extends AbstractConverterTest {
                 false, ContingencyContext.none());
 
         List<SensitivityFactor> factors = List.of(factor1, factor2, factor3, factor4, factor5);
+        factors.forEach(f -> assertEquals(3, f.getFunctionType().getSide().orElse(0)));
+
         List<Contingency> contingencies = List.of(new Contingency("NHV1_NHV2_2", new BranchContingency("NHV1_NHV2_2")));
         SensitivityValue value1 = new SensitivityValue(0, 0, 2d, 2d);
         SensitivityValue value2 = new SensitivityValue(1, -1, 6d, 4d);

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityFactorTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityFactorTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.OptionalInt;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -31,8 +32,10 @@ public class SensitivityFactorTest extends AbstractConverterTest {
                                                          false, ContingencyContext.all());
         assertEquals(ContingencyContext.all(), factor.getContingencyContext());
         assertEquals(SensitivityFunctionType.BRANCH_ACTIVE_POWER_1, factor.getFunctionType());
+        assertEquals(1, factor.getFunctionType().getSide().orElse(0));
         assertEquals("l", factor.getFunctionId());
         assertEquals(SensitivityVariableType.INJECTION_ACTIVE_POWER, factor.getVariableType());
+        assertEquals(OptionalInt.empty(), factor.getVariableType().getSide());
         assertEquals("g", factor.getVariableId());
         assertFalse(factor.isVariableSet());
         assertEquals("SensitivityFactor(functionType=BRANCH_ACTIVE_POWER_1, functionId='l', variableType=INJECTION_ACTIVE_POWER, variableId='g', variableSet=false, contingencyContext=ContingencyContext(contingencyId='', contextType=ALL))", factor.toString());
@@ -46,7 +49,9 @@ public class SensitivityFactorTest extends AbstractConverterTest {
         assertEquals(ContingencyContext.all(), factor1.getContingencyContext());
         assertEquals("l", factor1.getFunctionId());
         assertEquals(SensitivityFunctionType.BRANCH_ACTIVE_POWER_1, factor1.getFunctionType());
+        assertEquals(1, factor1.getFunctionType().getSide().orElse(0));
         assertEquals(SensitivityVariableType.TRANSFORMER_PHASE_1, factor1.getVariableType());
+        assertEquals(1, factor1.getVariableType().getSide().orElse(0));
         assertEquals("ptc1", factor1.getVariableId());
         assertFalse(factor1.isVariableSet());
         assertEquals("SensitivityFactor(functionType=BRANCH_ACTIVE_POWER_1, functionId='l', variableType=TRANSFORMER_PHASE_1, variableId='ptc1', variableSet=false, contingencyContext=ContingencyContext(contingencyId='', contextType=ALL))", factor1.toString());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Feature


**What is the current behavior?**
The side can be easily guessed from the enum name or the javadoc
Wrong formatting in Javadoc

**What is the new behavior (if this is a feature change)?**
The user can get the side with an `OptionalInt getSide()` method on the enums.
Javadoc formatted


**Does this PR introduce a breaking change or deprecate an API?** 
No
