### PR TITLE
Add a utility method to find the optional other side dangling line

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.iidm.network.DanglingLineFilter;
+import com.powsybl.iidm.network.TieLine;
 import org.apache.commons.math3.complex.Complex;
 
 import com.powsybl.iidm.network.Branch;
@@ -272,5 +273,21 @@ public final class TieLineUtil {
         } else {
             return adm.y21().getReal() == 0.0 && adm.y22().getImaginary() == 0.0;
         }
+    }
+
+    /**
+     * <p>Retrieve, if it exists, the dangling line on the other side of a tie line from a given dangling line.</p>
+     *
+     * @param danglingLine a dangling line
+     * @return an Optional containing the other side, if the given dangling line is paired. Else, `Optional.empty()`
+     */
+    public static Optional<DanglingLine> getOtherSide(DanglingLine danglingLine) {
+        Optional<TieLine> optionalTieLine = danglingLine.getTieLine();
+        if (optionalTieLine.isPresent()) {
+            TieLine tieLine = optionalTieLine.get();
+            DanglingLine otherSide = tieLine.getDanglingLine1() == danglingLine ? tieLine.getDanglingLine2() : tieLine.getDanglingLine1();
+            return Optional.of(otherSide);
+        }
+        return Optional.empty();
     }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -11,7 +11,6 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.iidm.network.DanglingLineFilter;
-import com.powsybl.iidm.network.TieLine;
 import org.apache.commons.math3.complex.Complex;
 
 import com.powsybl.iidm.network.Branch;
@@ -276,18 +275,13 @@ public final class TieLineUtil {
     }
 
     /**
-     * <p>Retrieve, if it exists, the dangling line on the other side of a tie line from a given dangling line.</p>
+     * <p>Retrieve, if it exists, the dangling line paired to the given one.</p>
      *
      * @param danglingLine a dangling line
-     * @return an Optional containing the other side, if the given dangling line is paired. Else, `Optional.empty()`
+     * @return an Optional containing the dangling line paired to the given one
      */
-    public static Optional<DanglingLine> getOtherSide(DanglingLine danglingLine) {
-        Optional<TieLine> optionalTieLine = danglingLine.getTieLine();
-        if (optionalTieLine.isPresent()) {
-            TieLine tieLine = optionalTieLine.get();
-            DanglingLine otherSide = tieLine.getDanglingLine1() == danglingLine ? tieLine.getDanglingLine2() : tieLine.getDanglingLine1();
-            return Optional.of(otherSide);
-        }
-        return Optional.empty();
+    public static Optional<DanglingLine> getPairedDanglingLine(DanglingLine danglingLine) {
+        return danglingLine.getTieLine().map(t ->
+                t.getDanglingLine1() == danglingLine ? t.getDanglingLine2() : t.getDanglingLine1());
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTieLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTieLineTest.java
@@ -93,9 +93,9 @@ public abstract class AbstractTieLineTest {
         assertFalse(network.getDanglingLines(DanglingLineFilter.PAIRED).iterator().hasNext());
         assertEquals(List.of(dl1, dl2), network.getDanglingLines());
 
-        // test other side retrieval - For unpaired dangling lines
-        assertFalse(TieLineUtil.getOtherSide(dl1).isPresent());
-        assertFalse(TieLineUtil.getOtherSide(dl2).isPresent());
+        // test paired dangling line retrieval - For unpaired dangling lines
+        assertFalse(TieLineUtil.getPairedDanglingLine(dl1).isPresent());
+        assertFalse(TieLineUtil.getPairedDanglingLine(dl2).isPresent());
 
         TieLineAdder adder = network.newTieLine().setId("testTie")
                 .setName("testNameTie")
@@ -180,11 +180,11 @@ public abstract class AbstractTieLineTest {
         assertEquals(expectedSV2.otherSideU(danglingLine2, true), danglingLine2.getBoundary().getV(), 0.0d);
         assertEquals(expectedSV2.otherSideA(danglingLine2, true), danglingLine2.getBoundary().getAngle(), 0.0d);
 
-        // test other side retrieval - For paired dangling lines
-        Optional<DanglingLine> otherSide1 = TieLineUtil.getOtherSide(danglingLine1);
+        // test paired dangling line retrieval - For paired dangling lines
+        Optional<DanglingLine> otherSide1 = TieLineUtil.getPairedDanglingLine(danglingLine1);
         assertTrue(otherSide1.isPresent());
         assertEquals(danglingLine2, otherSide1.orElseThrow());
-        Optional<DanglingLine> otherSide2 = TieLineUtil.getOtherSide(danglingLine2);
+        Optional<DanglingLine> otherSide2 = TieLineUtil.getPairedDanglingLine(danglingLine2);
         assertTrue(otherSide2.isPresent());
         assertEquals(danglingLine1, otherSide2.orElseThrow());
     }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTieLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTieLineTest.java
@@ -12,10 +12,12 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.NoEquipmentNetworkFactory;
 import com.powsybl.iidm.network.util.SV;
+import com.powsybl.iidm.network.util.TieLineUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -91,6 +93,10 @@ public abstract class AbstractTieLineTest {
         assertFalse(network.getDanglingLines(DanglingLineFilter.PAIRED).iterator().hasNext());
         assertEquals(List.of(dl1, dl2), network.getDanglingLines());
 
+        // test other side retrieval - For unpaired dangling lines
+        assertFalse(TieLineUtil.getOtherSide(dl1).isPresent());
+        assertFalse(TieLineUtil.getOtherSide(dl2).isPresent());
+
         TieLineAdder adder = network.newTieLine().setId("testTie")
                 .setName("testNameTie")
                 .setDanglingLine1(dl1.getId())
@@ -116,7 +122,6 @@ public abstract class AbstractTieLineTest {
         assertEquals(0.0285, tieLine.getB2(), tol);
 
         DanglingLine danglingLine1 = tieLine.getDanglingLine1();
-
         DanglingLine danglingLine2 = tieLine.getDanglingLine2();
 
         // Check notification on DanglingLine changes
@@ -160,20 +165,28 @@ public abstract class AbstractTieLineTest {
         double v2 = 380.0;
         double angle1 = -1e-4;
         double angle2 = -1.7e-3;
-        tieLine.getDanglingLine1().getTerminal().setP(p1).setQ(q1).getBusView().getBus().setV(v1).setAngle(angle1);
-        tieLine.getDanglingLine2().getTerminal().setP(p2).setQ(q2).getBusView().getBus().setV(v2).setAngle(angle2);
+        danglingLine1.getTerminal().setP(p1).setQ(q1).getBusView().getBus().setV(v1).setAngle(angle1);
+        danglingLine2.getTerminal().setP(p2).setQ(q2).getBusView().getBus().setV(v2).setAngle(angle2);
 
         // test boundaries values
         SV expectedSV1 = new SV(p1, q1, v1, angle1, Branch.Side.ONE);
         SV expectedSV2 = new SV(p2, q2, v2, angle2, Branch.Side.TWO);
-        assertEquals(expectedSV1.otherSideP(tieLine.getDanglingLine1(), true), tieLine.getDanglingLine1().getBoundary().getP(), 0.0d);
-        assertEquals(expectedSV1.otherSideQ(tieLine.getDanglingLine1(), true), tieLine.getDanglingLine1().getBoundary().getQ(), 0.0d);
-        assertEquals(expectedSV2.otherSideP(tieLine.getDanglingLine2(), true), tieLine.getDanglingLine2().getBoundary().getP(), 0.0d);
-        assertEquals(expectedSV2.otherSideQ(tieLine.getDanglingLine2(), true), tieLine.getDanglingLine2().getBoundary().getQ(), 0.0d);
-        assertEquals(expectedSV1.otherSideU(tieLine.getDanglingLine1(), true), tieLine.getDanglingLine1().getBoundary().getV(), 0.0d);
-        assertEquals(expectedSV1.otherSideA(tieLine.getDanglingLine1(), true), tieLine.getDanglingLine1().getBoundary().getAngle(), 0.0d);
-        assertEquals(expectedSV2.otherSideU(tieLine.getDanglingLine2(), true), tieLine.getDanglingLine2().getBoundary().getV(), 0.0d);
-        assertEquals(expectedSV2.otherSideA(tieLine.getDanglingLine2(), true), tieLine.getDanglingLine2().getBoundary().getAngle(), 0.0d);
+        assertEquals(expectedSV1.otherSideP(danglingLine1, true), danglingLine1.getBoundary().getP(), 0.0d);
+        assertEquals(expectedSV1.otherSideQ(danglingLine1, true), danglingLine1.getBoundary().getQ(), 0.0d);
+        assertEquals(expectedSV2.otherSideP(danglingLine2, true), danglingLine2.getBoundary().getP(), 0.0d);
+        assertEquals(expectedSV2.otherSideQ(danglingLine2, true), danglingLine2.getBoundary().getQ(), 0.0d);
+        assertEquals(expectedSV1.otherSideU(danglingLine1, true), danglingLine1.getBoundary().getV(), 0.0d);
+        assertEquals(expectedSV1.otherSideA(danglingLine1, true), danglingLine1.getBoundary().getAngle(), 0.0d);
+        assertEquals(expectedSV2.otherSideU(danglingLine2, true), danglingLine2.getBoundary().getV(), 0.0d);
+        assertEquals(expectedSV2.otherSideA(danglingLine2, true), danglingLine2.getBoundary().getAngle(), 0.0d);
+
+        // test other side retrieval - For paired dangling lines
+        Optional<DanglingLine> otherSide1 = TieLineUtil.getOtherSide(danglingLine1);
+        assertTrue(otherSide1.isPresent());
+        assertEquals(danglingLine2, otherSide1.orElseThrow());
+        Optional<DanglingLine> otherSide2 = TieLineUtil.getOtherSide(danglingLine2);
+        assertTrue(otherSide2.isPresent());
+        assertEquals(danglingLine1, otherSide2.orElseThrow());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #2650


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
No user-friendly method returns the dangling line on other side of a tie line.


**What is the new behavior (if this is a feature change)?**
A utility method returns an `Optional` corresponding to the dangling line on the other side of a tie line.
