### PR TITLE
Remove useless identifiableType from IdentifierContingencyList

### DIFF
--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/IdentifierContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/IdentifierContingencyList.java
@@ -22,12 +22,17 @@ import java.util.stream.Collectors;
  */
 public class IdentifierContingencyList implements ContingencyList {
 
+    private static final String VERSION = "1.1";
     private final String name;
     private final List<NetworkElementIdentifier> networkElementIdentifiers;
 
     public IdentifierContingencyList(String name, List<NetworkElementIdentifier> networkElementIdentifiers) {
         this.name = Objects.requireNonNull(name);
         this.networkElementIdentifiers = ImmutableList.copyOf(networkElementIdentifiers);
+    }
+
+    public static String getVersion() {
+        return VERSION;
     }
 
     @Override

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/IdentifierContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/IdentifierContingencyList.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableList;
 import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.ContingencyElement;
 import com.powsybl.contingency.contingency.list.identifier.NetworkElementIdentifier;
-import com.powsybl.iidm.network.IdentifiableType;
 import com.powsybl.iidm.network.Network;
 
 import java.util.List;
@@ -24,16 +23,10 @@ import java.util.stream.Collectors;
 public class IdentifierContingencyList implements ContingencyList {
 
     private final String name;
-    private final IdentifiableType identifiableType;
     private final List<NetworkElementIdentifier> networkElementIdentifiers;
 
-    public IdentifierContingencyList(String name, String identifiableType, List<NetworkElementIdentifier> networkElementIdentifiers) {
-        this(name, IdentifiableType.valueOf(identifiableType), networkElementIdentifiers);
-    }
-
-    public IdentifierContingencyList(String name, IdentifiableType identifiableType, List<NetworkElementIdentifier> networkElementIdentifiers) {
+    public IdentifierContingencyList(String name, List<NetworkElementIdentifier> networkElementIdentifiers) {
         this.name = Objects.requireNonNull(name);
-        this.identifiableType = Objects.requireNonNull(identifiableType);
         this.networkElementIdentifiers = ImmutableList.copyOf(networkElementIdentifiers);
     }
 
@@ -45,10 +38,6 @@ public class IdentifierContingencyList implements ContingencyList {
     @Override
     public String getType() {
         return "identifier";
-    }
-
-    public IdentifiableType getIdentifiableType() {
-        return identifiableType;
     }
 
     public List<NetworkElementIdentifier> getIdentifiants() {

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/IdentifierContingencyListDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/IdentifierContingencyListDeserializer.java
@@ -23,6 +23,8 @@ import java.util.List;
  */
 public class IdentifierContingencyListDeserializer extends StdDeserializer<IdentifierContingencyList> {
 
+    private static final String CONTEXT_NAME = "identifierContingencyList";
+
     public IdentifierContingencyListDeserializer() {
         super(IdentifierContingencyList.class);
     }
@@ -30,11 +32,17 @@ public class IdentifierContingencyListDeserializer extends StdDeserializer<Ident
     @Override
     public IdentifierContingencyList deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
         String name = null;
+        String version = null;
         List<NetworkElementIdentifier> networkElementIdentifiers = Collections.emptyList();
 
         while (parser.nextToken() != JsonToken.END_OBJECT) {
             switch (parser.getCurrentName()) {
                 case "version":
+                    version = parser.nextTextValue();
+                    break;
+
+                case "identifiableType":
+                    JsonUtil.assertLessThanOrEqualToReferenceVersion(CONTEXT_NAME, "identifiableType", version, "1.0");
                     parser.nextToken();
                     break;
 

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/IdentifierContingencyListDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/IdentifierContingencyListDeserializer.java
@@ -30,7 +30,6 @@ public class IdentifierContingencyListDeserializer extends StdDeserializer<Ident
     @Override
     public IdentifierContingencyList deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
         String name = null;
-        String identifiableType = null;
         List<NetworkElementIdentifier> networkElementIdentifiers = Collections.emptyList();
 
         while (parser.nextToken() != JsonToken.END_OBJECT) {
@@ -47,10 +46,6 @@ public class IdentifierContingencyListDeserializer extends StdDeserializer<Ident
                     parser.nextToken();
                     break;
 
-                case "identifiableType":
-                    identifiableType = parser.nextTextValue();
-                    break;
-
                 case "identifiers":
                     parser.nextToken();
                     networkElementIdentifiers = JsonUtil.readList(deserializationContext, parser, NetworkElementIdentifier.class);
@@ -60,6 +55,6 @@ public class IdentifierContingencyListDeserializer extends StdDeserializer<Ident
                     throw new IllegalStateException("Unexpected field: " + parser.getCurrentName());
             }
         }
-        return new IdentifierContingencyList(name, identifiableType, networkElementIdentifiers);
+        return new IdentifierContingencyList(name, networkElementIdentifiers);
     }
 }

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/IdentifierContingencyListSerializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/IdentifierContingencyListSerializer.java
@@ -9,7 +9,6 @@ package com.powsybl.contingency.json;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.powsybl.contingency.contingency.list.ContingencyList;
 import com.powsybl.contingency.contingency.list.IdentifierContingencyList;
 
 import java.io.IOException;
@@ -26,8 +25,8 @@ public class IdentifierContingencyListSerializer extends StdSerializer<Identifie
     @Override
     public void serialize(IdentifierContingencyList identifierContingencyList, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField("version", IdentifierContingencyList.getVersion());
         jsonGenerator.writeStringField("type", identifierContingencyList.getType());
-        jsonGenerator.writeStringField("version", ContingencyList.getVersion());
         jsonGenerator.writeStringField("name", identifierContingencyList.getName());
         serializerProvider.defaultSerializeField("identifiers",
                 identifierContingencyList.getIdentifiants(),

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/IdentifierContingencyListSerializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/IdentifierContingencyListSerializer.java
@@ -29,7 +29,6 @@ public class IdentifierContingencyListSerializer extends StdSerializer<Identifie
         jsonGenerator.writeStringField("type", identifierContingencyList.getType());
         jsonGenerator.writeStringField("version", ContingencyList.getVersion());
         jsonGenerator.writeStringField("name", identifierContingencyList.getName());
-        jsonGenerator.writeStringField("identifiableType", identifierContingencyList.getIdentifiableType().toString());
         serializerProvider.defaultSerializeField("identifiers",
                 identifierContingencyList.getIdentifiants(),
                 jsonGenerator);

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/NetworkElementIdentifierContingencyListTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/NetworkElementIdentifierContingencyListTest.java
@@ -33,7 +33,7 @@ class NetworkElementIdentifierContingencyListTest {
         networkElementIdentifierList.add(new IdBasedNetworkElementIdentifier("LINE_S3S4"));
         networkElementIdentifierList.add(new IdBasedNetworkElementIdentifier("LINE_S4S1"));
         networkElementIdentifierList.add(new IdBasedNetworkElementIdentifier("test"));
-        IdentifierContingencyList contingencyList = new IdentifierContingencyList("list", "LINE", networkElementIdentifierList);
+        IdentifierContingencyList contingencyList = new IdentifierContingencyList("list", networkElementIdentifierList);
         List<Contingency> contingencies = contingencyList.getContingencies(network);
         assertEquals(2, contingencies.size());
         assertEquals(new Contingency("LINE_S2S3", new LineContingency("LINE_S2S3")), contingencies.get(0));
@@ -45,7 +45,7 @@ class NetworkElementIdentifierContingencyListTest {
         Network network = EurostagTutorialExample1Factory.create();
         List<NetworkElementIdentifier> networkElementIdentifierList = new ArrayList<>();
         networkElementIdentifierList.add(new VoltageLevelAndOrderNetworkElementIdentifier("VLHV1", "VLHV2", '1'));
-        IdentifierContingencyList contingencyList = new IdentifierContingencyList("list", "LINE", networkElementIdentifierList);
+        IdentifierContingencyList contingencyList = new IdentifierContingencyList("list", networkElementIdentifierList);
         List<Contingency> contingencies = contingencyList.getContingencies(network);
         assertEquals(1, contingencies.size());
         assertEquals(new Contingency("NHV1_NHV2_1", new LineContingency("NHV1_NHV2_1")), contingencies.get(0));
@@ -61,7 +61,7 @@ class NetworkElementIdentifierContingencyListTest {
         networkElementIdentifierListElements.add(new VoltageLevelAndOrderNetworkElementIdentifier("VLHV1", "VLHV2", '2'));
         networkElementIdentifierListElements.add(new VoltageLevelAndOrderNetworkElementIdentifier("VLHV1", "VLHV2", '1'));
         networkElementIdentifierList.add(new NetworkElementIdentifierList(networkElementIdentifierListElements));
-        IdentifierContingencyList contingencyList = new IdentifierContingencyList("list", "LINE", networkElementIdentifierList);
+        IdentifierContingencyList contingencyList = new IdentifierContingencyList("list", networkElementIdentifierList);
         List<Contingency> contingencies = contingencyList.getContingencies(network);
         assertEquals(1, contingencies.size());
         assertEquals(new Contingency("NHV1_NHV2_2", new LineContingency("NHV1_NHV2_2")), contingencies.get(0));

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/NetworkElementIdentifierContingencyListJsonTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/NetworkElementIdentifierContingencyListJsonTest.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.powsybl.commons.test.AbstractConverterTest;
 import com.powsybl.commons.json.JsonUtil;
+import com.powsybl.commons.test.ComparisonUtils;
+import com.powsybl.contingency.contingency.list.ContingencyList;
 import com.powsybl.contingency.contingency.list.IdentifierContingencyList;
 import com.powsybl.contingency.contingency.list.identifier.NetworkElementIdentifier;
 import com.powsybl.contingency.contingency.list.identifier.NetworkElementIdentifierList;
@@ -17,10 +19,7 @@ import com.powsybl.contingency.contingency.list.identifier.IdBasedNetworkElement
 import com.powsybl.contingency.contingency.list.identifier.VoltageLevelAndOrderNetworkElementIdentifier;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.UncheckedIOException;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -32,6 +31,9 @@ import java.util.Objects;
  * @author Etienne Lesot <etienne.lesot@rte-france.com>
  */
 class NetworkElementIdentifierContingencyListJsonTest extends AbstractConverterTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new ContingencyJsonModule());
+    private static final ObjectWriter WRITER = MAPPER.writerWithDefaultPrettyPrinter();
 
     private static IdentifierContingencyList create() {
         List<NetworkElementIdentifier> networkElementIdentifiers = new ArrayList<>();
@@ -47,6 +49,19 @@ class NetworkElementIdentifierContingencyListJsonTest extends AbstractConverterT
                 "/identifierContingencyList.json");
     }
 
+    @Test
+    void readVersion10() {
+        ContingencyList contingencyList = NetworkElementIdentifierContingencyListJsonTest
+                .readJsonInputStream(Objects.requireNonNull(getClass()
+                        .getResourceAsStream("/identifierContingencyListv1_0.json")));
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            WRITER.writeValue(bos, contingencyList);
+            ComparisonUtils.compareTxt(getClass().getResourceAsStream("/identifierContingencyList.json"), new ByteArrayInputStream(bos.toByteArray()));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private static IdentifierContingencyList readContingencyList(Path jsonFile) {
         return read(jsonFile, IdentifierContingencyList.class);
     }
@@ -60,6 +75,15 @@ class NetworkElementIdentifierContingencyListJsonTest extends AbstractConverterT
             objectMapper.registerModule(module);
 
             return (T) objectMapper.readValue(is, clazz);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static IdentifierContingencyList readJsonInputStream(InputStream is) {
+        Objects.requireNonNull(is);
+        try {
+            return MAPPER.readValue(is, IdentifierContingencyList.class);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/NetworkElementIdentifierContingencyListJsonTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/NetworkElementIdentifierContingencyListJsonTest.java
@@ -38,7 +38,7 @@ class NetworkElementIdentifierContingencyListJsonTest extends AbstractConverterT
         networkElementIdentifiers.add(new IdBasedNetworkElementIdentifier("identifier"));
         networkElementIdentifiers.add(new VoltageLevelAndOrderNetworkElementIdentifier("vl1", "vl2", '1'));
         networkElementIdentifiers.add(new NetworkElementIdentifierList(Collections.singletonList(new IdBasedNetworkElementIdentifier("identifier1"))));
-        return new IdentifierContingencyList("list1", "LINE", networkElementIdentifiers);
+        return new IdentifierContingencyList("list1", networkElementIdentifiers);
     }
 
     @Test

--- a/contingency/contingency-api/src/test/resources/identifierContingencyList.json
+++ b/contingency/contingency-api/src/test/resources/identifierContingencyList.json
@@ -2,7 +2,6 @@
   "type" : "identifier",
   "version" : "1.0",
   "name" : "list1",
-  "identifiableType" : "LINE",
   "identifiers" : [ {
     "type" : "ID_BASED",
     "identifier" : "identifier"

--- a/contingency/contingency-api/src/test/resources/identifierContingencyListv1_0.json
+++ b/contingency/contingency-api/src/test/resources/identifierContingencyListv1_0.json
@@ -1,7 +1,8 @@
 {
-  "version" : "1.1",
+  "version" : "1.0",
   "type" : "identifier",
   "name" : "list1",
+  "identifiableType" : "type",
   "identifiers" : [ {
     "type" : "ID_BASED",
     "identifier" : "identifier"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the new behavior (if this is a feature change)?**
I removed the `identifiableType` from `IdentifierContingencyList` because it forbid to create hybrid contingency list (for instance a generator and a line) which is a valid use case.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
