### PR TITLE
Java S6355 rule: add arguments to @Deprecated annotations

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/compress/ZipHelper.java
+++ b/commons/src/main/java/com/powsybl/commons/compress/ZipHelper.java
@@ -14,7 +14,7 @@ import java.util.List;
  * @deprecated Use {@link ZipPackager} instead.
  * @author Yichen TANG <yichen.tang at rte-france.com>
  */
-@Deprecated
+@Deprecated(since = "2.6.0")
 public final class ZipHelper {
 
     /**

--- a/commons/src/main/java/com/powsybl/commons/config/ModuleConfigRepository.java
+++ b/commons/src/main/java/com/powsybl/commons/config/ModuleConfigRepository.java
@@ -15,7 +15,7 @@ public interface ModuleConfigRepository {
     /**
      * @deprecated Use the <code>Optional</code> returned by {@link #getModuleConfig(String)}
      */
-    @Deprecated
+    @Deprecated(since = "4.9.0")
     default boolean moduleExists(String name) {
         return getModuleConfig(name).isPresent();
     }

--- a/commons/src/main/java/com/powsybl/commons/config/PlatformConfig.java
+++ b/commons/src/main/java/com/powsybl/commons/config/PlatformConfig.java
@@ -37,7 +37,7 @@ public class PlatformConfig {
     /**
      * @deprecated Directly pass <code>PlatformConfig</code> instance to the code you want to test.
      */
-    @Deprecated
+    @Deprecated(since = "2.2.0")
     public static synchronized void setDefaultConfig(PlatformConfig defaultConfig) {
         PlatformConfig.defaultConfig = defaultConfig;
     }
@@ -102,7 +102,7 @@ public class PlatformConfig {
     /**
      * @deprecated Use the <code>Optional</code> returned by {@link #getOptionalModuleConfig(String)}
      */
-    @Deprecated
+    @Deprecated(since = "4.9.0")
     public boolean moduleExists(String name) {
         return getOptionalModuleConfig(name).isPresent();
     }
@@ -110,7 +110,7 @@ public class PlatformConfig {
     /**
      * @deprecated Use {@link #getOptionalModuleConfig(String)} instead
      */
-    @Deprecated
+    @Deprecated(since = "4.9.0")
     public ModuleConfig getModuleConfig(String name) {
         return getRepository().getModuleConfig(name).orElseThrow(() -> new PowsyblException("Module " + name + " not found"));
     }

--- a/commons/src/main/java/com/powsybl/commons/config/PlatformConfigNamedProvider.java
+++ b/commons/src/main/java/com/powsybl/commons/config/PlatformConfigNamedProvider.java
@@ -99,7 +99,7 @@ public interface PlatformConfigNamedProvider {
          *
          * @return the provider
          */
-        @Deprecated
+        @Deprecated(since = "3.2.0")
         public static <T extends PlatformConfigNamedProvider> T findDefaultBackwardsCompatible(
                 String moduleName, Class<T> clazz, PlatformConfig platformConfig) {
             return find(null, moduleName,
@@ -116,7 +116,7 @@ public interface PlatformConfigNamedProvider {
          *
          * @return the provider
          */
-        @Deprecated
+        @Deprecated(since = "3.2.0")
         public static <T extends PlatformConfigNamedProvider> T findBackwardsCompatible(String name,
                 String moduleName, Class<T> clazz, PlatformConfig platformConfig) {
             return find(name, moduleName,

--- a/commons/src/main/java/com/powsybl/commons/xml/XmlWriterContext.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlWriterContext.java
@@ -18,7 +18,7 @@ public interface XmlWriterContext {
     /**
      * @deprecated Use {@link #getWriter()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "4.0.0")
     default XMLStreamWriter getExtensionsWriter() {
         return getWriter();
     }

--- a/computation/src/main/java/com/powsybl/computation/SimpleCommand.java
+++ b/computation/src/main/java/com/powsybl/computation/SimpleCommand.java
@@ -42,7 +42,7 @@ public interface SimpleCommand extends Command {
      *
      * @return the timeout in milliseconds for this command execution.
      */
-    @Deprecated
+    @Deprecated(since = "2.5.0")
     int getTimeout();
 
 }

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
@@ -145,7 +145,7 @@ public class Contingency extends AbstractExtendable<Contingency> {
      * Return a list of valid contingencies.
      * @deprecated Use {@link ContingencyList#getValidContingencies(List, Network)} ()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "4.0.0")
     public static List<Contingency> checkValidity(List<Contingency> contingencies, Network network) {
         return ContingencyList.getValidContingencies(contingencies, network);
     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Importer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Importer.java
@@ -298,7 +298,7 @@ public interface Importer {
     /**
      * @deprecated Use {@link Importer#importData(ReadOnlyDataSource, NetworkFactory, Properties)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.6.0")
     default Network importData(ReadOnlyDataSource dataSource, Properties parameters) {
         return importData(dataSource, NetworkFactory.findDefault(), parameters);
     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactory.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactory.java
@@ -49,7 +49,7 @@ public interface NetworkFactory {
     /**
      * @deprecated Use {@link Network#create(String, String)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.6.0")
     static Network create(String id, String sourceFormat) {
         return findDefault().createNetwork(id, sourceFormat);
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractMultiVariantConnectableExtension.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractMultiVariantConnectableExtension.java
@@ -12,13 +12,13 @@ import com.powsybl.iidm.network.Connectable;
  * @deprecated use {@link AbstractMultiVariantIdentifiableExtension} instead.
  * @author Ghiles Abdellah <ghiles.abdellah at rte-france.com>
  */
-@Deprecated
+@Deprecated(since = "3.5.0")
 public abstract class AbstractMultiVariantConnectableExtension<T extends Connectable<T>> extends AbstractMultiVariantIdentifiableExtension<T> {
 
     /**
      * Deprecated, use {@link AbstractMultiVariantIdentifiableExtension} instead.
      */
-    @Deprecated
+    @Deprecated(since = "3.5.0")
     public AbstractMultiVariantConnectableExtension(T extendable) {
         super(extendable);
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateCouplingDevice.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateCouplingDevice.java
@@ -54,7 +54,7 @@ public class CreateCouplingDevice extends AbstractNetworkModification {
     /**
      * @deprecated Use {@link #getBusOrBbsId1()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "5.2.0")
     public String getBbsId1() {
         return getBusOrBbsId1();
     }
@@ -66,7 +66,7 @@ public class CreateCouplingDevice extends AbstractNetworkModification {
     /**
      * @deprecated Use {@link #getBusOrBbsId2()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "5.2.0")
     public String getBbsId2() {
         return getBusOrBbsId2();
     }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateCouplingDeviceBuilder.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateCouplingDeviceBuilder.java
@@ -29,7 +29,7 @@ public class CreateCouplingDeviceBuilder {
     /**
      * @deprecated Use {@link #withBusOrBusbarSectionId1(String)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "5.2.0")
     public CreateCouplingDeviceBuilder withBusbarSectionId1(String bbsId1) {
         return withBusOrBusbarSectionId1(bbsId1);
     }
@@ -42,7 +42,7 @@ public class CreateCouplingDeviceBuilder {
     /**
      * @deprecated Use {@link #withBusOrBusbarSectionId2(String)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "5.2.0")
     public CreateCouplingDeviceBuilder withBusbarSectionId2(String bbsId2) {
         return withBusOrBusbarSectionId2(bbsId2);
     }

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
@@ -375,7 +375,7 @@ public final class EurostagTutorialExample1Factory {
      *             an infinite value temporary limit, which make overload detection
      *             malfunction.
      */
-    @Deprecated
+    @Deprecated(since = "2.5.0")
     public static Network createWithCurrentLimits() {
         Network network = createWithFixedCurrentLimits();
         Line line = network.getLine("NHV1_NHV2_1");

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ConnectableXmlUtil.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/ConnectableXmlUtil.java
@@ -215,7 +215,7 @@ public final class ConnectableXmlUtil {
     /**
      * @deprecated Use {@link #writeCurrentLimits(Integer, CurrentLimits, XMLStreamWriter, IidmXmlVersion, ExportOptions)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "3.2.0")
     public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer, IidmXmlVersion version) throws XMLStreamException {
         writeCurrentLimits(index, limits, writer, version, new ExportOptions());
     }
@@ -233,7 +233,7 @@ public final class ConnectableXmlUtil {
     /**
      * @deprecated Use {@link #writeCurrentLimits(Integer, CurrentLimits, XMLStreamWriter, String, IidmXmlVersion, ExportOptions)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "3.2.0")
     public static void writeCurrentLimits(Integer index, CurrentLimits limits, XMLStreamWriter writer, String nsUri, IidmXmlVersion version) throws XMLStreamException {
         writeCurrentLimits(index, limits, writer, nsUri, version, new ExportOptions());
     }
@@ -274,7 +274,7 @@ public final class ConnectableXmlUtil {
     /**
      * @deprecated Use {@link TerminalRefXml#writeTerminalRef(Terminal, NetworkXmlWriterContext, String)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.5.0")
     public static void writeTerminalRef(Terminal t, NetworkXmlWriterContext context, String elementName) throws XMLStreamException {
         TerminalRefXml.writeTerminalRef(t, context, elementName);
     }
@@ -282,7 +282,7 @@ public final class ConnectableXmlUtil {
     /**
      * @deprecated Use {@link TerminalRefXml#readTerminalRef(Network, String, String)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "5.2.0")
     public static Terminal readTerminalRef(Network network, String id, String side) {
         return TerminalRefXml.readTerminalRef(network, id, side);
     }

--- a/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlWriterContext.java
+++ b/iidm/iidm-xml-converter/src/main/java/com/powsybl/iidm/xml/NetworkXmlWriterContext.java
@@ -65,7 +65,7 @@ public class NetworkXmlWriterContext extends AbstractNetworkXmlContext<ExportOpt
     /**
      * @deprecated Should not be used anymore.
      */
-    @Deprecated
+    @Deprecated(since = "3.8.1")
     public void setExtensionsWriter(XMLStreamWriter extensionsWriter) {
         // does nothing
         // only kept to prevent breaking change

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -232,7 +232,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
     /**
      * @deprecated Use {@link #isUseReactiveLimits} instead.
      */
-    @Deprecated
+    @Deprecated(since = "5.1.0")
     public boolean isNoGeneratorReactiveLimits() {
         return !useReactiveLimits;
     }
@@ -240,7 +240,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
     /**
      * @deprecated Use {@link #setNoGeneratorReactiveLimits} instead.
      */
-    @Deprecated
+    @Deprecated(since = "5.1.0")
     public LoadFlowParameters setNoGeneratorReactiveLimits(boolean noGeneratorReactiveLimits) {
         this.useReactiveLimits = !noGeneratorReactiveLimits;
         return this;
@@ -267,7 +267,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
     /**
      * @deprecated Use {@link #isShuntCompensatorVoltageControlOn()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "4.7.0")
     public boolean isSimulShunt() {
         return isShuntCompensatorVoltageControlOn();
     }
@@ -279,7 +279,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
     /**
      * @deprecated Use {@link #setShuntCompensatorVoltageControlOn(boolean)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "4.7.0")
     public LoadFlowParameters setSimulShunt(boolean simulShunt) {
         return setShuntCompensatorVoltageControlOn(simulShunt);
     }

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
@@ -123,7 +123,7 @@ public interface LoadFlowProvider extends Versionable, PlatformConfigNamedProvid
      *
      * @return the list of the specific parameters names.
      */
-    @Deprecated
+    @Deprecated(since = "5.1.0")
     default List<String> getSpecificParametersNames() {
         return getSpecificParameters().stream().map(Parameter::getName).collect(Collectors.toList());
     }

--- a/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
+++ b/math/src/main/java/com/powsybl/math/graph/UndirectedGraph.java
@@ -122,7 +122,7 @@ public interface UndirectedGraph<V, E> {
      *
      * @deprecated Use {@link #getVertexCapacity} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.5.0")
     default int getMaxVertex() {
         return getVertexCapacity();
     }

--- a/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
@@ -127,7 +127,7 @@ public class DenseMatrix extends AbstractMatrix {
     /**
      * @deprecated Use {@link #get(int, int)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.5.0")
     public double getValue(int i, int j) {
         return get(i, j);
     }

--- a/math/src/main/java/com/powsybl/math/matrix/Matrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/Matrix.java
@@ -91,7 +91,7 @@ public interface Matrix {
         /**
          * @deprecated Use {@link #onElement(int, int, double)} instead.
          */
-        @Deprecated
+        @Deprecated(since = "2.5.0")
         default void onValue(int i, int j, double value) {
             onElement(i, j, value);
         }
@@ -107,7 +107,7 @@ public interface Matrix {
     /**
      * @deprecated Use {@link #getRowCount()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.5.0")
     default int getM() {
         return getRowCount();
     }
@@ -122,7 +122,7 @@ public interface Matrix {
     /**
      * @deprecated Use {@link #getColumnCount()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.5.0")
     default int getN() {
         return getColumnCount();
     }
@@ -139,7 +139,7 @@ public interface Matrix {
     /**
      * @deprecated Use {@link #set(int, int, double)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.5.0")
     default void setValue(int i, int j, double value) {
         set(i, j, value);
     }
@@ -208,7 +208,7 @@ public interface Matrix {
     /**
      * @deprecated Use {@link #add(int, int, double)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "2.5.0")
     default void addValue(int i, int j, double value) {
         add(i, j, value);
     }

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/ShortCircuitParameters.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/ShortCircuitParameters.java
@@ -77,7 +77,7 @@ public class ShortCircuitParameters extends AbstractExtendable<ShortCircuitParam
     /**
      * @deprecated Use {@link #isWithVoltageResult()} instead. Used for backward compatibility.
      */
-    @Deprecated
+    @Deprecated(since = "5.2.0")
     public boolean isWithVoltageMap() {
         return isWithVoltageResult();
     }
@@ -85,7 +85,7 @@ public class ShortCircuitParameters extends AbstractExtendable<ShortCircuitParam
     /**
      * @deprecated Use {@link #setWithVoltageResult(boolean)} instead. Used for backward compatibility.
      */
-    @Deprecated
+    @Deprecated(since = "5.2.0")
     public ShortCircuitParameters setWithVoltageMap(boolean withVoltageMap) {
         this.withVoltageResult = withVoltageMap;
         return this;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Quality

**What is the current behavior?**
`@Deprecated` annotations without "since" and/or "forRemoval" arguments

**What is the new behavior (if this is a feature change)?**
Version number `(since = "X.Y.Z")` added to `@Deprecated` annotations
