### PR TITLE
CGMES: read tripping current (TC) limits, map to temporary limit with duration 0

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
@@ -206,6 +206,8 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
                 convertPatl(value);
             } else if (isTatl()) { // Temporary Admissible Transmission Loading
                 convertTatl(value);
+            } else if (isTc()) { // Tripping Current
+                convertTc(value);
             }
         }
     }
@@ -328,6 +330,30 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
         } else {
             context.invalid(TEMPORARY_LIMIT, () -> String.format("TATL %s does not have a valid direction", id));
         }
+    }
+
+    private boolean isTc() {
+        String limitTypeName = p.getLocal(OPERATIONAL_LIMIT_TYPE_NAME);
+        String limitType = p.getLocal(LIMIT_TYPE);
+        return limitTypeName.equals("TC") || "LimitTypeKind.tc".equals(limitType) || "LimitKind.tc".equals(limitType);
+    }
+
+    private void convertTc(double value) {
+        if (loadingLimitsAdder != null) {
+            addTc(value, loadingLimitsAdder);
+        } else {
+            if (loadingLimitsAdder1 != null) {
+                addTc(value, loadingLimitsAdder1);
+            }
+            if (loadingLimitsAdder2 != null) {
+                addTc(value, loadingLimitsAdder2);
+            }
+        }
+    }
+
+    private void addTc(double value, LoadingLimitsAdder<?, ?> adder) {
+        String name = Optional.ofNullable(p.getId("shortName")).orElse(p.getId("name"));
+        addTatl(name, value, 0, adder);
     }
 
     private void notAssigned() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Not intended for merging, just to show an approach on how to support this kind of limits.


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
