### PR TITLE
Fix proportional scaling with constant power factor

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ProportionalScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ProportionalScalable.java
@@ -140,7 +140,7 @@ class ProportionalScalable extends AbstractCompoundScalable {
             double askedOnScalable = iterationPercentage / 100 * asked;
             double doneOnScalable = 0;
             if (constantPowerFactor) {
-                doneOnScalable = s.scaleWithConstantPowerFactor(n, askedOnScalable);
+                doneOnScalable = s.scaleWithConstantPowerFactor(n, askedOnScalable, scalingConvention);
             } else {
                 doneOnScalable = s.scale(n, askedOnScalable, scalingConvention);
             }

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/ScalableTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/ScalableTest.java
@@ -297,6 +297,19 @@ public class ScalableTest {
     }
 
     @Test
+    public void testConstantPowerFactorScalingWithLoadConvention() {
+        reset();
+        network.getLoad("l1").setQ0(10);
+        network.getLoad("l1").setP0(100);
+        network.getGenerator("g1").setTargetP(70);
+        double done = Scalable.proportional(Arrays.asList(50.f, 50.f), Arrays.asList(g1, l1)).scaleWithConstantPowerFactor(network, 100.0, LOAD);
+        assertEquals(100.0, done, 1e-5);
+        assertEquals(150.0, network.getLoad("l1").getP0(), 1e-5);
+        assertEquals(15.0, network.getLoad("l1").getQ0(), 1e-5);
+        assertEquals(20.0, network.getGenerator("g1").getTargetP(), 1e-5);
+    }
+
+    @Test
     public void testStackScale() {
         //By default ScalingConvention.GENERATOR
         Scalable scalable = Scalable.stack(g1, g2);


### PR DESCRIPTION
Signed-off-by: Coline PILOQUET <coline.piloquet@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Proportional scaling with constant power factor possible in LOAD convention.


**What is the current behavior?** *(You can also link to an open issue here)*
Proportional scaling with constant power factor was always done in GENERATOR convention.