### PR TITLE
Notify listeners after invalidating cache when switches' status is updated: connectivity is then correctly taking the update into account

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
@@ -64,9 +64,9 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
         boolean oldValue = this.open.get(index);
         if (oldValue != open) {
             this.open.set(index, open);
+            voltageLevel.invalidateCache(isRetained());
             String variantId = network.getVariantManager().getVariantId(index);
             network.getListeners().notifyUpdate(this, "open", variantId, oldValue, open);
-            voltageLevel.invalidateCache(isRetained());
         }
     }
 
@@ -85,9 +85,9 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
         boolean oldValue = this.retained.get(index);
         if (oldValue != retained) {
             this.retained.set(index, retained);
+            voltageLevel.invalidateCache();
             String variantId = network.getVariantManager().getVariantId(index);
             network.getListeners().notifyUpdate(this, "retained", variantId, oldValue, retained);
-            voltageLevel.invalidateCache();
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix old regression: listeners were notified before invalidating cache, leading to inconsistencies in connectivity in methods called if checked



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
