### PR TITLE
Add bPerSection modification on shunt compensator

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ShuntCompensatorModification.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ShuntCompensatorModification.java
@@ -52,7 +52,7 @@ public class ShuntCompensatorModification extends AbstractNetworkModification {
             ((ShuntCompensatorLinearModel) (shuntCompensator.getModel())).setBPerSection(bPerSection);
         } else if (Objects.nonNull(bPerSection)) {
             logOrThrow(throwException,
-                "Shunt compensator is not linear but you wanted to modify its susceptance per section.");
+                "Shunt compensator model is non linear: bPerSection cannot be changed");
             return;
         }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ShuntCompensatorModification.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ShuntCompensatorModification.java
@@ -9,10 +9,7 @@ package com.powsybl.iidm.modification;
 import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.modification.util.VoltageRegulationUtils;
-import com.powsybl.iidm.network.IdentifiableType;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.ShuntCompensator;
-import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.*;
 
 import java.util.Objects;
 
@@ -26,11 +23,18 @@ public class ShuntCompensatorModification extends AbstractNetworkModification {
     private final String shuntCompensatorId;
     private final Boolean connect;
     private final Integer sectionCount;
+    private final Double bPerSection;
 
     public ShuntCompensatorModification(String shuntCompensatorId, Boolean connect, Integer sectionCount) {
+        this(shuntCompensatorId, connect, sectionCount, null);
+    }
+
+    public ShuntCompensatorModification(String shuntCompensatorId, Boolean connect, Integer sectionCount,
+                                        Double bPerSection) {
         this.shuntCompensatorId = Objects.requireNonNull(shuntCompensatorId);
         this.connect = connect;
         this.sectionCount = sectionCount;
+        this.bPerSection = bPerSection;
     }
 
     @Override
@@ -41,6 +45,9 @@ public class ShuntCompensatorModification extends AbstractNetworkModification {
         if (shuntCompensator == null) {
             logOrThrow(throwException, "Shunt Compensator '" + shuntCompensatorId + "' not found");
             return;
+        }
+        if (shuntCompensator.getModelType().equals(ShuntCompensatorModelType.LINEAR) && Objects.nonNull(bPerSection)) {
+            ((ShuntCompensatorLinearModel) (shuntCompensator.getModel())).setBPerSection(bPerSection);
         }
 
         if (connect != null) {

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ShuntCompensatorModification.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ShuntCompensatorModification.java
@@ -14,7 +14,8 @@ import com.powsybl.iidm.network.*;
 import java.util.Objects;
 
 /**
- * Simple {@link NetworkModification} to (dis)connect a shunt compensator and/or change its section.
+ * Simple {@link NetworkModification} to (dis)connect a shunt compensator and/or change its section,
+ * if the model is linear you can modify the b per section.
  *
  * @author Nicolas PIERRE <nicolas.pierre at artelys.com>
  */
@@ -46,8 +47,13 @@ public class ShuntCompensatorModification extends AbstractNetworkModification {
             logOrThrow(throwException, "Shunt Compensator '" + shuntCompensatorId + "' not found");
             return;
         }
+
         if (shuntCompensator.getModelType().equals(ShuntCompensatorModelType.LINEAR) && Objects.nonNull(bPerSection)) {
             ((ShuntCompensatorLinearModel) (shuntCompensator.getModel())).setBPerSection(bPerSection);
+        } else if (Objects.nonNull(bPerSection)) {
+            logOrThrow(throwException,
+                "Shunt compensator is not linear but you wanted to modify its susceptance per section.");
+            return;
         }
 
         if (connect != null) {
@@ -59,6 +65,7 @@ public class ShuntCompensatorModification extends AbstractNetworkModification {
                 t.disconnect();
             }
         }
+
         if (sectionCount != null) {
             shuntCompensator.setSectionCount(sectionCount);
         }

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ShuntCompensatorModificationTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ShuntCompensatorModificationTest.java
@@ -8,9 +8,7 @@ package com.powsybl.iidm.modification;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.reporter.Reporter;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.ShuntCompensator;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,6 +46,7 @@ class ShuntCompensatorModificationTest {
     @Test
     void testApplyChecks() {
         ShuntCompensatorModification modif = new ShuntCompensatorModification(shunt.getId(), null, 1);
+        assertEquals(shunt.getId(), modif.getShuntCompensatorId());
         assertDoesNotThrow(() -> modif.apply(network, true, Reporter.NO_OP));
         assertEquals(1, shunt.getSectionCount(), "A valid apply should modify the value");
         ShuntCompensatorModification modif1 = new ShuntCompensatorModification("UNKNOWN_ID", null, 0);
@@ -102,7 +101,7 @@ class ShuntCompensatorModificationTest {
     }
 
     @Test
-    void testConnectShuntCorrectSetPointWithNoRegulatingElmt() {
+    void testConnectShuntCorrectSetPointWithNoRegulatingElement() {
         network.getGenerator("GH1").getTerminal().disconnect();
         network.getGenerator("GH2").getTerminal().disconnect();
         Generator g3 = network.getGenerator("GH3");
@@ -118,8 +117,12 @@ class ShuntCompensatorModificationTest {
 
     @Test
     void testBPerSectionModification() {
+        Assertions.assertEquals(0, shunt.getSectionCount());
+        ShuntCompensatorModel model = shunt.getModel();
+        Assertions.assertTrue(model instanceof ShuntCompensatorLinearModel);
+        Assertions.assertEquals(-0.012, ((ShuntCompensatorLinearModel) model).getBPerSection());
         new ShuntCompensatorModification(shunt.getId(), true, 1, 10.).apply(network);
         Assertions.assertEquals(1, shunt.getSectionCount());
-        Assertions.assertEquals(10., shunt.getB());
+        Assertions.assertEquals(10., ((ShuntCompensatorLinearModel) model).getBPerSection());
     }
 }

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ShuntCompensatorModificationTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ShuntCompensatorModificationTest.java
@@ -115,4 +115,11 @@ class ShuntCompensatorModificationTest {
         Assertions.assertTrue(shunt.getTerminal().isConnected());
         Assertions.assertEquals(2.0, shunt.getTargetV(), 0.1);
     }
+
+    @Test
+    void testBPerSectionModification() {
+        new ShuntCompensatorModification(shunt.getId(), true, 1, 10.).apply(network);
+        Assertions.assertEquals(1, shunt.getSectionCount());
+        Assertions.assertEquals(10., shunt.getB());
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
feature to modify the b per section of shunts only if the model is linear.