### PR TITLE
Fixing min/max p for hvdc reduction into generator

### DIFF
--- a/iidm/iidm-reducer/pom.xml
+++ b/iidm/iidm-reducer/pom.xml
@@ -75,10 +75,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-iidm-extensions</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/iidm/iidm-reducer/pom.xml
+++ b/iidm/iidm-reducer/pom.xml
@@ -75,6 +75,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-extensions</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
@@ -7,10 +7,13 @@
 package com.powsybl.iidm.reducer;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+
+import static java.lang.Math.min;
 
 /**
  * @author Mathieu Bague <mathieu.bague at rte-france.com>
@@ -239,13 +242,26 @@ public class DefaultNetworkReducer extends AbstractNetworkReducer {
     }
 
     private void replaceHvdcLineByGenerator(HvdcLine hvdcLine, VoltageLevel vl, Terminal terminal) {
+        double maxP;
+        double minP;
+        double lineMaxP = hvdcLine.getMaxP();
+        HvdcOperatorActivePowerRange ext = hvdcLine.getExtension(HvdcOperatorActivePowerRange.class);
+        if (ext != null) {
+            boolean cs1Kept = hvdcLine.getConverterStation1().getTerminal() == terminal;
+            maxP = cs1Kept ? min(ext.getOprFromCS2toCS1(), lineMaxP) : min(ext.getOprFromCS1toCS2(), lineMaxP);
+            minP = cs1Kept ? -min(ext.getOprFromCS1toCS2(), lineMaxP) : -min(ext.getOprFromCS2toCS1(), lineMaxP);
+        } else {
+            maxP = lineMaxP;
+            minP = -lineMaxP;
+        }
+
         GeneratorAdder genAdder = vl.newGenerator()
                 .setId(hvdcLine.getId())
                 .setName(hvdcLine.getOptionalName().orElse(null))
                 .setEnergySource(EnergySource.OTHER)
                 .setVoltageRegulatorOn(false)
-                .setMaxP(checkP(terminal))
-                .setMinP(0)
+                .setMaxP(maxP)
+                .setMinP(minP)
                 .setTargetP(checkP(terminal))
                 .setTargetQ(checkQ(terminal));
         fillNodeOrBus(genAdder, terminal);

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.reducer;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRangeAdder;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
 import com.powsybl.iidm.network.test.HvdcTestNetwork;
@@ -276,7 +277,28 @@ class DefaultNetworkReducerTest {
         assertEquals(1, observerVsc.getHvdcLineReplacedCount());
         assertEquals(1, observerVsc.getHvdcLineRemovedCount());
         assertEquals(1, networkVsc.getGeneratorCount());
+        Generator gen = networkVsc.getGenerator("L");
+        assertEquals(300, gen.getMaxP());
+        assertEquals(-300, gen.getMinP());
 
+    }
+
+    @Test
+    void testHvdcReplacementActivePowerRange() {
+        Network networkVsc = HvdcTestNetwork.createVsc();
+        HvdcLine line = networkVsc.getHvdcLine("L");
+        line.newExtension(HvdcOperatorActivePowerRangeAdder.class)
+                .withOprFromCS2toCS1(120)
+                .withOprFromCS1toCS2(80)
+                .add();
+        NetworkReducer reducerVsc = NetworkReducer.builder()
+                .withNetworkPredicate(IdentifierNetworkPredicate.of("VL1"))
+                .build();
+        reducerVsc.reduce(networkVsc);
+
+        Generator gen = networkVsc.getGenerator("L");
+        assertEquals(120, gen.getMaxP());
+        assertEquals(-80, gen.getMinP());
     }
 
     @Test

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
@@ -7,7 +7,6 @@
 package com.powsybl.iidm.reducer;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRangeAdder;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
 import com.powsybl.iidm.network.test.HvdcTestNetwork;
@@ -281,24 +280,6 @@ class DefaultNetworkReducerTest {
         assertEquals(300, gen.getMaxP());
         assertEquals(-300, gen.getMinP());
 
-    }
-
-    @Test
-    void testHvdcReplacementActivePowerRange() {
-        Network networkVsc = HvdcTestNetwork.createVsc();
-        HvdcLine line = networkVsc.getHvdcLine("L");
-        line.newExtension(HvdcOperatorActivePowerRangeAdder.class)
-                .withOprFromCS2toCS1(120)
-                .withOprFromCS1toCS2(80)
-                .add();
-        NetworkReducer reducerVsc = NetworkReducer.builder()
-                .withNetworkPredicate(IdentifierNetworkPredicate.of("VL1"))
-                .build();
-        reducerVsc.reduce(networkVsc);
-
-        Generator gen = networkVsc.getGenerator("L");
-        assertEquals(120, gen.getMaxP());
-        assertEquals(-80, gen.getMinP());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When reducing an HVDC line and turning it into a generator, maxP is set to terminal P and minP to 0.
It's causing errors when P < 0.

**What is the new behavior (if this is a feature change)?**
The new generator has max and min P set based on maxP of HVDC line, or taking into consideration HvdcOperatorActivePowerRange extension if present
