### PR TITLE
Create a fictitious substation during CGMES export when a voltage level does not have a substation

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -233,12 +233,7 @@ public final class EquipmentExport {
             }
             Optional<String> substationId = voltageLevel.getSubstation().map(s -> context.getNamingStrategy().getCgmesId(s));
             if (substationId.isEmpty() && fictSubstationId == null) { // create a fictitious substation
-                String cgmesRegionId = CgmesExportUtil.getUniqueId();
-                writeGeographicalRegion(cgmesRegionId, "FICTITIOUS_REGION", cimNamespace, writer, context);
-                String subGeographicalRegionId = CgmesExportUtil.getUniqueId();
-                writeSubGeographicalRegion(subGeographicalRegionId, context.getSubRegionName(subGeographicalRegionId), cgmesRegionId, cimNamespace, writer, context);
-                fictSubstationId = CgmesExportUtil.getUniqueId();
-                SubstationEq.write(fictSubstationId, "FICTITIOUS_SUBSTATION", subGeographicalRegionId, cimNamespace, writer, context);
+                fictSubstationId = writeFictitiousSubstationFor("FICTITIOUS", cimNamespace, writer, context);
             }
             VoltageLevelEq.write(context.getNamingStrategy().getCgmesId(voltageLevel), voltageLevel.getNameOrId(), voltageLevel.getLowVoltageLimit(), voltageLevel.getHighVoltageLimit(),
                     substationId.orElse(fictSubstationId), baseVoltage.getId(), cimNamespace, writer, context);
@@ -663,15 +658,19 @@ public final class EquipmentExport {
     }
 
     private static String writeFictitiousSubstationFor(Identifiable<?> identifiable, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
+        return writeFictitiousSubstationFor(identifiable.getId(), cimNamespace, writer, context);
+    }
+
+    private static String writeFictitiousSubstationFor(String prefix, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
         // New Substation
         // We avoid using the name of the identifiable for the names of fictitious region and subregion
         // Because regions and subregions with the same name are merged
         String geographicalRegionId = CgmesExportUtil.getUniqueId();
-        GeographicalRegionEq.write(geographicalRegionId, identifiable.getId() + "_GR", cimNamespace, writer, context);
+        GeographicalRegionEq.write(geographicalRegionId, prefix + "_GR", cimNamespace, writer, context);
         String subGeographicalRegionId = CgmesExportUtil.getUniqueId();
-        SubGeographicalRegionEq.write(subGeographicalRegionId, identifiable.getId() + "_SGR", geographicalRegionId, cimNamespace, writer, context);
+        SubGeographicalRegionEq.write(subGeographicalRegionId, prefix + "_SGR", geographicalRegionId, cimNamespace, writer, context);
         String substationId = CgmesExportUtil.getUniqueId();
-        SubstationEq.write(substationId, identifiable.getNameOrId() + "_SUBSTATION", subGeographicalRegionId, cimNamespace, writer, context);
+        SubstationEq.write(substationId, prefix + "_SUBSTATION", subGeographicalRegionId, cimNamespace, writer, context);
         return substationId;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
NPE when trying to export in CGMES a network containing a voltage level without substation.


**What is the new behavior (if this is a feature change)?**
A fictitious substation is created in the CGMES file containing all voltage levels without substation.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
