### PR TITLE
Add comparison of intermediary file in roundTrip

### DIFF
--- a/commons-test/src/main/java/com/powsybl/commons/test/AbstractConverterTest.java
+++ b/commons-test/src/main/java/com/powsybl/commons/test/AbstractConverterTest.java
@@ -61,11 +61,14 @@ public abstract class AbstractConverterTest {
 
     protected <T> T roundTripTest(T data, BiConsumer<T, Path> out, Function<Path, T> in, BiConsumer<InputStream, InputStream> compare, String ref) throws IOException {
         Path xmlFile = writeTest(data, out, compare, ref);
+        try (InputStream is1 = Files.newInputStream(xmlFile)) {
+            compare.accept(getClass().getResourceAsStream(ref), is1);
+        }
         T data2 = in.apply(xmlFile);
         Path xmlFile2 = tmpDir.resolve("data2");
         out.accept(data2, xmlFile2);
-        try (InputStream is = Files.newInputStream(xmlFile2)) {
-            compare.accept(getClass().getResourceAsStream(ref), is);
+        try (InputStream is2 = Files.newInputStream(xmlFile2)) {
+            compare.accept(getClass().getResourceAsStream(ref), is2);
         }
         return data2;
     }


### PR DESCRIPTION
Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Make roundTrip more robust by checking intermediary result: checks that read and write are consistent


**What is the current behavior?** *(You can also link to an open issue here)*
RoundTrip only checks that the last file is identical with the reference


**What is the new behavior (if this is a feature change)?**
RoundTrip also checks that the intermediary file is identical with the reference


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
