### PR TITLE
Creating an modification with wrong bus bar section now throws an exception

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
@@ -116,8 +116,13 @@ public class ReplaceTeePointByVoltageLevelOnLine extends AbstractNetworkModifica
     // voltageLevel.getNodeBreakerView().getBusbarSection(bbsOrBusId) is currently returning any busbarSection from the network
     // even if this busbarSection is not included in the voltageLevel
     // this method returns null if the busbarSectionId does not belong to the voltageLevel
-    private BusbarSection getBusBarSectionFromVoltageLevel(VoltageLevel voltageLevel, String busBarSectionId) {
-        return voltageLevel.getNodeBreakerView().getBusbarSectionStream().filter(bbs -> busBarSectionId.equals(bbs.getId())).findFirst().orElse(null);
+    private BusbarSection getBusBarSectionFromVoltageLevel(Network network, VoltageLevel voltageLevel, String busBarSectionId) {
+        BusbarSection bbs = network.getBusbarSection(busBarSectionId);
+        if (bbs == null || !voltageLevel.equals(bbs.getTerminal().getVoltageLevel())) {
+            return null;
+        }
+
+        return bbs;
     }
 
     @Override
@@ -206,7 +211,7 @@ public class ReplaceTeePointByVoltageLevelOnLine extends AbstractNetworkModifica
             newLine2Adder.setBus1(bus2.getId());
             newLine2Adder.setConnectableBus1(bus2.getId());
         } else if (topologyKind == TopologyKind.NODE_BREAKER) {
-            BusbarSection bbs = getBusBarSectionFromVoltageLevel(tappedVoltageLevel, bbsOrBusId);
+            BusbarSection bbs = getBusBarSectionFromVoltageLevel(network, tappedVoltageLevel, bbsOrBusId);
             if (bbs == null) {
                 notFoundBusbarSectionInVoltageLevelReport(reporter, bbsOrBusId, tappedVoltageLevel.getId());
                 if (throwException) {

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
@@ -113,18 +113,6 @@ public class ReplaceTeePointByVoltageLevelOnLine extends AbstractNetworkModifica
         return newLine2Name;
     }
 
-    // voltageLevel.getNodeBreakerView().getBusbarSection(bbsOrBusId) is currently returning any busbarSection from the network
-    // even if this busbarSection is not included in the voltageLevel
-    // this method returns null if the busbarSectionId does not belong to the voltageLevel
-    private BusbarSection getBusBarSectionFromVoltageLevel(Network network, VoltageLevel voltageLevel, String busBarSectionId) {
-        BusbarSection bbs = network.getBusbarSection(busBarSectionId);
-        if (bbs == null || bbs.getTerminal().getVoltageLevel() != voltageLevel) {
-            return null;
-        }
-
-        return bbs;
-    }
-
     @Override
     public void apply(Network network, boolean throwException,
                       ComputationManager computationManager, Reporter reporter) {
@@ -211,7 +199,7 @@ public class ReplaceTeePointByVoltageLevelOnLine extends AbstractNetworkModifica
             newLine2Adder.setBus1(bus2.getId());
             newLine2Adder.setConnectableBus1(bus2.getId());
         } else if (topologyKind == TopologyKind.NODE_BREAKER) {
-            BusbarSection bbs = getBusBarSectionFromVoltageLevel(network, tappedVoltageLevel, bbsOrBusId);
+            BusbarSection bbs = tappedVoltageLevel.getNodeBreakerView().getBusbarSection(bbsOrBusId);
             if (bbs == null) {
                 notFoundBusbarSectionInVoltageLevelReport(reporter, bbsOrBusId, tappedVoltageLevel.getId());
                 if (throwException) {

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
@@ -118,7 +118,7 @@ public class ReplaceTeePointByVoltageLevelOnLine extends AbstractNetworkModifica
     // this method returns null if the busbarSectionId does not belong to the voltageLevel
     private BusbarSection getBusBarSectionFromVoltageLevel(Network network, VoltageLevel voltageLevel, String busBarSectionId) {
         BusbarSection bbs = network.getBusbarSection(busBarSectionId);
-        if (bbs == null || !voltageLevel.equals(bbs.getTerminal().getVoltageLevel())) {
+        if (bbs == null || bbs.getTerminal().getVoltageLevel() != voltageLevel) {
             return null;
         }
 

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
@@ -97,6 +97,15 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractConverterTest {
                 .withNewLine2Id("NEW LINE2").build();
         assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError6.apply(network, true, Reporter.NO_OP)).getMessage().contains("Unable to find the tee point and the tapped voltage level from lines CJ_1, CJ_2 and LINE34"));
 
+        NetworkModification modificationWithError7 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
+                .withTeePointLine1("CJ_1")
+                .withTeePointLine2("CJ_2")
+                .withTeePointLineToRemove("testLine")
+                .withBbsOrBusId("bbs3")
+                .withNewLine1Id("NEW LINE1")
+                .withNewLine2Id("NEW LINE2").build();
+        assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError7.apply(network, true, Reporter.NO_OP)).getMessage().contains("Busbar section bbs3 is not found in voltage level VLTEST"));
+
         modification = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("CJ_1")
                 .withTeePointLine2("CJ_2")

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
@@ -146,14 +146,26 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractConverterTest {
         NetworkModification modification = new CreateLineOnLineBuilder().withBusbarSectionOrBusId("bus").withLine(line).withLineAdder(adder).build();
         modification.apply(network);
 
-        NetworkModification modificationWithError = new ReplaceTeePointByVoltageLevelOnLineBuilder()
+        VoltageLevel vl = network.newVoltageLevel().setId("VL3").setNominalV(380).setTopologyKind(TopologyKind.BUS_BREAKER).add();
+        vl.getBusBreakerView().newBus().setId("bus3").add();
+
+        NetworkModification modificationWithError1 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("NHV1_NHV2_1_1")
                 .withTeePointLine2("NHV1_NHV2_1_2")
                 .withTeePointLineToRemove("testLine")
                 .withBbsOrBusId("busNotFound")
                 .withNewLine1Id("NEW LINE1")
                 .withNewLine2Id("NEW LINE2").build();
-        assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError.apply(network, true, Reporter.NO_OP)).getMessage().contains("Bus busNotFound is not found in voltage level " + VOLTAGE_LEVEL_ID));
+        assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError1.apply(network, true, Reporter.NO_OP)).getMessage().contains("Bus busNotFound is not found in voltage level " + VOLTAGE_LEVEL_ID));
+
+        NetworkModification modificationWithError2 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
+                .withTeePointLine1("NHV1_NHV2_1_1")
+                .withTeePointLine2("NHV1_NHV2_1_2")
+                .withTeePointLineToRemove("testLine")
+                .withBbsOrBusId("bus3")
+                .withNewLine1Id("NEW LINE1")
+                .withNewLine2Id("NEW LINE2").build();
+        assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError2.apply(network, true, Reporter.NO_OP)).getMessage().contains("Bus bus3 is not found in voltage level " + VOLTAGE_LEVEL_ID));
 
         modification = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("NHV1_NHV2_1_1")

--- a/iidm/iidm-modification/src/test/resources/eurostag-replace-tee-point-by-voltage-level-on-line-bb.xml
+++ b/iidm/iidm-modification/src/test/resources/eurostag-replace-tee-point-by-voltage-level-on-line-bb.xml
@@ -11,6 +11,11 @@
             <iidm:switch id="bus_SW_2" kind="BREAKER" retained="true" open="false" bus1="bus" bus2="NEW LINE2_BUS_2"/>
         </iidm:busBreakerTopology>
     </iidm:voltageLevel>
+    <iidm:voltageLevel id="VL3" nominalV="380.0" topologyKind="BUS_BREAKER">
+        <iidm:busBreakerTopology>
+            <iidm:bus id="bus3"/>
+        </iidm:busBreakerTopology>
+    </iidm:voltageLevel>
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Creating a modification "replace tee point by voltage level on line" with wrong bus bar section is not sending an exception and provoke an unexpected behaviour


**What is the new behavior (if this is a feature change)?**
Creating a modification "replace tee point by voltage level on line" with wrong bus bar section is throwing an exception
