### PR TITLE
Fix handling of T-Point during CGMES Bus-Branch import

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -518,6 +518,9 @@ public class Conversion {
                 .setEnsureIdUnicity(context.config().isEnsureIdAliasUnicity())
                 .add();
         vl.setProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "LineContainerId", vldata.lineId);
+        if (!context.nodeBreaker()) {
+            vl.getBusBreakerView().newBus().setId(vldata.nodeId).add();
+        }
     }
 
     private void convertSwitches(Context context, Set<String> delayedBoundaryNodes) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
@@ -506,7 +506,7 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
                 // its ID is composed by its connectivity node ID + '_VL' sufix
                 voltageLevel = context.network().getVoltageLevel(nodeId + "_VL");
                 if (voltageLevel != null) {
-                    iidmVoltageLevelId = t.connectivityNode() + "_VL";
+                    iidmVoltageLevelId = nodeId + "_VL";
                 } else {
                     iidmVoltageLevelId = null;
                 }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/EqOnlyConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/EqOnlyConversionTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.test;
+
+import com.powsybl.computation.local.LocalComputationManager;
+import com.powsybl.iidm.network.*;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ */
+class EqOnlyConversionTest {
+
+    @Test
+    void testTeePointBusBranch() {
+        Network network = Network.read(Paths.get(getClass().getResource("/t-line.xml").getPath()),
+                LocalComputationManager.getDefault(),
+                ImportConfig.load(),
+                new Properties());
+        assertEquals(4, network.getVoltageLevelCount());
+        assertEquals(3, network.getSubstationCount());
+        assertTrue(network.getVoltageLevel("Line1TPointBus_VL").getSubstation().isEmpty()); // tee point
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/EqOnlyConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/EqOnlyConversionTest.java
@@ -7,12 +7,8 @@
  */
 package com.powsybl.cgmes.conversion.test;
 
-import com.powsybl.computation.local.LocalComputationManager;
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,10 +20,7 @@ class EqOnlyConversionTest {
 
     @Test
     void testTeePointBusBranch() {
-        Network network = Network.read(new File(getClass().getResource("/t-line.xml").getFile()).toPath(),
-                LocalComputationManager.getDefault(),
-                ImportConfig.load(),
-                new Properties());
+        Network network = Network.read("t-line.xml", getClass().getResourceAsStream("/t-line.xml"));
         assertEquals(4, network.getVoltageLevelCount());
         assertEquals(3, network.getSubstationCount());
         assertTrue(network.getVoltageLevel("Line1TPointBus_VL").getSubstation().isEmpty()); // tee point

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/EqOnlyConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/EqOnlyConversionTest.java
@@ -11,7 +11,7 @@ import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Paths;
+import java.io.File;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,7 +24,7 @@ class EqOnlyConversionTest {
 
     @Test
     void testTeePointBusBranch() {
-        Network network = Network.read(Paths.get(getClass().getResource("/t-line.xml").getPath()),
+        Network network = Network.read(new File(getClass().getResource("/t-line.xml").getFile()).toPath(),
                 LocalComputationManager.getDefault(),
                 ImportConfig.load(),
                 new Properties());

--- a/cgmes/cgmes-conversion/src/test/resources/t-line.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/t-line.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF  xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <md:FullModel rdf:about="urn:uuid:d400c631-75a0-4c30-8aed-832b0d282e73">
+        <md:Model.created>2023-06-12T11:00:00Z</md:Model.created>
+        <md:Model.scenarioTime>2023-06-12T11:00:00Z</md:Model.scenarioTime>
+        <md:Model.version>2</md:Model.version>
+        <md:Model.description>T-line</md:Model.description>
+        <md:Model.modelingAuthoritySet>https://www.powsybl.org/</md:Model.modelingAuthoritySet>
+        <md:Model.profile>http://entsoe.eu/CIM/EquipmentCore/3/1</md:Model.profile>
+    </md:FullModel>
+
+    <!-- EQ -->
+    <cim:GeographicalRegion rdf:ID="_GeographicalRegionTest">
+        <cim:IdentifiedObject.name>GeographicalRegionTest</cim:IdentifiedObject.name>
+    </cim:GeographicalRegion>
+    <cim:SubGeographicalRegion rdf:ID="_SubGeographicalRegionTest">
+        <cim:IdentifiedObject.name>SubGeographicalRegionTest</cim:IdentifiedObject.name>
+        <cim:SubGeographicalRegion.Region rdf:resource="#_GeographicalRegionTest" />
+    </cim:SubGeographicalRegion>
+    <cim:Substation rdf:ID="_Substation1">
+        <cim:IdentifiedObject.name>Substation1</cim:IdentifiedObject.name>
+        <cim:Substation.Region rdf:resource="#_SubGeographicalRegionTest" />
+    </cim:Substation>
+    <cim:Substation rdf:ID="_Substation2">
+        <cim:IdentifiedObject.name>Substation2</cim:IdentifiedObject.name>
+        <cim:Substation.Region rdf:resource="#_SubGeographicalRegionTest" />
+    </cim:Substation>
+    <cim:Substation rdf:ID="_Substation3">
+        <cim:IdentifiedObject.name>Substation3</cim:IdentifiedObject.name>
+        <cim:Substation.Region rdf:resource="#_SubGeographicalRegionTest" />
+    </cim:Substation>
+    <cim:BaseVoltage rdf:ID="_BaseVoltage400">
+        <cim:IdentifiedObject.description>Base Voltage Level 400kV</cim:IdentifiedObject.description>
+        <cim:IdentifiedObject.name>400.0 kV</cim:IdentifiedObject.name>
+        <cim:BaseVoltage.nominalVoltage>400.0</cim:BaseVoltage.nominalVoltage>
+    </cim:BaseVoltage>
+    <cim:VoltageLevel rdf:ID="_VoltageLevel1">
+        <cim:IdentifiedObject.name>VoltageLevel1</cim:IdentifiedObject.name>
+        <cim:VoltageLevel.highVoltageLimit>420</cim:VoltageLevel.highVoltageLimit>
+        <cim:VoltageLevel.lowVoltageLimit>380</cim:VoltageLevel.lowVoltageLimit>
+        <cim:VoltageLevel.Substation rdf:resource="#_Substation1"/>
+        <cim:VoltageLevel.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+    </cim:VoltageLevel>
+    <cim:VoltageLevel rdf:ID="_VoltageLevel2">
+        <cim:IdentifiedObject.name>VoltageLevel2</cim:IdentifiedObject.name>
+        <cim:VoltageLevel.highVoltageLimit>420</cim:VoltageLevel.highVoltageLimit>
+        <cim:VoltageLevel.lowVoltageLimit>380</cim:VoltageLevel.lowVoltageLimit>
+        <cim:VoltageLevel.Substation rdf:resource="#_Substation2"/>
+        <cim:VoltageLevel.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+    </cim:VoltageLevel>
+    <cim:VoltageLevel rdf:ID="_VoltageLevel3">
+        <cim:IdentifiedObject.name>VoltageLevel3</cim:IdentifiedObject.name>
+        <cim:VoltageLevel.highVoltageLimit>420</cim:VoltageLevel.highVoltageLimit>
+        <cim:VoltageLevel.lowVoltageLimit>380</cim:VoltageLevel.lowVoltageLimit>
+        <cim:VoltageLevel.Substation rdf:resource="#_Substation3"/>
+        <cim:VoltageLevel.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+    </cim:VoltageLevel>
+    <cim:Line rdf:ID="_Line1">
+        <cim:IdentifiedObject.name>Line1</cim:IdentifiedObject.name>
+        <cim:Line.Region rdf:resource="#_SubGeographicalRegionTest"/>
+    </cim:Line>
+    <cim:ACLineSegment rdf:ID="_ACLineSegment1">
+        <cim:IdentifiedObject.name>ACLineSegment1</cim:IdentifiedObject.name>
+        <cim:Equipment.EquipmentContainer rdf:resource="#_Line1"/>
+        <cim:ConductingEquipment.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+        <cim:ACLineSegment.r>0.3</cim:ACLineSegment.r>
+        <cim:ACLineSegment.x>1.5</cim:ACLineSegment.x>
+        <cim:ACLineSegment.bch>0.0</cim:ACLineSegment.bch>
+    </cim:ACLineSegment>
+    <cim:Terminal rdf:ID="_ACLineSegment1Terminal1">
+        <cim:IdentifiedObject.name>ACLineSegment1Terminal1</cim:IdentifiedObject.name>
+        <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+        <cim:Terminal.ConductingEquipment rdf:resource="#_ACLineSegment1"/>
+    </cim:Terminal>
+    <cim:Terminal rdf:ID="_ACLineSegment1Terminal2">
+        <cim:IdentifiedObject.name>ACLineSegment1Terminal2</cim:IdentifiedObject.name>
+        <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+        <cim:Terminal.ConductingEquipment rdf:resource="#_ACLineSegment1"/>
+    </cim:Terminal>
+    <cim:ACLineSegment rdf:ID="_ACLineSegment2">
+        <cim:IdentifiedObject.name>ACLineSegment2</cim:IdentifiedObject.name>
+        <cim:Equipment.EquipmentContainer rdf:resource="#_Line1"/>
+        <cim:ConductingEquipment.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+        <cim:ACLineSegment.r>0.3</cim:ACLineSegment.r>
+        <cim:ACLineSegment.x>1.5</cim:ACLineSegment.x>
+        <cim:ACLineSegment.bch>0.0</cim:ACLineSegment.bch>
+    </cim:ACLineSegment>
+    <cim:Terminal rdf:ID="_ACLineSegment2Terminal1">
+        <cim:IdentifiedObject.name>ACLineSegment2Terminal1</cim:IdentifiedObject.name>
+        <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+        <cim:Terminal.ConductingEquipment rdf:resource="#_ACLineSegment2"/>
+    </cim:Terminal>
+    <cim:Terminal rdf:ID="_ACLineSegment2Terminal2">
+        <cim:IdentifiedObject.name>ACLineSegment2Terminal2</cim:IdentifiedObject.name>
+        <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+        <cim:Terminal.ConductingEquipment rdf:resource="#_ACLineSegment2"/>
+    </cim:Terminal>
+    <cim:ACLineSegment rdf:ID="_ACLineSegment3">
+        <cim:IdentifiedObject.name>ACLineSegment3</cim:IdentifiedObject.name>
+        <cim:Equipment.EquipmentContainer rdf:resource="#_Line1"/>
+        <cim:ConductingEquipment.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+        <cim:ACLineSegment.r>0.3</cim:ACLineSegment.r>
+        <cim:ACLineSegment.x>1.5</cim:ACLineSegment.x>
+        <cim:ACLineSegment.bch>0.0</cim:ACLineSegment.bch>
+    </cim:ACLineSegment>
+    <cim:Terminal rdf:ID="_ACLineSegment3Terminal1">
+        <cim:IdentifiedObject.name>ACLineSegment3Terminal1</cim:IdentifiedObject.name>
+        <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+        <cim:Terminal.ConductingEquipment rdf:resource="#_ACLineSegment3"/>
+    </cim:Terminal>
+    <cim:Terminal rdf:ID="_ACLineSegment3Terminal2">
+        <cim:IdentifiedObject.name>ACLineSegment3Terminal2</cim:IdentifiedObject.name>
+        <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+        <cim:Terminal.ConductingEquipment rdf:resource="#_ACLineSegment3"/>
+    </cim:Terminal>
+
+    <!-- TP -->
+    <cim:TopologicalNode rdf:ID="_VoltageLevel1Bus">
+        <cim:IdentifiedObject.name>VoltageLevel1Bus</cim:IdentifiedObject.name>
+        <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_VoltageLevel1"/>
+        <cim:TopologicalNode.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+    </cim:TopologicalNode>
+    <cim:TopologicalNode rdf:ID="_VoltageLevel2Bus">
+        <cim:IdentifiedObject.name>VoltageLevel2Bus</cim:IdentifiedObject.name>
+        <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_VoltageLevel2"/>
+        <cim:TopologicalNode.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+    </cim:TopologicalNode>
+    <cim:TopologicalNode rdf:ID="_VoltageLevel3Bus">
+        <cim:IdentifiedObject.name>VoltageLevel2Bus</cim:IdentifiedObject.name>
+        <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_VoltageLevel3"/>
+        <cim:TopologicalNode.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+    </cim:TopologicalNode>
+    <cim:TopologicalNode rdf:ID="_Line1TPointBus">
+        <cim:IdentifiedObject.name>Line1TPointBus</cim:IdentifiedObject.name>
+        <cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_Line1"/>
+        <cim:TopologicalNode.BaseVoltage rdf:resource="#_BaseVoltage400"/>
+    </cim:TopologicalNode>
+    <cim:Terminal rdf:about="#_ACLineSegment1Terminal1">
+        <cim:Terminal.TopologicalNode rdf:resource="#_VoltageLevel1Bus"/>
+    </cim:Terminal>
+    <cim:Terminal rdf:about="#_ACLineSegment1Terminal2">
+        <cim:Terminal.TopologicalNode rdf:resource="#_Line1TPointBus"/>
+    </cim:Terminal>
+    <cim:Terminal rdf:about="#_ACLineSegment2Terminal1">
+        <cim:Terminal.TopologicalNode rdf:resource="#_VoltageLevel2Bus"/>
+    </cim:Terminal>
+    <cim:Terminal rdf:about="#_ACLineSegment2Terminal2">
+        <cim:Terminal.TopologicalNode rdf:resource="#_Line1TPointBus"/>
+    </cim:Terminal>
+    <cim:Terminal rdf:about="#_ACLineSegment3Terminal1">
+        <cim:Terminal.TopologicalNode rdf:resource="#_VoltageLevel3Bus"/>
+    </cim:Terminal>
+    <cim:Terminal rdf:about="#_ACLineSegment3Terminal2">
+        <cim:Terminal.TopologicalNode rdf:resource="#_Line1TPointBus"/>
+    </cim:Terminal>
+</rdf:RDF>

--- a/commons/src/main/java/com/powsybl/commons/parameters/Parameter.java
+++ b/commons/src/main/java/com/powsybl/commons/parameters/Parameter.java
@@ -149,12 +149,12 @@ public class Parameter {
 
     public static double readDouble(String prefix, Properties parameters, Parameter configuredParameter, ParameterDefaultValueConfig defaultValueConfig) {
         return read(parameters, configuredParameter, defaultValueConfig.getDoubleValue(prefix, configuredParameter),
-            (moduleConfig, names) -> ModuleConfigUtil.getOptionalDoubleProperty(moduleConfig, names).orElse(Double.NaN), value -> value != null && !Double.isNaN(value));
+            (moduleConfig, names) -> ModuleConfigUtil.getOptionalDoubleProperty(moduleConfig, names).orElse(Double.NaN), value -> !Double.isNaN(value));
     }
 
     public static int readInteger(String prefix, Properties parameters, Parameter configuredParameter, ParameterDefaultValueConfig defaultValueConfig) {
         return read(parameters, configuredParameter, defaultValueConfig.getIntegerValue(prefix, configuredParameter),
-            (moduleConfig, names) -> ModuleConfigUtil.getOptionalIntProperty(moduleConfig, names).stream().boxed().findFirst().orElse(null), Objects::nonNull);
+            (moduleConfig, names) -> ModuleConfigUtil.getOptionalIntProperty(moduleConfig, names).stream().boxed().findFirst().orElse(null), t -> true);
     }
 
     public static double readDouble(String prefix, Properties parameters, Parameter configuredParameter) {
@@ -179,14 +179,14 @@ public class Parameter {
             }
         }
         // if none, use configured parameters
-        if (isPresent.test(value)) {
+        if (value != null && isPresent.test(value)) {
             return value;
         }
         return defaultValue;
     }
 
     private static <T> T read(Properties parameters, Parameter configuredParameter, T defaultValue, BiFunction<ModuleConfig, List<String>, Optional<T>> supplier) {
-        return read(parameters, configuredParameter, defaultValue, (moduleConfig, strings) -> supplier.apply(moduleConfig, strings).orElse(null), Objects::nonNull);
+        return read(parameters, configuredParameter, defaultValue, (moduleConfig, strings) -> supplier.apply(moduleConfig, strings).orElse(null), t -> true);
     }
 
     public Parameter addAdditionalNames(String... names) {

--- a/commons/src/main/java/com/powsybl/commons/parameters/Parameter.java
+++ b/commons/src/main/java/com/powsybl/commons/parameters/Parameter.java
@@ -149,12 +149,12 @@ public class Parameter {
 
     public static double readDouble(String prefix, Properties parameters, Parameter configuredParameter, ParameterDefaultValueConfig defaultValueConfig) {
         return read(parameters, configuredParameter, defaultValueConfig.getDoubleValue(prefix, configuredParameter),
-            (moduleConfig, names) -> ModuleConfigUtil.getOptionalDoubleProperty(moduleConfig, names).orElse(Double.NaN), value -> !Double.isNaN(value));
+            (moduleConfig, names) -> ModuleConfigUtil.getOptionalDoubleProperty(moduleConfig, names).orElse(Double.NaN), value -> value != null && !Double.isNaN(value));
     }
 
     public static int readInteger(String prefix, Properties parameters, Parameter configuredParameter, ParameterDefaultValueConfig defaultValueConfig) {
         return read(parameters, configuredParameter, defaultValueConfig.getIntegerValue(prefix, configuredParameter),
-            (moduleConfig, names) -> ModuleConfigUtil.getOptionalIntProperty(moduleConfig, names).stream().boxed().findFirst().orElse(null), t -> true);
+            (moduleConfig, names) -> ModuleConfigUtil.getOptionalIntProperty(moduleConfig, names).stream().boxed().findFirst().orElse(null), Objects::nonNull);
     }
 
     public static double readDouble(String prefix, Properties parameters, Parameter configuredParameter) {
@@ -179,14 +179,14 @@ public class Parameter {
             }
         }
         // if none, use configured parameters
-        if (value != null && isPresent.test(value)) {
+        if (isPresent.test(value)) {
             return value;
         }
         return defaultValue;
     }
 
     private static <T> T read(Properties parameters, Parameter configuredParameter, T defaultValue, BiFunction<ModuleConfig, List<String>, Optional<T>> supplier) {
-        return read(parameters, configuredParameter, defaultValue, (moduleConfig, strings) -> supplier.apply(moduleConfig, strings).orElse(null), t -> true);
+        return read(parameters, configuredParameter, defaultValue, (moduleConfig, strings) -> supplier.apply(moduleConfig, strings).orElse(null), Objects::nonNull);
     }
 
     public Parameter addAdditionalNames(String... names) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines



**What kind of change does this PR introduce?**
Bug fix to import T-Point (inside Line container) correctly from CGMES Bus-Branch.
On current version, T-Point are imported as dangling lines.



**Does this PR introduce a breaking change or deprecate an API?**
No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
