### PR TITLE
[Security analysis] Fix check on 0 value in tap changer tap position action

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/action/AbstractTapChangerTapPositionActionDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/action/AbstractTapChangerTapPositionActionDeserializer.java
@@ -63,9 +63,6 @@ public abstract class AbstractTapChangerTapPositionActionDeserializer<T extends 
     }
 
     protected void checkFields(ParsingContext context, JsonParser jsonParser) throws JsonMappingException {
-        if (context.tapPosition == 0) {
-            throw JsonMappingException.from(jsonParser, "for phase tap changer tap position action tapPosition field can't equal zero");
-        }
         if (context.relativeValue == null) {
             throw JsonMappingException.from(jsonParser, "for phase tap changer tap position action relative value field can't be null");
         }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/JsonActionAndOperatorStrategyTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/JsonActionAndOperatorStrategyTest.java
@@ -103,11 +103,6 @@ class JsonActionAndOperatorStrategyTest extends AbstractConverterTest {
                 " at [Source: (BufferedInputStream); line: 8, column: 3] (through reference chain: java.util.ArrayList[0])", assertThrows(UncheckedIOException.class, () ->
                 ActionList.readJsonInputStream(inputStream)).getMessage());
 
-        final InputStream inputStream2 = getClass().getResourceAsStream("/WrongActionFileTest2.json");
-        assertEquals("com.fasterxml.jackson.databind.JsonMappingException: for phase tap changer tap position action tapPosition field can't equal zero\n" +
-                " at [Source: (BufferedInputStream); line: 8, column: 3] (through reference chain: java.util.ArrayList[0])", assertThrows(UncheckedIOException.class, () ->
-                ActionList.readJsonInputStream(inputStream2)).getMessage());
-
         final InputStream inputStream3 = getClass().getResourceAsStream("/ActionFileTestWrongVersion.json");
         assertTrue(assertThrows(UncheckedIOException.class, () -> ActionList
                 .readJsonInputStream(inputStream3))

--- a/security-analysis/security-analysis-api/src/test/resources/WrongActionFileTest2.json
+++ b/security-analysis/security-analysis-api/src/test/resources/WrongActionFileTest2.json
@@ -1,9 +1,0 @@
-{
-  "version" : "1.0",
-  "actions" : [ {
-    "type" : "PHASE_TAP_CHANGER_TAP_POSITION",
-    "id" : "id6",
-    "transformerId" : "transformerId2",
-    "relativeValue" : true
-  } ]
-}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
it prevents AbstractTapChangerTapPositionActionDeserializer to have a 0 tap position
