### PR TITLE
Remove dangling lines merge by ID

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -7,7 +7,6 @@
 package com.powsybl.iidm.network.util;
 
 import com.google.common.collect.Sets;
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.iidm.network.DanglingLineFilter;
@@ -158,61 +157,40 @@ public final class TieLineUtil {
     /**
      * If it exists, find the dangling line in the merging network that should be associated to a candidate dangling line in the network to be merged.
      * Two dangling lines in different IGM should be associated if:
-     * - they have the same ID and at least one has a non-null X-node code
-     * OR
      * - they have the same non-null X-node code and are the only dangling lines to have this X-node code in their respective networks
      * OR
      * - they have the same non-null X-node code and are the only connected dangling lines to have this X-node code in their respective networks
      *
      * @param candidateDanglingLine candidate dangling line in the network to be merged
-     * @param danglingLine dangling line in the merging network with same ID as the candidate dangling line. Can be null.
      * @param getDanglingLinesByXnodeCode function to retrieve dangling lines with a given X-node code in the merging network.
      * @param associateDanglingLines function associating two dangling lines
      */
-    public static void findAndAssociateDanglingLines(DanglingLine candidateDanglingLine, DanglingLine danglingLine,
+    public static void findAndAssociateDanglingLines(DanglingLine candidateDanglingLine,
                                                      Function<String, List<DanglingLine>> getDanglingLinesByXnodeCode,
                                                      BiConsumer<DanglingLine, DanglingLine> associateDanglingLines) {
         Objects.requireNonNull(candidateDanglingLine);
         Objects.requireNonNull(getDanglingLinesByXnodeCode);
         Objects.requireNonNull(associateDanglingLines);
-        if (danglingLine == null) { // if dangling line with same ID not present, find dangling line(s) with same X-node code in merging network if present
-            // mapping by ucte xnode code
-            if (candidateDanglingLine.getUcteXnodeCode() != null) { // if X-node code null: no associated dangling line
-                if (candidateDanglingLine.getNetwork().getDanglingLineStream(DanglingLineFilter.UNPAIRED)
-                        .filter(d -> d != candidateDanglingLine)
-                        .filter(d -> candidateDanglingLine.getUcteXnodeCode().equals(d.getUcteXnodeCode()))
-                        .anyMatch(d -> d.getTerminal().isConnected())) { // check that there is no connected dangling line with same X-node code in the network to be merged
-                    return;                                         // in that case, do nothing
+        // mapping by ucte xnode code
+        if (candidateDanglingLine.getUcteXnodeCode() != null) { // if X-node code null: no associated dangling line
+            if (candidateDanglingLine.getNetwork().getDanglingLineStream(DanglingLineFilter.UNPAIRED)
+                    .filter(d -> d != candidateDanglingLine)
+                    .filter(d -> candidateDanglingLine.getUcteXnodeCode().equals(d.getUcteXnodeCode()))
+                    .anyMatch(d -> d.getTerminal().isConnected())) { // check that there is no connected dangling line with same X-node code in the network to be merged
+                return;                                         // in that case, do nothing
+            }
+            List<DanglingLine> dls = getDanglingLinesByXnodeCode.apply(candidateDanglingLine.getUcteXnodeCode());
+            if (dls != null) {
+                if (dls.size() == 1) { // if there is exactly one dangling line in the merging network, merge it
+                    associateDanglingLines.accept(dls.get(0), candidateDanglingLine);
                 }
-                List<DanglingLine> dls = getDanglingLinesByXnodeCode.apply(candidateDanglingLine.getUcteXnodeCode());
-                if (dls != null) {
-                    if (dls.size() == 1) { // if there is exactly one dangling line in the merging network, merge it
-                        associateDanglingLines.accept(dls.get(0), candidateDanglingLine);
-                    }
-                    if (dls.size() > 1) { // if more than one dangling line in the merging network, check how many are connected
-                        List<DanglingLine> connectedDls = dls.stream().filter(dl -> dl.getTerminal().isConnected()).toList();
-                        if (connectedDls.size() == 1) { // if there is exactly one connected dangling line in the merging network, merge it. Otherwise, do nothing
-                            associateDanglingLines.accept(connectedDls.get(0), candidateDanglingLine);
-                        }
+                if (dls.size() > 1) { // if more than one dangling line in the merging network, check how many are connected
+                    List<DanglingLine> connectedDls = dls.stream().filter(dl -> dl.getTerminal().isConnected()).toList();
+                    if (connectedDls.size() == 1) { // if there is exactly one connected dangling line in the merging network, merge it. Otherwise, do nothing
+                        associateDanglingLines.accept(connectedDls.get(0), candidateDanglingLine);
                     }
                 }
             }
-        } else {
-            // if dangling line with same ID present, there is only one: they are associated if the X-node code is identical (if not: throw exception)
-            boolean nonNullAndDifferent = danglingLine.getUcteXnodeCode() != null && candidateDanglingLine.getUcteXnodeCode() != null
-                    && !danglingLine.getUcteXnodeCode().equals(candidateDanglingLine.getUcteXnodeCode());
-            boolean bothNull = danglingLine.getUcteXnodeCode() == null && candidateDanglingLine.getUcteXnodeCode() == null;
-            if (nonNullAndDifferent || bothNull) {
-                throw new PowsyblException("Dangling line couple " + danglingLine.getId()
-                        + " have inconsistent Xnodes (" + danglingLine.getUcteXnodeCode()
-                        + "!=" + candidateDanglingLine.getUcteXnodeCode() + ")");
-            }
-            String code = Optional.ofNullable(danglingLine.getUcteXnodeCode()).orElseGet(candidateDanglingLine::getUcteXnodeCode);
-            List<DanglingLine> dls = getDanglingLinesByXnodeCode.apply(code);
-            if (dls != null && dls.size() > 1) {
-                throw new PowsyblException("Should not have any dangling lines other than " + danglingLine.getId() + " linked to " + code);
-            }
-            associateDanglingLines.accept(danglingLine, candidateDanglingLine);
         }
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -891,9 +891,6 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
         Multimap<Class<? extends Identifiable>, String> intersection = index.intersection(otherNetwork.index);
         for (Map.Entry<Class<? extends Identifiable>, Collection<String>> entry : intersection.asMap().entrySet()) {
             Class<? extends Identifiable> clazz = entry.getKey();
-            if (clazz == DanglingLineImpl.class) { // fine for dangling lines
-                continue;
-            }
             Collection<String> objs = entry.getValue();
             if (!objs.isEmpty()) {
                 throw new PowsyblException("The following object(s) of type "
@@ -912,7 +909,7 @@ class NetworkImpl extends AbstractIdentifiable<Network> implements Network, Vari
             }
         }
         for (DanglingLine dl2 : Lists.newArrayList(other.getDanglingLines(DanglingLineFilter.ALL))) {
-            findAndAssociateDanglingLines(dl2, getDanglingLine(dl2.getId()), dl1byXnodeCode::get, (dll1, dll2) -> pairDanglingLines(lines, dll1, dll2, dl1byXnodeCode));
+            findAndAssociateDanglingLines(dl2, dl1byXnodeCode::get, (dll1, dll2) -> pairDanglingLines(lines, dll1, dll2, dl1byXnodeCode));
         }
 
         // do not forget to remove the other network from its index!!!

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
@@ -45,15 +45,6 @@ public abstract class AbstractMergeNetworkTest {
     }
 
     @Test
-    public void xnodeNonCompatible() {
-        addSubstationAndVoltageLevel();
-        addDanglingLines("dl", "code", "dl", "deco");
-        merge.merge(n1);
-        PowsyblException e = assertThrows(PowsyblException.class, () -> merge.merge(n2));
-        assertTrue(e.getMessage().contains("Dangling line couple dl have inconsistent Xnodes (code!=deco)"));
-    }
-
-    @Test
     public void testMerge() {
         addSubstationAndVoltageLevel();
         addDanglingLines("dl1", "code", "dl2", "code");
@@ -64,14 +55,12 @@ public abstract class AbstractMergeNetworkTest {
     }
 
     @Test
-    public void testMergeSameId() {
+
+    public void failMergeDanglingLinesWithSameId() {
         addSubstationAndVoltageLevel();
         addDanglingLines("dl", null, "dl", "code");
-        merge.merge(n1, n2);
-        assertNotNull(merge.getTieLine("dl"));
-        assertEquals("dl", merge.getTieLine("dl").getId());
-        assertEquals("dl_name", merge.getTieLine("dl").getOptionalName().orElse(null));
-        assertEquals("dl_name", merge.getTieLine("dl").getNameOrId());
+        PowsyblException e = assertThrows(PowsyblException.class, () -> merge.merge(n1, n2));
+        assertTrue(e.getMessage().contains("The following object(s) of type DanglingLineImpl exist(s) in both networks: [dl]"));
     }
 
     private void addSubstation(Network network, String substationId) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When 2 dangling lines have the same id, if one or two of them don't have a `ucteXnodeCode`, they are merged into a tie line during networks' merge.


**What is the new behavior (if this is a feature change)?**
If 2 dangling lines have the same id, regardless of their `ucteXnodeCode`, the networks' merge will fail.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
