### PR TITLE
Improve move connectable notification

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/BusTopologyPoint.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/BusTopologyPoint.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.iidm.network;
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/BusTopologyPoint.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/BusTopologyPoint.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public interface BusTopologyPoint extends TopologyPoint {
+
+    String getConnectableBusId();
+
+    boolean isConnected();
+}

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NodeTopologyPoint.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NodeTopologyPoint.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.iidm.network;
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NodeTopologyPoint.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NodeTopologyPoint.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public interface NodeTopologyPoint extends TopologyPoint {
+
+    int getNode();
+}

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TopologyPoint.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TopologyPoint.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.iidm.network;
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TopologyPoint.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TopologyPoint.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public interface TopologyPoint {
+
+    TopologyKind getTopologyKind();
+
+    String getVoltageLevelId();
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
@@ -10,6 +10,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Connectable;
 import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.iidm.network.TopologyPoint;
 import com.powsybl.iidm.network.impl.util.Ref;
 
 import java.util.ArrayList;
@@ -119,7 +120,7 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         }
     }
 
-    protected void move(TerminalExt oldTerminal, String oldConnectionInfo, int node, String voltageLevelId) {
+    protected void move(TerminalExt oldTerminal, TopologyPoint oldTopologyPoint, int node, String voltageLevelId) {
         VoltageLevelExt voltageLevel = getNetwork().getVoltageLevel(voltageLevelId);
         if (voltageLevel == null) {
             throw new PowsyblException("Voltage level '" + voltageLevelId + "' not found");
@@ -139,10 +140,10 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
                 .build();
 
         // detach the terminal from its previous voltage level
-        attachTerminal(oldTerminal, oldConnectionInfo, voltageLevel, terminalExt);
+        attachTerminal(oldTerminal, oldTopologyPoint, voltageLevel, terminalExt);
     }
 
-    protected void move(TerminalExt oldTerminal, String oldConnectionInfo, String busId, boolean connected) {
+    protected void move(TerminalExt oldTerminal, TopologyPoint oldTopologyPoint, String busId, boolean connected) {
         Bus bus = getNetwork().getBusBreakerView().getBus(busId);
         if (bus == null) {
             throw new PowsyblException("Bus '" + busId + "' not found");
@@ -162,10 +163,10 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
                 .build();
 
         // detach the terminal from its previous voltage level
-        attachTerminal(oldTerminal, oldConnectionInfo, (VoltageLevelExt) bus.getVoltageLevel(), terminalExt);
+        attachTerminal(oldTerminal, oldTopologyPoint, (VoltageLevelExt) bus.getVoltageLevel(), terminalExt);
     }
 
-    private void attachTerminal(TerminalExt oldTerminal, String oldConnectionInfo, VoltageLevelExt voltageLevel, TerminalExt terminalExt) {
+    private void attachTerminal(TerminalExt oldTerminal, TopologyPoint oldTopologyPoint, VoltageLevelExt voltageLevel, TerminalExt terminalExt) {
         // first, attach new terminal to connectable and to voltage level of destination, to ensure that the new terminal is valid
         terminalExt.setConnectable(this);
         voltageLevel.attach(terminalExt, false);
@@ -177,6 +178,6 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         int iSide = terminals.indexOf(oldTerminal);
         terminals.set(iSide, terminalExt);
 
-        notifyUpdate("terminal" + (iSide + 1), oldConnectionInfo, terminalExt.getConnectionInfo());
+        notifyUpdate("terminal" + (iSide + 1), oldTopologyPoint, terminalExt.getTopologyPoint());
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTerminal.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTerminal.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.network.impl;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.util.trove.TBooleanArrayList;
 import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.TopologyPoint;
 import com.powsybl.iidm.network.impl.util.Ref;
 
 import java.util.ArrayList;
@@ -33,7 +34,7 @@ class BusTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(UNMODIFIABLE_REMOVED_EQUIPMENT + connectable.id);
             }
-            getConnectable().move(BusTerminal.this, getConnectionInfo(), node, voltageLevelId);
+            getConnectable().move(BusTerminal.this, getTopologyPoint(), node, voltageLevelId);
         }
     };
 
@@ -79,15 +80,14 @@ class BusTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(UNMODIFIABLE_REMOVED_EQUIPMENT + connectable.id);
             }
-            getConnectable().move(BusTerminal.this, getConnectionInfo(), busId, connected);
+            getConnectable().move(BusTerminal.this, getTopologyPoint(), busId, connected);
         }
 
     };
 
     @Override
-    public String getConnectionInfo() {
-        return "bus " + getBusBreakerView().getConnectableBus().getId() + ", "
-                + (getBusBreakerView().getBus() != null ? "connected" : "disconnected");
+    public TopologyPoint getTopologyPoint() {
+        return new BusTopologyPointImpl(getVoltageLevel().getId(), getConnectableBusId(), isConnected());
     }
 
     private final BusViewExt busView = new BusViewExt() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTopologyPointImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTopologyPointImpl.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.iidm.network.impl;
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTopologyPointImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTopologyPointImpl.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.impl;
+
+import com.powsybl.iidm.network.BusTopologyPoint;
+import com.powsybl.iidm.network.TopologyKind;
+
+import java.util.Objects;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class BusTopologyPointImpl implements BusTopologyPoint {
+
+    private final String voltageLevelId;
+
+    private final String connectableBusId;
+
+    private final boolean connected;
+
+    public BusTopologyPointImpl(String voltageLevelId, String connectableBusId, boolean connected) {
+        this.voltageLevelId = Objects.requireNonNull(voltageLevelId);
+        this.connectableBusId = Objects.requireNonNull(connectableBusId);
+        this.connected = connected;
+    }
+
+    @Override
+    public TopologyKind getTopologyKind() {
+        return TopologyKind.BUS_BREAKER;
+    }
+
+    @Override
+    public String getVoltageLevelId() {
+        return voltageLevelId;
+    }
+
+    @Override
+    public String getConnectableBusId() {
+        return connectableBusId;
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connected;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeTopologyPoint(" +
+                "voltageLevelId='" + voltageLevelId + '\'' +
+                ", connectableBusId='" + connectableBusId + '\'' +
+                ", connected=" + connected +
+                ')';
+    }
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTerminal.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTerminal.java
@@ -8,6 +8,7 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.TopologyPoint;
 import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.impl.util.Ref;
 import gnu.trove.list.array.TDoubleArrayList;
@@ -49,7 +50,7 @@ class NodeTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(UNMODIFIABLE_REMOVED_EQUIPMENT + connectable.id);
             }
-            getConnectable().move(NodeTerminal.this, getConnectionInfo(), node, voltageLevelId);
+            getConnectable().move(NodeTerminal.this, getTopologyPoint(), node, voltageLevelId);
         }
     };
 
@@ -81,14 +82,14 @@ class NodeTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(UNMODIFIABLE_REMOVED_EQUIPMENT + connectable.id);
             }
-            getConnectable().move(NodeTerminal.this, getConnectionInfo(), busId, connected);
+            getConnectable().move(NodeTerminal.this, getTopologyPoint(), busId, connected);
         }
 
     };
 
     @Override
-    public String getConnectionInfo() {
-        return "node " + getNode() + ", Voltage level " + getVoltageLevel().getId();
+    public TopologyPoint getTopologyPoint() {
+        return new NodeTopologyPointImpl(getVoltageLevel().getId(), getNode());
     }
 
     private final BusViewExt busView = new BusViewExt() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTopologyPointImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTopologyPointImpl.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.iidm.network.impl;
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTopologyPointImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTopologyPointImpl.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.impl;
+
+import com.powsybl.iidm.network.NodeTopologyPoint;
+import com.powsybl.iidm.network.TopologyKind;
+
+import java.util.Objects;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class NodeTopologyPointImpl implements NodeTopologyPoint {
+
+    private final String voltageLevelId;
+
+    private final int node;
+
+    public NodeTopologyPointImpl(String voltageLevelId, int node) {
+        this.voltageLevelId = Objects.requireNonNull(voltageLevelId);
+        this.node = node;
+    }
+
+    @Override
+    public TopologyKind getTopologyKind() {
+        return TopologyKind.NODE_BREAKER;
+    }
+
+    @Override
+    public String getVoltageLevelId() {
+        return voltageLevelId;
+    }
+
+    @Override
+    public int getNode() {
+        return node;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeTopologyPoint(" +
+                "voltageLevelId='" + voltageLevelId + '\'' +
+                ", node=" + node +
+                ')';
+    }
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalExt.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalExt.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.network.impl;
 
 import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.TopologyPoint;
 import com.powsybl.math.graph.TraverseResult;
 
 import java.util.Set;
@@ -52,7 +53,7 @@ interface TerminalExt extends Terminal, MultiVariantObject {
      */
     boolean traverse(TopologyTraverser traverser, Set<Terminal> visitedTerminals);
 
-    String getConnectionInfo();
+    TopologyPoint getTopologyPoint();
 
     void removeAsRegulationPoint();
 

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/MoveConnectableNotifTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/MoveConnectableNotifTest.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.iidm.network.impl.tck;
 

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/MoveConnectableNotifTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/MoveConnectableNotifTest.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.impl.tck;
+
+import com.powsybl.iidm.network.tck.AbstractMoveConnectableNotifTest;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+class MoveConnectableNotifTest extends AbstractMoveConnectableNotifTest {
+}

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLoadTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLoadTest.java
@@ -9,7 +9,6 @@ package com.powsybl.iidm.network.tck;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
-import org.apache.commons.lang3.mutable.MutableObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -272,25 +271,6 @@ public abstract class AbstractLoadTest {
         } catch (PowsyblException e) {
             assertEquals("Voltage level 'unknownVl' not found", e.getMessage());
         }
-    }
-
-    @Test
-    public void moveListenerTest() {
-        MutableObject<Object> obj = new MutableObject<>();
-        network.addListener(new DefaultNetworkListener() {
-            @Override
-            public void onUpdate(Identifiable identifiable, String attribute, Object oldValue, Object newValue) {
-                obj.setValue(newValue);
-            }
-        });
-        Load loadNbv = network.getLoad("CF");
-        loadNbv.getTerminal().getNodeBreakerView().moveConnectable(3, voltageLevel.getId());
-        assertNotNull(obj.getValue());
-        assertTrue(obj.getValue() instanceof NodeTopologyPoint);
-        NodeTopologyPoint topologyPoint = (NodeTopologyPoint) obj.getValue();
-        assertSame(TopologyKind.NODE_BREAKER, topologyPoint.getTopologyKind());
-        assertEquals("C", topologyPoint.getVoltageLevelId());
-        assertEquals(3, topologyPoint.getNode());
     }
 
     private void createLoad(String id, double p0, double q0) {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLoadTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLoadTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.network.tck;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -271,6 +272,25 @@ public abstract class AbstractLoadTest {
         } catch (PowsyblException e) {
             assertEquals("Voltage level 'unknownVl' not found", e.getMessage());
         }
+    }
+
+    @Test
+    public void moveListenerTest() {
+        MutableObject<Object> obj = new MutableObject<>();
+        network.addListener(new DefaultNetworkListener() {
+            @Override
+            public void onUpdate(Identifiable identifiable, String attribute, Object oldValue, Object newValue) {
+                obj.setValue(newValue);
+            }
+        });
+        Load loadNbv = network.getLoad("CF");
+        loadNbv.getTerminal().getNodeBreakerView().moveConnectable(3, voltageLevel.getId());
+        assertNotNull(obj.getValue());
+        assertTrue(obj.getValue() instanceof NodeTopologyPoint);
+        NodeTopologyPoint topologyPoint = (NodeTopologyPoint) obj.getValue();
+        assertSame(TopologyKind.NODE_BREAKER, topologyPoint.getTopologyKind());
+        assertEquals("C", topologyPoint.getVoltageLevelId());
+        assertEquals(3, topologyPoint.getNode());
     }
 
     private void createLoad(String id, double p0, double q0) {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMoveConnectableNotifTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMoveConnectableNotifTest.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.iidm.network.tck;
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMoveConnectableNotifTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMoveConnectableNotifTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.tck;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
+import org.apache.commons.lang3.mutable.MutableObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public abstract class AbstractMoveConnectableNotifTest {
+
+    @Test
+    void nodeBreakerTest() {
+        var network = FictitiousSwitchFactory.create();
+        MutableObject<Object> obj = new MutableObject<>();
+        network.addListener(new DefaultNetworkListener() {
+            @Override
+            public void onUpdate(Identifiable identifiable, String attribute, Object oldValue, Object newValue) {
+                obj.setValue(newValue);
+            }
+        });
+        Load cf = network.getLoad("CF");
+        cf.getTerminal().getNodeBreakerView().moveConnectable(3, "C");
+        assertNotNull(obj.getValue());
+        assertTrue(obj.getValue() instanceof NodeTopologyPoint);
+        NodeTopologyPoint topologyPoint = (NodeTopologyPoint) obj.getValue();
+        assertSame(TopologyKind.NODE_BREAKER, topologyPoint.getTopologyKind());
+        assertEquals("C", topologyPoint.getVoltageLevelId());
+        assertEquals(3, topologyPoint.getNode());
+    }
+
+    @Test
+    void busBreakerTest() {
+        var network = EurostagTutorialExample1Factory.create();
+        MutableObject<Object> obj = new MutableObject<>();
+        network.addListener(new DefaultNetworkListener() {
+            @Override
+            public void onUpdate(Identifiable identifiable, String attribute, Object oldValue, Object newValue) {
+                obj.setValue(newValue);
+            }
+        });
+        Load load = network.getLoad("LOAD");
+        load.getTerminal().getBusBreakerView().moveConnectable("NGEN", true);
+        assertNotNull(obj.getValue());
+        assertTrue(obj.getValue() instanceof BusTopologyPoint);
+        BusTopologyPoint topologyPoint = (BusTopologyPoint) obj.getValue();
+        assertSame(TopologyKind.BUS_BREAKER, topologyPoint.getTopologyKind());
+        assertEquals("VLGEN", topologyPoint.getVoltageLevelId());
+        assertEquals("NGEN", topologyPoint.getConnectableBusId());
+        assertTrue(topologyPoint.isConnected());
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
moveConnectable emits a event when a listener is connected, but this is just a String and not formatted in a way it could be easily parsed. 


**What is the new behavior (if this is a feature change)?**
moveConnectable emits a `TopologyPoint` object as a value containing all information about the new connection point.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
