### PR TITLE
PlaftormConfig: config folder not created if non existing

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/config/InMemoryPlatformConfig.java
+++ b/commons/src/main/java/com/powsybl/commons/config/InMemoryPlatformConfig.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.commons.config;
 
+import com.powsybl.commons.io.FileUtil;
+
 import java.nio.file.FileSystem;
 
 /**
@@ -15,7 +17,8 @@ import java.nio.file.FileSystem;
 public class InMemoryPlatformConfig extends PlatformConfig {
 
     public InMemoryPlatformConfig(FileSystem fileSystem) {
-        super(new InMemoryModuleConfigRepository(fileSystem), fileSystem.getPath("inmemory").toAbsolutePath());
+        super(new InMemoryModuleConfigRepository(fileSystem),
+                FileUtil.createDirectory(fileSystem.getPath("inmemory").toAbsolutePath()));
     }
 
     public MapModuleConfig createModuleConfig(String name) {

--- a/commons/src/main/java/com/powsybl/commons/config/PlatformConfig.java
+++ b/commons/src/main/java/com/powsybl/commons/config/PlatformConfig.java
@@ -10,13 +10,14 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.commons.io.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.ServiceLoader;
 
 /**
@@ -87,7 +88,7 @@ public class PlatformConfig {
 
     protected PlatformConfig(Supplier<ModuleConfigRepository> repositorySupplier, Path configDir) {
         this.repositorySupplier = Suppliers.memoize(Objects.requireNonNull(repositorySupplier));
-        this.configDir = configDir != null ? FileUtil.createDirectory(configDir) : null;
+        this.configDir = configDir;
     }
 
     public Optional<Path> getConfigDir() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
Yes, fixes #2482 


**Other information**:
Note that InMemoryPlatformConfig still creates a config dir. Indeed this PlatformConfig is (only) used in unit tests, and in some of them files are copied into the config dir.