### PR TITLE
[WIP] Slack terminals priority

### DIFF
--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/SlackTerminalAdder.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/SlackTerminalAdder.java
@@ -20,6 +20,11 @@ public interface SlackTerminalAdder extends ExtensionAdder<VoltageLevel, SlackTe
         return SlackTerminal.class;
     }
 
-    SlackTerminalAdder withTerminal(Terminal terminal);
+    default SlackTerminalAdder withTerminal(Terminal terminal) {
+        return withTerminal(terminal, 1);
+    }
 
+    SlackTerminalAdder withTerminal(Terminal terminal, int priority);
+
+    SlackTerminalAdder withTerminal(TerminalWithPriority terminal);
 }

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/TerminalWithPriority.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/TerminalWithPriority.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.VoltageLevel;
+
+public interface TerminalWithPriority {
+
+    public Terminal getTerminal();
+
+    public int getPriority();
+
+    default VoltageLevel getVoltageLevel() {
+        return getTerminal().getVoltageLevel();
+    }
+}

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/TerminalWithPriorityImpl.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/TerminalWithPriorityImpl.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.iidm.network.Terminal;
+
+import java.util.Objects;
+
+public class TerminalWithPriorityImpl implements TerminalWithPriority {
+
+    private final Terminal terminal;
+    private final int priority;
+
+    public TerminalWithPriorityImpl(final Terminal terminal, final int priority) {
+        this.terminal = Objects.requireNonNull(terminal);
+        this.priority = priority;
+    }
+
+    @Override
+    public Terminal getTerminal() {
+        return terminal;
+    }
+
+    @Override
+    public int getPriority() {
+        return priority;
+    }
+
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/SlackTerminalAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/SlackTerminalAdderImpl.java
@@ -12,33 +12,46 @@ import com.powsybl.iidm.network.Terminal;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.extensions.SlackTerminal;
 import com.powsybl.iidm.network.extensions.SlackTerminalAdder;
+import com.powsybl.iidm.network.extensions.TerminalWithPriority;
+import com.powsybl.iidm.network.extensions.TerminalWithPriorityImpl;
+
+import java.util.ArrayList;
 
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
-public class SlackTerminalAdderImpl extends AbstractExtensionAdder<VoltageLevel, SlackTerminal> implements SlackTerminalAdder {
+public class SlackTerminalAdderImpl extends AbstractExtensionAdder<VoltageLevel, SlackTerminal>
+        implements SlackTerminalAdder {
 
-    private Terminal terminal;
+    private ArrayList<TerminalWithPriority> terminals;
 
     public SlackTerminalAdderImpl(VoltageLevel voltageLevel) {
         super(voltageLevel);
+        this.terminals = new ArrayList<>();
     }
 
     @Override
-    public SlackTerminalAdder withTerminal(Terminal terminal) {
-        this.terminal = terminal;
+    public SlackTerminalAdder withTerminal(Terminal terminal, int priority) {
+        return withTerminal(new TerminalWithPriorityImpl(terminal, priority));
+    }
+
+    @Override
+    public SlackTerminalAdder withTerminal(TerminalWithPriority terminal) {
+        this.terminals.add(terminal);
         return this;
     }
 
     @Override
     public SlackTerminal createExtension(VoltageLevel voltageLevel) {
-        if (terminal == null) {
+        if (terminals.isEmpty()) {
             throw new PowsyblException("Terminal needs to be set to create a SlackTerminal extension");
         }
-        if (!terminal.getVoltageLevel().equals(voltageLevel)) {
-            throw new PowsyblException("Terminal given is not in the right VoltageLevel ("
-                + terminal.getVoltageLevel().getId() + " instead of " + voltageLevel.getId() + ")");
+        for (var terminal : terminals) {
+            if (!terminal.getVoltageLevel().equals(voltageLevel)) {
+                throw new PowsyblException("Terminal given is not in the right VoltageLevel ("
+                        + terminal.getVoltageLevel().getId() + " instead of " + voltageLevel.getId() + ")");
+            }
         }
-        return new SlackTerminalImpl(voltageLevel, terminal);
+        return new SlackTerminalImpl(voltageLevel, terminals);
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/SlackTerminalImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/SlackTerminalImpl.java
@@ -37,9 +37,15 @@ public class SlackTerminalImpl extends AbstractMultiVariantIdentifiableExtension
 
     @Override
     public Terminal getTerminal() {
-        var variantTerminals = terminals.get(getVariantIndex());
+        List<TerminalWithPriority> variantTerminals = getTerminals();
         if (variantTerminals == null || variantTerminals.isEmpty()) {
             return null;
+        }
+
+        for (TerminalWithPriority terminalWithPriority : variantTerminals) {
+            if (terminalWithPriority.getTerminal().isConnected()) {
+                return terminalWithPriority.getTerminal();
+            }
         }
         return variantTerminals.get(0).getTerminal();
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**

Fixes #2412 


**What kind of change does this PR introduce?**
This PR allows several terminals to be defined as "slack terminals" instead of just one.


**What is the current behavior?**

It is possible to have one slack terminal per voltage level.


**What is the new behavior (if this is a feature change)?**

Several slack terminals can be set for each voltage level, and priorities define which terminal should be considered as the current slack terminal.

The CGMES importer should work as intended, with `referencePriority` as the slack terminal priority.

**Does this PR introduce a breaking change or deprecate an API?**

I tried to keep it consistent with the current API, but marked some methods as deprecated.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

I am not sure about what I should do with the iidm (de)serialization.
I feel like I am lacking some tests: I added the same tests as there was for the AbstractSlackTerminal, and I keep the old ones to be sure to be compatible, but I doubt it guarantees it works as intended.
