### PR TITLE
[WIP] Activate control on Qmin and Qmax on ReactiveCapabilityCurve

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveAdderImpl.java
@@ -76,10 +76,9 @@ class ReactiveCapabilityCurveAdderImpl<OWNER extends ReactiveLimitsOwner & Valid
                     LOGGER.warn("{}duplicate point for active power {}", owner.getMessageHeader(), p);
                 }
             }
-             if (maxQ < minQ) {
-                 throw new ValidationException(owner,
-                         "maximum reactive power is expected to be greater than or equal to minimum reactive power");
-             }
+            if (maxQ < minQ) {
+                throw new ValidationException(owner, "maximum reactive power is expected to be greater than or equal to minimum reactive power");
+            }
             points.put(p, new PointImpl(p, minQ, maxQ));
             return ReactiveCapabilityCurveAdderImpl.this;
         }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveAdderImpl.java
@@ -76,11 +76,10 @@ class ReactiveCapabilityCurveAdderImpl<OWNER extends ReactiveLimitsOwner & Valid
                     LOGGER.warn("{}duplicate point for active power {}", owner.getMessageHeader(), p);
                 }
             }
-            // TODO: to be activated in IIDM v1.1
-            // if (maxQ < minQ) {
-            //     throw new ValidationException(owner,
-            //             "maximum reactive power is expected to be greater than or equal to minimum reactive power");
-            // }
+             if (maxQ < minQ) {
+                 throw new ValidationException(owner,
+                         "maximum reactive power is expected to be greater than or equal to minimum reactive power");
+             }
             points.put(p, new PointImpl(p, minQ, maxQ));
             return ReactiveCapabilityCurveAdderImpl.this;
         }


### PR DESCRIPTION
PR open for discussion: do we need to keep those rows commented as it will raise an exception for many network files that contain incohent values Qmin and Qmax ? 
Was it an omission to remove the TODO after IIDM 1.1 as it is said in the comment ?

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?**
Remove an old TODO and activate the control on Qmin < Qmax



**What is the current behavior?**
No control



**What is the new behavior (if this is a feature change)?**
An exception is raised if Qmin > Qmax

