### PR TITLE
Fix hvdc removal reporting

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
@@ -117,8 +117,7 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
     private static void reportConverterStationRemoved(Reporter reporter, String stationId, HvdcConverterStation.HvdcType converterStationType) {
         if (converterStationType == HvdcConverterStation.HvdcType.LCC) {
             removedLccConverterStationReport(reporter, stationId);
-        }
-        if (converterStationType == HvdcConverterStation.HvdcType.VSC) {
+        } else if (converterStationType == HvdcConverterStation.HvdcType.VSC) {
             removedVscConverterStationReport(reporter, stationId);
         }
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
@@ -108,10 +108,12 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
         String station2Id = hvdcConverterStation2.getId();
         boolean isStation1LccStation = isLccConverterStation(hvdcConverterStation1);
         boolean isStation2LccStation = isLccConverterStation(hvdcConverterStation2);
+        boolean isStation1VscStation = isVscConverterStation(hvdcConverterStation1);
+        boolean isStation2VscStation = isVscConverterStation(hvdcConverterStation2);
         new RemoveFeederBay(station1Id).apply(network, throwException, computationManager, reporter);
         new RemoveFeederBay(station2Id).apply(network, throwException, computationManager, reporter);
-        reportConverterStationRemoved(reporter, station1Id, isStation1LccStation);
-        reportConverterStationRemoved(reporter, station2Id, isStation2LccStation);
+        reportConverterStationRemoved(reporter, station1Id, isStation1LccStation, isStation1VscStation);
+        reportConverterStationRemoved(reporter, station2Id, isStation2LccStation, isStation2VscStation);
     }
 
     private static boolean isLccConverterStation(HvdcConverterStation<?> hvdcConverterStation) {
@@ -122,11 +124,11 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
         return hvdcConverterStation.getHvdcType() == HvdcConverterStation.HvdcType.VSC;
     }
 
-    private static void reportConverterStationRemoved(Reporter reporter, String stationId, boolean isLccConverterStation) {
+    private static void reportConverterStationRemoved(Reporter reporter, String stationId, boolean isLccConverterStation, boolean isVscConverterStation) {
         if (isLccConverterStation) {
             removedLccConverterStationReport(reporter, stationId);
         }
-        if (isLccConverterStation) {
+        if (isVscConverterStation) {
             removedVscConverterStationReport(reporter, stationId);
         }
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
@@ -107,7 +107,7 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
         String station1Id = hvdcConverterStation1.getId();
         String station2Id = hvdcConverterStation2.getId();
         HvdcConverterStation.HvdcType station1Type = hvdcConverterStation1.getHvdcType();
-        HvdcConverterStation.HvdcType station2Type = hvdcConverterStation1.getHvdcType();
+        HvdcConverterStation.HvdcType station2Type = hvdcConverterStation2.getHvdcType();
         new RemoveFeederBay(station1Id).apply(network, throwException, computationManager, reporter);
         new RemoveFeederBay(station2Id).apply(network, throwException, computationManager, reporter);
         reportConverterStationRemoved(reporter, station1Id, station1Type);

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
@@ -104,10 +104,14 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
     }
 
     private static void removeConverterStations(Network network, HvdcConverterStation<?> hvdcConverterStation1, HvdcConverterStation<?> hvdcConverterStation2, boolean throwException, ComputationManager computationManager, Reporter reporter) {
-        new RemoveFeederBay(hvdcConverterStation1.getId()).apply(network, throwException, computationManager, reporter);
-        new RemoveFeederBay(hvdcConverterStation2.getId()).apply(network, throwException, computationManager, reporter);
-        reportConverterStationRemoved(reporter, hvdcConverterStation1);
-        reportConverterStationRemoved(reporter, hvdcConverterStation2);
+        String station1Id = hvdcConverterStation1.getId();
+        String station2Id = hvdcConverterStation2.getId();
+        boolean isStation1LccStation = isLccConverterStation(hvdcConverterStation1);
+        boolean isStation2LccStation = isLccConverterStation(hvdcConverterStation2);
+        new RemoveFeederBay(station1Id).apply(network, throwException, computationManager, reporter);
+        new RemoveFeederBay(station2Id).apply(network, throwException, computationManager, reporter);
+        reportConverterStationRemoved(reporter, station1Id, isStation1LccStation);
+        reportConverterStationRemoved(reporter, station2Id, isStation2LccStation);
     }
 
     private static boolean isLccConverterStation(HvdcConverterStation<?> hvdcConverterStation) {
@@ -118,12 +122,12 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
         return hvdcConverterStation.getHvdcType() == HvdcConverterStation.HvdcType.VSC;
     }
 
-    private static void reportConverterStationRemoved(Reporter reporter, HvdcConverterStation<?> hvdcConverterStation) {
-        if (isLccConverterStation(hvdcConverterStation)) {
-            removedLccConverterStationReport(reporter, hvdcConverterStation.getId());
+    private static void reportConverterStationRemoved(Reporter reporter, String stationId, boolean isLccConverterStation) {
+        if (isLccConverterStation) {
+            removedLccConverterStationReport(reporter, stationId);
         }
-        if (isVscConverterStation(hvdcConverterStation)) {
-            removedVscConverterStationReport(reporter, hvdcConverterStation.getId());
+        if (isLccConverterStation) {
+            removedVscConverterStationReport(reporter, stationId);
         }
     }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
@@ -45,7 +45,7 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
             HvdcConverterStation<?> hvdcConverterStation1 = hvdcLine.getConverterStation1();
             HvdcConverterStation<?> hvdcConverterStation2 = hvdcLine.getConverterStation2();
             Set<ShuntCompensator> shunts = null;
-            if (isLccConverterStation(hvdcConverterStation1)) { // in real-life cases, both converter stations are of the same type
+            if (hvdcConverterStation1.getHvdcType() == HvdcConverterStation.HvdcType.LCC) { // in real-life cases, both converter stations are of the same type
                 shunts = shuntCompensatorIds.stream()
                         .map(id -> getShuntCompensator(id, network, throwException, reporter))
                         .filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
@@ -106,29 +106,19 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
     private static void removeConverterStations(Network network, HvdcConverterStation<?> hvdcConverterStation1, HvdcConverterStation<?> hvdcConverterStation2, boolean throwException, ComputationManager computationManager, Reporter reporter) {
         String station1Id = hvdcConverterStation1.getId();
         String station2Id = hvdcConverterStation2.getId();
-        boolean isStation1LccStation = isLccConverterStation(hvdcConverterStation1);
-        boolean isStation2LccStation = isLccConverterStation(hvdcConverterStation2);
-        boolean isStation1VscStation = isVscConverterStation(hvdcConverterStation1);
-        boolean isStation2VscStation = isVscConverterStation(hvdcConverterStation2);
+        HvdcConverterStation.HvdcType station1Type = hvdcConverterStation1.getHvdcType();
+        HvdcConverterStation.HvdcType station2Type = hvdcConverterStation1.getHvdcType();
         new RemoveFeederBay(station1Id).apply(network, throwException, computationManager, reporter);
         new RemoveFeederBay(station2Id).apply(network, throwException, computationManager, reporter);
-        reportConverterStationRemoved(reporter, station1Id, isStation1LccStation, isStation1VscStation);
-        reportConverterStationRemoved(reporter, station2Id, isStation2LccStation, isStation2VscStation);
+        reportConverterStationRemoved(reporter, station1Id, station1Type);
+        reportConverterStationRemoved(reporter, station2Id, station2Type);
     }
 
-    private static boolean isLccConverterStation(HvdcConverterStation<?> hvdcConverterStation) {
-        return hvdcConverterStation.getHvdcType() == HvdcConverterStation.HvdcType.LCC;
-    }
-
-    private static boolean isVscConverterStation(HvdcConverterStation<?> hvdcConverterStation) {
-        return hvdcConverterStation.getHvdcType() == HvdcConverterStation.HvdcType.VSC;
-    }
-
-    private static void reportConverterStationRemoved(Reporter reporter, String stationId, boolean isLccConverterStation, boolean isVscConverterStation) {
-        if (isLccConverterStation) {
+    private static void reportConverterStationRemoved(Reporter reporter, String stationId, HvdcConverterStation.HvdcType converterStationType) {
+        if (converterStationType == HvdcConverterStation.HvdcType.LCC) {
             removedLccConverterStationReport(reporter, stationId);
         }
-        if (isVscConverterStation) {
+        if (converterStationType == HvdcConverterStation.HvdcType.VSC) {
             removedVscConverterStationReport(reporter, stationId);
         }
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
@@ -45,7 +45,7 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
             HvdcConverterStation<?> hvdcConverterStation1 = hvdcLine.getConverterStation1();
             HvdcConverterStation<?> hvdcConverterStation2 = hvdcLine.getConverterStation2();
             Set<ShuntCompensator> shunts = null;
-            if (isLccConverterStation(hvdcConverterStation1.getHvdcType())) { // in real-life cases, both converter stations are of the same type
+            if (hvdcConverterStation1.getHvdcType() == HvdcConverterStation.HvdcType.LCC) { // in real-life cases, both converter stations are of the same type
                 shunts = shuntCompensatorIds.stream()
                         .map(id -> getShuntCompensator(id, network, throwException, reporter))
                         .filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
@@ -114,19 +114,11 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
         reportConverterStationRemoved(reporter, station2Id, station2Type);
     }
 
-    private static boolean isLccConverterStation(HvdcConverterStation.HvdcType converterStationType) {
-        return converterStationType == HvdcConverterStation.HvdcType.LCC;
-    }
-
-    private static boolean isVscConverterStation(HvdcConverterStation.HvdcType converterStationType) {
-        return converterStationType == HvdcConverterStation.HvdcType.VSC;
-    }
-
     private static void reportConverterStationRemoved(Reporter reporter, String stationId, HvdcConverterStation.HvdcType converterStationType) {
-        if (isLccConverterStation(converterStationType)) {
+        if (converterStationType == HvdcConverterStation.HvdcType.LCC) {
             removedLccConverterStationReport(reporter, stationId);
         }
-        if (isVscConverterStation(converterStationType)) {
+        if (converterStationType == HvdcConverterStation.HvdcType.VSC) {
             removedVscConverterStationReport(reporter, stationId);
         }
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
@@ -45,7 +45,7 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
             HvdcConverterStation<?> hvdcConverterStation1 = hvdcLine.getConverterStation1();
             HvdcConverterStation<?> hvdcConverterStation2 = hvdcLine.getConverterStation2();
             Set<ShuntCompensator> shunts = null;
-            if (hvdcConverterStation1.getHvdcType() == HvdcConverterStation.HvdcType.LCC) { // in real-life cases, both converter stations are of the same type
+            if (isLccConverterStation(hvdcConverterStation1.getHvdcType())) { // in real-life cases, both converter stations are of the same type
                 shunts = shuntCompensatorIds.stream()
                         .map(id -> getShuntCompensator(id, network, throwException, reporter))
                         .filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
@@ -114,11 +114,19 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
         reportConverterStationRemoved(reporter, station2Id, station2Type);
     }
 
+    private static boolean isLccConverterStation(HvdcConverterStation.HvdcType converterStationType) {
+        return converterStationType == HvdcConverterStation.HvdcType.LCC;
+    }
+
+    private static boolean isVscConverterStation(HvdcConverterStation.HvdcType converterStationType) {
+        return converterStationType == HvdcConverterStation.HvdcType.VSC;
+    }
+
     private static void reportConverterStationRemoved(Reporter reporter, String stationId, HvdcConverterStation.HvdcType converterStationType) {
-        if (converterStationType == HvdcConverterStation.HvdcType.LCC) {
+        if (isLccConverterStation(converterStationType)) {
             removedLccConverterStationReport(reporter, stationId);
         }
-        if (converterStationType == HvdcConverterStation.HvdcType.VSC) {
+        if (isVscConverterStation(converterStationType)) {
             removedVscConverterStationReport(reporter, stationId);
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
converterStation.getId() is called after the station had been deleted.


**What is the new behavior (if this is a feature change)?**
We store the id and the converter station type before the station is removed.


**Does this PR introduce a breaking change or deprecate an API?**
No
