### PR TITLE
Fix conversion of boundary lines: consider all (g,b) at network side

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ACLineSegmentConversion.java
@@ -65,7 +65,12 @@ public class ACLineSegmentConversion extends AbstractBranchConversion implements
         double x = p.asDouble("x");
         double g = p.asDouble("gch", 0);
         double b = p.asDouble("bch", 0);
-        boundaryLine.setParameters(r, x, g, b, 0, 0);
+        // Assign all (g, b) to the network side
+        if (boundaryLine.getBoundarySide().equals(Branch.Side.TWO)) {
+            boundaryLine.setParameters(r, x, g, b, 0, 0);
+        } else {
+            boundaryLine.setParameters(r, x, 0, 0, g, b);
+        }
         return boundaryLine;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
The fix is related to the checks made in the powsybl/powsybl-entsoe#88.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
All network merge methods consider the whole (g, b) of boundary lines at network side.
When both lines of a boundary were imported and a tie line must be created, the same criteria has to be applied.


**What is the new behavior (if this is a feature change)?**
When both lines of a boundary point are seen in the input files during a conversion from CGMES to IIDM, the (g, b) of the ACLS is assigned to the network side.


