### PR TITLE
Validation level management when merging networks

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -887,6 +887,15 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
 
         long start = System.currentTimeMillis();
 
+        // If the validation level of other is lower than the current network's minimum validation level, we can not incorporate it
+        if (other.getValidationLevel().compareTo(getMinValidationLevel()) < 0) {
+            throw new PowsyblException("Network " + other.getNetwork() + " cannot be merged: its validation level " +
+                    "is lower than the minimum acceptable validation level of network " + getId() + " (" +
+                    other.getValidationLevel() + " < " + getMinValidationLevel() + ")");
+        }
+        // Update the validation level (without recomputing it)
+        this.validationLevel = ValidationLevel.min(this.getValidationLevel(), other.getValidationLevel());
+
         // check mergeability
         Multimap<Class<? extends Identifiable>, String> intersection = index.intersection(otherNetwork.index);
         for (Map.Entry<Class<? extends Identifiable>, Collection<String>> entry : intersection.asMap().entrySet()) {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
@@ -45,6 +45,20 @@ public abstract class AbstractMergeNetworkTest {
     }
 
     @Test
+    public void failMergeValidationLevelLowerThanMin() {
+        n1.setMinimumAcceptableValidationLevel(ValidationLevel.EQUIPMENT);
+        addSubstationAndVoltageLevel();
+        n1.getVoltageLevel("vl1").newLoad()
+                .setId("unchecked1")
+                .setBus("b1")
+                .setConnectableBus("b1")
+                .add();
+        PowsyblException e = assertThrows(PowsyblException.class, () -> merge.merge(n1));
+        assertTrue(e.getMessage().contains("cannot be merged: its validation level is lower than the minimum acceptable " +
+                "validation level of network"));
+    }
+
+    @Test
     public void xnodeNonCompatible() {
         addSubstationAndVoltageLevel();
         addDanglingLines("dl", "code", "dl", "deco");


### PR DESCRIPTION
…te validationLevel

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
- An EQ network can be merged in a network with SSH as minimal validation level
- The validation level of the network is **not** updated after a merge


**What is the new behavior (if this is a feature change)?**
- An exception is thrown when trying to merge an EQ network in a network with SSH as minimal validation level
- The validation level of the network is updated after a merge


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
