### PR TITLE
Fix post-removal shunt compensator access

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/RemoveHvdcLine.java
@@ -94,13 +94,14 @@ public class RemoveHvdcLine extends AbstractNetworkModification {
         for (ShuntCompensator shuntCompensator : shunts) {
             VoltageLevel shuntVl = shuntCompensator.getTerminal().getVoltageLevel();
             // check whether the shunt compensator is connected to the same voltage level as the lcc
+            String shuntId = shuntCompensator.getId();
             if (vl1 == shuntVl || vl2 == shuntVl) {
-                new RemoveFeederBay(shuntCompensator.getId()).apply(network, throwException, computationManager, reporter);
-                removedShuntCompensatorReport(reporter, shuntCompensator.getId());
-                LOGGER.info("Shunt compensator {} has been removed", shuntCompensator.getId());
+                new RemoveFeederBay(shuntId).apply(network, throwException, computationManager, reporter);
+                removedShuntCompensatorReport(reporter, shuntId);
+                LOGGER.info("Shunt compensator {} has been removed", shuntId);
             } else {
-                LOGGER.warn("Shunt compensator {} has been ignored because it is not in the same voltage levels as the Lcc ({} or {})", shuntCompensator.getId(), vl1.getId(), vl2.getId());
-                ignoredShuntInAnotherVoltageLevel(reporter, shuntCompensator.getId(), vl1.getId(), vl2.getId());
+                LOGGER.warn("Shunt compensator {} has been ignored because it is not in the same voltage levels as the Lcc ({} or {})", shuntId, vl1.getId(), vl2.getId());
+                ignoredShuntInAnotherVoltageLevel(reporter, shuntId, vl1.getId(), vl2.getId());
             }
         }
     }

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveHvdcLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveHvdcLineTest.java
@@ -44,7 +44,7 @@ class RemoveHvdcLineTest extends AbstractConverterTest {
         assertNull(network.getLccConverterStation("C1"));
         assertNull(network.getShuntCompensator("C1_Filter1"));
         assertNull(network.getShuntCompensator("C1_Filter2"));
-        assertNotNull(network.getShuntCompensator("C5_Filter5"));
+        assertNotNull(network.getShuntCompensator("C5_Filter5")); // not removed because it is not in the same VLs as the Lcc
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
This is a fix only visible in the persistent implementation of the iidm model, dealing with a known issue: we try to access an equipment after its deletion. This procudes an exception in powsybl-network-store (_Object has been removed in current variant_). Its happens in method removeShuntCompensators().
Because it is not visible in powsybl-core, there is no specific test to show this issue.



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
