### PR TITLE
Check dense matrix max element count

### DIFF
--- a/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
@@ -7,6 +7,8 @@
 package com.powsybl.math.matrix;
 
 import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
@@ -21,6 +23,10 @@ import java.util.function.Supplier;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class DenseMatrix extends AbstractMatrix {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DenseMatrix.class);
+
+    public static final int MAX_ELEMENT_COUNT = Integer.MAX_VALUE / Double.BYTES;
 
     /**
      * Dense element implementation.
@@ -61,8 +67,15 @@ public class DenseMatrix extends AbstractMatrix {
     private final ByteBuffer buffer;
 
     private static ByteBuffer createBuffer(int rowCount, int columnCount) {
-        return ByteBuffer.allocateDirect(rowCount * columnCount * Double.BYTES)
-                .order(ByteOrder.LITTLE_ENDIAN);
+        try {
+            int capacity = Math.multiplyExact(Math.multiplyExact(rowCount, columnCount), Double.BYTES);
+            return ByteBuffer.allocateDirect(capacity)
+                    .order(ByteOrder.LITTLE_ENDIAN);
+        } catch (ArithmeticException e) {
+            LOGGER.error(e.toString(), e);
+            throw new MatrixException("Too many elements for a dense matrix, maximum allowed is "
+                    + MAX_ELEMENT_COUNT);
+        }
     }
 
     public DenseMatrix(int rowCount, int columnCount, double[] values) {

--- a/math/src/test/java/com/powsybl/math/matrix/DenseMatrixTest.java
+++ b/math/src/test/java/com/powsybl/math/matrix/DenseMatrixTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.math.matrix;
 
 import com.google.common.collect.ImmutableList;
+import com.powsybl.commons.PowsyblException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -106,5 +107,12 @@ class DenseMatrixTest extends AbstractMatrixTest {
         assertEquals(15, c.get(1, 0), EPSILON);
         assertEquals(0, c.get(0, 1), EPSILON);
         assertEquals(0, c.get(1, 1), EPSILON);
+    }
+
+    @Test
+    void testTooManyElementDenseMatrix() {
+        PowsyblException e = assertThrows(PowsyblException.class, () -> new DenseMatrix(100000, 10000));
+        assertEquals("Too many elements for a dense matrix, maximum allowed is 268435455", e.getMessage());
+        assertEquals(268435455, DenseMatrix.MAX_ELEMENT_COUNT);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When we create large dense matrices we may encounter the maximum allowed size which is dependent of Java max integer value and unfortunately it silently fail because of an integer overflow. The buffer capacity is allowed without any error but with max integer value and later on we end up when setting element value to an index out of bound issue.


**What is the new behavior (if this is a feature change)?**
We throw an exception if the created dense matrix is too large.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
