### PR TITLE
[Network modifications] Fix: Remove disconnectors and breakers in RemoveHvdcLine and RemoveVoltageLevel

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
@@ -57,8 +57,8 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
             hvdcLine.remove();
             removedHvdcLineReport(reporter, hvdcLineId);
             // Remove the Shunt compensators that represent the filters of the LCC
-            removeShuntCompensators(hvdcConverterStation1, hvdcConverterStation2, shunts, reporter);
-            removeConverterStations(hvdcConverterStation1, hvdcConverterStation2, reporter);
+            removeShuntCompensators(network, hvdcConverterStation1, hvdcConverterStation2, shunts, throwException, computationManager, reporter);
+            removeConverterStations(network, hvdcConverterStation1, hvdcConverterStation2, throwException, computationManager, reporter);
         } else {
             LOGGER.error("Hvdc Line {} not found", hvdcLineId);
             notFoundHvdcLineReport(reporter, hvdcLineId);
@@ -80,7 +80,7 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
         return sc;
     }
 
-    private static void removeShuntCompensators(HvdcConverterStation<?> hvdcConverterStation1, HvdcConverterStation<?> hvdcConverterStation2, Set<ShuntCompensator> shunts, Reporter reporter) {
+    private static void removeShuntCompensators(Network network, HvdcConverterStation<?> hvdcConverterStation1, HvdcConverterStation<?> hvdcConverterStation2, Set<ShuntCompensator> shunts, boolean throwException, ComputationManager computationManager, Reporter reporter) {
         if (shunts == null) {
             return;
         }
@@ -94,7 +94,7 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
             VoltageLevel shuntVl = shuntCompensator.getTerminal().getVoltageLevel();
             // check whether the shunt compensator is connected to the same voltage level as the lcc
             if (vl1 == shuntVl || vl2 == shuntVl) {
-                shuntCompensator.remove();
+                new RemoveFeederBay(shuntCompensator.getId()).apply(network, throwException, computationManager, reporter);
                 removedShuntCompensatorReport(reporter, shuntCompensator.getId());
             } else {
                 LOGGER.warn("Shunt compensator {} has been ignored because it is not in the same voltage levels as the Lcc ({} or {})", shuntCompensator.getId(), vl1.getId(), vl2.getId());
@@ -103,9 +103,9 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
         }
     }
 
-    private static void removeConverterStations(HvdcConverterStation<?> hvdcConverterStation1, HvdcConverterStation<?> hvdcConverterStation2, Reporter reporter) {
-        hvdcConverterStation1.remove();
-        hvdcConverterStation2.remove();
+    private static void removeConverterStations(Network network, HvdcConverterStation<?> hvdcConverterStation1, HvdcConverterStation<?> hvdcConverterStation2, boolean throwException, ComputationManager computationManager, Reporter reporter) {
+        new RemoveFeederBay(hvdcConverterStation1.getId()).apply(network, throwException, computationManager, reporter);
+        new RemoveFeederBay(hvdcConverterStation2.getId()).apply(network, throwException, computationManager, reporter);
         reportConverterStationRemoved(reporter, hvdcConverterStation1);
         reportConverterStationRemoved(reporter, hvdcConverterStation2);
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevel.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevel.java
@@ -50,9 +50,13 @@ public class RemoveVoltageLevel extends AbstractNetworkModification {
             }
         });
 
-        voltageLevel.getConnectables(Branch.class).forEach(branch -> new RemoveFeederBayBuilder().withConnectableId(branch.getId()).build().apply(network, throwException, computationManager, reporter));
-        voltageLevel.getConnectables(ThreeWindingsTransformer.class).forEach(threewt -> new RemoveFeederBayBuilder().withConnectableId(threewt.getId()).build().apply(network, throwException, computationManager, reporter));
-        voltageLevel.getConnectables().forEach(Connectable::remove);
+        voltageLevel.getConnectables().forEach(connectable -> {
+            if (connectable instanceof Injection) {
+                connectable.remove();
+            } else {
+                new RemoveFeederBayBuilder().withConnectableId(connectable.getId()).build().apply(network, throwException, computationManager, reporter);
+            }
+        });
 
         voltageLevel.remove();
         removedVoltageLevelReport(reporter, voltageLevelId);

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevel.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevel.java
@@ -46,12 +46,11 @@ public class RemoveVoltageLevel extends AbstractNetworkModification {
 
         voltageLevel.getConnectables(HvdcConverterStation.class).forEach(hcs -> {
             if (hcs.getHvdcLine() != null) {
-                hcs.getHvdcLine().remove();
+                new RemoveHvdcLineBuilder().withHvdcLineId(hcs.getHvdcLine().getId()).build().apply(network, throwException, computationManager, reporter);
             }
-            hcs.remove();
         });
 
-        voltageLevel.getConnectables().forEach(Connectable::remove);
+        voltageLevel.getConnectables().forEach(connectable -> new RemoveFeederBayBuilder().withConnectableId(connectable.getId()).build().apply(network, throwException, computationManager, reporter));
 
         voltageLevel.remove();
         removedVoltageLevelReport(reporter, voltageLevelId);

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevel.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevel.java
@@ -50,7 +50,9 @@ public class RemoveVoltageLevel extends AbstractNetworkModification {
             }
         });
 
-        voltageLevel.getConnectables().forEach(connectable -> new RemoveFeederBayBuilder().withConnectableId(connectable.getId()).build().apply(network, throwException, computationManager, reporter));
+        voltageLevel.getConnectables(Branch.class).forEach(branch -> new RemoveFeederBayBuilder().withConnectableId(branch.getId()).build().apply(network, throwException, computationManager, reporter));
+        voltageLevel.getConnectables(ThreeWindingsTransformer.class).forEach(threewt -> new RemoveFeederBayBuilder().withConnectableId(threewt.getId()).build().apply(network, throwException, computationManager, reporter));
+        voltageLevel.getConnectables().forEach(Connectable::remove);
 
         voltageLevel.remove();
         removedVoltageLevelReport(reporter, voltageLevelId);

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevelTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevelTest.java
@@ -59,8 +59,8 @@ class RemoveVoltageLevelTest extends AbstractConverterTest {
         addListener(network);
 
         new RemoveVoltageLevelBuilder().withVoltageLevelId("S1VL1").build().apply(network);
-        assertEquals(Set.of("TWT", "S1VL1_BBS", "S1VL1_BBS_TWT_DISCONNECTOR", "S1VL1", "S1VL1_LD1_BREAKER", "LD1", "S1VL1_TWT_BREAKER", "S1VL1_BBS_LD1_DISCONNECTOR"), beforeRemovalObjects);
-        assertEquals(Set.of("TWT", "S1VL1_BBS", "S1VL1_BBS_TWT_DISCONNECTOR", "S1VL1", "S1VL1_LD1_BREAKER", "LD1", "S1VL1_TWT_BREAKER", "S1VL1_BBS_LD1_DISCONNECTOR"), removedObjects);
+        assertEquals(Set.of("TWT", "S1VL1_BBS", "S1VL1_BBS_TWT_DISCONNECTOR", "S1VL1", "S1VL1_LD1_BREAKER", "LD1", "S1VL1_TWT_BREAKER", "S1VL1_BBS_LD1_DISCONNECTOR", "S1VL2_BBS1_TWT_DISCONNECTOR", "S1VL2_BBS2_TWT_DISCONNECTOR", "S1VL2_TWT_BREAKER"), beforeRemovalObjects);
+        assertEquals(Set.of("TWT", "S1VL1_BBS", "S1VL1_BBS_TWT_DISCONNECTOR", "S1VL1", "S1VL1_LD1_BREAKER", "LD1", "S1VL1_TWT_BREAKER", "S1VL1_BBS_LD1_DISCONNECTOR", "S1VL2_BBS1_TWT_DISCONNECTOR", "S1VL2_BBS2_TWT_DISCONNECTOR", "S1VL2_TWT_BREAKER"), removedObjects);
         assertNull(network.getVoltageLevel("S1VL1"));
         assertNull(network.getTwoWindingsTransformer("TWT"));
 
@@ -86,7 +86,7 @@ class RemoveVoltageLevelTest extends AbstractConverterTest {
         Network network = createNbNetwork();
         NetworkModification modification = new RemoveVoltageLevelBuilder().withVoltageLevelId("C").build();
         modification.apply(network);
-        roundTripXmlTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead,
+        roundTripTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead,
                 "/eurostag-remove-voltage-level-nb.xml");
     }
 

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevelTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevelTest.java
@@ -86,7 +86,7 @@ class RemoveVoltageLevelTest extends AbstractConverterTest {
         Network network = createNbNetwork();
         NetworkModification modification = new RemoveVoltageLevelBuilder().withVoltageLevelId("C").build();
         modification.apply(network);
-        roundTripTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead,
+        roundTripXmlTest(network, NetworkXml::writeAndValidate, NetworkXml::validateAndRead,
                 "/eurostag-remove-voltage-level-nb.xml");
     }
 

--- a/iidm/iidm-modification/src/test/resources/eurostag-remove-voltage-level-nb.xml
+++ b/iidm/iidm-modification/src/test/resources/eurostag-remove-voltage-level-nb.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_9" id="fictitious" caseDate="2021-08-27T14:44:56.567+02:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:voltageLevel id="VLTEST" nominalV="380.0" topologyKind="NODE_BREAKER">
-        <iidm:nodeBreakerTopology/>
+        <iidm:nodeBreakerTopology></iidm:nodeBreakerTopology>
     </iidm:voltageLevel>
     <iidm:substation id="A" country="FR">
         <iidm:voltageLevel id="N" nominalV="225.0" lowVoltageLimit="220.0" highVoltageLimit="245.00002" topologyKind="NODE_BREAKER">
@@ -13,7 +14,6 @@
                 <iidm:switch id="X" name="Y" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="11"/>
                 <iidm:switch id="Z" name="AA" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="13"/>
                 <iidm:switch id="AB" name="AC" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="15"/>
-                <iidm:switch id="AD" name="AE" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="8"/>
                 <iidm:switch id="AF" name="AG" fictitious="true" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="2"/>
                 <iidm:switch id="AH" name="AI" kind="DISCONNECTOR" retained="false" open="false" node1="7" node2="0"/>
                 <iidm:switch id="AJ" name="AK" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="6"/>
@@ -23,22 +23,17 @@
                 <iidm:switch id="AR" name="AS" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="11"/>
                 <iidm:switch id="AT" name="AU" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="13"/>
                 <iidm:switch id="AV" name="AW" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="15"/>
-                <iidm:switch id="AX" name="AY" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="8"/>
                 <iidm:switch id="AZ" name="BA" fictitious="true" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="2"/>
                 <iidm:switch id="BB" name="BC" fictitious="true" kind="BREAKER" retained="true" open="true" node1="2" node2="3"/>
                 <iidm:switch id="BD" name="BE" kind="BREAKER" retained="true" open="false" node1="3" node2="4"/>
-                <iidm:switch id="BF" name="BG" kind="DISCONNECTOR" retained="false" open="false" node1="3" node2="5"/>
-                <iidm:switch id="BH" name="BI" kind="DISCONNECTOR" retained="false" open="true" node1="9" node2="3"/>
                 <iidm:switch id="BJ" name="BK" kind="BREAKER" retained="true" open="false" node1="6" node2="7"/>
-                <iidm:switch id="BL" name="BM" kind="BREAKER" retained="true" open="false" node1="8" node2="9"/>
-                <iidm:switch id="BN" name="BO" kind="DISCONNECTOR" retained="false" open="false" node1="9" node2="10"/>
                 <iidm:switch id="BP" name="BQ" kind="BREAKER" retained="true" open="true" node1="11" node2="12"/>
                 <iidm:switch id="BR" name="BS" kind="BREAKER" retained="true" open="true" node1="13" node2="14"/>
                 <iidm:switch id="BT" name="BU" kind="BREAKER" retained="true" open="false" node1="15" node2="16"/>
                 <iidm:switch id="BV" name="BW" kind="BREAKER" retained="true" open="false" node1="17" node2="18"/>
                 <iidm:switch id="BX" name="BY" kind="BREAKER" retained="true" open="false" node1="19" node2="20"/>
                 <iidm:switch id="BZ" name="CA" kind="BREAKER" retained="true" open="false" node1="21" node2="22"/>
-                <iidm:bus v="236.44736" angle="15.250391" nodes="0,1,6,7,8,9,10,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="236.44736" angle="15.250391" nodes="0,1,6,7,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="CB" energySource="HYDRO" minP="0.0" maxP="70.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" node="12">
                 <iidm:reactiveCapabilityCurve>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The breakers and disconnectors are not removed.


**What is the new behavior (if this is a feature change)?**
In RemoveHvdcLine: the switches of the HVDC line and of the shunts are removed.
In RemoveVoltageLevel: the switches of branches in other voltage levels are removed. 
                                       the converting stations of HVDC lines on the other side are removed.

