### PR TITLE
Fix severity for remove vl or hvdc reports

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
@@ -352,7 +352,7 @@ final class ModificationReports {
                 .withKey("removeVoltageLevel")
                 .withDefaultMessage("Voltage level ${voltageLevelId}, its equipments and the branches it is connected to have been removed")
                 .withValue(VOLTAGE_LEVEL_ID, voltageLevelId)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .withSeverity(TypedValue.INFO_SEVERITY)
                 .build());
     }
 
@@ -361,7 +361,7 @@ final class ModificationReports {
                 .withKey("removeHvdcLine")
                 .withDefaultMessage("Hvdc line ${hvdcLineId} has been removed")
                 .withValue(HVDC_LINE_ID, hvdcLineId)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .withSeverity(TypedValue.INFO_SEVERITY)
                 .build());
     }
 
@@ -370,7 +370,7 @@ final class ModificationReports {
                 .withKey("removeVscConverterStation")
                 .withDefaultMessage("Vsc converter station ${vscConverterStationId} has been removed")
                 .withValue("vscConverterStationId", vscConverterStationId)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .withSeverity(TypedValue.INFO_SEVERITY)
                 .build());
     }
 
@@ -379,7 +379,7 @@ final class ModificationReports {
                 .withKey("removeLccConverterStation")
                 .withDefaultMessage("Lcc converter station ${lccConverterStationId} has been removed")
                 .withValue("lccConverterStationId", lccConverterStationId)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .withSeverity(TypedValue.INFO_SEVERITY)
                 .build());
     }
 
@@ -388,7 +388,7 @@ final class ModificationReports {
                 .withKey("removeShuntCompensator")
                 .withDefaultMessage("Shunt compensator ${shuntCompensatorId} has been removed")
                 .withValue("shuntCompensatorId", shuntCompensatorId)
-                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .withSeverity(TypedValue.INFO_SEVERITY)
                 .build());
     }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ModificationReports.java
@@ -156,6 +156,51 @@ final class ModificationReports {
                 .build());
     }
 
+    static void removedVoltageLevelReport(Reporter reporter, String voltageLevelId) {
+        reporter.report(Report.builder()
+                .withKey("removeVoltageLevel")
+                .withDefaultMessage("Voltage level ${voltageLevelId}, its equipments and the branches it is connected to have been removed")
+                .withValue(VOLTAGE_LEVEL_ID, voltageLevelId)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    static void removedHvdcLineReport(Reporter reporter, String hvdcLineId) {
+        reporter.report(Report.builder()
+                .withKey("removeHvdcLine")
+                .withDefaultMessage("Hvdc line ${hvdcLineId} has been removed")
+                .withValue(HVDC_LINE_ID, hvdcLineId)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    static void removedVscConverterStationReport(Reporter reporter, String vscConverterStationId) {
+        reporter.report(Report.builder()
+                .withKey("removeVscConverterStation")
+                .withDefaultMessage("Vsc converter station ${vscConverterStationId} has been removed")
+                .withValue("vscConverterStationId", vscConverterStationId)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    static void removedLccConverterStationReport(Reporter reporter, String lccConverterStationId) {
+        reporter.report(Report.builder()
+                .withKey("removeLccConverterStation")
+                .withDefaultMessage("Lcc converter station ${lccConverterStationId} has been removed")
+                .withValue("lccConverterStationId", lccConverterStationId)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
+    static void removedShuntCompensatorReport(Reporter reporter, String shuntCompensatorId) {
+        reporter.report(Report.builder()
+                .withKey("removeShuntCompensator")
+                .withDefaultMessage("Shunt compensator ${shuntCompensatorId} has been removed")
+                .withValue("shuntCompensatorId", shuntCompensatorId)
+                .withSeverity(TypedValue.INFO_SEVERITY)
+                .build());
+    }
+
     // WARN
     static void ignoredVscShunts(Reporter reporter, String shuntsIds, String converterStationId1, String converterStationId2) {
         reporter.report(Report.builder()
@@ -344,51 +389,6 @@ final class ModificationReports {
                 .withValue("busOrBusbarSectionId1", busOrBusbarSectionId1)
                 .withValue("busOrBusbarSectionId2", busOrBusbarSectionId2)
                 .withSeverity(TypedValue.ERROR_SEVERITY)
-                .build());
-    }
-
-    static void removedVoltageLevelReport(Reporter reporter, String voltageLevelId) {
-        reporter.report(Report.builder()
-                .withKey("removeVoltageLevel")
-                .withDefaultMessage("Voltage level ${voltageLevelId}, its equipments and the branches it is connected to have been removed")
-                .withValue(VOLTAGE_LEVEL_ID, voltageLevelId)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
-    static void removedHvdcLineReport(Reporter reporter, String hvdcLineId) {
-        reporter.report(Report.builder()
-                .withKey("removeHvdcLine")
-                .withDefaultMessage("Hvdc line ${hvdcLineId} has been removed")
-                .withValue(HVDC_LINE_ID, hvdcLineId)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
-    static void removedVscConverterStationReport(Reporter reporter, String vscConverterStationId) {
-        reporter.report(Report.builder()
-                .withKey("removeVscConverterStation")
-                .withDefaultMessage("Vsc converter station ${vscConverterStationId} has been removed")
-                .withValue("vscConverterStationId", vscConverterStationId)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
-    static void removedLccConverterStationReport(Reporter reporter, String lccConverterStationId) {
-        reporter.report(Report.builder()
-                .withKey("removeLccConverterStation")
-                .withDefaultMessage("Lcc converter station ${lccConverterStationId} has been removed")
-                .withValue("lccConverterStationId", lccConverterStationId)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
-    }
-
-    static void removedShuntCompensatorReport(Reporter reporter, String shuntCompensatorId) {
-        reporter.report(Report.builder()
-                .withKey("removeShuntCompensator")
-                .withDefaultMessage("Shunt compensator ${shuntCompensatorId} has been removed")
-                .withValue("shuntCompensatorId", shuntCompensatorId)
-                .withSeverity(TypedValue.INFO_SEVERITY)
                 .build());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
The report severity for a removedVoltageLevelReport or removedHvdcLineReport is ERROR_SEVERITY



**What is the new behavior (if this is a feature change)?**
The report severity for a removedVoltageLevelReport or removedHvdcLineReport should be INFO_SEVERITY.


**Does this PR introduce a breaking change or deprecate an API?**
No

