### PR TITLE
Add option in XMLExporter to export a network without equipment which don't have a connectable electrical bus (BusView) at every terminal

### DIFF
--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractConnectableXml.java
@@ -39,6 +39,11 @@ public abstract class AbstractConnectableXml<T extends Connectable, A extends Id
         return index != null ? index.toString() : "";
     }
 
+    @Override
+    protected boolean isValid(T identifiable, P parent, NetworkXmlWriterContext context) {
+        return !context.getOptions().ignoreEquipmentWithoutConnectableBus() || identifiable.getTerminals().stream().allMatch(t -> ((Terminal) t).getBusView().getConnectableBus() != null);
+    }
+
     protected static boolean hasValidOperationalLimits(Branch<?> branch, NetworkXmlWriterContext context) {
         if (context.getVersion().compareTo(IidmXmlVersion.V_1_5) >= 0) {
             return !branch.getOperationalLimits1().isEmpty() || !branch.getOperationalLimits2().isEmpty();

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractIdentifiableXml.java
@@ -30,7 +30,7 @@ abstract class AbstractIdentifiableXml<T extends Identifiable, A extends Identif
         return hasSubElements(identifiable);
     }
 
-    protected boolean isValid(T identifiable, P parent) {
+    protected boolean isValid(T identifiable, P parent, NetworkXmlWriterContext context) {
         return true;
     }
 
@@ -40,7 +40,7 @@ abstract class AbstractIdentifiableXml<T extends Identifiable, A extends Identif
     }
 
     public final void write(T identifiable, P parent, NetworkXmlWriterContext context) throws XMLStreamException {
-        if (!isValid(identifiable, parent)) {
+        if (!isValid(identifiable, parent, context)) {
             return;
         }
         boolean isNotEmptyElement = hasSubElements(identifiable, context) || identifiable.hasProperty() || identifiable.hasAliases();

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/BusBreakerViewSwitchXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/BusBreakerViewSwitchXml.java
@@ -25,7 +25,7 @@ public class BusBreakerViewSwitchXml extends AbstractSwitchXml<VoltageLevel.BusB
     static final BusBreakerViewSwitchXml INSTANCE = new BusBreakerViewSwitchXml();
 
     @Override
-    protected boolean isValid(Switch s, VoltageLevel vl) {
+    protected boolean isValid(Switch s, VoltageLevel vl, NetworkXmlWriterContext context) {
         VoltageLevel.BusBreakerView v = vl.getBusBreakerView();
         if (v.getBus1(s.getId()).getId().equals(v.getBus2(s.getId()).getId())) {
             LOGGER.warn("Discard switch with same bus at both ends. Id: {}", s.getId());

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ExportOptions.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ExportOptions.java
@@ -62,6 +62,8 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
      */
     private boolean sorted = false;
 
+    private boolean ignoreEquipmentWithoutConnectableBus = false;
+
     public ExportOptions() {
     }
 
@@ -83,6 +85,11 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
 
     public ExportOptions(boolean withBranchSV, boolean indent, boolean onlyMainCc, TopologyLevel topologyLevel, boolean throwExceptionIfExtensionNotFound, boolean sorted, String version,
                          IidmVersionIncompatibilityBehavior iidmVersionIncompatibilityBehavior) {
+        this(withBranchSV, indent, onlyMainCc, topologyLevel, throwExceptionIfExtensionNotFound, sorted, version, iidmVersionIncompatibilityBehavior, false);
+    }
+
+    public ExportOptions(boolean withBranchSV, boolean indent, boolean onlyMainCc, TopologyLevel topologyLevel, boolean throwExceptionIfExtensionNotFound, boolean sorted, String version,
+                         IidmVersionIncompatibilityBehavior iidmVersionIncompatibilityBehavior, boolean ignoreEquipmentWithoutConnectableBus) {
         this.withBranchSV = withBranchSV;
         this.indent = indent;
         this.onlyMainCc = onlyMainCc;
@@ -91,6 +98,7 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
         this.sorted = sorted;
         this.version = version;
         this.iidmVersionIncompatibilityBehavior = Objects.requireNonNull(iidmVersionIncompatibilityBehavior);
+        this.ignoreEquipmentWithoutConnectableBus = ignoreEquipmentWithoutConnectableBus;
     }
 
     @Override
@@ -231,6 +239,15 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
 
     public ExportOptions setSorted(boolean sorted) {
         this.sorted = sorted;
+        return this;
+    }
+
+    public boolean ignoreEquipmentWithoutConnectableBus() {
+        return ignoreEquipmentWithoutConnectableBus;
+    }
+
+    public ExportOptions setIgnoreEquipmentWithoutConnectableBus(boolean ignoreEquipmentWithoutConnectableBus) {
+        this.ignoreEquipmentWithoutConnectableBus = ignoreEquipmentWithoutConnectableBus;
         return this;
     }
 }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewSwitchXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NodeBreakerViewSwitchXml.java
@@ -25,7 +25,7 @@ public class NodeBreakerViewSwitchXml extends AbstractSwitchXml<VoltageLevel.Nod
     static final NodeBreakerViewSwitchXml INSTANCE = new NodeBreakerViewSwitchXml();
 
     @Override
-    protected boolean isValid(Switch s, VoltageLevel vl) {
+    protected boolean isValid(Switch s, VoltageLevel vl, NetworkXmlWriterContext context) {
         VoltageLevel.NodeBreakerView v = vl.getNodeBreakerView();
         if (v.getNode1(s.getId()) == v.getNode2(s.getId())) {
             LOGGER.warn("Discard switch with same node at both ends. Id: {}", s.getId());

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/XMLExporter.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/XMLExporter.java
@@ -109,6 +109,7 @@ public class XMLExporter implements Exporter {
     public static final String EXTENSIONS_LIST = "iidm.export.xml.extensions";
     public static final String SORTED = "iidm.export.xml.sorted";
     public static final String VERSION = "iidm.export.xml.version";
+    public static final String IGNORE_EQUIPMENT_WITHOUT_CONNECTABLE_BUS = "iidm.export.xml.ignore-disconnected-equipment";
 
     private static final Parameter INDENT_PARAMETER = new Parameter(INDENT, ParameterType.BOOLEAN, "Indent export output file", Boolean.TRUE);
     private static final Parameter WITH_BRANCH_STATE_VARIABLES_PARAMETER = new Parameter(WITH_BRANCH_STATE_VARIABLES, ParameterType.BOOLEAN, "Export network with branch state variables", Boolean.TRUE);
@@ -126,11 +127,12 @@ public class XMLExporter implements Exporter {
     private static final Parameter SORTED_PARAMETER = new Parameter(SORTED, ParameterType.BOOLEAN, "Sort export output file", Boolean.FALSE);
     private static final Parameter VERSION_PARAMETER = new Parameter(VERSION, ParameterType.STRING, "IIDM-XML version in which files will be generated", IidmXmlConstants.CURRENT_IIDM_XML_VERSION.toString("."),
             Arrays.stream(IidmXmlVersion.values()).map(v -> v.toString(".")).collect(Collectors.toList()));
+    private static final Parameter IGNORE_EQUIPMENT_WITHOUT_CONNECTABLE_BUS_PARAMETER = new Parameter(IGNORE_EQUIPMENT_WITHOUT_CONNECTABLE_BUS, ParameterType.BOOLEAN, "Ignore equipment without connectable bus at their ends", Boolean.FALSE);
 
     private static final List<Parameter> STATIC_PARAMETERS = List.of(INDENT_PARAMETER, WITH_BRANCH_STATE_VARIABLES_PARAMETER,
             ONLY_MAIN_CC_PARAMETER, ANONYMISED_PARAMETER, IIDM_VERSION_INCOMPATIBILITY_BEHAVIOR_PARAMETER,
             TOPOLOGY_LEVEL_PARAMETER, THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER, EXTENSIONS_LIST_PARAMETER,
-            SORTED_PARAMETER, VERSION_PARAMETER);
+            SORTED_PARAMETER, VERSION_PARAMETER, IGNORE_EQUIPMENT_WITHOUT_CONNECTABLE_BUS_PARAMETER);
 
     private final ParameterDefaultValueConfig defaultValueConfig;
 
@@ -200,7 +202,8 @@ public class XMLExporter implements Exporter {
                 .setThrowExceptionIfExtensionNotFound(Parameter.readBoolean(getFormat(), parameters, THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER, defaultValueConfig))
                 .setExtensions(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig) != null ? new HashSet<>(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig)) : null)
                 .setSorted(Parameter.readBoolean(getFormat(), parameters, SORTED_PARAMETER, defaultValueConfig))
-                .setVersion(Parameter.readString(getFormat(), parameters, VERSION_PARAMETER, defaultValueConfig));
+                .setVersion(Parameter.readString(getFormat(), parameters, VERSION_PARAMETER, defaultValueConfig))
+                .setIgnoreEquipmentWithoutConnectableBus(Parameter.readBoolean(getFormat(), parameters, IGNORE_EQUIPMENT_WITHOUT_CONNECTABLE_BUS_PARAMETER, defaultValueConfig));
         addExtensionsVersions(parameters, options);
         return options;
     }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TopologyLevelTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/TopologyLevelTest.java
@@ -37,7 +37,6 @@ public class TopologyLevelTest extends AbstractXmlConverterTest {
     @Test
     public void testConversion() throws IOException {
         testConversion(NetworkXml.read(getVersionedNetworkAsStream("fictitiousSwitchRef.xml", IidmXmlVersion.V_1_0)));
-
         testConversion(FictitiousSwitchFactory.create());
     }
 
@@ -52,6 +51,14 @@ public class TopologyLevelTest extends AbstractXmlConverterTest {
                 getVersionedNetworkPath("fictitiousSwitchRef-bbk.xml", CURRENT_IIDM_XML_VERSION));
         writeXmlTest(network, TopologyLevelTest::writeBusBranch,
                 getVersionedNetworkPath("fictitiousSwitchRef-bbr.xml", CURRENT_IIDM_XML_VERSION));
+
+        network.newVoltageLevel().setId("ZZZ").setTopologyKind(TopologyKind.NODE_BREAKER).setNominalV(20).add();
+        network.newLine().setId("disconnected").setR(1).setX(1).setNode1(0).setNode2(1).setVoltageLevel1("ZZZ").setVoltageLevel2("C").add();
+
+        writeXmlTest(network, TopologyLevelTest::writeBusBranch,
+                getVersionedNetworkPath("fictitiousSwitchRef-bbr-disconnected.xml", CURRENT_IIDM_XML_VERSION));
+        writeXmlTest(network, TopologyLevelTest::writeBusBranchWithoutDisconnectedEquipment,
+                getVersionedNetworkPath("fictitiousSwitchRef-bbr-connected.xml", CURRENT_IIDM_XML_VERSION));
     }
 
     private static void writeNodeBreaker(Network network, Path path) {
@@ -71,6 +78,13 @@ public class TopologyLevelTest extends AbstractXmlConverterTest {
     private static void writeBusBranch(Network network, Path path) {
         ExportOptions options = new ExportOptions()
                 .setTopologyLevel(TopologyLevel.BUS_BRANCH);
+
+        NetworkXml.write(network, options, path);
+    }
+
+    private static void writeBusBranchWithoutDisconnectedEquipment(Network network, Path path) {
+        ExportOptions options = new ExportOptions()
+                .setTopologyLevel(TopologyLevel.BUS_BRANCH).setIgnoreEquipmentWithoutConnectableBus(true);
 
         NetworkXml.write(network, options, path);
     }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLExporterTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/XMLExporterTest.java
@@ -56,7 +56,7 @@ public class XMLExporterTest extends AbstractXmlConverterTest {
     @Test
     public void paramsTest() {
         var xmlExporter = new XMLExporter();
-        assertEquals(10, xmlExporter.getParameters().size());
+        assertEquals(11, xmlExporter.getParameters().size());
         assertEquals("IIDM XML v" + CURRENT_IIDM_XML_VERSION.toString(".") + " exporter", xmlExporter.getComment());
     }
 

--- a/iidm/iidm-xml-converter/src/test/resources/V1_9/fictitiousSwitchRef-bbr-connected.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_9/fictitiousSwitchRef-bbr-connected.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_9" id="fictitious" caseDate="2017-06-25T17:43:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:voltageLevel id="ZZZ" nominalV="20.0" topologyKind="BUS_BREAKER">
+        <iidm:busBreakerTopology></iidm:busBreakerTopology>
+    </iidm:voltageLevel>
+    <iidm:substation id="A" country="FR">
+        <iidm:voltageLevel id="C" nominalV="225.0" lowVoltageLimit="0.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="C_0" v="234.40912" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="N" nominalV="225.0" lowVoltageLimit="220.0" highVoltageLimit="245.00002" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="N_0" v="236.44736" angle="15.250391"/>
+                <iidm:bus id="N_3"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="CB" energySource="HYDRO" minP="0.0" maxP="70.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" connectableBus="N_0">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>
+                    <iidm:point p="70.0" minQ="-54.55" maxQ="46.25"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CC" energySource="HYDRO" minP="0.0" maxP="80.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" connectableBus="N_0">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-56.8" maxQ="57.4"/>
+                    <iidm:point p="80.0" minQ="-53.514" maxQ="36.4"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CD" energySource="HYDRO" minP="0.0" maxP="35.0" voltageRegulatorOn="true" targetP="21.789589" targetV="236.44736" targetQ="-20.701546" bus="N_0" connectableBus="N_0" p="-21.789589" q="20.693394">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-20.6" maxQ="18.1"/>
+                    <iidm:point p="35.0" minQ="-21.725" maxQ="6.3500004"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:load id="CE" loadType="UNDEFINED" p0="-72.18689" q0="50.168945" bus="N_3" connectableBus="N_3" p="-72.18689" q="50.168945"/>
+            <iidm:load id="CF" loadType="UNDEFINED" p0="8.455854" q0="-23.695925" bus="N_0" connectableBus="N_0" p="8.455854" q="-23.695925"/>
+            <iidm:load id="CG" loadType="UNDEFINED" p0="90.39911" q0="-51.96869" bus="N_0" connectableBus="N_0" p="90.39911" q="-51.96869"/>
+            <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" bus="N_0" connectableBus="N_0" p="-5.102249" q="4.9081216"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" bus1="C_0" connectableBus1="C_0" voltageLevelId1="C" bus2="N_0" connectableBus2="N_0" voltageLevelId2="N">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+                <iidm:terminalRef id="CI" side="ONE"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="-37.54"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="-34.9"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="-32.26"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="-29.6"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="-26.94"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="-24.26"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="-21.58"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="-18.9"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="-16.22"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="-13.52"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="-10.82"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="-8.12"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="-5.42"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="-2.7"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="2.7"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="5.42"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="8.12"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="10.82"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="13.52"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="16.22"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="18.9"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="21.58"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="24.26"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="26.94"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="29.6"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="32.26"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="34.9"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="37.54"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="40.18"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="42.8"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits1 permanentLimit="931.0"/>
+            <iidm:currentLimits2 permanentLimit="931.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="CJ" r="0.009999999" x="0.100000024" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="C_0" connectableBus1="C_0" voltageLevelId1="C" bus2="N_3" connectableBus2="N_3" voltageLevelId2="N">
+        <iidm:currentLimits1 permanentLimit="931.0"/>
+        <iidm:currentLimits2 permanentLimit="931.0">
+            <iidm:temporaryLimit name="IST" value="1640.0" fictitious="true"/>
+            <iidm:temporaryLimit name="IT1" acceptableDuration="60"/>
+        </iidm:currentLimits2>
+    </iidm:line>
+</iidm:network>

--- a/iidm/iidm-xml-converter/src/test/resources/V1_9/fictitiousSwitchRef-bbr-disconnected.xml
+++ b/iidm/iidm-xml-converter/src/test/resources/V1_9/fictitiousSwitchRef-bbr-disconnected.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_9" id="fictitious" caseDate="2017-06-25T17:43:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:voltageLevel id="ZZZ" nominalV="20.0" topologyKind="BUS_BREAKER">
+        <iidm:busBreakerTopology></iidm:busBreakerTopology>
+    </iidm:voltageLevel>
+    <iidm:substation id="A" country="FR">
+        <iidm:voltageLevel id="C" nominalV="225.0" lowVoltageLimit="0.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="C_0" v="234.40912" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="N" nominalV="225.0" lowVoltageLimit="220.0" highVoltageLimit="245.00002" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="N_0" v="236.44736" angle="15.250391"/>
+                <iidm:bus id="N_3"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="CB" energySource="HYDRO" minP="0.0" maxP="70.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" connectableBus="N_0">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>
+                    <iidm:point p="70.0" minQ="-54.55" maxQ="46.25"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CC" energySource="HYDRO" minP="0.0" maxP="80.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" connectableBus="N_0">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-56.8" maxQ="57.4"/>
+                    <iidm:point p="80.0" minQ="-53.514" maxQ="36.4"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CD" energySource="HYDRO" minP="0.0" maxP="35.0" voltageRegulatorOn="true" targetP="21.789589" targetV="236.44736" targetQ="-20.701546" bus="N_0" connectableBus="N_0" p="-21.789589" q="20.693394">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-20.6" maxQ="18.1"/>
+                    <iidm:point p="35.0" minQ="-21.725" maxQ="6.3500004"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:load id="CE" loadType="UNDEFINED" p0="-72.18689" q0="50.168945" bus="N_3" connectableBus="N_3" p="-72.18689" q="50.168945"/>
+            <iidm:load id="CF" loadType="UNDEFINED" p0="8.455854" q0="-23.695925" bus="N_0" connectableBus="N_0" p="8.455854" q="-23.695925"/>
+            <iidm:load id="CG" loadType="UNDEFINED" p0="90.39911" q0="-51.96869" bus="N_0" connectableBus="N_0" p="90.39911" q="-51.96869"/>
+            <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" bus="N_0" connectableBus="N_0" p="-5.102249" q="4.9081216"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" bus1="C_0" connectableBus1="C_0" voltageLevelId1="C" bus2="N_0" connectableBus2="N_0" voltageLevelId2="N">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+                <iidm:terminalRef id="CI" side="ONE"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="-37.54"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="-34.9"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="-32.26"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="-29.6"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="-26.94"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="-24.26"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="-21.58"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="-18.9"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="-16.22"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="-13.52"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="-10.82"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="-8.12"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="-5.42"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="-2.7"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="2.7"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="5.42"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="8.12"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="10.82"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="13.52"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="16.22"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="18.9"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="21.58"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="24.26"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="26.94"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="29.6"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="32.26"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="34.9"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="37.54"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="40.18"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="42.8"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits1 permanentLimit="931.0"/>
+            <iidm:currentLimits2 permanentLimit="931.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="CJ" r="0.009999999" x="0.100000024" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="C_0" connectableBus1="C_0" voltageLevelId1="C" bus2="N_3" connectableBus2="N_3" voltageLevelId2="N">
+        <iidm:currentLimits1 permanentLimit="931.0"/>
+        <iidm:currentLimits2 permanentLimit="931.0">
+            <iidm:temporaryLimit name="IST" value="1640.0" fictitious="true"/>
+            <iidm:temporaryLimit name="IT1" acceptableDuration="60"/>
+        </iidm:currentLimits2>
+    </iidm:line>
+    <iidm:line id="disconnected" r="1.0" x="1.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="ZZZ" bus2="C_0" connectableBus2="C_0" voltageLevelId2="C"/>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature: add an option to not export equipment without a connectable electrical bus (i.e. calculated bus from the BusView)


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
