### PR TITLE
Fix Java17 syntax detection with maven-checkstyle-plugin

### DIFF
--- a/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/LoadFlowActionSimulatorLogPrinter.java
+++ b/action/action-simulator/src/main/java/com/powsybl/action/simulator/loadflow/LoadFlowActionSimulatorLogPrinter.java
@@ -68,7 +68,7 @@ public class LoadFlowActionSimulatorLogPrinter extends DefaultLoadFlowActionSimu
         if (verbose || status == RuleEvaluationStatus.TRUE) {
             out.println("        Rule '" + rule.getId() + "' evaluated to " + status);
         }
-        if (verbose && (variables.size() + actions.size() > 0)) {
+        if (verbose && variables.size() + actions.size() > 0) {
             Writer writer = new OutputStreamWriter(out);
             try (AbstractTableFormatter formatter = new AsciiTableFormatter(writer, null,
                          new Column("Variable"),

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForTransformers.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForTransformers.java
@@ -133,19 +133,23 @@ public class RegulatingControlMappingForTransformers {
 
         rtcRegulating1 = checkOnlyOneEnabled(twt.getId(), rtcRegulating1, regulatingSet, "ratioTapChanger at Leg1");
         setRatioTapChangerControl(rtcRegulating1, rc.ratioTapChanger1, rtcControl1, twt.getLeg1().getRatioTapChanger());
-        regulatingSet = regulatingSet || (twt.getLeg1().hasRatioTapChanger() && twt.getLeg1().getRatioTapChanger().isRegulating());
+        regulatingSet = regulatingSet
+                || twt.getLeg1().hasRatioTapChanger() && twt.getLeg1().getRatioTapChanger().isRegulating();
 
         ptcRegulating2 = checkOnlyOneEnabled(twt.getId(), ptcRegulating2, regulatingSet, "phaseTapChanger at Leg2");
         setPhaseTapChangerControl(ptcRegulating2, rc.phaseTapChanger2, ptcControl2, twt.getLeg2().getPhaseTapChanger());
-        regulatingSet = regulatingSet || (twt.getLeg2().hasPhaseTapChanger() && twt.getLeg2().getPhaseTapChanger().isRegulating());
+        regulatingSet = regulatingSet
+                || twt.getLeg2().hasPhaseTapChanger() && twt.getLeg2().getPhaseTapChanger().isRegulating();
 
         rtcRegulating2 = checkOnlyOneEnabled(twt.getId(), rtcRegulating2, regulatingSet, "ratioTapChanger at Leg2");
         setRatioTapChangerControl(rtcRegulating2, rc.ratioTapChanger2, rtcControl2, twt.getLeg2().getRatioTapChanger());
-        regulatingSet = regulatingSet || (twt.getLeg2().hasRatioTapChanger() && twt.getLeg2().getRatioTapChanger().isRegulating());
+        regulatingSet = regulatingSet
+                || twt.getLeg2().hasRatioTapChanger() && twt.getLeg2().getRatioTapChanger().isRegulating();
 
         ptcRegulating3 = checkOnlyOneEnabled(twt.getId(), ptcRegulating3, regulatingSet, "phaseTapChanger at Leg3");
         setPhaseTapChangerControl(ptcRegulating3, rc.phaseTapChanger3, ptcControl3, twt.getLeg3().getPhaseTapChanger());
-        regulatingSet = regulatingSet || (twt.getLeg3().hasPhaseTapChanger() && twt.getLeg3().getPhaseTapChanger().isRegulating());
+        regulatingSet = regulatingSet
+                || twt.getLeg3().hasPhaseTapChanger() && twt.getLeg3().getPhaseTapChanger().isRegulating();
 
         rtcRegulating3 = checkOnlyOneEnabled(twt.getId(), rtcRegulating3, regulatingSet, "ratioTapChanger at Leg3");
         setRatioTapChangerControl(rtcRegulating3, rc.ratioTapChanger3, rtcControl3, twt.getLeg3().getRatioTapChanger());

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SvInjectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SvInjectionConversion.java
@@ -33,8 +33,8 @@ public class SvInjectionConversion extends AbstractIdentifiedObjectConversion {
     @Override
     public boolean valid() {
         return voltageLevel != null
-                && ((context.nodeBreaker() && node != -1)
-                || (!context.nodeBreaker() && voltageLevel.getBusBreakerView().getBus(busId) != null));
+                && (context.nodeBreaker() && node != -1
+                    || !context.nodeBreaker() && voltageLevel.getBusBreakerView().getBus(busId) != null);
     }
 
     @Override

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
@@ -713,7 +713,7 @@ public final class SteadyStateHypothesisExport {
     }
 
     private static GeneratingUnit generatingUnitForGeneratorAndBatteries(Injection<?> i, CgmesExportContext context) {
-        if (i.hasProperty(GENERATING_UNIT_PROPERTY) && ((i.getExtension(ActivePowerControl.class) != null) || i.hasProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "normalPF"))) {
+        if (i.hasProperty(GENERATING_UNIT_PROPERTY) && (i.getExtension(ActivePowerControl.class) != null || i.hasProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "normalPF"))) {
             GeneratingUnit gu = new GeneratingUnit();
             gu.id = context.getNamingStrategy().getCgmesIdFromProperty(i, GENERATING_UNIT_PROPERTY);
             if (i.getExtension(ActivePowerControl.class) != null) {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportXmlCompare.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportXmlCompare.java
@@ -109,8 +109,8 @@ final class ExportXmlCompare {
         }
         if (attr.getLocalName().equals("value")) {
             Element e = attr.getOwnerElement();
-            return !e.getLocalName().equals("property") ||
-                    (!"CGMES.TP_ID".equals(e.getAttribute("name")) && !"CGMES.SSH_ID".equals(e.getAttribute("name")));
+            return !e.getLocalName().equals("property")
+                    || !"CGMES.TP_ID".equals(e.getAttribute("name")) && !"CGMES.SSH_ID".equals(e.getAttribute("name"));
         }
         return true;
     }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesSubset.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesSubset.java
@@ -48,13 +48,15 @@ public enum CgmesSubset {
     EQUIPMENT_BOUNDARY("EQ_BD") {
         @Override
         public boolean isValidName(String contextName) {
-            return super.isValidName(contextName) || (EQUIPMENT.isValidName(contextName) && isBoundary(contextName));
+            return super.isValidName(contextName)
+                    || EQUIPMENT.isValidName(contextName) && isBoundary(contextName);
         }
     },
     TOPOLOGY_BOUNDARY("TP_BD") {
         @Override
         public boolean isValidName(String contextName) {
-            return super.isValidName(contextName) || (TOPOLOGY.isValidName(contextName) && isBoundary(contextName));
+            return super.isValidName(contextName)
+                    || TOPOLOGY.isValidName(contextName) && isBoundary(contextName);
         }
     };
 

--- a/commons/src/main/java/com/powsybl/commons/extensions/AbstractExtension.java
+++ b/commons/src/main/java/com/powsybl/commons/extensions/AbstractExtension.java
@@ -28,7 +28,7 @@ public abstract class AbstractExtension<T> implements Extension<T> {
     }
 
     public void setExtendable(T extendable) {
-        if ((extendable != null) && (this.extendable != null) && (this.extendable != extendable)) {
+        if (extendable != null && this.extendable != null && this.extendable != extendable) {
             throw new PowsyblException("Extension is already associated to the extendable " + this.extendable);
         }
 

--- a/commons/src/test/java/com/powsybl/commons/io/table/AsciiTableFormatterTest.java
+++ b/commons/src/test/java/com/powsybl/commons/io/table/AsciiTableFormatterTest.java
@@ -75,8 +75,8 @@ class AsciiTableFormatterTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try (Writer writer = new OutputStreamWriter(bos, StandardCharsets.UTF_8);
              AsciiTableFormatter formatter = new AsciiTableFormatter(writer, null, config,
-                new Column("column1").setColspan(4).setHorizontalAlignment(HorizontalAlignment.CENTER),
-                new Column("column2").setColspan(2).setHorizontalAlignment(HorizontalAlignment.CENTER))) {
+                 new Column("column1").setColspan(4).setHorizontalAlignment(HorizontalAlignment.CENTER),
+                 new Column("column2").setColspan(2).setHorizontalAlignment(HorizontalAlignment.CENTER))) {
             IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> formatter.writeCell("Line:1 Cell:1", 1)
                     .writeCell("Line:1 Cell:2", 1)
                     .writeCell("Line:1 Cell:3", 1)
@@ -91,8 +91,8 @@ class AsciiTableFormatterTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try (Writer writer = new OutputStreamWriter(bos, StandardCharsets.UTF_8);
              AsciiTableFormatter formatter = new AsciiTableFormatter(writer, null, config,
-                new Column("column1").setColspan(4),
-                new Column("column2").setColspan(2))) {
+                 new Column("column1").setColspan(4),
+                 new Column("column2").setColspan(2))) {
             formatter.writeCell("Line:1 Cell:1")
                     .writeCell("Line:1 Cell:2")
                     .writeCell("Line:1 Cell:3")

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
@@ -177,9 +177,10 @@ public class Contingency extends AbstractExtendable<Contingency> {
 
     private static boolean checkBranchContingency(Contingency contingency, BranchContingency element, Network network) {
         Branch branch = network.getBranch(element.getId());
-        if (branch == null || (element.getVoltageLevelId() != null &&
-                !(element.getVoltageLevelId().equals(branch.getTerminal1().getVoltageLevel().getId()) ||
-                        element.getVoltageLevelId().equals(branch.getTerminal2().getVoltageLevel().getId())))) {
+        if (branch == null
+                || element.getVoltageLevelId() != null
+                    && !(element.getVoltageLevelId().equals(branch.getTerminal1().getVoltageLevel().getId())
+                        || element.getVoltageLevelId().equals(branch.getTerminal2().getVoltageLevel().getId()))) {
             LOGGER.warn("Branch '{}' of contingency '{}' not found", element.getId(), contingency.getId());
             return false;
         }
@@ -188,9 +189,10 @@ public class Contingency extends AbstractExtendable<Contingency> {
 
     private static boolean checkLineContingency(Contingency contingency, LineContingency element, Network network) {
         Line line = network.getLine(element.getId());
-        if (line == null || (element.getVoltageLevelId() != null &&
-                !(element.getVoltageLevelId().equals(line.getTerminal1().getVoltageLevel().getId()) ||
-                        element.getVoltageLevelId().equals(line.getTerminal2().getVoltageLevel().getId())))) {
+        if (line == null
+                || element.getVoltageLevelId() != null
+                    && !(element.getVoltageLevelId().equals(line.getTerminal1().getVoltageLevel().getId())
+                        || element.getVoltageLevelId().equals(line.getTerminal2().getVoltageLevel().getId()))) {
             LOGGER.warn("Line '{}' of contingency '{}' not found", element.getId(), contingency.getId());
             return false;
         }
@@ -199,9 +201,10 @@ public class Contingency extends AbstractExtendable<Contingency> {
 
     private static boolean checkTwoWindingsTransformerContingency(Contingency contingency, TwoWindingsTransformerContingency element, Network network) {
         TwoWindingsTransformer twt = network.getTwoWindingsTransformer(element.getId());
-        if (twt == null || (element.getVoltageLevelId() != null &&
-                !(element.getVoltageLevelId().equals(twt.getTerminal1().getVoltageLevel().getId()) ||
-                        element.getVoltageLevelId().equals(twt.getTerminal2().getVoltageLevel().getId())))) {
+        if (twt == null
+                || element.getVoltageLevelId() != null
+                    && !(element.getVoltageLevelId().equals(twt.getTerminal1().getVoltageLevel().getId())
+                        || element.getVoltageLevelId().equals(twt.getTerminal2().getVoltageLevel().getId()))) {
             LOGGER.warn("TwoWindingsTransformer '{}' of contingency '{}' not found", element.getId(), contingency.getId());
             return false;
         }
@@ -210,9 +213,10 @@ public class Contingency extends AbstractExtendable<Contingency> {
 
     private static boolean checkHvdcLineContingency(Contingency contingency, HvdcLineContingency element, Network network) {
         HvdcLine hvdcLine = network.getHvdcLine(element.getId());
-        if (hvdcLine == null || (element.getVoltageLevelId() != null &&
-                !(element.getVoltageLevelId().equals(hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getId()) ||
-                        element.getVoltageLevelId().equals(hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getId())))) {
+        if (hvdcLine == null
+                || element.getVoltageLevelId() != null
+                    && !(element.getVoltageLevelId().equals(hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getId())
+                        || element.getVoltageLevelId().equals(hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getId()))) {
             LOGGER.warn("HVDC line '{}' of contingency '{}' not found", element.getId(), contingency.getId());
             return false;
         }
@@ -261,9 +265,10 @@ public class Contingency extends AbstractExtendable<Contingency> {
 
     private static boolean checkTieLineContingency(Contingency contingency, TieLineContingency element, Network network) {
         TieLine tieLine = network.getTieLine(element.getId());
-        if (tieLine == null || (element.getVoltageLevelId() != null &&
-                !(element.getVoltageLevelId().equals(tieLine.getDanglingLine1().getTerminal().getVoltageLevel().getId()) ||
-                        element.getVoltageLevelId().equals(tieLine.getDanglingLine2().getTerminal().getVoltageLevel().getId())))) {
+        if (tieLine == null
+                || element.getVoltageLevelId() != null
+                    && !(element.getVoltageLevelId().equals(tieLine.getDanglingLine1().getTerminal().getVoltageLevel().getId())
+                        || element.getVoltageLevelId().equals(tieLine.getDanglingLine2().getTerminal().getVoltageLevel().getId()))) {
             LOGGER.warn("Tie line '{}' of contingency '{}' not found", element.getId(), contingency.getId());
             return false;
         }

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/criterion/PropertyCriterion.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/criterion/PropertyCriterion.java
@@ -118,9 +118,9 @@ public class PropertyCriterion implements Criterion {
                 return filterSubstationOrVoltageLevel(voltageLevel1) || filterSubstationOrVoltageLevel(voltageLevel2) ||
                         filterSubstationOrVoltageLevel(voltageLevel3);
             case BOTH:
-                return (filterSubstationOrVoltageLevel(voltageLevel1) && filterSubstationOrVoltageLevel(voltageLevel2)) ||
-                        (filterSubstationOrVoltageLevel(voltageLevel1) && filterSubstationOrVoltageLevel(voltageLevel3)) ||
-                        (filterSubstationOrVoltageLevel(voltageLevel2) && filterSubstationOrVoltageLevel(voltageLevel3));
+                return filterSubstationOrVoltageLevel(voltageLevel1) && filterSubstationOrVoltageLevel(voltageLevel2)
+                        || filterSubstationOrVoltageLevel(voltageLevel1) && filterSubstationOrVoltageLevel(voltageLevel3)
+                        || filterSubstationOrVoltageLevel(voltageLevel2) && filterSubstationOrVoltageLevel(voltageLevel3);
             case ALL_THREE:
                 return filterSubstationOrVoltageLevel(voltageLevel1) && filterSubstationOrVoltageLevel(voltageLevel2) &&
                         filterSubstationOrVoltageLevel(voltageLevel3);

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/criterion/TwoCountriesCriterion.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/criterion/TwoCountriesCriterion.java
@@ -61,11 +61,11 @@ public class TwoCountriesCriterion implements Criterion {
         if (countrySide1 == null && !countries1.isEmpty() || countrySide2 == null && !countries2.isEmpty()) {
             return false;
         }
-        return (countries1.isEmpty() && countries2.isEmpty()) ||
-                (countries1.isEmpty() && (countries2.contains(countrySide2) || countries2.contains(countrySide1))) ||
-                (countries2.isEmpty() && (countries1.contains(countrySide2) || countries1.contains(countrySide1))) ||
-                (countries1.contains(countrySide1) && countries2.contains(countrySide2)) ||
-                (countries1.contains(countrySide2) && countries2.contains(countrySide1));
+        return countries1.isEmpty() && countries2.isEmpty()
+                || countries1.isEmpty() && (countries2.contains(countrySide2) || countries2.contains(countrySide1))
+                || countries2.isEmpty() && (countries1.contains(countrySide2) || countries1.contains(countrySide1))
+                || countries1.contains(countrySide1) && countries2.contains(countrySide2)
+                || countries1.contains(countrySide2) && countries2.contains(countrySide1);
     }
 
     public List<Country> getCountries1() {

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/HvdcUtils.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/HvdcUtils.java
@@ -59,8 +59,8 @@ public final class HvdcUtils {
     public static boolean isRectifier(HvdcConverterStation<?> station) {
         Objects.requireNonNull(station);
         HvdcLine line = station.getHvdcLine();
-        return (line.getConverterStation1() == station && line.getConvertersMode() == HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER)
-            || (line.getConverterStation2() == station && line.getConvertersMode() == HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER);
+        return line.getConverterStation1() == station && line.getConvertersMode() == HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER
+            || line.getConverterStation2() == station && line.getConvertersMode() == HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER;
     }
 
     private static double getAbsoluteValuePAc(HvdcConverterStation<?> station) {

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LimitViolationUtils.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LimitViolationUtils.java
@@ -58,7 +58,7 @@ public final class LimitViolationUtils {
         return branch.getLimits(type, side)
                 .map(l -> !Double.isNaN(l.getPermanentLimit()) &&
                         !Double.isNaN(i) &&
-                        (i >= l.getPermanentLimit() * limitReduction))
+                        i >= l.getPermanentLimit() * limitReduction)
                 .orElse(false);
     }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -200,8 +200,10 @@ public final class TieLineUtil {
             }
         } else {
             // if dangling line with same ID present, there is only one: they are associated if the X-node code is identical (if not: throw exception)
-            if ((danglingLine.getUcteXnodeCode() != null && candidateDanglingLine.getUcteXnodeCode() != null
-                    && !danglingLine.getUcteXnodeCode().equals(candidateDanglingLine.getUcteXnodeCode())) || (danglingLine.getUcteXnodeCode() == null && candidateDanglingLine.getUcteXnodeCode() == null)) {
+            boolean nonNullAndDifferent = danglingLine.getUcteXnodeCode() != null && candidateDanglingLine.getUcteXnodeCode() != null
+                    && !danglingLine.getUcteXnodeCode().equals(candidateDanglingLine.getUcteXnodeCode());
+            boolean bothNull = danglingLine.getUcteXnodeCode() == null && candidateDanglingLine.getUcteXnodeCode() == null;
+            if (nonNullAndDifferent || bothNull) {
                 throw new PowsyblException("Dangling line couple " + danglingLine.getId()
                         + " have inconsistent Xnodes (" + danglingLine.getUcteXnodeCode()
                         + "!=" + candidateDanglingLine.getUcteXnodeCode() + ")");

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -480,8 +480,8 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                     }
                 }
             }
-            return (busbarSectionCount >= 1 && feederCount >= 1)
-                    || (branchCount >= 1 && feederCount >= 2);
+            return busbarSectionCount >= 1 && feederCount >= 1
+                    || branchCount >= 1 && feederCount >= 2;
         }
     }
 
@@ -822,8 +822,8 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         public void removeInternalConnections(int node1, int node2) {
             int[] internalConnectionsToBeRemoved = Arrays.stream(graph.getEdges())
                     .filter(e -> graph.getEdgeObject(e) == null)
-                    .filter(e -> (graph.getEdgeVertex1(e) == node1 && graph.getEdgeVertex2(e) == node2) ||
-                            (graph.getEdgeVertex1(e) == node2 && graph.getEdgeVertex2(e) == node1))
+                    .filter(e -> graph.getEdgeVertex1(e) == node1 && graph.getEdgeVertex2(e) == node2
+                            || graph.getEdgeVertex1(e) == node2 && graph.getEdgeVertex2(e) == node1)
                     .toArray();
             if (internalConnectionsToBeRemoved.length == 0) {
                 throw new PowsyblException("Internal connection not found between " + node1 + " and " + node2);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
@@ -64,7 +64,7 @@ final class Substations {
     private static void checkRemovability(Substation substation, Branch branch) {
         Substation s1 = branch.getTerminal1().getVoltageLevel().getSubstation().orElse(null);
         Substation s2 = branch.getTerminal2().getVoltageLevel().getSubstation().orElse(null);
-        if ((s1 != substation) || (s2 != substation)) {
+        if (s1 != substation || s2 != substation) {
             throw createIsolationException(substation);
         }
     }
@@ -73,7 +73,7 @@ final class Substations {
         Substation s1 = twt.getLeg1().getTerminal().getVoltageLevel().getSubstation().orElse(null);
         Substation s2 = twt.getLeg2().getTerminal().getVoltageLevel().getSubstation().orElse(null);
         Substation s3 = twt.getLeg3().getTerminal().getVoltageLevel().getSubstation().orElse(null);
-        if ((s1 != substation) || (s2 != substation) || (s3 != substation)) {
+        if (s1 != substation || s2 != substation || s3 != substation) {
             throw createIsolationException(substation);
         }
     }
@@ -83,7 +83,7 @@ final class Substations {
         if (hvdcLine != null) {
             Substation s1 = hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getSubstation().orElse(null);
             Substation s2 = hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getSubstation().orElse(null);
-            if ((s1 != substation) || (s2 != substation)) {
+            if (s1 != substation || s2 != substation) {
                 throw createIsolationException(substation);
             }
         }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalBuilder.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalBuilder.java
@@ -66,7 +66,7 @@ class TerminalBuilder {
 
     private String getConnectionBus() {
         if (bus != null) {
-            if ((connectableBus != null) && (!bus.equals(connectableBus))) {
+            if (connectableBus != null && !bus.equals(connectableBus)) {
                 throw new ValidationException(validable, "connection bus is different to connectable bus");
             }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevels.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevels.java
@@ -36,7 +36,7 @@ final class VoltageLevels {
             if (MULTIPLE_TERMINALS_CONNECTABLE_TYPES.contains(type)) {
                 // Reject lines, 2WT and 3WT
                 throw new IllegalStateException("The voltage level '" + voltageLevel.getId() + "' cannot be removed because of a remaining " + type);
-            } else if ((type == IdentifiableType.HVDC_CONVERTER_STATION) && (network.getHvdcLine((HvdcConverterStation) connectable) != null)) {
+            } else if (type == IdentifiableType.HVDC_CONVERTER_STATION && network.getHvdcLine((HvdcConverterStation) connectable) != null) {
                 // Reject all converter stations connected to a HVDC line
                 throw new IllegalStateException("The voltage level '" + voltageLevel.getId() + "' cannot be removed because of a remaining HVDC line");
             }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/HvdcOperatorActivePowerRangeImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/HvdcOperatorActivePowerRangeImpl.java
@@ -68,7 +68,7 @@ public class HvdcOperatorActivePowerRangeImpl extends AbstractMultiVariantIdenti
     }
 
     private float checkOPR(float opr, HvdcConverterStation<?> from, HvdcConverterStation<?> to) {
-        if ((!Float.isNaN(opr)) && (opr < 0)) {
+        if (!Float.isNaN(opr) && opr < 0) {
             String message = "OPR from " + from.getId() + " to " + to.getId() + " must be greater than 0 (current value " + Float.toString(opr) + ").";
             throw new IllegalArgumentException(message);
         }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/SubstationsTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/SubstationsTest.java
@@ -1,0 +1,43 @@
+package com.powsybl.iidm.network.impl;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.HvdcTestNetwork;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SubstationsTest {
+
+    @Test
+    void test() {
+        Network network = EurostagTutorialExample1Factory.create();
+        network.getLine("NHV1_NHV2_1").remove();
+        network.getLine("NHV1_NHV2_2").remove();
+        assertDoesNotThrow(() -> Substations.checkRemovability(network.getSubstation("P1")));
+    }
+
+    @Test
+    void failCheckRemovabilityBecauseOfBranches() {
+        Network network = EurostagTutorialExample1Factory.create();
+        assertFail(() -> Substations.checkRemovability(network.getSubstation("P1")));
+        assertFail(() -> Substations.checkRemovability(network.getSubstation("P2")));
+    }
+
+    @Test
+    void failCheckRemovabilityBecauseOfHvdcLines() {
+        Network network = HvdcTestNetwork.createLcc();
+        assertFail(() -> Substations.checkRemovability(network.getSubstation("S1")));
+        assertFail(() -> Substations.checkRemovability(network.getSubstation("S2")));
+    }
+
+    private void assertFail(Executable executable) {
+        PowsyblException e = Assertions.assertThrows(PowsyblException.class, executable);
+        assertTrue(e.getMessage().contains("is still connected to another substation"));
+    }
+
+}

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/AbstractTransformerXml.java
@@ -144,10 +144,10 @@ abstract class AbstractTransformerXml<T extends Connectable<T>, A extends Identi
         context.getWriter().writeStartElement(context.getVersion().getNamespaceURI(context.isValid()), name);
         writeTapChanger(ptc, context);
         XmlUtil.writeOptionalEnum("regulationMode", ptc.getRegulationMode(), context.getWriter());
-        if ((ptc.getRegulationMode() != null && ptc.getRegulationMode() != PhaseTapChanger.RegulationMode.FIXED_TAP) || !Double.isNaN(ptc.getRegulationValue())) {
+        if (ptc.getRegulationMode() != null && ptc.getRegulationMode() != PhaseTapChanger.RegulationMode.FIXED_TAP || !Double.isNaN(ptc.getRegulationValue())) {
             XmlUtil.writeDouble("regulationValue", ptc.getRegulationValue(), context.getWriter());
         }
-        if ((ptc.getRegulationMode() != null && ptc.getRegulationMode() != PhaseTapChanger.RegulationMode.FIXED_TAP) || ptc.isRegulating()) {
+        if (ptc.getRegulationMode() != null && ptc.getRegulationMode() != PhaseTapChanger.RegulationMode.FIXED_TAP || ptc.isRegulating()) {
             context.getWriter().writeAttribute(ATTR_REGULATING, Boolean.toString(ptc.isRegulating()));
         }
         if (ptc.getRegulationTerminal() != null) {

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/BusFilter.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/BusFilter.java
@@ -61,7 +61,7 @@ public class BusFilter {
             if (options.getTopologyLevel() == TopologyLevel.BUS_BRANCH) {
                 Bus b1 = t1.getBusView().getConnectableBus();
                 Bus b2 = t2.getBusView().getConnectableBus();
-                if ((b1 != null && b1.isInMainConnectedComponent()) && b2 != null && !b2.isInMainConnectedComponent()) {
+                if (b1 != null && b1.isInMainConnectedComponent() && b2 != null && !b2.isInMainConnectedComponent()) {
                     buses.add(b2.getId());
                 } else if (b1 != null && !b1.isInMainConnectedComponent() && b2 != null && b2.isInMainConnectedComponent()) {
                     buses.add(b1.getId());

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ThreeWindingsTransformerXml.java
@@ -44,12 +44,12 @@ class ThreeWindingsTransformerXml extends AbstractTransformerXml<ThreeWindingsTr
 
     @Override
     protected boolean hasSubElements(ThreeWindingsTransformer twt, NetworkXmlWriterContext context) {
-        return (twt.getLeg1().hasRatioTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0)
+        return twt.getLeg1().hasRatioTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0
                 || twt.getLeg2().hasRatioTapChanger()
                 || twt.getLeg3().hasRatioTapChanger()
-                || (twt.getLeg1().hasPhaseTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0)
-                || (twt.getLeg2().hasPhaseTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0)
-                || (twt.getLeg3().hasPhaseTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0)
+                || twt.getLeg1().hasPhaseTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0
+                || twt.getLeg2().hasPhaseTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0
+                || twt.getLeg3().hasPhaseTapChanger() && context.getVersion().compareTo(IidmXmlVersion.V_1_1) > 0
                 || hasValidOperationalLimits(twt.getLeg1(), context)
                 || hasValidOperationalLimits(twt.getLeg2(), context)
                 || hasValidOperationalLimits(twt.getLeg3(), context);

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/VoltageLevelXml.java
@@ -204,7 +204,7 @@ class VoltageLevelXml extends AbstractSimpleIdentifiableXml<VoltageLevel, Voltag
 
     private void writeDanglingLines(VoltageLevel vl, NetworkXmlWriterContext context) throws XMLStreamException {
         for (DanglingLine dl : IidmXmlUtil.sorted(vl.getDanglingLines(DanglingLineFilter.ALL), context.getOptions())) {
-            if (!context.getFilter().test(dl) || (context.getVersion().compareTo(IidmXmlVersion.V_1_10) < 0 && dl.isPaired())) {
+            if (!context.getFilter().test(dl) || context.getVersion().compareTo(IidmXmlVersion.V_1_10) < 0 && dl.isPaired()) {
                 continue;
             }
             DanglingLineXml.INSTANCE.write(dl, vl, context);

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/GeneratorsValidation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/GeneratorsValidation.java
@@ -169,8 +169,8 @@ public final class GeneratorsValidation {
 
     private static boolean checkGeneratorsNaNValues(String id, double p, double q, double targetP, double targetQ) {
         // a validation error should be detected if there is both a voltage and a target but no p or q
-        if ((!Double.isNaN(targetP) && targetP != 0)
-            || (!Double.isNaN(targetQ) && targetQ != 0)) {
+        if (!Double.isNaN(targetP) && targetP != 0
+                || !Double.isNaN(targetQ) && targetQ != 0) {
             LOGGER.warn("{} {}: {}: P={} targetP={} - Q={} targetQ={}", ValidationType.GENERATORS, ValidationUtils.VALIDATION_ERROR, id, p, targetP, q, targetQ);
             return false;
         }
@@ -197,9 +197,9 @@ public final class GeneratorsValidation {
         double qGen = -q;
         if (voltageRegulatorOn
             && (ValidationUtils.areNaN(config, minQ, maxQ, targetV)
-                || (v > targetV + config.getThreshold() && Math.abs(qGen - getMinQ(minQ, maxQ)) > config.getThreshold())
-                || (v < targetV - config.getThreshold() && Math.abs(qGen - getMaxQ(minQ, maxQ)) > config.getThreshold())
-                || (Math.abs(v - targetV) <= config.getThreshold()) && !ValidationUtils.boundedWithin(minQ, maxQ, qGen, config.getThreshold()))) {
+                || v > targetV + config.getThreshold() && Math.abs(qGen - getMinQ(minQ, maxQ)) > config.getThreshold()
+                || v < targetV - config.getThreshold() && Math.abs(qGen - getMaxQ(minQ, maxQ)) > config.getThreshold()
+                || Math.abs(v - targetV) <= config.getThreshold() && !ValidationUtils.boundedWithin(minQ, maxQ, qGen, config.getThreshold()))) {
             LOGGER.warn("{} {}: {}: voltage regulator on - Q={} minQ={} maxQ={} - V={} targetV={}", ValidationType.GENERATORS, ValidationUtils.VALIDATION_ERROR, id, qGen, minQ, maxQ, v, targetV);
             validated = false;
         }

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/ValidationUtils.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/ValidationUtils.java
@@ -69,7 +69,8 @@ public final class ValidationUtils {
     }
 
     public static boolean boundedWithin(double lowerBound, double upperBound, double value, double margin) {
-        if (Double.isNaN(value) || (Double.isNaN(lowerBound) && Double.isNaN(upperBound))) {
+        if (Double.isNaN(value)
+                || Double.isNaN(lowerBound) && Double.isNaN(upperBound)) {
             return false;
         }
         if (Double.isNaN(lowerBound)) {

--- a/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/util/TwtDataTest.java
+++ b/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/util/TwtDataTest.java
@@ -161,10 +161,10 @@ class TwtDataTest {
 
     private static boolean t3xCompareStarBusVoltage(TwtData twtData, double starU, double starAngle) {
         double tol = 0.00001;
-        if ((Double.isNaN(twtData.getStarU()) && !Double.isNaN(starU)) ||
-            (Double.isNaN(twtData.getStarTheta()) && !Double.isNaN(starAngle)) ||
-            Math.abs(twtData.getStarU() - starU) > tol ||
-            Math.abs(Math.toDegrees(twtData.getStarTheta()) - starAngle) > tol) {
+        if (Double.isNaN(twtData.getStarU()) && !Double.isNaN(starU)
+                || Double.isNaN(twtData.getStarTheta()) && !Double.isNaN(starAngle)
+                || Math.abs(twtData.getStarU() - starU) > tol
+                || Math.abs(Math.toDegrees(twtData.getStarTheta()) - starAngle) > tol) {
             LOG.info("ThreeWindingsTransformer {} Expected {} {} Actual {} {}", twtData.getId(),
                 starU, starAngle, twtData.getStarU(), Math.toDegrees(twtData.getStarTheta()));
             return false;
@@ -194,18 +194,18 @@ class TwtDataTest {
 
     private static boolean sameFlow(T3xFlow expected, T3xFlow actual) {
         double tol = 0.00001;
-        if ((!Double.isNaN(expected.p1) && Double.isNaN(actual.p1)) ||
-            (!Double.isNaN(expected.q1) && Double.isNaN(actual.q1)) ||
-            (!Double.isNaN(expected.p2) && Double.isNaN(actual.p2)) ||
-            (!Double.isNaN(expected.q2) && Double.isNaN(actual.q2)) ||
-            (!Double.isNaN(expected.p3) && Double.isNaN(actual.p3)) ||
-            (!Double.isNaN(expected.q3) && Double.isNaN(actual.q3)) ||
-            Math.abs(expected.p1 - actual.p1) > tol ||
-            Math.abs(expected.q1 - actual.q1) > tol ||
-            Math.abs(expected.p2 - actual.p2) > tol ||
-            Math.abs(expected.q2 - actual.q2) > tol ||
-            Math.abs(expected.p3 - actual.p3) > tol ||
-            Math.abs(expected.q3 - actual.q3) > tol) {
+        if (!Double.isNaN(expected.p1) && Double.isNaN(actual.p1)
+                || !Double.isNaN(expected.q1) && Double.isNaN(actual.q1)
+                || !Double.isNaN(expected.p2) && Double.isNaN(actual.p2)
+                || !Double.isNaN(expected.q2) && Double.isNaN(actual.q2)
+                || !Double.isNaN(expected.p3) && Double.isNaN(actual.p3)
+                || !Double.isNaN(expected.q3) && Double.isNaN(actual.q3)
+                || Math.abs(expected.p1 - actual.p1) > tol
+                || Math.abs(expected.q1 - actual.q1) > tol
+                || Math.abs(expected.p2 - actual.p2) > tol
+                || Math.abs(expected.q2 - actual.q2) > tol
+                || Math.abs(expected.p3 - actual.p3) > tol
+                || Math.abs(expected.q3 - actual.q3) > tol) {
             return false;
         }
         return true;

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraphImpl.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraphImpl.java
@@ -398,8 +398,8 @@ public class UndirectedGraphImpl<V, E> implements UndirectedGraph<V, E> {
         for (int i = 0; i < adjacentEdges.size(); i++) {
             int e = adjacentEdges.getQuick(i);
             Edge<E> edge = edges.get(e);
-            if ((edge.getV1() == v1 && edge.getV2() == v2)
-                    || (edge.getV1() == v2 && edge.getV2() == v1)) {
+            if (edge.getV1() == v1 && edge.getV2() == v2
+                    || edge.getV1() == v2 && edge.getV2() == v1) {
                 edgeObjects.add(edge.getObject());
             }
         }

--- a/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerExporter.java
+++ b/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerExporter.java
@@ -86,7 +86,8 @@ public class MatpowerExporter implements Exporter {
     }
 
     private static MBus.Type getType(Bus bus, Context context) {
-        if ((context.refBusId != null && context.refBusId.equals(bus.getId())) || hasSlackExtension(bus)) {
+        if (context.refBusId != null && context.refBusId.equals(bus.getId())
+                || hasSlackExtension(bus)) {
             return MBus.Type.REF;
         }
         for (Generator g : bus.getGenerators()) {

--- a/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
+++ b/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
@@ -199,7 +199,7 @@ public class MatpowerImporter implements Importer {
                     .setRatedS(mGen.getTotalMbase() != 0 ? mGen.getTotalMbase() : Double.NaN)
                     .add();
 
-            if ((mGen.getPc1() != 0) || (mGen.getPc2() != 0)) {
+            if (mGen.getPc1() != 0 || mGen.getPc2() != 0) {
                 generator.newReactiveCapabilityCurve()
                         .beginPoint()
                         .setP(mGen.getPc1())

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>12</version>
+        <version>13</version>
         <relativePath/>
     </parent>
 

--- a/psse/psse-converter/src/main/java/com/powsybl/psse/converter/TransformerConverter.java
+++ b/psse/psse-converter/src/main/java/com/powsybl/psse/converter/TransformerConverter.java
@@ -389,7 +389,8 @@ class TransformerConverter extends AbstractConverter {
             if (distanceRatio == 0.0 && distanceAngle == 0.0) {
                 return i;
             }
-            if (distanceAngle > 0.0 || (distanceAngle == 0.0 && distanceRatio > 0.0)) {
+            if (distanceAngle > 0.0
+                    || distanceAngle == 0.0 && distanceRatio > 0.0) {
                 tapChanger.getSteps().add(i, new TapChangerStep(complexRatio.getRatio(), complexRatio.getAngle()));
                 return i;
             }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/detectors/DefaultLimitViolationDetector.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/detectors/DefaultLimitViolationDetector.java
@@ -77,7 +77,7 @@ public class DefaultLimitViolationDetector extends AbstractContingencyBlindDetec
 
     public void checkLimitViolation(Branch branch, Branch.Side side, double value, Consumer<LimitViolation> consumer, LimitType type) {
         Branch.Overload overload = LimitViolationUtils.checkTemporaryLimits(branch, side, limitReduction, value, type);
-        if (currentLimitTypes.contains(LoadingLimitType.TATL) && (overload != null)) {
+        if (currentLimitTypes.contains(LoadingLimitType.TATL) && overload != null) {
             checkTemporary(branch, side, limitReduction, value, consumer, type);
         } else if (currentLimitTypes.contains(LoadingLimitType.PATL)) {
             checkPermanentLimit(branch, side, limitReduction, value, consumer, type);

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/DoublePoint.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/DoublePoint.java
@@ -35,7 +35,8 @@ public class DoublePoint extends AbstractPoint {
         if (obj instanceof DoublePoint) {
             DoublePoint other = (DoublePoint) obj;
             return index == other.index && time == other.time
-                    && ((Double.isNaN(value) && Double.isNaN(other.value)) || value == other.value);
+                    && (Double.isNaN(value) && Double.isNaN(other.value)
+                        || value == other.value);
         }
         return false;
     }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/DoublePointTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/DoublePointTest.java
@@ -32,8 +32,9 @@ class DoublePointTest {
         new EqualsTester()
                 .addEqualityGroup(new DoublePoint(0, Instant.parse("2015-01-01T00:00:00Z").toEpochMilli(), 10d),
                         new DoublePoint(0, Instant.parse("2015-01-01T00:00:00Z").toEpochMilli(), 10d))
-                .addEqualityGroup(new DoublePoint(1, Instant.parse("2015-01-01T00:15:00Z").toEpochMilli(), 8d),
-                        new DoublePoint(1, Instant.parse("2015-01-01T00:15:00Z").toEpochMilli(), 8d))
+                .addEqualityGroup(new DoublePoint(1, Instant.parse("2015-01-01T00:00:00Z").toEpochMilli(), 10d))
+                .addEqualityGroup(new DoublePoint(0, Instant.parse("2015-01-01T11:11:11Z").toEpochMilli(), 10d))
+                .addEqualityGroup(new DoublePoint(0, Instant.parse("2015-01-01T00:00:00Z").toEpochMilli(), 8d))
                 .testEquals();
     }
 }

--- a/triple-store/triple-store-impl-rdf4j/src/main/java/com/powsybl/triplestore/impl/rdf4j/PowsyblWriter.java
+++ b/triple-store/triple-store-impl-rdf4j/src/main/java/com/powsybl/triplestore/impl/rdf4j/PowsyblWriter.java
@@ -105,8 +105,9 @@ public class PowsyblWriter extends RDFXMLWriter {
             }
         }
         if (prefix != null && prefix.equals("data")) {
-            if (ctxt.contains("_SSH_") || (ctxt.contains("_DY_") && objLocalName.equals("EnergyConsumer"))
-                    || (ctxt.contains("_TP_") && !objLocalName.equals("TopologicalNode"))) {
+            if (ctxt.contains("_SSH_")
+                    || ctxt.contains("_DY_") && objLocalName.equals("EnergyConsumer")
+                    || ctxt.contains("_TP_") && !objLocalName.equals("TopologicalNode")) {
                 attName = "about";
                 value = "#" + uri.getLocalName();
             } else {

--- a/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/UcteNode.java
+++ b/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/UcteNode.java
@@ -387,16 +387,16 @@ public class UcteNode implements UcteRecord, Comparable<UcteNode> {
         //   - or active limits are both defined (min and max), one is non null and there are not equal
         //   - or reactive limits are both defined (min and max), one is non null and there are not equal
         return isRegulatingVoltage()
-                || (!Double.isNaN(activePowerGeneration) && activePowerGeneration != 0)
-                || (!Double.isNaN(reactivePowerGeneration) && reactivePowerGeneration != 0)
-                || (!Double.isNaN(minimumPermissibleActivePowerGeneration)
+                || !Double.isNaN(activePowerGeneration) && activePowerGeneration != 0
+                || !Double.isNaN(reactivePowerGeneration) && reactivePowerGeneration != 0
+                || !Double.isNaN(minimumPermissibleActivePowerGeneration)
                     && !Double.isNaN(maximumPermissibleActivePowerGeneration)
                     && (minimumPermissibleActivePowerGeneration != 0 || maximumPermissibleActivePowerGeneration != 0)
-                    && minimumPermissibleActivePowerGeneration != maximumPermissibleActivePowerGeneration)
-                || (!Double.isNaN(minimumPermissibleReactivePowerGeneration)
+                    && minimumPermissibleActivePowerGeneration != maximumPermissibleActivePowerGeneration
+                || !Double.isNaN(minimumPermissibleReactivePowerGeneration)
                     && !Double.isNaN(maximumPermissibleReactivePowerGeneration)
                     && (minimumPermissibleReactivePowerGeneration != 0 || maximumPermissibleReactivePowerGeneration != 0)
-                    && minimumPermissibleReactivePowerGeneration != maximumPermissibleReactivePowerGeneration);
+                    && minimumPermissibleReactivePowerGeneration != maximumPermissibleReactivePowerGeneration;
     }
 
     public boolean isRegulatingVoltage() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Quality


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The new java17 syntax is **not** recognized by maven-checkstyle-plugin.


**What is the new behavior (if this is a feature change)?**
The new java17 syntax is recognized by maven-checkstyle-plugin.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Java17 syntax is not fully supported by the currently used version of maven-checkstyle-plugin (v3.1.1). This plugin's version provided by powsybl-parent v13 (maven-checkstyle-plugin v3.3.0) supports it but introduces or redefines some rules. Among them are changes about the `UnnecessaryParentheses` rule, which now considers the precedence between the `&&` and `||` logical operators (on this subject, you can see [this discussion](https://github.com/checkstyle/checkstyle/issues/10946)).

