### PR TITLE
[Shortcircuit API] Make the method toThreePhaseValue public in FortescueValue

### DIFF
--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FortescueValue.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FortescueValue.java
@@ -112,7 +112,7 @@ public class FortescueValue {
         return negativeAngle;
     }
 
-    ThreePhaseValue toThreePhaseValue() {
+    public ThreePhaseValue toThreePhaseValue() {
 
         // [G1]   [ 1  1  1 ]   [Gh]
         // [G2] = [ 1  a²  a] * [Gd]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Bug fix (?)



**What is the current behavior?**
The method toThreePhaseValue is package private so inaccessible.


**What is the new behavior (if this is a feature change)?**
The class is public