### PR TITLE
SV: support of DC approximation

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/SV.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/SV.java
@@ -43,18 +43,6 @@ public class SV {
         this.side = side;
     }
 
-    /**
-     * @deprecated Not used anymore. The end associated to the voltage and flow must be defined. Use {@link #SV(double, double, double, double, Branch.Side)} instead.
-     */
-    @Deprecated(since = "4.3.0")
-    public SV(double p, double q, double u, double a) {
-        this.p = p;
-        this.q = q;
-        this.u = u;
-        this.a = a;
-        this.side = Branch.Side.ONE;
-    }
-
     private final double p;
 
     private final double q;
@@ -85,26 +73,6 @@ public class SV {
         return side;
     }
 
-    /**
-     * @deprecated Not used anymore. This version with a simplified view of the parameters
-     * of a generic branch has been deprecated to avoid misuse. Use the version that includes rho AND alpha.
-     * {@link SV#otherSide(double, double, double, double, double, double, double, double)}
-     */
-    @Deprecated(since = "4.3.0")
-    public SV otherSide(double r, double x, double g, double b, double rho) {
-        return otherSide(r, x, g / 2, b / 2, g / 2, b / 2, rho, 0.0);
-    }
-
-    /**
-     * @deprecated Not used anymore. This version with a simplified view of the parameters
-     * of a generic branch has been deprecated to avoid misuse. Use the version that includes rho AND alpha.
-     * {@link SV#otherSide(double, double, double, double, double, double, double, double)}
-     */
-    @Deprecated(since = "4.3.0")
-    public SV otherSide(double r, double x, double g1, double b1, double g2, double b2, double rho) {
-        return otherSide(r, x, g1, b1, g2, b2, rho, 0.0);
-    }
-
     public SV otherSide(double r, double x, double g1, double b1, double g2, double b2, double rho, double alpha) {
         LinkData.BranchAdmittanceMatrix adm = LinkData.calculateBranchAdmittance(r, x, 1 / rho, -alpha, 1.0, 0.0,
             new Complex(g1, b1), new Complex(g2, b2));
@@ -117,14 +85,6 @@ public class SV {
 
     public SV otherSide(TieLine l) {
         return otherSide(l.getR(), l.getX(), l.getG1(), l.getB1(), l.getG2(), l.getB2(), 1.0, 0.0);
-    }
-
-    /**
-     * @deprecated Should not be used anymore. Use {@link SV#otherSide(Line)} instead.
-     */
-    @Deprecated(since = "4.3.0")
-    public SV otherSideY1Y2(Line l) {
-        return otherSide(l.getR(), l.getX(), l.getG1(), l.getB1(), l.getG2(), l.getB2(), 1, 0.0);
     }
 
     public SV otherSide(TwoWindingsTransformer twt) {
@@ -151,16 +111,6 @@ public class SV {
         }
     }
 
-    /**
-     * @deprecated Not used anymore. This version with a simplified view of the parameters
-     * of a generic branch has been deprecated to avoid misuse. Use the version that includes rho AND alpha.
-     * {@link SV#otherSideP(double, double, double, double, double, double, double, double)}
-     */
-    @Deprecated(since = "4.3.0")
-    public double otherSideP(double r, double x, double g1, double b1, double g2, double b2, double rho) {
-        return otherSideP(r, x, g1, b1, g2, b2, rho, 0.0);
-    }
-
     public double otherSideP(double r, double x, double g1, double b1, double g2, double b2, double rho, double alpha) {
         LinkData.BranchAdmittanceMatrix adm = LinkData.calculateBranchAdmittance(r, x, 1 / rho, -alpha, 1.0, 0.0,
             new Complex(g1, b1), new Complex(g2, b2));
@@ -177,16 +127,6 @@ public class SV {
         } else {
             return otherSideP(dl);
         }
-    }
-
-    /**
-     * @deprecated Not used anymore. This version with a simplified view of the parameters
-     * of a generic branch has been deprecated to avoid misuse. Use the version that includes rho AND alpha.
-     * {@link SV#otherSideQ(double, double, double, double, double, double, double, double)}
-     */
-    @Deprecated(since = "4.3.0")
-    public double otherSideQ(double r, double x, double g1, double b1, double g2, double b2, double rho) {
-        return otherSideQ(r, x, g1, b1, g2, b2, rho, 0.0);
     }
 
     public double otherSideQ(double r, double x, double g1, double b1, double g2, double b2, double rho, double alpha) {
@@ -207,16 +147,6 @@ public class SV {
         }
     }
 
-    /**
-     * @deprecated Not used anymore. This version with a simplified view of the parameters
-     * of a generic branch has been deprecated to avoid misuse. Use the version that includes rho AND alpha.
-     * {@link SV#otherSideU(double, double, double, double, double, double, double, double)}
-     */
-    @Deprecated(since = "4.3.0")
-    public double otherSideU(double r, double x, double g1, double b1, double rho) {
-        return otherSideU(r, x, g1, b1, 0.0, 0.0, rho, 0.0);
-    }
-
     public double otherSideU(double r, double x, double g1, double b1, double g2, double b2, double rho, double alpha) {
         LinkData.BranchAdmittanceMatrix adm = LinkData.calculateBranchAdmittance(r, x, 1 / rho, -alpha, 1.0, 0.0,
             new Complex(g1, b1), new Complex(g2, b2));
@@ -233,16 +163,6 @@ public class SV {
         } else {
             return otherSideU(dl);
         }
-    }
-
-    /**
-     * @deprecated Not used anymore. This version with a simplified view of the parameters
-     * of a generic branch has been deprecated to avoid misuse. Use the version that includes rho AND alpha.
-     * {@link SV#otherSideA(double, double, double, double, double, double, double, double)}
-     */
-    @Deprecated(since = "4.3.0")
-    public double otherSideA(double r, double x, double g1, double b1, double rho) {
-        return otherSideA(r, x, g1, b1, 0.0, 0.0, rho, 0.0);
     }
 
     public double otherSideA(double r, double x, double g1, double b1, double g2, double b2, double rho, double alpha) {
@@ -347,6 +267,9 @@ public class SV {
             v = voltageAtEnd1(adm, v2, s2);
             s = flowAtEnd1(adm, v, v2);
             otherSide = Branch.Side.ONE;
+        }
+        if (Double.isNaN(q) || Double.isNaN(u)) { // DC approximation
+            return new SV(-p, Double.NaN, Double.NaN, a, otherSide);
         }
         return new SV(s.getReal(), s.getImaginary(), v.abs(), Math.toDegrees(v.getArgument()), otherSide);
     }

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/util/SVTest.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/util/SVTest.java
@@ -394,4 +394,178 @@ class SVTest {
             return twt;
         }
     }
+
+    @Test
+    void testDcLine() {
+        Line line = new LineDcTestData().getLine();
+
+        double tol = 0.0001;
+        double p1 = 148.70937259543686;
+        double q1 = Double.NaN;
+        double v1 = Double.NaN;
+        double a1 = 0.0;
+
+        double p2 = -148.70937259543686;
+        double q2 = Double.NaN;
+        double v2 = Double.NaN;
+        double a2 = -5.041532173036991;
+
+        SV svA1 = new SV(p1, q1, v1, a1, Branch.Side.ONE);
+        SV svA2 = svA1.otherSide(line);
+        assertEquals(p2, svA2.getP(), tol);
+        assertEquals(a2, svA2.getA(), tol);
+
+        SV svB2 = new SV(p2, q2, v2, a2, Branch.Side.TWO);
+        SV svB1 = svB2.otherSide(line);
+        assertEquals(p1, svB1.getP(), tol);
+        assertEquals(a1, svB1.getA(), tol);
+    }
+
+    @Test
+    void testDcTwoWindingsTransformer() {
+        TwoWindingsTransformer twt = new TwoWindingsTransformerDcTestData().getTwoWindingsTransformer();
+
+        double tol = 0.0001;
+        double p1 = 1.4792780985886924;
+        double q1 = Double.NaN;
+        double v1 = Double.NaN;
+        double a1 = -10.76932587556957;
+
+        double p2 = -1.4792780985886924;
+        double q2 = Double.NaN;
+        double v2 = Double.NaN;
+        double a2 = -11.226110634252219;
+
+        SV svA1 = new SV(p1, q1, v1, a1, Branch.Side.ONE);
+        SV svA2 = svA1.otherSide(twt);
+        assertEquals(p2, svA2.getP(), tol);
+        assertEquals(a2, svA2.getA(), tol);
+
+        SV svB2 = new SV(p2, q2, v2, a2, Branch.Side.TWO);
+        SV svB1 = svB2.otherSide(twt);
+        assertEquals(p1, svB1.getP(), tol);
+        assertEquals(a1, svB1.getA(), tol);
+    }
+
+    @Test
+    void testDcPhaseShifter() {
+        TwoWindingsTransformer twt = new PhaseShifterDcTestData().getTwoWindingsTransformer();
+
+        double tol = 0.0001;
+        double p1 = 58.02489256054598;
+        double q1 = Double.NaN;
+        double v1 = Double.NaN;
+        double a1 = -10.76932587556957;
+
+        double p2 = -58.02489256054598;
+        double q2 = Double.NaN;
+        double v2 = Double.NaN;
+        double a2 = -7.56873858064591;
+
+        SV svA1 = new SV(p1, q1, v1, a1, Branch.Side.ONE);
+        SV svA2 = svA1.otherSide(twt);
+        assertEquals(p2, svA2.getP(), tol);
+        assertEquals(a2, svA2.getA(), tol);
+
+        SV svB2 = new SV(p2, q2, v2, a2, Branch.Side.TWO);
+        SV svB1 = svB2.otherSide(twt);
+        assertEquals(p1, svB1.getP(), tol);
+        assertEquals(a1, svB1.getA(), tol);
+    }
+
+    private static final class LineDcTestData {
+        private static double R = 0.0;
+        private static double X = 5.917E-4;
+        private static double G1 = 0.01;
+        private static double B1 = 0.0020;
+        private static double G2 = 0.01;
+        private static double B2 = 0.0020;
+        private Line line;
+
+        private LineDcTestData() {
+            line = Mockito.mock(Line.class);
+            Mockito.when(line.getR()).thenReturn(R);
+            Mockito.when(line.getX()).thenReturn(X);
+            Mockito.when(line.getG1()).thenReturn(G1);
+            Mockito.when(line.getB1()).thenReturn(B1);
+            Mockito.when(line.getG2()).thenReturn(G2);
+            Mockito.when(line.getB2()).thenReturn(B2);
+        }
+
+        private Line getLine() {
+            return line;
+        }
+    }
+
+    private static final class TwoWindingsTransformerDcTestData {
+        private static double R = 0.0043;
+        private static double X = 0.0055618;
+        private static double G = 0.0;
+        private static double B = 0.0;
+        private static double RTC_RHO = 1.0;
+        private static double RATEDU1 = 0.969;
+        private static double RATEDU2 = 1.0;
+
+        private static RatioTapChanger rtc;
+        private static RatioTapChangerStep rtcStep;
+        private static TwoWindingsTransformer twt;
+
+        private TwoWindingsTransformerDcTestData() {
+            twt = Mockito.mock(TwoWindingsTransformer.class);
+            Mockito.when(twt.getR()).thenReturn(R);
+            Mockito.when(twt.getX()).thenReturn(X);
+            Mockito.when(twt.getG()).thenReturn(G);
+            Mockito.when(twt.getB()).thenReturn(B);
+
+            rtc = Mockito.mock(RatioTapChanger.class);
+            rtcStep = Mockito.mock(RatioTapChangerStep.class);
+            Mockito.when(twt.getRatioTapChanger()).thenReturn(rtc);
+            Mockito.when(rtc.getCurrentStep()).thenReturn(rtcStep);
+            Mockito.when(rtcStep.getRho()).thenReturn(RTC_RHO);
+
+            Mockito.when(twt.getRatedU1()).thenReturn(RATEDU1);
+            Mockito.when(twt.getRatedU2()).thenReturn(RATEDU2);
+        }
+
+        private TwoWindingsTransformer getTwoWindingsTransformer() {
+            return twt;
+        }
+    }
+
+    private static final class PhaseShifterDcTestData {
+        private static double R = 0.00043;
+        private static double X = 0.0020912;
+        private static double G = 0.0;
+        private static double B = 0.0;
+        private static double PTC_RHO = 1.0;
+        private static double PTC_ALPHA = 10.0;
+        private static double RATEDU1 = 0.978;
+        private static double RATEDU2 = 1.0;
+
+        private static PhaseTapChanger ptc;
+        private static PhaseTapChangerStep ptcStep;
+        private static TwoWindingsTransformer twt;
+
+        private PhaseShifterDcTestData() {
+            twt = Mockito.mock(TwoWindingsTransformer.class);
+            Mockito.when(twt.getR()).thenReturn(R);
+            Mockito.when(twt.getX()).thenReturn(X);
+            Mockito.when(twt.getG()).thenReturn(G);
+            Mockito.when(twt.getB()).thenReturn(B);
+
+            ptc = Mockito.mock(PhaseTapChanger.class);
+            ptcStep = Mockito.mock(PhaseTapChangerStep.class);
+            Mockito.when(twt.getPhaseTapChanger()).thenReturn(ptc);
+            Mockito.when(ptc.getCurrentStep()).thenReturn(ptcStep);
+            Mockito.when(ptcStep.getRho()).thenReturn(PTC_RHO);
+            Mockito.when(ptcStep.getAlpha()).thenReturn(PTC_ALPHA);
+
+            Mockito.when(twt.getRatedU1()).thenReturn(RATEDU1);
+            Mockito.when(twt.getRatedU2()).thenReturn(RATEDU2);
+        }
+
+        private TwoWindingsTransformer getTwoWindingsTransformer() {
+            return twt;
+        }
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Dc approximation is not supported in the SV class.

**What is the new behavior (if this is a feature change)?**
Dc approximation is supported in the SV class. When there is not enough information to calculate all the values on the other side, the Dc approximation is calculated if the `p` and `a` are defined.



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
