### PR TITLE
itools-packager, add scope provided for dependency on maven-core

### DIFF
--- a/itools-packager/pom.xml
+++ b/itools-packager/pom.xml
@@ -58,6 +58,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven.core.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
TODO is this really the right thing to do ? Someone needs to look into it a bit..

This fixes the new maven 3.9.2 warning:
[WARNING]
[WARNING] Plugin validation issues were detected in 1 plugin(s) [WARNING]
[WARNING]  * com.powsybl:powsybl-itools-packager-maven-plugin:5.4.0-SNAPSHOT
[WARNING]   Declared at location(s):
[WARNING]    * com.powsybl:powsybl-distribution-core:5.4.0-SNAPSHOT (pom.xml) @ line 492
[WARNING]   Used in module(s):
[WARNING]    * com.powsybl:powsybl-distribution-core:5.4.0-SNAPSHOT (pom.xml)
[WARNING]   Plugin issue(s):
[WARNING]    * Plugin should declare these Maven artifacts in `provided` scope: [org.apache.maven:maven-repository-metadata:3.8.5, org.apache.maven:maven-artifact:3.8.5, org.apache.maven:maven-settings-builder:3.8.5, org.apache.maven:maven-resolver-provider:3.8.5, org.apache.maven:maven-model-builder:3.8.5, org.apache.maven:maven-core:3.8.5, org.apache.maven:maven-plugin-api:3.8.5, org.apache.maven:maven-model:3.8.5, org.apache.maven:maven-builder-support:3.8.5, org.apache.maven:maven-settings:3.8.5]
[WARNING]
[WARNING]
[WARNING] Fix reported issues by adjusting plugin configuration or by upgrading above listed plugins. If no upgrade available, please notify plugin maintainers about reported issues.
[WARNING] For more or less details, use 'maven.plugin.validation' property with one of the values (case insensitive): [BRIEF, DEFAULT, VERBOSE]
[WARNING]

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
NO


**What kind of change does this PR introduce?**
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
with maven 3.9.2, the build ends with 
```
[WARNING] 
[WARNING] Plugin validation issues were detected in 1 plugin(s)
[WARNING] 
```


**What is the new behavior (if this is a feature change)?**
No warning


**Does this PR introduce a breaking change or deprecate an API?**
NO


**Other information**:
TODO is this really the right thing to do ? Someone needs to look into it a bit..
