### PR TITLE
Create severity filter in Reporter API

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/reporter/Reporter.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/Reporter.java
@@ -131,6 +131,10 @@ public interface Reporter {
      */
     void report(Report report);
 
+    boolean isEnabled(TypedValue severityType);
+
+    void setSeverityThreshold(TypedValue severityThreshold);
+
     class NoOpImpl extends AbstractReporter {
         public NoOpImpl() {
             super("noOp", "NoOp", Collections.emptyMap());
@@ -144,6 +148,15 @@ public interface Reporter {
         @Override
         public void report(Report report) {
             // No-op
+        }
+
+        @Override
+        public boolean isEnabled(TypedValue severityType) {
+            return false;
+        }
+
+        @Override
+        public void setSeverityThreshold(TypedValue severityThreshold) {
         }
 
     }

--- a/commons/src/main/java/com/powsybl/commons/reporter/ReporterModel.java
+++ b/commons/src/main/java/com/powsybl/commons/reporter/ReporterModel.java
@@ -18,6 +18,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 
+import static com.powsybl.commons.reporter.TypedValue.*;
+
 /**
  * An in-memory implementation of {@link Reporter}.
  *
@@ -34,6 +36,7 @@ public class ReporterModel extends AbstractReporter {
 
     private final List<ReporterModel> subReporters = new ArrayList<>();
     private final List<Report> reports = new ArrayList<>();
+    TypedValue severityThreshold;
 
     /**
      * ReporterModel constructor, with no associated values.
@@ -148,5 +151,18 @@ public class ReporterModel extends AbstractReporter {
         }
 
         return reporter;
+    }
+
+    @Override
+    public void setSeverityThreshold(TypedValue severityType) {
+        if (TRACE_SEVERITY.equals(severityType) || DEBUG_SEVERITY.equals(severityType) || INFO_SEVERITY.equals(severityType) || WARN_SEVERITY.equals(severityType) || ERROR_SEVERITY.equals(severityType)) {
+            severityThreshold = severityType;
+        } else {
+            throw new IllegalArgumentException("Severity not supported");
+        }
+    }
+
+    public boolean isEnabled(TypedValue severityType) {
+        return severityType == severityThreshold;
     }
 }

--- a/commons/src/test/java/com/powsybl/commons/reporter/ReporterTest.java
+++ b/commons/src/test/java/com/powsybl/commons/reporter/ReporterTest.java
@@ -1,0 +1,33 @@
+package com.powsybl.commons.reporter;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.powsybl.commons.reporter.TypedValue.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReporterTest {
+
+    @Test
+    void testReporterIsEnabled() {
+        ReporterModel reporter = new ReporterModel("reporterTest", "Reporter Test");
+
+        // Check that isEnabled works for all combinations of severities and thresholds
+        List<TypedValue> severities = List.of(TRACE_SEVERITY, DEBUG_SEVERITY, INFO_SEVERITY, WARN_SEVERITY);
+        for (TypedValue severityThreshold : severities) {
+            reporter.setSeverityThreshold(severityThreshold);
+            for (TypedValue severity : severities) {
+                if (severity == severityThreshold) {
+                    assertTrue(reporter.isEnabled(severity));
+                } else {
+                    assertFalse(reporter.isEnabled(severity));
+                }
+            }
+        }
+
+        // Check if an unknown severity is set
+        TypedValue unknownSeverity = new TypedValue("unknownSeverity", TypedValue.SEVERITY);
+        assertThrows(IllegalArgumentException.class, () -> reporter.setSeverityThreshold(unknownSeverity));
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
It is currently not possible to filter reports based on their severity


**What is the new behavior (if this is a feature change)?**
This PR creates a method to be able to filter out reports according to a severity threshold in the Reporter API


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
