### PR TITLE
Improve error message for lines between 2 Xnodes

### DIFF
--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -281,7 +281,7 @@ public class UcteImporter implements Importer {
     private static void createDanglingLine(UcteLine ucteLine, boolean connected,
                                            UcteNode xnode, UcteNodeCode nodeCode, UcteVoltageLevel ucteVoltageLevel,
                                            Network network) {
-        LOGGER.trace("Create dangling line '{}' (Xnode='{}')", ucteLine.getId(), xnode.getCode());
+        LOGGER.trace("Create dangling line '{}' (X-node='{}')", ucteLine.getId(), xnode.getCode());
 
         double p0 = isValueValid(xnode.getActiveLoad()) ? xnode.getActiveLoad() : 0;
         double q0 = isValueValid(xnode.getReactiveLoad()) ? xnode.getReactiveLoad() : 0;
@@ -457,7 +457,7 @@ public class UcteImporter implements Importer {
                 createDanglingLine(ucteLine, connected, xnode, nodeCode1, ucteVoltageLevel1, network);
 
             } else {
-                throw new UcteException("Line between 2 Xnodes: '" + nodeCode1 + "' and '" + nodeCode2 + "'");
+                throw new UcteException("Line between 2 X-nodes: '" + nodeCode1 + "' and '" + nodeCode2 + "'");
             }
         }
     }
@@ -664,7 +664,7 @@ public class UcteImporter implements Importer {
 
         UcteNode ucteXnode = ucteNetwork.getNode(xNodeCode);
 
-        LOGGER.warn("Create small impedance dangling line '{}{}' (transformer connected to XNODE '{}')",
+        LOGGER.warn("Create small impedance dangling line '{}{}' (transformer connected to X-node '{}')",
                 xNodeName, yNodeName, ucteXnode.getCode());
 
         double p0 = isValueValid(ucteXnode.getActiveLoad()) ? ucteXnode.getActiveLoad() : 0;
@@ -853,7 +853,7 @@ public class UcteImporter implements Importer {
             if (connectedMatchingDanglingLines.size() == 1) {
                 return connectedMatchingDanglingLines.get(0);
             } else {
-                throw new UcteException("More that 2 connected dangling lines have the same XNODE " + dl1.getUcteXnodeCode());
+                throw new UcteException("More that 2 connected dangling lines have the same X-node " + dl1.getUcteXnodeCode());
             }
         }
     }

--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -457,7 +457,7 @@ public class UcteImporter implements Importer {
                 createDanglingLine(ucteLine, connected, xnode, nodeCode1, ucteVoltageLevel1, network);
 
             } else {
-                throw new UcteException("Line between 2 Xnodes");
+                throw new UcteException("Line between 2 Xnodes: '" + nodeCode1 + "' and '" + nodeCode2 + "'");
             }
         }
     }

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
@@ -281,7 +281,7 @@ class UcteImporterTest {
         ReadOnlyDataSource dataSource = new ResourceDataSource("lineBetweenTwoXnodes", new ResourceSet("/", "lineBetweenTwoXnodes.uct"));
         NetworkFactory networkFactory = NetworkFactory.findDefault();
         PowsyblException e = assertThrows(PowsyblException.class, () -> new UcteImporter().importData(dataSource, networkFactory, null));
-        assertEquals("Line between 2 Xnodes: 'XXNODE11' and 'XXNODE12'", e.getMessage());
+        assertEquals("Line between 2 X-nodes: 'XXNODE11' and 'XXNODE12'", e.getMessage());
     }
 }
 

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.ucte.converter;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
 import com.powsybl.commons.datasource.ResourceSet;
@@ -273,6 +274,14 @@ class UcteImporterTest {
         Network network2 = new UcteImporter().importData(dataSource, new NetworkFactoryImpl(), parameters);
         assertEquals(1.92419, network2.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getCurrentStep().getAlpha(), 0.001);
         assertEquals(1.00000694, network2.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1").getPhaseTapChanger().getCurrentStep().getRho(), 0.0000001); // FIXME, symmetrical no impact
+    }
+
+    @Test
+    void lineBetweenTwoXnodesTest() {
+        ReadOnlyDataSource dataSource = new ResourceDataSource("lineBetweenTwoXnodes", new ResourceSet("/", "lineBetweenTwoXnodes.uct"));
+        NetworkFactory networkFactory = NetworkFactory.findDefault();
+        PowsyblException e = assertThrows(PowsyblException.class, () -> new UcteImporter().importData(dataSource, networkFactory, null));
+        assertEquals("Line between 2 Xnodes: 'XXNODE11' and 'XXNODE12'", e.getMessage());
     }
 }
 

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterTest.java
@@ -280,8 +280,8 @@ class UcteImporterTest {
     void lineBetweenTwoXnodesTest() {
         ReadOnlyDataSource dataSource = new ResourceDataSource("lineBetweenTwoXnodes", new ResourceSet("/", "lineBetweenTwoXnodes.uct"));
         NetworkFactory networkFactory = NetworkFactory.findDefault();
-        PowsyblException e = assertThrows(PowsyblException.class, () -> new UcteImporter().importData(dataSource, networkFactory, null));
+        UcteImporter importer = new UcteImporter();
+        PowsyblException e = assertThrows(PowsyblException.class, () -> importer.importData(dataSource, networkFactory, null));
         assertEquals("Line between 2 X-nodes: 'XXNODE11' and 'XXNODE12'", e.getMessage());
     }
 }
-

--- a/ucte/ucte-converter/src/test/resources/lineBetweenTwoXnodes.uct
+++ b/ucte/ucte-converter/src/test/resources/lineBetweenTwoXnodes.uct
@@ -1,0 +1,8 @@
+##C 2007.05.01
+Test case for a line between 2 xnodes error
+##N
+##ZXX
+XXNODE11              1 0      0       0       0       0       0       0       0       0       0     0       0       0
+XXNODE12              1 0      0       0       0       0       0       0       0       0       0     0       0       0
+##L
+XXNODE11 XXNODE12 1 0      2     10       65    200 INTERCO FR


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Error message improvement


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When we have a line between 2 xnodes in a UCTE file, we get an error message but without the information of the 2 xnodes.


**What is the new behavior (if this is a feature change)?**
We have the name of the 2 xnodes.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
